### PR TITLE
fix(firebase_crashlytics): Exit the add crashlytics upload-symbols script if the required json isn't present

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/crashlytics_add_upload_symbols
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/crashlytics_add_upload_symbols
@@ -44,6 +44,7 @@ end
 if(options_dict[:flutter_project])
     unless File.exist?("#{options_dict[:project_dir]}/firebase_app_id_file.json")
         puts("Warning: firebase_app_id_file.json file does not exist. This may cause issues in upload-symbols. If this error is unexpected, try running flutterfire configure again.")
+        exit(0)
     end
 end
 


### PR DESCRIPTION
## Description

Modifies the changes made for the iOS automated onboarding to exit the add upload-symbols script if the required app ID json isn't present.

## Related Issues

Fixes https://github.com/firebase/flutterfire/issues/8376

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
