### PR TITLE
refactor(firebase_messaging): Remove deprecated `Tasks.call()` API from android.

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -16,6 +16,7 @@ import androidx.annotation.Nullable;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
@@ -126,141 +127,207 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
   }
 
   private Task<Void> deleteToken() {
-    return Tasks.call(
-        cachedThreadPool,
+    TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
         () -> {
-          Tasks.await(FirebaseMessaging.getInstance().deleteToken());
-          return null;
+          try {
+            Tasks.await(FirebaseMessaging.getInstance().deleteToken());
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
         });
+
+    return taskCompletionSource.getTask();
   }
 
   private Task<Map<String, Object>> getToken() {
-    return Tasks.call(
-        cachedThreadPool,
+    TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
         () -> {
-          String token = Tasks.await(FirebaseMessaging.getInstance().getToken());
-          return new HashMap<String, Object>() {
-            {
-              put("token", token);
-            }
-          };
+          try {
+            String token = Tasks.await(FirebaseMessaging.getInstance().getToken());
+            taskCompletionSource.setResult(
+                new HashMap<String, Object>() {
+                  {
+                    put("token", token);
+                  }
+                });
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
         });
+
+    return taskCompletionSource.getTask();
   }
 
   private Task<Void> subscribeToTopic(Map<String, Object> arguments) {
-    return Tasks.call(
-        cachedThreadPool,
+    TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
         () -> {
-          FirebaseMessaging firebaseMessaging =
-              FlutterFirebaseMessagingUtils.getFirebaseMessagingForArguments(arguments);
-          String topic = (String) Objects.requireNonNull(arguments.get("topic"));
-          Tasks.await(firebaseMessaging.subscribeToTopic(topic));
-          return null;
+          try {
+            FirebaseMessaging firebaseMessaging =
+                FlutterFirebaseMessagingUtils.getFirebaseMessagingForArguments(arguments);
+            String topic = (String) Objects.requireNonNull(arguments.get("topic"));
+            Tasks.await(firebaseMessaging.subscribeToTopic(topic));
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
         });
+
+    return taskCompletionSource.getTask();
   }
 
   private Task<Void> unsubscribeFromTopic(Map<String, Object> arguments) {
-    return Tasks.call(
-        cachedThreadPool,
+    TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
         () -> {
-          FirebaseMessaging firebaseMessaging =
-              FlutterFirebaseMessagingUtils.getFirebaseMessagingForArguments(arguments);
-          String topic = (String) Objects.requireNonNull(arguments.get("topic"));
-          Tasks.await(firebaseMessaging.unsubscribeFromTopic(topic));
-          return null;
+          try {
+            FirebaseMessaging firebaseMessaging =
+                FlutterFirebaseMessagingUtils.getFirebaseMessagingForArguments(arguments);
+            String topic = (String) Objects.requireNonNull(arguments.get("topic"));
+            Tasks.await(firebaseMessaging.unsubscribeFromTopic(topic));
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
         });
+
+    return taskCompletionSource.getTask();
   }
 
   private Task<Void> sendMessage(Map<String, Object> arguments) {
-    return Tasks.call(
-        cachedThreadPool,
+    TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
         () -> {
-          FirebaseMessaging firebaseMessaging =
-              FlutterFirebaseMessagingUtils.getFirebaseMessagingForArguments(arguments);
-          RemoteMessage remoteMessage =
-              FlutterFirebaseMessagingUtils.getRemoteMessageForArguments(arguments);
-          firebaseMessaging.send(remoteMessage);
-          return null;
+          try {
+            FirebaseMessaging firebaseMessaging =
+                FlutterFirebaseMessagingUtils.getFirebaseMessagingForArguments(arguments);
+            RemoteMessage remoteMessage =
+                FlutterFirebaseMessagingUtils.getRemoteMessageForArguments(arguments);
+            firebaseMessaging.send(remoteMessage);
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
         });
+
+    return taskCompletionSource.getTask();
   }
 
   private Task<Map<String, Object>> setAutoInitEnabled(Map<String, Object> arguments) {
-    return Tasks.call(
-        cachedThreadPool,
+    TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
         () -> {
-          FirebaseMessaging firebaseMessaging =
-              FlutterFirebaseMessagingUtils.getFirebaseMessagingForArguments(arguments);
-          Boolean enabled = (Boolean) Objects.requireNonNull(arguments.get("enabled"));
-          firebaseMessaging.setAutoInitEnabled(enabled);
-          return new HashMap<String, Object>() {
-            {
-              put(
-                  FlutterFirebaseMessagingUtils.IS_AUTO_INIT_ENABLED,
-                  firebaseMessaging.isAutoInitEnabled());
-            }
-          };
+          try {
+            FirebaseMessaging firebaseMessaging =
+                FlutterFirebaseMessagingUtils.getFirebaseMessagingForArguments(arguments);
+            Boolean enabled = (Boolean) Objects.requireNonNull(arguments.get("enabled"));
+            firebaseMessaging.setAutoInitEnabled(enabled);
+            taskCompletionSource.setResult(
+                new HashMap<String, Object>() {
+                  {
+                    put(
+                        FlutterFirebaseMessagingUtils.IS_AUTO_INIT_ENABLED,
+                        firebaseMessaging.isAutoInitEnabled());
+                  }
+                });
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
         });
+
+    return taskCompletionSource.getTask();
   }
 
   private Task<Map<String, Object>> getInitialMessage(Map<String, Object> arguments) {
-    return Tasks.call(
-        cachedThreadPool,
+    TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
         () -> {
-          if (initialMessage != null) {
-            Map<String, Object> remoteMessageMap =
-                FlutterFirebaseMessagingUtils.remoteMessageToMap(initialMessage);
-            initialMessage = null;
-            return remoteMessageMap;
+          try {
+            if (initialMessage != null) {
+              Map<String, Object> remoteMessageMap =
+                  FlutterFirebaseMessagingUtils.remoteMessageToMap(initialMessage);
+              initialMessage = null;
+              taskCompletionSource.setResult(remoteMessageMap);
+              return;
+            }
+
+            if (mainActivity == null) {
+              taskCompletionSource.setResult(null);
+              return;
+            }
+
+            Intent intent = mainActivity.getIntent();
+
+            if (intent == null || intent.getExtras() == null) {
+              taskCompletionSource.setResult(null);
+              return;
+            }
+
+            // Remote Message ID can be either one of the following...
+            String messageId = intent.getExtras().getString("google.message_id");
+            if (messageId == null) messageId = intent.getExtras().getString("message_id");
+
+            // We only want to handle non-consumed initial messages.
+            if (messageId == null || consumedInitialMessages.get(messageId) != null) {
+              taskCompletionSource.setResult(null);
+              return;
+            }
+
+            RemoteMessage remoteMessage =
+                FlutterFirebaseMessagingReceiver.notifications.get(messageId);
+
+            // If we can't find a copy of the remote message in memory then check from our persisted store.
+            if (remoteMessage == null) {
+              remoteMessage =
+                  FlutterFirebaseMessagingStore.getInstance().getFirebaseMessage(messageId);
+              FlutterFirebaseMessagingStore.getInstance().removeFirebaseMessage(messageId);
+            }
+
+            if (remoteMessage == null) {
+              taskCompletionSource.setResult(null);
+              return;
+            }
+
+            consumedInitialMessages.put(messageId, true);
+
+            taskCompletionSource.setResult(
+                FlutterFirebaseMessagingUtils.remoteMessageToMap(remoteMessage));
+
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
           }
-
-          if (mainActivity == null) {
-            return null;
-          }
-
-          Intent intent = mainActivity.getIntent();
-
-          if (intent == null || intent.getExtras() == null) {
-            return null;
-          }
-
-          // Remote Message ID can be either one of the following...
-          String messageId = intent.getExtras().getString("google.message_id");
-          if (messageId == null) messageId = intent.getExtras().getString("message_id");
-
-          // We only want to handle non-consumed initial messages.
-          if (messageId == null || consumedInitialMessages.get(messageId) != null) {
-            return null;
-          }
-
-          RemoteMessage remoteMessage =
-              FlutterFirebaseMessagingReceiver.notifications.get(messageId);
-
-          // If we can't find a copy of the remote message in memory then check from our persisted store.
-          if (remoteMessage == null) {
-            remoteMessage =
-                FlutterFirebaseMessagingStore.getInstance().getFirebaseMessage(messageId);
-            FlutterFirebaseMessagingStore.getInstance().removeFirebaseMessage(messageId);
-          }
-
-          if (remoteMessage == null) {
-            return null;
-          }
-
-          consumedInitialMessages.put(messageId, true);
-          return FlutterFirebaseMessagingUtils.remoteMessageToMap(remoteMessage);
         });
+
+    return taskCompletionSource.getTask();
   }
 
   private Task<Map<String, Integer>> getPermissions() {
-    return Tasks.call(
-        cachedThreadPool,
+    TaskCompletionSource<Map<String, Integer>> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
         () -> {
-          final Map<String, Integer> permissions = new HashMap<>();
-          final boolean areNotificationsEnabled =
-              NotificationManagerCompat.from(mainActivity).areNotificationsEnabled();
-          permissions.put("authorizationStatus", areNotificationsEnabled ? 1 : 0);
-          return permissions;
+          try {
+            final Map<String, Integer> permissions = new HashMap<>();
+            final boolean areNotificationsEnabled =
+                NotificationManagerCompat.from(mainActivity).areNotificationsEnabled();
+            permissions.put("authorizationStatus", areNotificationsEnabled ? 1 : 0);
+            taskCompletionSource.setResult(permissions);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
         });
+
+    return taskCompletionSource.getTask();
   }
 
   @Override
@@ -405,20 +472,39 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
 
   @Override
   public Task<Map<String, Object>> getPluginConstantsForFirebaseApp(FirebaseApp firebaseApp) {
-    return Tasks.call(
-        cachedThreadPool,
+    TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
         () -> {
-          Map<String, Object> constants = new HashMap<>();
-          if (firebaseApp.getName().equals("[DEFAULT]")) {
-            FirebaseMessaging firebaseMessaging = FirebaseMessaging.getInstance();
-            constants.put("AUTO_INIT_ENABLED", firebaseMessaging.isAutoInitEnabled());
+          try {
+            Map<String, Object> constants = new HashMap<>();
+            if (firebaseApp.getName().equals("[DEFAULT]")) {
+              FirebaseMessaging firebaseMessaging = FirebaseMessaging.getInstance();
+              constants.put("AUTO_INIT_ENABLED", firebaseMessaging.isAutoInitEnabled());
+            }
+            taskCompletionSource.setResult(constants);
+
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
           }
-          return constants;
         });
+
+    return taskCompletionSource.getTask();
   }
 
   @Override
   public Task<Void> didReinitializeFirebaseCore() {
-    return Tasks.call(cachedThreadPool, () -> null);
+    TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
+        () -> {
+          try {
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
+
+    return taskCompletionSource.getTask();
   }
 }

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -496,14 +496,7 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
   public Task<Void> didReinitializeFirebaseCore() {
     TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
 
-    cachedThreadPool.execute(
-        () -> {
-          try {
-            taskCompletionSource.setResult(null);
-          } catch (Exception e) {
-            taskCompletionSource.setException(e);
-          }
-        });
+    cachedThreadPool.execute(() -> taskCompletionSource.setResult(null));
 
     return taskCompletionSource.getTask();
   }

--- a/packages/firebase_messaging/firebase_messaging/example/android/app/build.gradle
+++ b/packages/firebase_messaging/firebase_messaging/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     lintOptions {
         disable 'InvalidPackage'
@@ -35,7 +35,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.plugins.firebase.messaging.example"
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
## Description

See title.

## Related Issues

related to https://github.com/firebase/flutterfire/issues/8073

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
