### PR TITLE
docs(storage): adds missing line of code in upload file snippet

### DIFF
--- a/docs/storage/upload-files.mdx
+++ b/docs/storage/upload-files.mdx
@@ -206,6 +206,9 @@ final file = File(filePath);
 // Create the file metadata
 final metadata = SettableMetadata(contentType: "image/jpeg");
 
+// Create a reference to the Firebase Storage bucket
+final storageRef = FirebaseStorage.instance.ref();
+
 // Upload file and metadata to the path 'images/mountains.jpg'
 final uploadTask = storageRef
     .child("images/path/to/mountains.jpg")


### PR DESCRIPTION
## Description

Fixing a small code error in a Cloud Storage Flutter snippet. There was a missing variable declaration that would break the snippet if copied.

## Related Issues

N/A, only a documentation fix

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
