### PR TITLE
feat(ui): Allow setting `resizeToAvoidBottomInset` from LoginScreen and set as default `false` for backwards compatibility.

### DIFF
--- a/packages/flutterfire_ui/lib/src/auth/screens/forgot_password_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/forgot_password_screen.dart
@@ -14,6 +14,7 @@ class ForgotPasswordScreen extends StatelessWidget {
   final double? headerMaxExtent;
   final SideBuilder? sideBuilder;
   final TextDirection? desktopLayoutDirection;
+  final bool? resizeToAvoidBottomInset;
   final double breakpoint;
 
   const ForgotPasswordScreen({
@@ -26,6 +27,7 @@ class ForgotPasswordScreen extends StatelessWidget {
     this.headerMaxExtent,
     this.sideBuilder,
     this.desktopLayoutDirection,
+    this.resizeToAvoidBottomInset,
     this.breakpoint = 600,
   }) : super(key: key);
 
@@ -45,6 +47,7 @@ class ForgotPasswordScreen extends StatelessWidget {
         headerMaxExtent: headerMaxExtent,
         sideBuilder: sideBuilder,
         breakpoint: breakpoint,
+        resizeToAvoidBottomInset: resizeToAvoidBottomInset,
         maxWidth: 1200,
         contentFlex: 1,
         child: Padding(

--- a/packages/flutterfire_ui/lib/src/auth/screens/forgot_password_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/forgot_password_screen.dart
@@ -41,13 +41,13 @@ class ForgotPasswordScreen extends StatelessWidget {
     );
 
     return UniversalScaffold(
+      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
       body: ResponsivePage(
         desktopLayoutDirection: desktopLayoutDirection,
         headerBuilder: headerBuilder,
         headerMaxExtent: headerMaxExtent,
         sideBuilder: sideBuilder,
         breakpoint: breakpoint,
-        resizeToAvoidBottomInset: resizeToAvoidBottomInset,
         maxWidth: 1200,
         contentFlex: 1,
         child: Padding(

--- a/packages/flutterfire_ui/lib/src/auth/screens/internal/login_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/internal/login_screen.dart
@@ -17,6 +17,7 @@ class LoginScreen extends StatelessWidget {
   final TextDirection? desktopLayoutDirection;
   final String? email;
   final bool? showAuthActionSwitch;
+  final bool? resizeToAvoidBottomInset;
   final AuthViewContentBuilder? subtitleBuilder;
   final AuthViewContentBuilder? footerBuilder;
   final Key? loginViewKey;
@@ -34,6 +35,7 @@ class LoginScreen extends StatelessWidget {
     this.desktopLayoutDirection = TextDirection.ltr,
     this.email,
     this.showAuthActionSwitch,
+    this.resizeToAvoidBottomInset = false,
     this.subtitleBuilder,
     this.footerBuilder,
     this.loginViewKey,
@@ -71,7 +73,7 @@ class LoginScreen extends StatelessWidget {
 
     return UniversalScaffold(
       body: body,
-      resizeToAvoidBottomInset: false,
+      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
     );
   }
 }

--- a/packages/flutterfire_ui/lib/src/auth/screens/register_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/register_screen.dart
@@ -18,6 +18,7 @@ class RegisterScreen extends MultiProviderScreen {
   final OAuthButtonVariant? oauthButtonVariant;
   final TextDirection? desktopLayoutDirection;
   final String? email;
+  final bool? resizeToAvoidBottomInset;
   final bool? showAuthActionSwitch;
   final AuthViewContentBuilder? subtitleBuilder;
   final AuthViewContentBuilder? footerBuilder;
@@ -33,6 +34,7 @@ class RegisterScreen extends MultiProviderScreen {
     this.oauthButtonVariant = OAuthButtonVariant.icon_and_text,
     this.desktopLayoutDirection,
     this.email,
+    this.resizeToAvoidBottomInset = false,
     this.showAuthActionSwitch,
     this.subtitleBuilder,
     this.footerBuilder,
@@ -44,6 +46,7 @@ class RegisterScreen extends MultiProviderScreen {
     return LoginScreen(
       action: AuthAction.signUp,
       providerConfigs: providerConfigs,
+      resizeToAvoidBottomInset: resizeToAvoidBottomInset,
       auth: auth,
       headerMaxExtent: headerMaxExtent,
       headerBuilder: headerBuilder,

--- a/packages/flutterfire_ui/lib/src/auth/screens/sign_in_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/sign_in_screen.dart
@@ -19,6 +19,7 @@ class SignInScreen extends MultiProviderScreen {
   final OAuthButtonVariant? oauthButtonVariant;
   final TextDirection? desktopLayoutDirection;
   final String? email;
+  final bool? resizeToAvoidBottomInset;
   final bool? showAuthActionSwitch;
   final AuthViewContentBuilder? subtitleBuilder;
   final AuthViewContentBuilder? footerBuilder;
@@ -35,6 +36,7 @@ class SignInScreen extends MultiProviderScreen {
     this.sideBuilder,
     this.oauthButtonVariant = OAuthButtonVariant.icon_and_text,
     this.desktopLayoutDirection,
+    this.resizeToAvoidBottomInset = false,
     this.showAuthActionSwitch,
     this.email,
     this.subtitleBuilder,
@@ -80,12 +82,14 @@ class SignInScreen extends MultiProviderScreen {
         action: AuthAction.signIn,
         providerConfigs: providerConfigs,
         auth: auth,
+        resizeToAvoidBottomInset: resizeToAvoidBottomInset,
         headerMaxExtent: headerMaxExtent,
         headerBuilder: headerBuilder,
         sideBuilder: sideBuilder,
         desktopLayoutDirection: desktopLayoutDirection,
         oauthButtonVariant: oauthButtonVariant,
         email: email,
+        resizeToAvoidBottomInset: resizeToAvoidBottomInset,
         showAuthActionSwitch: showAuthActionSwitch,
         subtitleBuilder: subtitleBuilder,
         footerBuilder: footerBuilder,

--- a/packages/flutterfire_ui/lib/src/auth/screens/sign_in_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/sign_in_screen.dart
@@ -82,7 +82,6 @@ class SignInScreen extends MultiProviderScreen {
         action: AuthAction.signIn,
         providerConfigs: providerConfigs,
         auth: auth,
-        resizeToAvoidBottomInset: resizeToAvoidBottomInset,
         headerMaxExtent: headerMaxExtent,
         headerBuilder: headerBuilder,
         sideBuilder: sideBuilder,


### PR DESCRIPTION
## Description

The UniversalScaffold used by LoginScreen() and SignInScreen() (among others) sets resizeToAvoidBottomInset=false, which means on smaller screen devices (particularly on mobile web, which pulls in relatively high resolution devices eg. the Pixel 4a) and means the password box is obscured when a header is set.

This change is to expose resizeToAvoidBottomInset as an option which can be set directly from the externally exposed api points, while not breaking any of the expected behaviour elsewhere unless explicit.

There are other screens I could implement this on as well (eg. sign in link.) 

Happy to provide screenshots if necessary.

## Related Issues

Closes #8084

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/