### PR TITLE
docs(firebase_core): Fix typo in "firebase_core_web.dart" documentation.

### DIFF
--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -226,7 +226,7 @@ class FirebaseCoreWeb extends FirebasePlatform {
             file or by providing an override - this may lead to unexpected issues in your application. It is recommended that you change all of the versions of the
             Firebase JS SDK version "$supportedFirebaseJsSdkVersion":
 
-            If you override the version manully:
+            If you override the version manually:
               change:
                 <script>window.flutterfire_web_sdk_version = '${firebase.SDK_VERSION}';</script>
               to:


### PR DESCRIPTION
Fix typo "manully" to "manually

## Description

Simply replacing a typo I found while working in flutter.

## Related Issues

None found

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x ] All existing and new tests are passing.
- [x ] I updated/added relevant documentation (doc comments with `///`).
- [x ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x ] I read and followed the [Flutter Style Guide].
- [x ] I signed the [CLA].
- [x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
