### PR TITLE
fix(firebase_auth): TenantId can be reset to null after being set to something else

### DIFF
--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -145,9 +145,7 @@ public class FlutterFirebaseAuthPlugin
     FirebaseApp app = FirebaseApp.getInstance(appName);
     FirebaseAuth auth = FirebaseAuth.getInstance(app);
     String tenantId = (String) arguments.get(Constants.TENANT_ID);
-    if (tenantId != null) {
-      auth.setTenantId(tenantId);
-    }
+    auth.setTenantId(tenantId);
     return auth;
   }
 

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -1054,7 +1054,9 @@ NSString *const kErrMsgInvalidCredential =
   FIRApp *app = [FLTFirebasePlugin firebaseAppNamed:appNameDart];
   FIRAuth *auth = [FIRAuth authWithApp:app];
 
-  if (tenantId != nil && ![tenantId isEqual:[NSNull null]]) {
+  if ([tenantId isEqual:[NSNull null]]) {
+    auth.tenantID = nil;
+  } else {
     auth.tenantID = tenantId;
   }
 


### PR DESCRIPTION
## Description

Existing behavior
- Cannot set tenantId to null after setting it to something else

New behavior
- Setting tenantId back to null works as expected

Motivation
- This is how the native SDKs work

I was unsure how to write tests for this. The existing tenantId tests don't look like they actually interact with the platform code. If anyone could point me in the right direction I would be happy to write them.

## Related Issues

https://github.com/FirebaseExtended/flutterfire/issues/7896#issue-1107115648

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
