### PR TITLE
docs(app-check): Fix unreachable in-file links

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,3 +59,4 @@ Alessandro Rossi <alexodus71@gmail.com>
 Timur Dyushaliev <timurdyushaliev@gmail.com>
 Maaku Saito <maaku0810@gmail.com>
 Markus Köhne <markus@koehne.dev>
+Shuchen Liu <shuchenliu2014@gmail.com>

--- a/docs/app-check/custom-resource.mdx
+++ b/docs/app-check/custom-resource.mdx
@@ -13,7 +13,7 @@ with App Check. To do so, you will need to do both of the following:
 
 ## Before you begin
 
-Add App Check to your app, using the [default providers](default-providers).
+Add App Check to your app, using the [default providers](default-providers.mdx).
 
 ## Send App Check tokens with backend requests
 

--- a/docs/app-check/default-providers.mdx
+++ b/docs/app-check/default-providers.mdx
@@ -12,7 +12,7 @@ only your app can access your project's Firebase resources. See an
 
 ## 1. Set up your Firebase project {#project-setup}
 
-1.  [Install and initialize FlutterFire](../overview) if you haven't
+1.  [Install and initialize FlutterFire](../overview.mdx) if you haven't
     already done so.
 
 1.  Register your apps to use App Check with the SafetyNet, Device Check, and reCAPTCHA providers in the
@@ -217,4 +217,4 @@ such as an emulator during development, or from a continuous integration (CI)
 environment, you can create a debug build of your app that uses the
 App Check debug provider instead of a real attestation provider.
 
-See [Use App Check with the debug provider](debug-provider).
+See [Use App Check with the debug provider](debug-provider.mdx).

--- a/docs/app-check/overview.mdx
+++ b/docs/app-check/overview.mdx
@@ -29,6 +29,6 @@ with a CDN.
 
 ## Next Steps
 
-- [Enable App Check in a Flutter app](default-providers)
-- [Debugging apps that use App Check](debug-provider)
-- [Protect non-Firebase resources](custom-resource)
+- [Enable App Check in a Flutter app](default-providers.mdx)
+- [Debugging apps that use App Check](debug-provider.mdx)
+- [Protect non-Firebase resources](custom-resource.mdx)


### PR DESCRIPTION
## Description

Markdown documents within directory `docs/app-check/` contain unreachable relative links to other `.mdx` files, causing `404` error on GitHub when visited.  These links were subsequently updated with complete file extensions.

Similar behaviors may exist in `.mdx` format documentations on other `flutterfire` extensions and `app-check` is chosen as an example due to the relatively small size of changes to be made. Larger scope of updates on the documentations can be worked on if deemed worthwhile by repository maintainers.

## Related Issues

None.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
