### PR TITLE
refactor(firebase_storage): Remove deprecated `Tasks.call()` API from android.

### DIFF
--- a/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStoragePlugin.java
+++ b/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStoragePlugin.java
@@ -214,6 +214,7 @@ public class FlutterFirebaseStoragePlugin
       String host = (String) Objects.requireNonNull(arguments.get("host"));
       int port = (int) Objects.requireNonNull((arguments.get("port")));
       firebaseStorage.useEmulator(host, port);
+      taskCompletionSource.setResult(null);
     });
 
     return taskCompletionSource.getTask();

--- a/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStoragePlugin.java
+++ b/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStoragePlugin.java
@@ -6,9 +6,7 @@ package io.flutter.plugins.firebase.storage;
 
 import android.net.Uri;
 import android.util.Base64;
-
 import androidx.annotation.NonNull;
-
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
@@ -18,7 +16,6 @@ import com.google.firebase.storage.ListResult;
 import com.google.firebase.storage.StorageException;
 import com.google.firebase.storage.StorageMetadata;
 import com.google.firebase.storage.StorageReference;
-
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
@@ -27,7 +24,6 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugins.firebase.core.FlutterFirebasePlugin;
 import io.flutter.plugins.firebase.core.FlutterFirebasePluginRegistry;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,7 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public class FlutterFirebaseStoragePlugin
