### PR TITLE
Create OAuthCredentialOptions to add nonce to oauth credential

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -833,11 +833,38 @@ class OAuthProvider extends AuthProvider<auth_interop.OAuthProviderJsImpl> {
     );
   }
 
-  /// Creates a credential for Google.
+  /// Creates a credential for OAuth.
   /// At least one of [idToken] and [accessToken] is required.
-  auth_interop.OAuthCredential credential(
-          [String? idToken, String? accessToken]) =>
-      jsObject.credential(idToken, accessToken);
+  auth_interop.OAuthCredential credential(OAuthCredentialOptions options) =>
+      jsObject.credential(options.jsObject);
+}
+
+/// Defines the options for initializing an [auth_interop.OAuthCredential].
+/// For ID tokens with nonce claim, the raw nonce has to also be provided.
+///
+/// See: <https://firebase.google.com/docs/reference/js/firebase.auth.OAuthCredentialOptions>
+class OAuthCredentialOptions
+    extends JsObjectWrapper<auth_interop.OAuthCredentialOptionsJsImpl> {
+  /// Creates a new OAuthCredentialOptions with
+  /// the optional [accessToken], [idToken] and [rawNonce].
+  factory OAuthCredentialOptions([
+    String? accessToken,
+    String? idToken,
+    String? rawNonce,
+  ]) {
+    return OAuthCredentialOptions.fromJsObject(
+      auth_interop.OAuthCredentialOptionsJsImpl(
+        accessToken: accessToken,
+        idToken: idToken,
+        rawNonce: rawNonce,
+      ),
+    );
+  }
+
+  /// Creates a new OAuthCredentialOptions from a [jsObject].
+  OAuthCredentialOptions.fromJsObject(
+      auth_interop.OAuthCredentialOptionsJsImpl jsObject)
+      : super.fromJsObject(jsObject);
 }
 
 /// Twitter auth provider.

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
@@ -279,7 +279,21 @@ class OAuthProviderJsImpl extends AuthProviderJsImpl {
   external OAuthProviderJsImpl setCustomParameters(
     dynamic customOAuthParameters,
   );
-  external OAuthCredential credential([String? idToken, String? accessToken]);
+  external OAuthCredential credential(OAuthCredentialOptionsJsImpl options);
+}
+
+@JS('OAuthCredentialOptions')
+@anonymous
+class OAuthCredentialOptionsJsImpl {
+  external factory OAuthCredentialOptionsJsImpl({
+    String? accessToken,
+    String? idToken,
+    String? rawNonce,
+  });
+
+  external String? accessToken;
+  external String? idToken;
+  external String? rawNonce;
 }
 
 @JS('TwitterAuthProvider')

--- a/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
@@ -262,8 +262,11 @@ auth_interop.OAuthCredential? convertPlatformCredential(
 
   if (credential is OAuthCredential) {
     return auth_interop.OAuthProvider(credential.providerId).credential(
-      credential.idToken,
-      credential.accessToken,
+      auth_interop.OAuthCredentialOptions(
+        credential.accessToken,
+        credential.idToken,
+        credential.rawNonce,
+      ),
     );
   }
 
@@ -278,13 +281,6 @@ auth_interop.OAuthCredential? convertPlatformCredential(
     return auth_interop.PhoneAuthProvider.credential(
       credential.verificationId!,
       credential.smsCode!,
-    );
-  }
-
-  if (credential is OAuthCredential) {
-    return auth_interop.OAuthProvider(credential.providerId).credential(
-      credential.idToken,
-      credential.accessToken,
     );
   }
 


### PR DESCRIPTION
## Description

Support nonce to associate credential obtained by apple sign in with flutter web.

## Related Issues

https://github.com/firebase/flutterfire/issues/6594

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
