### PR TITLE
refactor(firebase_dynamic_links): Remove deprecated Tasks.call() API from android.

### DIFF
--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -387,15 +387,7 @@ public class FlutterFirebaseDynamicLinksPlugin
   @Override
   public Task<Void> didReinitializeFirebaseCore() {
     TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
-
-    cachedThreadPool.execute(
-        () -> {
-          try {
-            taskCompletionSource.setResult(null);
-          } catch (Exception e) {
-            taskCompletionSource.setException(e);
-          }
-        });
+    cachedThreadPool.execute(() -> taskCompletionSource.setResult(null));
 
     return taskCompletionSource.getTask();
   }


### PR DESCRIPTION
## Description

See title.

## Related Issues

none.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