-  implements FlutterFirebasePlugin, MethodCallHandler, FlutterPlugin {
+    implements FlutterFirebasePlugin, MethodCallHandler, FlutterPlugin {
   private MethodChannel channel;
 
   static Map<String, Object> parseMetadata(StorageMetadata storageMetadata) {
@@ -113,11 +109,11 @@ public class FlutterFirebaseStoragePlugin
       storageException = new FlutterFirebaseStorageException(exception, exception.getCause());
     } else if (exception.getCause() != null && exception.getCause() instanceof StorageException) {
       storageException =
-        new FlutterFirebaseStorageException(
-          (StorageException) exception.getCause(),
-          exception.getCause().getCause() != null
-            ? exception.getCause().getCause()
-            : exception.getCause());
+          new FlutterFirebaseStorageException(
+              (StorageException) exception.getCause(),
+              exception.getCause().getCause() != null
+                  ? exception.getCause().getCause()
+                  : exception.getCause());
     }
 
     if (storageException != null) {
@@ -209,13 +205,14 @@ public class FlutterFirebaseStoragePlugin
   private Task<Void> useEmulator(Map<String, Object> arguments) {
     TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
 
-    cachedThreadPool.execute(() -> {
-      FirebaseStorage firebaseStorage = getStorage(arguments);
-      String host = (String) Objects.requireNonNull(arguments.get("host"));
-      int port = (int) Objects.requireNonNull((arguments.get("port")));
-      firebaseStorage.useEmulator(host, port);
-      taskCompletionSource.setResult(null);
-    });
+    cachedThreadPool.execute(
+        () -> {
+          FirebaseStorage firebaseStorage = getStorage(arguments);
+          String host = (String) Objects.requireNonNull(arguments.get("host"));
+          int port = (int) Objects.requireNonNull((arguments.get("port")));
+          firebaseStorage.useEmulator(host, port);
+          taskCompletionSource.setResult(null);
+        });
 
     return taskCompletionSource.getTask();
   }
@@ -223,34 +220,35 @@ public class FlutterFirebaseStoragePlugin
   private Task<Void> referenceDelete(Map<String, Object> arguments) {
     TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
 
-    cachedThreadPool.execute(() -> {
-      StorageReference reference = getReference(arguments);
-      try {
-        Tasks.await(reference.delete());
-        taskCompletionSource.setResult(null);
-      } catch (Exception e) {
-        taskCompletionSource.setException(e);
-      }
-    });
+    cachedThreadPool.execute(
+        () -> {
+          StorageReference reference = getReference(arguments);
+          try {
+            Tasks.await(reference.delete());
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
 
     return taskCompletionSource.getTask();
-
   }
 
   private Task<Map<String, Object>> referenceGetDownloadURL(Map<String, Object> arguments) {
     TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
 
-    cachedThreadPool.execute(() -> {
-      StorageReference reference = getReference(arguments);
-      try {
-        Uri downloadURL = Tasks.await(reference.getDownloadUrl());
-        Map<String, Object> out = new HashMap<>();
-        out.put("downloadURL", downloadURL.toString());
-        taskCompletionSource.setResult(out);
-      } catch (Exception e) {
-        taskCompletionSource.setException(e);
-      }
-    });
+    cachedThreadPool.execute(
+        () -> {
+          StorageReference reference = getReference(arguments);
+          try {
+            Uri downloadURL = Tasks.await(reference.getDownloadUrl());
+            Map<String, Object> out = new HashMap<>();
+            out.put("downloadURL", downloadURL.toString());
+            taskCompletionSource.setResult(out);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
 
     return taskCompletionSource.getTask();
   }
@@ -258,29 +256,31 @@ public class FlutterFirebaseStoragePlugin
   private Task<byte[]> referenceGetData(Map<String, Object> arguments) {
     TaskCompletionSource<byte[]> taskCompletionSource = new TaskCompletionSource<>();
 
-    cachedThreadPool.execute(() -> {
-      Integer maxSize = (Integer) Objects.requireNonNull(arguments.get("maxSize"));
-      StorageReference reference = getReference(arguments);
-      try {
-        taskCompletionSource.setResult(Tasks.await(reference.getBytes(maxSize)));
-      } catch (Exception e) {
-        taskCompletionSource.setException(e);
-      }
-    });
+    cachedThreadPool.execute(
+        () -> {
+          Integer maxSize = (Integer) Objects.requireNonNull(arguments.get("maxSize"));
+          StorageReference reference = getReference(arguments);
+          try {
+            taskCompletionSource.setResult(Tasks.await(reference.getBytes(maxSize)));
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
 
     return taskCompletionSource.getTask();
   }
 
   private Task<Map<String, Object>> referenceGetMetadata(Map<String, Object> arguments) {
     TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
-    cachedThreadPool.execute(() -> {
-      StorageReference reference = getReference(arguments);
-      try {
-        taskCompletionSource.setResult(parseMetadata(Tasks.await(reference.getMetadata())));
-      } catch (Exception e) {
-        taskCompletionSource.setException(e);
-      }
-    });
+    cachedThreadPool.execute(
+        () -> {
+          StorageReference reference = getReference(arguments);
+          try {
+            taskCompletionSource.setResult(parseMetadata(Tasks.await(reference.getMetadata())));
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
 
     return taskCompletionSource.getTask();
   }
@@ -288,30 +288,31 @@ public class FlutterFirebaseStoragePlugin
   private Task<Map<String, Object>> referenceList(Map<String, Object> arguments) {
     TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
 
-    cachedThreadPool.execute(() -> {
-      StorageReference reference = getReference(arguments);
-      Task<ListResult> task;
+    cachedThreadPool.execute(
+        () -> {
+          StorageReference reference = getReference(arguments);
+          Task<ListResult> task;
 
-      @SuppressWarnings("unchecked")
-      Map<String, Object> listOptions =
-        (Map<String, Object>) Objects.requireNonNull(arguments.get("options"));
+          @SuppressWarnings("unchecked")
+          Map<String, Object> listOptions =
+              (Map<String, Object>) Objects.requireNonNull(arguments.get("options"));
 
-      int maxResults = (Integer) Objects.requireNonNull(listOptions.get("maxResults"));
+          int maxResults = (Integer) Objects.requireNonNull(listOptions.get("maxResults"));
 
-      if (listOptions.get("pageToken") != null) {
-        task =
-          reference.list(
-            maxResults, (String) Objects.requireNonNull(listOptions.get("pageToken")));
-      } else {
-        task = reference.list(maxResults);
-      }
+          if (listOptions.get("pageToken") != null) {
+            task =
+                reference.list(
+                    maxResults, (String) Objects.requireNonNull(listOptions.get("pageToken")));
+          } else {
+            task = reference.list(maxResults);
+          }
 
-      try {
-        taskCompletionSource.setResult(parseListResult(Tasks.await(task)));
-      } catch (Exception e) {
-        taskCompletionSource.setException(e);
-      }
-    });
+          try {
+            taskCompletionSource.setResult(parseListResult(Tasks.await(task)));
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
 
     return taskCompletionSource.getTask();
   }
@@ -319,34 +320,37 @@ public class FlutterFirebaseStoragePlugin
   private Task<Map<String, Object>> referenceListAll(Map<String, Object> arguments) {
     TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
 
-    cachedThreadPool.execute(() -> {
-      StorageReference reference = getReference(arguments);
+    cachedThreadPool.execute(
+        () -> {
+          StorageReference reference = getReference(arguments);
 
-      try {
-        taskCompletionSource.setResult(parseListResult(Tasks.await(reference.listAll())));
-      } catch (Exception e) {
-        taskCompletionSource.setException(e);
-      }
-    });
+          try {
+            taskCompletionSource.setResult(parseListResult(Tasks.await(reference.listAll())));
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
     return taskCompletionSource.getTask();
   }
 
   private Task<Map<String, Object>> referenceUpdateMetadata(Map<String, Object> arguments) {
     TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
 
-    cachedThreadPool.execute(() -> {
-      StorageReference reference = getReference(arguments);
+    cachedThreadPool.execute(
+        () -> {
+          StorageReference reference = getReference(arguments);
 
-      @SuppressWarnings("unchecked")
-      Map<String, Object> metadata =
-        (Map<String, Object>) Objects.requireNonNull(arguments.get("metadata"));
+          @SuppressWarnings("unchecked")
+          Map<String, Object> metadata =
+              (Map<String, Object>) Objects.requireNonNull(arguments.get("metadata"));
 
-      try {
-        taskCompletionSource.setResult(parseMetadata(Tasks.await(reference.updateMetadata(parseMetadata(metadata)))));
-      } catch (Exception e) {
-        taskCompletionSource.setException(e);
-      }
-    });
+          try {
+            taskCompletionSource.setResult(
+                parseMetadata(Tasks.await(reference.updateMetadata(parseMetadata(metadata)))));
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
 
     return taskCompletionSource.getTask();
   }
@@ -354,24 +358,25 @@ public class FlutterFirebaseStoragePlugin
   private Task<Void> taskPutData(Map<String, Object> arguments) {
     TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
 
-    cachedThreadPool.execute(() -> {
-      StorageReference reference = getReference(arguments);
-      byte[] bytes = (byte[]) Objects.requireNonNull(arguments.get("data"));
+    cachedThreadPool.execute(
+        () -> {
+          StorageReference reference = getReference(arguments);
+          byte[] bytes = (byte[]) Objects.requireNonNull(arguments.get("data"));
 
-      @SuppressWarnings("unchecked")
-      Map<String, Object> metadata = (Map<String, Object>) arguments.get("metadata");
+          @SuppressWarnings("unchecked")
+          Map<String, Object> metadata = (Map<String, Object>) arguments.get("metadata");
 
-      final int handle = (int) Objects.requireNonNull(arguments.get("handle"));
-      FlutterFirebaseStorageTask task =
-        FlutterFirebaseStorageTask.uploadBytes(
-          handle, reference, bytes, parseMetadata(metadata));
-      try {
-        task.startTaskWithMethodChannel(channel);
-        taskCompletionSource.setResult(null);
-      } catch (Exception e) {
-        taskCompletionSource.setException(e);
-      }
-    });
+          final int handle = (int) Objects.requireNonNull(arguments.get("handle"));
+          FlutterFirebaseStorageTask task =
+              FlutterFirebaseStorageTask.uploadBytes(
+                  handle, reference, bytes, parseMetadata(metadata));
+          try {
+            task.startTaskWithMethodChannel(channel);
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
 
     return taskCompletionSource.getTask();
   }
@@ -379,26 +384,27 @@ public class FlutterFirebaseStoragePlugin
   private Task<Void> taskPutString(Map<String, Object> arguments) {
     TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
 
-    cachedThreadPool.execute(() -> {
-      StorageReference reference = getReference(arguments);
-      String data = (String) Objects.requireNonNull(arguments.get("data"));
-      int format = (int) Objects.requireNonNull(arguments.get("format"));
+    cachedThreadPool.execute(
+        () -> {
+          StorageReference reference = getReference(arguments);
+          String data = (String) Objects.requireNonNull(arguments.get("data"));
+          int format = (int) Objects.requireNonNull(arguments.get("format"));
 
-      @SuppressWarnings("unchecked")
-      Map<String, Object> metadata = (Map<String, Object>) arguments.get("metadata");
+          @SuppressWarnings("unchecked")
+          Map<String, Object> metadata = (Map<String, Object>) arguments.get("metadata");
 
-      final int handle = (int) Objects.requireNonNull(arguments.get("handle"));
-      FlutterFirebaseStorageTask task =
-        FlutterFirebaseStorageTask.uploadBytes(
-          handle, reference, stringToByteData(data, format), parseMetadata(metadata));
+          final int handle = (int) Objects.requireNonNull(arguments.get("handle"));
+          FlutterFirebaseStorageTask task =
+              FlutterFirebaseStorageTask.uploadBytes(
+                  handle, reference, stringToByteData(data, format), parseMetadata(metadata));
 
-      try {
-        task.startTaskWithMethodChannel(channel);
-        taskCompletionSource.setResult(null);
-      } catch (Exception e) {
-        taskCompletionSource.setException(e);
-      }
-    });
+          try {
+            task.startTaskWithMethodChannel(channel);
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
 
     return taskCompletionSource.getTask();
   }
@@ -406,135 +412,143 @@ public class FlutterFirebaseStoragePlugin
   private Task<Void> taskPutFile(Map<String, Object> arguments) {
     TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
 
-    cachedThreadPool.execute(() -> {
-      StorageReference reference = getReference(arguments);
-      String filePath = (String) Objects.requireNonNull(arguments.get("filePath"));
+    cachedThreadPool.execute(
+        () -> {
+          StorageReference reference = getReference(arguments);
+          String filePath = (String) Objects.requireNonNull(arguments.get("filePath"));
 
-      @SuppressWarnings("unchecked")
-      Map<String, Object> metadata = (Map<String, Object>) arguments.get("metadata");
+          @SuppressWarnings("unchecked")
+          Map<String, Object> metadata = (Map<String, Object>) arguments.get("metadata");
 
-      final int handle = (int) Objects.requireNonNull(arguments.get("handle"));
-      FlutterFirebaseStorageTask task =
-        FlutterFirebaseStorageTask.uploadFile(
-          handle, reference, Uri.fromFile(new File(filePath)), parseMetadata(metadata));
+          final int handle = (int) Objects.requireNonNull(arguments.get("handle"));
+          FlutterFirebaseStorageTask task =
+              FlutterFirebaseStorageTask.uploadFile(
+                  handle, reference, Uri.fromFile(new File(filePath)), parseMetadata(metadata));
 
-      try {
-        task.startTaskWithMethodChannel(channel);
-        taskCompletionSource.setResult(null);
-      } catch (Exception e) {
-        taskCompletionSource.setException(e);
-      }
-    });
+          try {
+            task.startTaskWithMethodChannel(channel);
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
 
     return taskCompletionSource.getTask();
   }
 
   private Task<Void> taskWriteToFile(Map<String, Object> arguments) {
     TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
-    cachedThreadPool.execute(() -> {
-      StorageReference reference = getReference(arguments);
-      String filePath = (String) Objects.requireNonNull(arguments.get("filePath"));
+    cachedThreadPool.execute(
+        () -> {
+          StorageReference reference = getReference(arguments);
+          String filePath = (String) Objects.requireNonNull(arguments.get("filePath"));
 
-      final int handle = (int) Objects.requireNonNull(arguments.get("handle"));
-      FlutterFirebaseStorageTask task =
-        FlutterFirebaseStorageTask.downloadFile(handle, reference, new File(filePath));
+          final int handle = (int) Objects.requireNonNull(arguments.get("handle"));
+          FlutterFirebaseStorageTask task =
+              FlutterFirebaseStorageTask.downloadFile(handle, reference, new File(filePath));
 
-      try {
-        task.startTaskWithMethodChannel(channel);
-        taskCompletionSource.setResult(null);
-      } catch (Exception e) {
-        taskCompletionSource.setException(e);
-      }
-    });
+          try {
+            task.startTaskWithMethodChannel(channel);
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
 
     return taskCompletionSource.getTask();
   }
 
   private Task<Map<String, Object>> taskPause(Map<String, Object> arguments) {
     TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
-    cachedThreadPool.execute(() -> {
-      final int handle = (int) Objects.requireNonNull(arguments.get("handle"));
-      FlutterFirebaseStorageTask task =
-        FlutterFirebaseStorageTask.getInProgressTaskForHandle(handle);
+    cachedThreadPool.execute(
+        () -> {
+          final int handle = (int) Objects.requireNonNull(arguments.get("handle"));
+          FlutterFirebaseStorageTask task =
+              FlutterFirebaseStorageTask.getInProgressTaskForHandle(handle);
 
-      if (task == null) {
-        taskCompletionSource.setException(new Exception("Pause operation was called on a task which does not exist."));
-        return;
-      }
+          if (task == null) {
+            taskCompletionSource.setException(
+                new Exception("Pause operation was called on a task which does not exist."));
+            return;
+          }
 
-      Map<String, Object> statusMap = new HashMap<>();
-      try {
-        boolean paused = Tasks.await(task.pause());
-        statusMap.put("status", paused);
-        if (paused) {
-          statusMap.put(
-            "snapshot", FlutterFirebaseStorageTask.parseTaskSnapshot(task.getSnapshot()));
-        }
+          Map<String, Object> statusMap = new HashMap<>();
+          try {
+            boolean paused = Tasks.await(task.pause());
+            statusMap.put("status", paused);
+            if (paused) {
+              statusMap.put(
+                  "snapshot", FlutterFirebaseStorageTask.parseTaskSnapshot(task.getSnapshot()));
+            }
 
-        taskCompletionSource.setResult(statusMap);
-      } catch (Exception e) {
-        taskCompletionSource.setException(e);
-      }
-    });
+            taskCompletionSource.setResult(statusMap);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
 
     return taskCompletionSource.getTask();
   }
 
   private Task<Map<String, Object>> taskResume(Map<String, Object> arguments) {
     TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
-    cachedThreadPool.execute(() -> {
-      final int handle = (int) Objects.requireNonNull(arguments.get("handle"));
-      FlutterFirebaseStorageTask task =
-        FlutterFirebaseStorageTask.getInProgressTaskForHandle(handle);
+    cachedThreadPool.execute(
+        () -> {
+          final int handle = (int) Objects.requireNonNull(arguments.get("handle"));
+          FlutterFirebaseStorageTask task =
+              FlutterFirebaseStorageTask.getInProgressTaskForHandle(handle);
 
-      if (task == null) {
-        taskCompletionSource.setException(new Exception("Resume operation was called on a task which does not exist."));
-        return;
-      }
+          if (task == null) {
+            taskCompletionSource.setException(
+                new Exception("Resume operation was called on a task which does not exist."));
+            return;
+          }
 
-      try {
-        boolean resumed = Tasks.await(task.resume());
-        Map<String, Object> statusMap = new HashMap<>();
-        statusMap.put("status", resumed);
-        if (resumed) {
-          statusMap.put(
-            "snapshot", FlutterFirebaseStorageTask.parseTaskSnapshot(task.getSnapshot()));
-        }
+          try {
+            boolean resumed = Tasks.await(task.resume());
+            Map<String, Object> statusMap = new HashMap<>();
+            statusMap.put("status", resumed);
+            if (resumed) {
+              statusMap.put(
+                  "snapshot", FlutterFirebaseStorageTask.parseTaskSnapshot(task.getSnapshot()));
+            }
 
-        taskCompletionSource.setResult(statusMap);
-      } catch (Exception e) {
-        taskCompletionSource.setException(e);
-      }
-    });
+            taskCompletionSource.setResult(statusMap);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
 
     return taskCompletionSource.getTask();
   }
 
   private Task<Map<String, Object>> taskCancel(Map<String, Object> arguments) {
     TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
-    cachedThreadPool.execute(() -> {
-      final int handle = (int) Objects.requireNonNull(arguments.get("handle"));
-      FlutterFirebaseStorageTask task =
-        FlutterFirebaseStorageTask.getInProgressTaskForHandle(handle);
-      if (task == null) {
-        taskCompletionSource.setException(new Exception("Cancel operation was called on a task which does not exist."));
-        return;
-      }
+    cachedThreadPool.execute(
+        () -> {
+          final int handle = (int) Objects.requireNonNull(arguments.get("handle"));
+          FlutterFirebaseStorageTask task =
+              FlutterFirebaseStorageTask.getInProgressTaskForHandle(handle);
+          if (task == null) {
+            taskCompletionSource.setException(
+                new Exception("Cancel operation was called on a task which does not exist."));
+            return;
+          }
 
-      try {
-        boolean canceled = Tasks.await(task.cancel());
-        Map<String, Object> statusMap = new HashMap<>();
-        statusMap.put("status", canceled);
-        if (canceled) {
-          statusMap.put(
-            "snapshot", FlutterFirebaseStorageTask.parseTaskSnapshot(task.getSnapshot()));
-        }
+          try {
+            boolean canceled = Tasks.await(task.cancel());
+            Map<String, Object> statusMap = new HashMap<>();
+            statusMap.put("status", canceled);
+            if (canceled) {
+              statusMap.put(
+                  "snapshot", FlutterFirebaseStorageTask.parseTaskSnapshot(task.getSnapshot()));
+            }
 
-        taskCompletionSource.setResult(statusMap);
-      } catch (Exception e) {
-        taskCompletionSource.setException(e);
-      }
-    });
+            taskCompletionSource.setResult(statusMap);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
     return taskCompletionSource.getTask();
   }
 
@@ -594,19 +608,19 @@ public class FlutterFirebaseStoragePlugin
     }
 
     methodCallTask.addOnCompleteListener(
-      task -> {
-        if (task.isSuccessful()) {
-          result.success(task.getResult());
-        } else {
-          Exception exception = task.getException();
-          Map<String, String> exceptionDetails = getExceptionDetails(exception);
+        task -> {
+          if (task.isSuccessful()) {
+            result.success(task.getResult());
+          } else {
+            Exception exception = task.getException();
+            Map<String, String> exceptionDetails = getExceptionDetails(exception);
 
-          result.error(
-            "firebase_storage",
-            exception != null ? exception.getMessage() : null,
-            exceptionDetails);
-        }
-      });
+            result.error(
+                "firebase_storage",
+                exception != null ? exception.getMessage() : null,
+                exceptionDetails);
+          }
+        });
   }
 
   private StorageMetadata parseMetadata(Map<String, Object> metadata) {
@@ -634,7 +648,7 @@ public class FlutterFirebaseStoragePlugin
     if (metadata.get("customMetadata") != null) {
       @SuppressWarnings("unchecked")
       Map<String, String> customMetadata =
-        (Map<String, String>) Objects.requireNonNull(metadata.get("customMetadata"));
+          (Map<String, String>) Objects.requireNonNull(metadata.get("customMetadata"));
       for (String key : customMetadata.keySet()) {
         builder.setCustomMetadata(key, customMetadata.get(key));
       }
@@ -667,10 +681,11 @@ public class FlutterFirebaseStoragePlugin
   @Override
   public Task<Map<String, Object>> getPluginConstantsForFirebaseApp(FirebaseApp firebaseApp) {
     TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
-    cachedThreadPool.execute(() -> {
-      HashMap<String, Object> obj = new HashMap<String, Object>();
-      taskCompletionSource.setResult(obj);
-    });
+    cachedThreadPool.execute(
+        () -> {
+          HashMap<String, Object> obj = new HashMap<String, Object>();
+          taskCompletionSource.setResult(obj);
+        });
 
     return taskCompletionSource.getTask();
   }
@@ -678,10 +693,11 @@ public class FlutterFirebaseStoragePlugin
   @Override
   public Task<Void> didReinitializeFirebaseCore() {
     TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
-    cachedThreadPool.execute(() -> {
-      FlutterFirebaseStorageTask.cancelInProgressTasks();
-      taskCompletionSource.setResult(null);
-    });
+    cachedThreadPool.execute(
+        () -> {
+          FlutterFirebaseStorageTask.cancelInProgressTasks();
+          taskCompletionSource.setResult(null);
+        });
 
     return taskCompletionSource.getTask();
   }

--- a/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStoragePlugin.java
+++ b/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStoragePlugin.java
@@ -227,6 +227,7 @@ public class FlutterFirebaseStoragePlugin
       StorageReference reference = getReference(arguments);
       try {
         Tasks.await(reference.delete());
+        taskCompletionSource.setResult(null);
       } catch (Exception e) {
         taskCompletionSource.setException(e);
       }
@@ -366,6 +367,7 @@ public class FlutterFirebaseStoragePlugin
           handle, reference, bytes, parseMetadata(metadata));
       try {
         task.startTaskWithMethodChannel(channel);
+        taskCompletionSource.setResult(null);
       } catch (Exception e) {
         taskCompletionSource.setException(e);
       }
@@ -392,6 +394,7 @@ public class FlutterFirebaseStoragePlugin
 
       try {
         task.startTaskWithMethodChannel(channel);
+        taskCompletionSource.setResult(null);
       } catch (Exception e) {
         taskCompletionSource.setException(e);
       }
@@ -417,6 +420,7 @@ public class FlutterFirebaseStoragePlugin
 
       try {
         task.startTaskWithMethodChannel(channel);
+        taskCompletionSource.setResult(null);
       } catch (Exception e) {
         taskCompletionSource.setException(e);
       }
@@ -437,6 +441,7 @@ public class FlutterFirebaseStoragePlugin
 
       try {
         task.startTaskWithMethodChannel(channel);
+        taskCompletionSource.setResult(null);
       } catch (Exception e) {
         taskCompletionSource.setException(e);
       }

--- a/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.java
+++ b/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.java
@@ -218,21 +218,7 @@ class FlutterFirebaseStorageTask {
   Task<Boolean> cancel() {
     TaskCompletionSource<Boolean> taskCompletionSource = new TaskCompletionSource<>();
     FlutterFirebasePlugin.cachedThreadPool.execute(() -> {
-      synchronized (cancelSyncObject) {
-        boolean canceled = storageTask.cancel();
-        if (!canceled) {
-          taskCompletionSource.setResult(false);
-          return;
-        }
-        try {
-          cancelSyncObject.wait();
-        } catch (InterruptedException e) {
-          taskCompletionSource.setResult(false);
-          return;
-        }
-
-        taskCompletionSource.setResult(true);
-      }
+      taskCompletionSource.setResult(storageTask.cancel());
     });
 
     return taskCompletionSource.getTask();

--- a/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.java
+++ b/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.java
@@ -7,17 +7,21 @@ import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.SparseArray;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import com.google.android.gms.tasks.Task;
-import com.google.android.gms.tasks.Tasks;
+import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.firebase.storage.FileDownloadTask;
 import com.google.firebase.storage.StorageMetadata;
 import com.google.firebase.storage.StorageReference;
 import com.google.firebase.storage.StorageTask;
 import com.google.firebase.storage.UploadTask;
+
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugins.firebase.core.FlutterFirebasePlugin;
+
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,7 +30,7 @@ import java.util.concurrent.Executors;
 
 class FlutterFirebaseStorageTask {
   static final SparseArray<FlutterFirebaseStorageTask> inProgressTasks = new SparseArray<>();
-  private static Executor taskExecutor = Executors.newSingleThreadExecutor();
+  private static final Executor taskExecutor = Executors.newSingleThreadExecutor();
   private final FlutterFirebaseStorageTaskType type;
   private final int handle;
   private final StorageReference reference;
@@ -40,12 +44,12 @@ class FlutterFirebaseStorageTask {
   private Boolean destroyed = false;
 
   private FlutterFirebaseStorageTask(
-      FlutterFirebaseStorageTaskType type,
-      int handle,
-      StorageReference reference,
-      @Nullable byte[] bytes,
-      @Nullable Uri fileUri,
-      @Nullable StorageMetadata metadata) {
+    FlutterFirebaseStorageTaskType type,
+    int handle,
+    StorageReference reference,
+    @Nullable byte[] bytes,
+    @Nullable Uri fileUri,
+    @Nullable StorageMetadata metadata) {
     this.type = type;
     this.handle = handle;
     this.reference = reference;
@@ -82,24 +86,24 @@ class FlutterFirebaseStorageTask {
   }
 
   public static FlutterFirebaseStorageTask uploadBytes(
-      int handle, StorageReference reference, byte[] data, @Nullable StorageMetadata metadata) {
+    int handle, StorageReference reference, byte[] data, @Nullable StorageMetadata metadata) {
     return new FlutterFirebaseStorageTask(
-        FlutterFirebaseStorageTaskType.BYTES, handle, reference, data, null, metadata);
+      FlutterFirebaseStorageTaskType.BYTES, handle, reference, data, null, metadata);
   }
 
   public static FlutterFirebaseStorageTask uploadFile(
-      int handle,
-      StorageReference reference,
-      @NonNull Uri fileUri,
-      @Nullable StorageMetadata metadata) {
+    int handle,
+    StorageReference reference,
+    @NonNull Uri fileUri,
+    @Nullable StorageMetadata metadata) {
     return new FlutterFirebaseStorageTask(
-        FlutterFirebaseStorageTaskType.FILE, handle, reference, null, fileUri, metadata);
+      FlutterFirebaseStorageTaskType.FILE, handle, reference, null, fileUri, metadata);
   }
 
   public static FlutterFirebaseStorageTask downloadFile(
-      int handle, StorageReference reference, @NonNull File file) {
+    int handle, StorageReference reference, @NonNull File file) {
     return new FlutterFirebaseStorageTask(
-        FlutterFirebaseStorageTaskType.DOWNLOAD, handle, reference, null, Uri.fromFile(file), null);
+      FlutterFirebaseStorageTaskType.DOWNLOAD, handle, reference, null, Uri.fromFile(file), null);
   }
 
   public static Map<String, Object> parseUploadTaskSnapshot(UploadTask.TaskSnapshot snapshot) {
@@ -114,7 +118,7 @@ class FlutterFirebaseStorageTask {
   }
 
   public static Map<String, Object> parseDownloadTaskSnapshot(
-      FileDownloadTask.TaskSnapshot snapshot) {
+    FileDownloadTask.TaskSnapshot snapshot) {
     Map<String, Object> out = new HashMap<>();
     out.put("path", snapshot.getStorage().getPath());
     if (snapshot.getTask().isSuccessful()) {
@@ -166,54 +170,72 @@ class FlutterFirebaseStorageTask {
   }
 
   Task<Boolean> pause() {
-    return Tasks.call(
-        FlutterFirebasePlugin.cachedThreadPool,
-        () -> {
-          synchronized (pauseSyncObject) {
-            boolean paused = storageTask.pause();
-            if (!paused) return false;
-            try {
-              pauseSyncObject.wait();
-            } catch (InterruptedException e) {
-              return false;
-            }
-            return true;
-          }
-        });
+    TaskCompletionSource<Boolean> taskCompletionSource = new TaskCompletionSource<>();
+
+    FlutterFirebasePlugin.cachedThreadPool.execute(() -> {
+      synchronized (pauseSyncObject) {
+        boolean paused = storageTask.pause();
+        if (!paused) {
+          taskCompletionSource.setResult(false);
+          return;
+        }
+        try {
+          pauseSyncObject.wait();
+        } catch (InterruptedException e) {
+          taskCompletionSource.setResult(false);
+          return;
+        }
+        taskCompletionSource.setResult(true);
+      }
+    });
+
+    return taskCompletionSource.getTask();
   }
 
   Task<Boolean> resume() {
-    return Tasks.call(
-        FlutterFirebasePlugin.cachedThreadPool,
-        () -> {
-          synchronized (resumeSyncObject) {
-            boolean resumed = storageTask.resume();
-            if (!resumed) return false;
-            try {
-              resumeSyncObject.wait();
-            } catch (InterruptedException e) {
-              return false;
-            }
-            return true;
-          }
-        });
+    TaskCompletionSource<Boolean> taskCompletionSource = new TaskCompletionSource<>();
+
+    FlutterFirebasePlugin.cachedThreadPool.execute(() -> {
+      synchronized (resumeSyncObject) {
+        boolean resumed = storageTask.resume();
+        if (!resumed) {
+          taskCompletionSource.setResult(false);
+          return;
+        }
+        try {
+          resumeSyncObject.wait();
+        } catch (InterruptedException e) {
+          taskCompletionSource.setResult(false);
+          return;
+        }
+        taskCompletionSource.setResult(true);
+      }
+    });
+
+    return taskCompletionSource.getTask();
   }
 
   Task<Boolean> cancel() {
-    return Tasks.call(
-        FlutterFirebasePlugin.cachedThreadPool,
-        () -> {
-          synchronized (cancelSyncObject) {
-            boolean canceled = storageTask.cancel();
-            if (!canceled) return false;
-            try {
-              cancelSyncObject.wait();
-            } catch (InterruptedException e) {
-              return false;
-            }
-            return true;
-          }
-        });
+    TaskCompletionSource<Boolean> taskCompletionSource = new TaskCompletionSource<>();
+    FlutterFirebasePlugin.cachedThreadPool.execute(() -> {
+      synchronized (cancelSyncObject) {
+        boolean canceled = storageTask.cancel();
+        if (!canceled) {
+          taskCompletionSource.setResult(false);
+          return;
+        }
+        try {
+          cancelSyncObject.wait();
+        } catch (InterruptedException e) {
+          taskCompletionSource.setResult(false);
+          return;
+        }
+
+        taskCompletionSource.setResult(true);
+      }
+    });
+
+    return taskCompletionSource.getTask();
   }
 
   void startTaskWithMethodChannel(@NonNull MethodChannel channel) throws Exception {
@@ -236,68 +258,68 @@ class FlutterFirebaseStorageTask {
     }
 
     storageTask.addOnProgressListener(
-        taskExecutor,
-        taskSnapshot -> {
-          if (destroyed) return;
-          new Handler(Looper.getMainLooper())
-              .post(
-                  () ->
-                      channel.invokeMethod("Task#onProgress", getTaskEventMap(taskSnapshot, null)));
-          synchronized (resumeSyncObject) {
-            resumeSyncObject.notifyAll();
-          }
-        });
+      taskExecutor,
+      taskSnapshot -> {
+        if (destroyed) return;
+        new Handler(Looper.getMainLooper())
+          .post(
+            () ->
+              channel.invokeMethod("Task#onProgress", getTaskEventMap(taskSnapshot, null)));
+        synchronized (resumeSyncObject) {
+          resumeSyncObject.notifyAll();
+        }
+      });
 
     storageTask.addOnPausedListener(
-        taskExecutor,
-        taskSnapshot -> {
-          if (destroyed) return;
-          new Handler(Looper.getMainLooper())
-              .post(
-                  () -> channel.invokeMethod("Task#onPaused", getTaskEventMap(taskSnapshot, null)));
-          synchronized (pauseSyncObject) {
-            pauseSyncObject.notifyAll();
-          }
-        });
+      taskExecutor,
+      taskSnapshot -> {
+        if (destroyed) return;
+        new Handler(Looper.getMainLooper())
+          .post(
+            () -> channel.invokeMethod("Task#onPaused", getTaskEventMap(taskSnapshot, null)));
+        synchronized (pauseSyncObject) {
+          pauseSyncObject.notifyAll();
+        }
+      });
 
     storageTask.addOnSuccessListener(
-        taskExecutor,
-        taskSnapshot -> {
-          if (destroyed) return;
-          new Handler(Looper.getMainLooper())
-              .post(
-                  () ->
-                      channel.invokeMethod("Task#onSuccess", getTaskEventMap(taskSnapshot, null)));
-          destroy();
-        });
+      taskExecutor,
+      taskSnapshot -> {
+        if (destroyed) return;
+        new Handler(Looper.getMainLooper())
+          .post(
+            () ->
+              channel.invokeMethod("Task#onSuccess", getTaskEventMap(taskSnapshot, null)));
+        destroy();
+      });
 
     storageTask.addOnCanceledListener(
-        taskExecutor,
-        () -> {
-          if (destroyed) return;
-          new Handler(Looper.getMainLooper())
-              .post(
-                  () -> {
-                    channel.invokeMethod("Task#onCanceled", getTaskEventMap(null, null));
-                    destroy();
-                  });
-        });
+      taskExecutor,
+      () -> {
+        if (destroyed) return;
+        new Handler(Looper.getMainLooper())
+          .post(
+            () -> {
+              channel.invokeMethod("Task#onCanceled", getTaskEventMap(null, null));
+              destroy();
+            });
+      });
 
     storageTask.addOnFailureListener(
-        taskExecutor,
-        exception -> {
-          if (destroyed) return;
-          new Handler(Looper.getMainLooper())
-              .post(
-                  () -> {
-                    channel.invokeMethod("Task#onFailure", getTaskEventMap(null, exception));
-                    destroy();
-                  });
-        });
+      taskExecutor,
+      exception -> {
+        if (destroyed) return;
+        new Handler(Looper.getMainLooper())
+          .post(
+            () -> {
+              channel.invokeMethod("Task#onFailure", getTaskEventMap(null, exception));
+              destroy();
+            });
+      });
   }
 
   private Map<String, Object> getTaskEventMap(
-      @Nullable Object snapshot, @Nullable Exception exception) {
+    @Nullable Object snapshot, @Nullable Exception exception) {
     Map<String, Object> arguments = new HashMap<>();
     arguments.put("handle", handle);
     arguments.put("appName", reference.getStorage().getApp().getName());


### PR DESCRIPTION
## Description

See title

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/8375

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
