### PR TITLE
feat(flutterfire_ui): added the empty builder to firestoreListView

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,3 +59,4 @@ Alessandro Rossi <alexodus71@gmail.com>
 Timur Dyushaliev <timurdyushaliev@gmail.com>
 Maaku Saito <maaku0810@gmail.com>
 Markus Köhne <markus@koehne.dev>
+Atif Siddiqui <itsatifsiddiqui@gmail.com>

--- a/packages/flutterfire_ui/lib/src/firestore/query_builder.dart
+++ b/packages/flutterfire_ui/lib/src/firestore/query_builder.dart
@@ -355,6 +355,9 @@ typedef FirestoreItemBuilder<Document> = Widget Function(
 /// A type representing the function passed to [FirestoreListView] for its `loadingBuilder`.
 typedef FirestoreLoadingBuilder = Widget Function(BuildContext context);
 
+/// A type representing the function passed to [FirestoreListView] for its `emptyBuilder`.
+typedef FirestoreEmptyBuilder = Widget Function(BuildContext context);
+
 /// A type representing the function passed to [FirestoreListView] for its `errorBuilder`.
 typedef FirestoreErrorBuilder = Widget Function(
   BuildContext context,
@@ -421,6 +424,7 @@ class FirestoreListView<Document> extends FirestoreQueryBuilder<Document> {
     required FirestoreItemBuilder<Document> itemBuilder,
     int pageSize = 10,
     FirestoreLoadingBuilder? loadingBuilder,
+    FirestoreEmptyBuilder? emptyBuilder,
     FirestoreErrorBuilder? errorBuilder,
     Axis scrollDirection = Axis.vertical,
     bool reverse = false,
@@ -457,6 +461,10 @@ class FirestoreListView<Document> extends FirestoreQueryBuilder<Document> {
                 snapshot.error!,
                 snapshot.stackTrace!,
               );
+            }
+            
+            if (snapshot.docs.isEmpty && emptyBuilder != null) {
+              return emptyBuilder(context);
             }
 
             return ListView.builder(


### PR DESCRIPTION
## Description

A new constructor parameter (emptyBuilder) added to  FirestoreListView Widget. This allow to show empty state ui if no documents are fetched using the provided query.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
