### PR TITLE
feat(firebase_messaging): add `toMap()` method to `RemoteMessage` and its properties

### DIFF
--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_message.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_message.dart
@@ -52,6 +52,25 @@ class RemoteMessage {
     );
   }
 
+  /// Returns the [RemoteMessage] as a raw Map.
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'senderId': senderId,
+      'category': category,
+      'collapseKey': collapseKey,
+      'contentAvailable': contentAvailable,
+      'data': data,
+      'from': from,
+      'messageId': messageId,
+      'messageType': messageType,
+      'mutableContent': mutableContent,
+      'notification': notification?.toMap(),
+      'sentTime': sentTime?.millisecondsSinceEpoch,
+      'threadId': threadId,
+      'ttl': ttl,
+    };
+  }
+
   /// The ID of the upstream sender location.
   final String? senderId;
 

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_notification.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_notification.dart
@@ -25,54 +25,6 @@ class RemoteNotification {
 
   /// Constructs a [RemoteNotification] from a raw Map.
   factory RemoteNotification.fromMap(Map<String, dynamic> map) {
-    AndroidNotification? _android;
-    AppleNotification? _apple;
-    WebNotification? _web;
-
-    if (map['android'] != null) {
-      _android = AndroidNotification(
-        channelId: map['android']['channelId'],
-        clickAction: map['android']['clickAction'],
-        color: map['android']['color'],
-        count: map['android']['count'],
-        imageUrl: map['android']['imageUrl'],
-        link: map['android']['link'],
-        priority:
-            convertToAndroidNotificationPriority(map['android']['priority']),
-        smallIcon: map['android']['smallIcon'],
-        sound: map['android']['sound'],
-        ticker: map['android']['ticker'],
-        tag: map['android']['tag'],
-        visibility: convertToAndroidNotificationVisibility(
-            map['android']['visibility']),
-      );
-    }
-
-    if (map['apple'] != null) {
-      _apple = AppleNotification(
-        badge: map['apple']['badge'],
-        subtitle: map['apple']['subtitle'],
-        subtitleLocArgs: _toList(map['apple']['subtitleLocArgs']),
-        subtitleLocKey: map['apple']['subtitleLocKey'],
-        imageUrl: map['apple']['imageUrl'],
-        sound: map['apple']['sound'] == null
-            ? null
-            : AppleNotificationSound(
-                critical: map['apple']['sound']['critical'] ?? false,
-                name: map['apple']['sound']['name'],
-                volume: map['apple']['sound']['volume'] ?? 0,
-              ),
-      );
-    }
-
-    if (map['web'] != null) {
-      _web = WebNotification(
-        analyticsLabel: map['web']['analyticsLabel'],
-        image: map['web']['image'],
-        link: map['web']['link'],
-      );
-    }
-
     return RemoteNotification(
       title: map['title'],
       titleLocArgs: _toList(map['titleLocArgs']),
@@ -80,10 +32,32 @@ class RemoteNotification {
       body: map['body'],
       bodyLocArgs: _toList(map['bodyLocArgs']),
       bodyLocKey: map['bodyLocKey'],
-      android: _android,
-      apple: _apple,
-      web: _web,
+      android: map['android'] != null
+          ? AndroidNotification.fromMap(
+              Map<String, dynamic>.from(map['android']))
+          : null,
+      apple: map['apple'] != null
+          ? AppleNotification.fromMap(Map<String, dynamic>.from(map['apple']))
+          : null,
+      web: map['web'] != null
+          ? WebNotification.fromMap(Map<String, dynamic>.from(map['web']))
+          : null,
     );
+  }
+
+  /// Returns the [RemoteNotification] as a raw Map.
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'title': title,
+      'titleLocArgs': titleLocArgs,
+      'titleLocKey': titleLocKey,
+      'body': body,
+      'bodyLocArgs': bodyLocArgs,
+      'bodyLocKey': bodyLocKey,
+      'android': android?.toMap(),
+      'apple': apple?.toMap(),
+      'web': web?.toMap(),
+    };
   }
 
   /// Android specific notification properties.
@@ -132,6 +106,42 @@ class AndroidNotification {
       this.ticker,
       this.tag,
       this.visibility = AndroidNotificationVisibility.private});
+
+  /// Constructs an [AndroidNotification] from a raw Map.
+  factory AndroidNotification.fromMap(Map<String, dynamic> map) {
+    return AndroidNotification(
+      channelId: map['channelId'],
+      clickAction: map['clickAction'],
+      color: map['color'],
+      count: map['count'],
+      imageUrl: map['imageUrl'],
+      link: map['link'],
+      priority: convertToAndroidNotificationPriority(map['priority']),
+      smallIcon: map['smallIcon'],
+      sound: map['sound'],
+      ticker: map['ticker'],
+      tag: map['tag'],
+      visibility: convertToAndroidNotificationVisibility(map['visibility']),
+    );
+  }
+
+  /// Returns the [AndroidNotification] as a raw Map.
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'channelId': channelId,
+      'clickAction': clickAction,
+      'color': color,
+      'count': count,
+      'imageUrl': imageUrl,
+      'link': link,
+      'priority': convertAndroidNotificationPriorityToInt(priority),
+      'smallIcon': smallIcon,
+      'sound': sound,
+      'ticker': ticker,
+      'tag': tag,
+      'visibility': convertAndroidNotificationVisibilityToInt(visibility),
+    };
+  }
 
   /// The channel the notification is delivered on.
   final String? channelId;
@@ -190,6 +200,33 @@ class AppleNotification {
       this.subtitleLocArgs = const <String>[],
       this.subtitleLocKey});
 
+  /// Constructs an [AppleNotification] from a raw Map.
+  factory AppleNotification.fromMap(Map<String, dynamic> map) {
+    return AppleNotification(
+      badge: map['badge'],
+      subtitle: map['subtitle'],
+      subtitleLocArgs: _toList(map['subtitleLocArgs']),
+      subtitleLocKey: map['subtitleLocKey'],
+      imageUrl: map['imageUrl'],
+      sound: map['sound'] == null
+          ? null
+          : AppleNotificationSound.fromMap(
+              Map<String, dynamic>.from(map['sound'])),
+    );
+  }
+
+  /// Returns the [AppleNotification] as a raw Map.
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'badge': badge,
+      'subtitle': subtitle,
+      'subtitleLocArgs': subtitleLocArgs,
+      'subtitleLocKey': subtitleLocKey,
+      'imageUrl': imageUrl,
+      'sound': sound?.toMap(),
+    };
+  }
+
   /// The value which sets the application badge.
   final String? badge;
 
@@ -216,6 +253,24 @@ class AppleNotificationSound {
   // ignore: public_member_api_docs
   const AppleNotificationSound(
       {this.critical = false, this.name, this.volume = 0});
+
+  /// Constructs an [AppleNotificationSound] from a raw Map.
+  factory AppleNotificationSound.fromMap(Map<String, dynamic> map) {
+    return AppleNotificationSound(
+      critical: map['critical'] ?? false,
+      name: map['name'],
+      volume: map['volume'] ?? 0,
+    );
+  }
+
+  /// Returns the [AppleNotificationSound] as a raw Map.
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'critical': critical,
+      'name': name,
+      'volume': volume,
+    };
+  }
 
   /// Whether or not the notification sound was critical.
   final bool critical;
@@ -245,6 +300,24 @@ class WebNotification {
     this.image,
     this.link,
   });
+
+  /// Constructs a [WebNotification] from a raw Map.
+  factory WebNotification.fromMap(Map<String, dynamic> map) {
+    return WebNotification(
+      analyticsLabel: map['analyticsLabel'],
+      image: map['image'],
+      link: map['link'],
+    );
+  }
+
+  /// Returns the [WebNotification] as a raw Map.
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'analyticsLabel': analyticsLabel,
+      'image': image,
+      'link': link,
+    };
+  }
 
   /// Optional message label for custom analytics.
   final String? analyticsLabel;

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/utils.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/utils.dart
@@ -24,6 +24,25 @@ AndroidNotificationPriority convertToAndroidNotificationPriority(
   }
 }
 
+/// Converts an [AndroidNotificationPriority] into it's [int] representation.
+int convertAndroidNotificationPriorityToInt(
+    AndroidNotificationPriority? priority) {
+  switch (priority) {
+    case AndroidNotificationPriority.minimumPriority:
+      return -2;
+    case AndroidNotificationPriority.lowPriority:
+      return -1;
+    case AndroidNotificationPriority.defaultPriority:
+      return 0;
+    case AndroidNotificationPriority.highPriority:
+      return 1;
+    case AndroidNotificationPriority.maximumPriority:
+      return 2;
+    default:
+      return 0;
+  }
+}
+
 /// Converts an [int] into it's [AndroidNotificationVisibility] representation.
 AndroidNotificationVisibility convertToAndroidNotificationVisibility(
     int? visibility) {
@@ -36,6 +55,21 @@ AndroidNotificationVisibility convertToAndroidNotificationVisibility(
       return AndroidNotificationVisibility.public;
     default:
       return AndroidNotificationVisibility.private;
+  }
+}
+
+/// Converts an [AndroidNotificationVisibility] into it's [int] representation.
+int convertAndroidNotificationVisibilityToInt(
+    AndroidNotificationVisibility? visibility) {
+  switch (visibility) {
+    case AndroidNotificationVisibility.secret:
+      return -1;
+    case AndroidNotificationVisibility.private:
+      return 0;
+    case AndroidNotificationVisibility.public:
+      return 1;
+    default:
+      return 0;
   }
 }
 

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/test/notification_test.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/test/notification_test.dart
@@ -8,6 +8,55 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('RemoteNotification', () {
+    test('Provide every type of argument', () {
+      Map<String, dynamic> mockNotificationMap = {
+        'title': 'title',
+        'titleLocArgs': ['titleLocArgs'],
+        'titleLocKey': 'titleLocKey',
+        'body': 'body',
+        'bodyLocArgs': ['bodyLocArgs'],
+        'bodyLocKey': 'bodyLocKey',
+        'android': {},
+        'apple': {},
+        'web': {},
+      };
+
+      RemoteNotification notification = RemoteNotification(
+          android: const AndroidNotification(),
+          apple: const AppleNotification(),
+          web: const WebNotification(),
+          title: mockNotificationMap['title'],
+          titleLocArgs: mockNotificationMap['titleLocArgs'],
+          titleLocKey: mockNotificationMap['titleLocKey'],
+          body: mockNotificationMap['body'],
+          bodyLocArgs: mockNotificationMap['bodyLocArgs'],
+          bodyLocKey: mockNotificationMap['bodyLocKey']);
+
+      expect(notification.title, mockNotificationMap['title']);
+      expect(notification.titleLocArgs, mockNotificationMap['titleLocArgs']);
+      expect(notification.titleLocKey, mockNotificationMap['titleLocKey']);
+      expect(notification.body, mockNotificationMap['body']);
+      expect(notification.bodyLocArgs, mockNotificationMap['bodyLocArgs']);
+      expect(notification.bodyLocKey, mockNotificationMap['bodyLocKey']);
+      expect(notification.android, isA<AndroidNotification>());
+      expect(notification.apple, isA<AppleNotification>());
+      expect(notification.web, isA<WebNotification>());
+    });
+
+    test('Provide no arguments', () {
+      RemoteNotification notification = const RemoteNotification();
+
+      expect(notification.title, null);
+      expect(notification.titleLocArgs, []);
+      expect(notification.titleLocKey, null);
+      expect(notification.body, null);
+      expect(notification.bodyLocArgs, []);
+      expect(notification.bodyLocKey, null);
+      expect(notification.android, null);
+      expect(notification.apple, null);
+      expect(notification.web, null);
+    });
+
     test('"RemoteNotification.fromMap" with every possible property expected',
         () {
       Map<String, dynamic> mockNotificationMap = {
@@ -51,68 +100,61 @@ void main() {
       RemoteNotification notification =
           RemoteNotification.fromMap(mockNullNotificationMap);
 
-      expect(notification.title, mockNullNotificationMap['title']);
-      expect(notification.titleLocArgs, []);
-      expect(notification.titleLocKey, mockNullNotificationMap['titleLocKey']);
-      expect(notification.body, mockNullNotificationMap['body']);
-      expect(notification.bodyLocArgs, []);
-      expect(notification.bodyLocKey, mockNullNotificationMap['bodyLocKey']);
-      expect(notification.android, null);
-      expect(notification.apple, null);
-      expect(notification.web, null);
+      RemoteNotification defaultNotification = const RemoteNotification();
+
+      expect(notification.title, defaultNotification.title);
+      expect(notification.titleLocArgs, defaultNotification.titleLocArgs);
+      expect(notification.titleLocKey, defaultNotification.titleLocKey);
+      expect(notification.body, defaultNotification.body);
+      expect(notification.bodyLocArgs, defaultNotification.bodyLocArgs);
+      expect(notification.bodyLocKey, defaultNotification.bodyLocKey);
+      expect(notification.android, defaultNotification.android);
+      expect(notification.apple, defaultNotification.apple);
+      expect(notification.web, defaultNotification.web);
     });
 
     test(
-        'Use RemoteMessage.fromMap constructor to create every available property',
+        '"RemoteNotification.fromMap" with no properties & default values invoked',
         () {
-      Map<String, dynamic> mockNotificationMap = {
-        'title': 'title',
-        'titleLocArgs': ['titleLocArgs'],
-        'titleLocKey': 'titleLocKey',
-        'body': 'body',
-        'bodyLocArgs': ['bodyLocArgs'],
-        'bodyLocKey': 'bodyLocKey',
-        'android': {},
-        'apple': {},
-        'web': {},
-      };
+      RemoteNotification notification = RemoteNotification.fromMap({});
 
-      RemoteNotification notification = RemoteNotification(
-          android: const AndroidNotification(),
-          apple: const AppleNotification(),
-          web: const WebNotification(),
-          title: mockNotificationMap['title'],
-          titleLocArgs: mockNotificationMap['titleLocArgs'],
-          titleLocKey: mockNotificationMap['titleLocKey'],
-          body: mockNotificationMap['body'],
-          bodyLocArgs: mockNotificationMap['bodyLocArgs'],
-          bodyLocKey: mockNotificationMap['bodyLocKey']);
+      RemoteNotification defaultNotification = const RemoteNotification();
 
-      expect(notification.title, mockNotificationMap['title']);
-      expect(notification.titleLocArgs, mockNotificationMap['titleLocArgs']);
-      expect(notification.titleLocKey, mockNotificationMap['titleLocKey']);
-      expect(notification.body, mockNotificationMap['body']);
-      expect(notification.bodyLocArgs, mockNotificationMap['bodyLocArgs']);
-      expect(notification.bodyLocKey, mockNotificationMap['bodyLocKey']);
-      expect(notification.android, isA<AndroidNotification>());
-      expect(notification.apple, isA<AppleNotification>());
-      expect(notification.web, isA<WebNotification>());
+      expect(notification.title, defaultNotification.title);
+      expect(notification.titleLocArgs, defaultNotification.titleLocArgs);
+      expect(notification.titleLocKey, defaultNotification.titleLocKey);
+      expect(notification.body, defaultNotification.body);
+      expect(notification.bodyLocArgs, defaultNotification.bodyLocArgs);
+      expect(notification.bodyLocKey, defaultNotification.bodyLocKey);
+      expect(notification.android, defaultNotification.android);
+      expect(notification.apple, defaultNotification.apple);
+      expect(notification.web, defaultNotification.web);
     });
 
-    test(
-        'Use RemoteMessage constructor with nullable properties mapped as null & default values invoked',
-        () {
-      RemoteNotification notification = const RemoteNotification();
+    test('RemoteNotification.toMap returns "RemoteNotification" as Map', () {
+      RemoteNotification notification = const RemoteNotification(
+        android: AndroidNotification(),
+        apple: AppleNotification(),
+        web: WebNotification(),
+        title: 'title',
+        titleLocArgs: ['arg1'],
+        titleLocKey: 'titleLocKey',
+        body: 'body',
+        bodyLocArgs: ['arg1'],
+        bodyLocKey: 'bodyLocKey',
+      );
 
-      expect(notification.title, null);
-      expect(notification.titleLocArgs, []);
-      expect(notification.titleLocKey, null);
-      expect(notification.body, null);
-      expect(notification.bodyLocArgs, []);
-      expect(notification.bodyLocKey, null);
-      expect(notification.android, null);
-      expect(notification.apple, null);
-      expect(notification.web, null);
+      final Map<String, dynamic> notificationMap = notification.toMap();
+
+      expect(notificationMap['android'], const AndroidNotification().toMap());
+      expect(notificationMap['apple'], const AppleNotification().toMap());
+      expect(notificationMap['web'], const WebNotification().toMap());
+      expect(notificationMap['title'], notification.title);
+      expect(notificationMap['titleLocArgs'], notification.titleLocArgs);
+      expect(notificationMap['titleLocKey'], notification.titleLocKey);
+      expect(notificationMap['body'], notification.body);
+      expect(notificationMap['bodyLocArgs'], notification.bodyLocArgs);
+      expect(notificationMap['bodyLocKey'], notification.bodyLocKey);
     });
   });
 
@@ -165,6 +207,7 @@ void main() {
 
     test('Provide no arguments', () {
       AndroidNotification notification = const AndroidNotification();
+
       expect(notification.channelId, null);
       expect(notification.clickAction, null);
       expect(notification.color, null);
@@ -178,11 +221,136 @@ void main() {
       expect(notification.ticker, null);
       expect(notification.visibility, AndroidNotificationVisibility.private);
     });
+
+    test('"AndroidNotification.fromMap" with every possible property expected',
+        () {
+      Map<String, dynamic>? androidNotificationMap = {
+        'channelId': 'channelId',
+        'clickAction': 'clickAction',
+        'color': 'color',
+        'count': 5,
+        'imageUrl': 'imageUrl',
+        'link': 'link',
+        'priority': 2,
+        'smallIcon': 'smallIcon',
+        'sound': 'sound',
+        'ticker': 'ticker',
+        'tag': 'tag',
+        'visibility': -1,
+      };
+
+      final AndroidNotification notification =
+          AndroidNotification.fromMap(androidNotificationMap);
+
+      expect(notification.channelId, androidNotificationMap['channelId']);
+      expect(notification.clickAction, androidNotificationMap['clickAction']);
+      expect(notification.color, androidNotificationMap['color']);
+      expect(notification.count, androidNotificationMap['count']);
+      expect(notification.imageUrl, androidNotificationMap['imageUrl']);
+      expect(notification.link, androidNotificationMap['link']);
+      expect(
+          notification.priority, AndroidNotificationPriority.maximumPriority);
+      expect(notification.smallIcon, androidNotificationMap['smallIcon']);
+      expect(notification.sound, androidNotificationMap['sound']);
+      expect(notification.ticker, androidNotificationMap['ticker']);
+      expect(notification.tag, androidNotificationMap['tag']);
+      expect(notification.visibility, AndroidNotificationVisibility.secret);
+    });
+
+    test(
+        '"AndroidNotification.fromMap" with nullable properties mapped as null & default values invoked',
+        () {
+      Map<String, dynamic>? androidNotificationMap = {
+        'channelId': null,
+        'clickAction': null,
+        'color': null,
+        'count': null,
+        'imageUrl': null,
+        'link': null,
+        'priority': null,
+        'smallIcon': null,
+        'sound': null,
+        'ticker': null,
+        'tag': null,
+        'visibility': null,
+      };
+
+      final AndroidNotification notification =
+          AndroidNotification.fromMap(androidNotificationMap);
+
+      const AndroidNotification defaultNotification = AndroidNotification();
+
+      expect(notification.channelId, defaultNotification.channelId);
+      expect(notification.clickAction, defaultNotification.clickAction);
+      expect(notification.color, defaultNotification.color);
+      expect(notification.count, defaultNotification.count);
+      expect(notification.imageUrl, defaultNotification.imageUrl);
+      expect(notification.link, defaultNotification.link);
+      expect(notification.priority, defaultNotification.priority);
+      expect(notification.smallIcon, defaultNotification.smallIcon);
+      expect(notification.sound, defaultNotification.sound);
+      expect(notification.ticker, defaultNotification.ticker);
+      expect(notification.tag, defaultNotification.tag);
+      expect(notification.visibility, defaultNotification.visibility);
+    });
+
+    test(
+        '"AndroidNotification.fromMap" with no properties & default values invoked',
+        () {
+      final AndroidNotification notification = AndroidNotification.fromMap({});
+
+      const AndroidNotification defaultNotification = AndroidNotification();
+
+      expect(notification.channelId, defaultNotification.channelId);
+      expect(notification.clickAction, defaultNotification.clickAction);
+      expect(notification.color, defaultNotification.color);
+      expect(notification.count, defaultNotification.count);
+      expect(notification.imageUrl, defaultNotification.imageUrl);
+      expect(notification.link, defaultNotification.link);
+      expect(notification.priority, defaultNotification.priority);
+      expect(notification.smallIcon, defaultNotification.smallIcon);
+      expect(notification.sound, defaultNotification.sound);
+      expect(notification.ticker, defaultNotification.ticker);
+      expect(notification.tag, defaultNotification.tag);
+      expect(notification.visibility, defaultNotification.visibility);
+    });
+
+    test('AndroidNotification.toMap returns "AndroidNotification" as Map', () {
+      const AndroidNotification notification = AndroidNotification(
+        channelId: 'channelId',
+        clickAction: 'clickAction',
+        color: 'color',
+        count: 5,
+        imageUrl: 'imageUrl',
+        link: 'link',
+        priority: AndroidNotificationPriority.lowPriority,
+        smallIcon: 'smallIcon',
+        sound: 'sound',
+        ticker: 'ticker',
+        tag: 'tag',
+        visibility: AndroidNotificationVisibility.public,
+      );
+
+      final Map<String, dynamic> androidNotificationMap = notification.toMap();
+
+      expect(androidNotificationMap['channelId'], notification.channelId);
+      expect(androidNotificationMap['clickAction'], notification.clickAction);
+      expect(androidNotificationMap['color'], notification.color);
+      expect(androidNotificationMap['count'], notification.count);
+      expect(androidNotificationMap['imageUrl'], notification.imageUrl);
+      expect(androidNotificationMap['link'], notification.link);
+      expect(androidNotificationMap['priority'], -1);
+      expect(androidNotificationMap['smallIcon'], notification.smallIcon);
+      expect(androidNotificationMap['sound'], notification.sound);
+      expect(androidNotificationMap['ticker'], notification.ticker);
+      expect(androidNotificationMap['tag'], notification.tag);
+      expect(androidNotificationMap['visibility'], 1);
+    });
   });
 
   group('AppleNotification', () {
     test('Provide every type of argument', () {
-      Map<String, dynamic>? mockAppleNotificationMap = {
+      Map<String, dynamic>? appleNotificationMap = {
         'badge': 'badge',
         'sound': const AppleNotificationSound(),
         'imageUrl': 'imageUrl',
@@ -192,21 +360,21 @@ void main() {
       };
 
       AppleNotification notification = AppleNotification(
-          badge: mockAppleNotificationMap['badge'],
-          sound: mockAppleNotificationMap['sound'],
-          imageUrl: mockAppleNotificationMap['imageUrl'],
-          subtitle: mockAppleNotificationMap['subtitle'],
-          subtitleLocArgs: mockAppleNotificationMap['subtitleLocArgs'],
-          subtitleLocKey: mockAppleNotificationMap['subtitleLocKey']);
+          badge: appleNotificationMap['badge'],
+          sound: appleNotificationMap['sound'],
+          imageUrl: appleNotificationMap['imageUrl'],
+          subtitle: appleNotificationMap['subtitle'],
+          subtitleLocArgs: appleNotificationMap['subtitleLocArgs'],
+          subtitleLocKey: appleNotificationMap['subtitleLocKey']);
 
-      expect(notification.sound, mockAppleNotificationMap['sound']);
-      expect(notification.badge, mockAppleNotificationMap['badge']);
-      expect(notification.imageUrl, mockAppleNotificationMap['imageUrl']);
-      expect(notification.subtitle, mockAppleNotificationMap['subtitle']);
+      expect(notification.sound, appleNotificationMap['sound']);
+      expect(notification.badge, appleNotificationMap['badge']);
+      expect(notification.imageUrl, appleNotificationMap['imageUrl']);
+      expect(notification.subtitle, appleNotificationMap['subtitle']);
       expect(notification.subtitleLocArgs,
-          mockAppleNotificationMap['subtitleLocArgs']);
-      expect(notification.subtitleLocKey,
-          mockAppleNotificationMap['subtitleLocKey']);
+          appleNotificationMap['subtitleLocArgs']);
+      expect(
+          notification.subtitleLocKey, appleNotificationMap['subtitleLocKey']);
     });
 
     test('Provide no arguments', () {
@@ -219,6 +387,94 @@ void main() {
       expect(notification.subtitleLocArgs, []);
       expect(notification.subtitleLocKey, null);
     });
+
+    test('"AppleNotification.fromMap" with every possible property expected',
+        () {
+      Map<String, dynamic> appleNotificationMap = {
+        'badge': 'badge',
+        'sound': {},
+        'imageUrl': 'imageUrl',
+        'subtitle': 'subtitle',
+        'subtitleLocArgs': ['subtitleLocArgs'],
+        'subtitleLocKey': 'subtitleLocKey'
+      };
+
+      AppleNotification notification =
+          AppleNotification.fromMap(appleNotificationMap);
+
+      expect(notification.badge, 'badge');
+      expect(notification.sound, isA<AppleNotificationSound>());
+      expect(notification.imageUrl, 'imageUrl');
+      expect(notification.subtitle, 'subtitle');
+      expect(notification.subtitleLocArgs, ['subtitleLocArgs']);
+      expect(notification.subtitleLocKey, 'subtitleLocKey');
+    });
+
+    test(
+        '"AppleNotification.fromMap" with nullable properties mapped as null & default values invoked',
+        () {
+      Map<String, dynamic> appleNotificationMap = {
+        'badge': null,
+        'sound': null,
+        'imageUrl': null,
+        'subtitle': null,
+        'subtitleLocArgs': null,
+        'subtitleLocKey': null
+      };
+
+      AppleNotification notification =
+          AppleNotification.fromMap(appleNotificationMap);
+
+      const AppleNotification defaultNotification = AppleNotification();
+
+      expect(notification.badge, defaultNotification.badge);
+      expect(notification.sound, defaultNotification.sound);
+      expect(notification.imageUrl, defaultNotification.imageUrl);
+      expect(notification.subtitle, defaultNotification.subtitle);
+      expect(notification.subtitleLocArgs, defaultNotification.subtitleLocArgs);
+      expect(notification.subtitleLocKey, defaultNotification.subtitleLocKey);
+    });
+
+    test(
+        '"AppleNotification.fromMap" with no properties & default values invoked',
+        () {
+      AppleNotification notification = AppleNotification.fromMap({});
+
+      const AppleNotification defaultNotification = AppleNotification();
+
+      expect(notification.badge, defaultNotification.badge);
+      expect(notification.sound, defaultNotification.sound);
+      expect(notification.imageUrl, defaultNotification.imageUrl);
+      expect(notification.subtitle, defaultNotification.subtitle);
+      expect(notification.subtitleLocArgs, defaultNotification.subtitleLocArgs);
+      expect(notification.subtitleLocKey, defaultNotification.subtitleLocKey);
+    });
+
+    test('AppleNotification.toMap returns "AppleNotification" as Map', () {
+      const AppleNotificationSound appleSound = AppleNotificationSound(
+        critical: true,
+        name: 'name',
+        volume: 0.5,
+      );
+
+      const AppleNotification notification = AppleNotification(
+        badge: 'badge',
+        sound: appleSound,
+        imageUrl: 'imageUrl',
+        subtitle: 'subtitle',
+        subtitleLocArgs: ['subtitleLocArgs'],
+        subtitleLocKey: 'subtitleLocKey',
+      );
+
+      final Map<String, dynamic> appleNotificationMap = notification.toMap();
+
+      expect(appleNotificationMap['badge'], 'badge');
+      expect(appleNotificationMap['sound'], appleSound.toMap());
+      expect(appleNotificationMap['imageUrl'], 'imageUrl');
+      expect(appleNotificationMap['subtitle'], 'subtitle');
+      expect(appleNotificationMap['subtitleLocArgs'], ['subtitleLocArgs']);
+      expect(appleNotificationMap['subtitleLocKey'], 'subtitleLocKey');
+    });
   });
 
   group('AppleNotificationSound', () {
@@ -229,42 +485,105 @@ void main() {
         'volume': 0.5
       };
 
-      AppleNotificationSound iosSound = AppleNotificationSound(
+      AppleNotificationSound appleSound = AppleNotificationSound(
           critical: appleSoundMap['critical'],
           name: appleSoundMap['name'],
           volume: appleSoundMap['volume']);
-      expect(iosSound.critical, appleSoundMap['critical']);
-      expect(iosSound.name, appleSoundMap['name']);
-      expect(iosSound.volume, appleSoundMap['volume']);
+      expect(appleSound.critical, appleSoundMap['critical']);
+      expect(appleSound.name, appleSoundMap['name']);
+      expect(appleSound.volume, appleSoundMap['volume']);
     });
 
     test('Provide no arguments', () {
-      AppleNotificationSound iosSound = const AppleNotificationSound();
+      AppleNotificationSound appleSound = const AppleNotificationSound();
 
-      expect(iosSound.critical, false);
-      expect(iosSound.name, null);
-      expect(iosSound.volume, 0);
+      expect(appleSound.critical, false);
+      expect(appleSound.name, null);
+      expect(appleSound.volume, 0);
+    });
+
+    test(
+        '"AppleNotificationSound.fromMap" with every possible property expected',
+        () {
+      Map<String, dynamic> appleSoundMap = {
+        'critical': true,
+        'name': 'name',
+        'volume': 0.57,
+      };
+
+      final AppleNotificationSound appleSound =
+          AppleNotificationSound.fromMap(appleSoundMap);
+
+      expect(appleSound.critical, appleSoundMap['critical']);
+      expect(appleSound.name, appleSoundMap['name']);
+      expect(appleSound.volume, appleSoundMap['volume']);
+    });
+
+    test(
+        '"AppleNotificationSound.fromMap" with nullable properties mapped as null & default values invoked',
+        () {
+      Map<String, dynamic> webNotificationMap = {
+        'critical': null,
+        'name': null,
+        'volume': null,
+      };
+
+      final AppleNotificationSound appleSound =
+          AppleNotificationSound.fromMap(webNotificationMap);
+
+      const AppleNotificationSound defaultAppleSound = AppleNotificationSound();
+
+      expect(appleSound.critical, defaultAppleSound.critical);
+      expect(appleSound.name, defaultAppleSound.name);
+      expect(appleSound.volume, defaultAppleSound.volume);
+    });
+
+    test(
+        '"AppleNotificationSound.fromMap" with no properties & default values invoked',
+        () {
+      final AppleNotificationSound appleSound =
+          AppleNotificationSound.fromMap({});
+
+      const AppleNotificationSound defaultAppleSound = AppleNotificationSound();
+
+      expect(appleSound.critical, defaultAppleSound.critical);
+      expect(appleSound.name, defaultAppleSound.name);
+      expect(appleSound.volume, defaultAppleSound.volume);
+    });
+
+    test('AppleNotificationSound.toMap returns "AppleNotificationSound" as Map',
+        () {
+      const appleSound = AppleNotificationSound(
+        critical: true,
+        name: 'name',
+        volume: 0.9,
+      );
+
+      final Map<String, dynamic> appleSoundMap = appleSound.toMap();
+
+      expect(appleSoundMap['critical'], appleSound.critical);
+      expect(appleSoundMap['name'], appleSound.name);
+      expect(appleSoundMap['volume'], appleSound.volume);
     });
   });
 
   group('WebNotification', () {
     test('Provide every type of argument', () {
-      Map<String, dynamic>? mockWebNotificationMap = {
+      Map<String, dynamic>? webNotificationMap = {
         'analyticsLabel': 'analyticsLabel',
         'image': 'imageLink',
         'link': 'httpLink',
       };
 
       final WebNotification notification = WebNotification(
-        analyticsLabel: mockWebNotificationMap['analyticsLabel'],
-        image: mockWebNotificationMap['image'],
-        link: mockWebNotificationMap['link'],
+        analyticsLabel: webNotificationMap['analyticsLabel'],
+        image: webNotificationMap['image'],
+        link: webNotificationMap['link'],
       );
 
-      expect(notification.analyticsLabel,
-          mockWebNotificationMap['analyticsLabel']);
-      expect(notification.image, mockWebNotificationMap['image']);
-      expect(notification.link, mockWebNotificationMap['link']);
+      expect(notification.analyticsLabel, webNotificationMap['analyticsLabel']);
+      expect(notification.image, webNotificationMap['image']);
+      expect(notification.link, webNotificationMap['link']);
     });
 
     test('Provide no argument', () {
@@ -273,6 +592,67 @@ void main() {
       expect(notification.analyticsLabel, null);
       expect(notification.image, null);
       expect(notification.link, null);
+    });
+
+    test('"WebNotification.fromMap" with every possible property expected', () {
+      Map<String, dynamic>? webNotificationMap = {
+        'analyticsLabel': 'analyticsLabel',
+        'image': 'imageLink',
+        'link': 'httpLink',
+      };
+
+      final WebNotification notification =
+          WebNotification.fromMap(webNotificationMap);
+
+      expect(notification.analyticsLabel, webNotificationMap['analyticsLabel']);
+      expect(notification.image, webNotificationMap['image']);
+      expect(notification.link, webNotificationMap['link']);
+    });
+
+    test(
+        '"WebNotification.fromMap" with nullable properties mapped as null & default values invoked',
+        () {
+      Map<String, dynamic>? webNotificationMap = {
+        'analyticsLabel': null,
+        'image': null,
+        'link': null,
+      };
+
+      final WebNotification notification =
+          WebNotification.fromMap(webNotificationMap);
+
+      const WebNotification defaultWebNotification = WebNotification();
+
+      expect(
+          notification.analyticsLabel, defaultWebNotification.analyticsLabel);
+      expect(notification.image, defaultWebNotification.image);
+      expect(notification.link, defaultWebNotification.link);
+    });
+
+    test(
+        '"WebNotification.fromMap" with no properties & default values invoked',
+        () {
+      final WebNotification notification = WebNotification.fromMap({});
+      const WebNotification defaultWebNotification = WebNotification();
+
+      expect(
+          notification.analyticsLabel, defaultWebNotification.analyticsLabel);
+      expect(notification.image, defaultWebNotification.image);
+      expect(notification.link, defaultWebNotification.link);
+    });
+
+    test('WebNotification.toMap returns "WebNotification" as Map', () {
+      const WebNotification notification = WebNotification(
+        analyticsLabel: 'analyticsLabel',
+        image: 'imageLink',
+        link: 'httpLink',
+      );
+
+      Map<String, dynamic> webNotificationMap = notification.toMap();
+
+      expect(webNotificationMap['analyticsLabel'], notification.analyticsLabel);
+      expect(webNotificationMap['image'], notification.image);
+      expect(webNotificationMap['link'], notification.link);
     });
   });
 }

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/test/remote_message_test.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/test/remote_message_test.dart
@@ -130,6 +130,7 @@ void main() {
       expect(message.threadId, mockMessageMap!['threadId']);
       expect(message.ttl, mockMessageMap!['ttl']);
     });
+
     test(
         'Use RemoteMessage constructor with nullable properties passed as null & default values invoked',
         () {
@@ -162,6 +163,50 @@ void main() {
       expect(message.sentTime, null);
       expect(message.threadId, mockNullableMessageMap['threadId']);
       expect(message.ttl, mockNullableMessageMap['ttl']);
+    });
+
+    test('"RemoteMessage.toMap" returns "RemoteMessage" as Map', () {
+      final RemoteMessage remoteMessage = RemoteMessage(
+        senderId: 'senderId',
+        category: 'category',
+        collapseKey: 'collapseKey',
+        contentAvailable: true,
+        data: {},
+        from: 'from',
+        messageId: 'messageId',
+        messageType: 'messageType',
+        mutableContent: true,
+        notification: const RemoteNotification(
+          title: 'notification_title',
+          body: 'notification_body',
+        ),
+        sentTime: DateTime.now(),
+        threadId: 'threadId',
+        ttl: 30000,
+      );
+
+      final Map<String, dynamic> map = remoteMessage.toMap();
+
+      expect(map['senderId'], remoteMessage.senderId);
+      expect(map['category'], remoteMessage.category);
+      expect(map['collapseKey'], remoteMessage.collapseKey);
+      expect(map['contentAvailable'], remoteMessage.contentAvailable);
+      expect(map['data'], remoteMessage.data);
+      expect(map['from'], remoteMessage.from);
+      expect(map['messageId'], remoteMessage.messageId);
+      expect(map['messageType'], remoteMessage.messageType);
+      expect(map['mutableContent'], remoteMessage.mutableContent);
+
+      expect(
+          map['notification'],
+          RemoteNotification(
+            title: remoteMessage.notification!.title,
+            body: remoteMessage.notification!.body,
+          ).toMap());
+
+      expect(map['sentTime'], remoteMessage.sentTime!.millisecondsSinceEpoch);
+      expect(map['threadId'], remoteMessage.threadId);
+      expect(map['ttl'], remoteMessage.ttl);
     });
   });
 }

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/test/utils_test.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/test/utils_test.dart
@@ -9,18 +9,205 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Utilities', () {
-    test('convertToNotificationPriority()', () {
-      expect(convertToAndroidNotificationPriority(1),
-          isA<AndroidNotificationPriority>());
+    group('convertToAndroidNotificationPriority', () {
+      test('returns correct AndroidNotificationPriority for priority value',
+          () {
+        expect(convertToAndroidNotificationPriority(-2),
+            AndroidNotificationPriority.minimumPriority);
+        expect(convertToAndroidNotificationPriority(-1),
+            AndroidNotificationPriority.lowPriority);
+        expect(convertToAndroidNotificationPriority(0),
+            AndroidNotificationPriority.defaultPriority);
+        expect(convertToAndroidNotificationPriority(1),
+            AndroidNotificationPriority.highPriority);
+        expect(convertToAndroidNotificationPriority(2),
+            AndroidNotificationPriority.maximumPriority);
+      });
+
+      test(
+          'returns AndroidNotificationPriority.defaultPriority '
+          'if priority is not a possible value', () {
+        expect(convertToAndroidNotificationPriority(-3),
+            AndroidNotificationPriority.defaultPriority);
+        expect(convertToAndroidNotificationPriority(3),
+            AndroidNotificationPriority.defaultPriority);
+      });
+
+      test(
+          'returns AndroidNotificationPriority.defaultPriority '
+          'if priority is null', () {
+        expect(convertToAndroidNotificationPriority(null),
+            AndroidNotificationPriority.defaultPriority);
+      });
     });
 
-    test('convertToAndroidNotificationVisibility()', () {
-      expect(convertToAndroidNotificationVisibility(1),
-          isA<AndroidNotificationVisibility>());
+    group('convertAndroidNotificationPriorityToInt', () {
+      test('returns correct priority value for AndroidNotificationPriority',
+          () {
+        expect(
+            convertAndroidNotificationPriorityToInt(
+                AndroidNotificationPriority.minimumPriority),
+            -2);
+        expect(
+            convertAndroidNotificationPriorityToInt(
+                AndroidNotificationPriority.lowPriority),
+            -1);
+        expect(
+            convertAndroidNotificationPriorityToInt(
+                AndroidNotificationPriority.defaultPriority),
+            0);
+        expect(
+            convertAndroidNotificationPriorityToInt(
+                AndroidNotificationPriority.highPriority),
+            1);
+        expect(
+            convertAndroidNotificationPriorityToInt(
+                AndroidNotificationPriority.maximumPriority),
+            2);
+      });
+
+      test(
+          'returns the priority value that represents '
+          'AndroidNotificationPriority.defaultPriority '
+          'if AndroidNotificationPriority is null', () {
+        expect(convertAndroidNotificationPriorityToInt(null), 0);
+      });
     });
 
-    test('convertToIOSAuthorizationStatus()', () {
-      expect(convertToAuthorizationStatus(1), isA<AuthorizationStatus>());
+    group('convertToAndroidNotificationVisibility', () {
+      test('returns correct AndroidNotificationVisibility for visibility value',
+          () {
+        expect(convertToAndroidNotificationVisibility(-1),
+            AndroidNotificationVisibility.secret);
+        expect(convertToAndroidNotificationVisibility(0),
+            AndroidNotificationVisibility.private);
+        expect(convertToAndroidNotificationVisibility(1),
+            AndroidNotificationVisibility.public);
+      });
+
+      test(
+          'returns AndroidNotificationVisibility.private '
+          'if visibility is no a possible value', () {
+        expect(convertToAndroidNotificationVisibility(-2),
+            AndroidNotificationVisibility.private);
+        expect(convertToAndroidNotificationVisibility(2),
+            AndroidNotificationVisibility.private);
+      });
+
+      test(
+          'returns AndroidNotificationVisibility.private '
+          'if visibility is null', () {
+        expect(convertToAndroidNotificationVisibility(null),
+            AndroidNotificationVisibility.private);
+      });
+    });
+
+    group('convertAndroidNotificationVisibilityToInt', () {
+      test('returns correct visibility value for AndroidNotificationVisibility',
+          () {
+        expect(
+            convertAndroidNotificationVisibilityToInt(
+                AndroidNotificationVisibility.secret),
+            -1);
+        expect(
+            convertAndroidNotificationVisibilityToInt(
+                AndroidNotificationVisibility.private),
+            0);
+        expect(
+            convertAndroidNotificationVisibilityToInt(
+                AndroidNotificationVisibility.public),
+            1);
+      });
+
+      test(
+          'returns the visibility value that represents '
+          'AndroidNotificationVisibility.private '
+          'if AndroidNotificationVisibility is null', () {
+        expect(convertAndroidNotificationVisibilityToInt(null), 0);
+      });
+    });
+
+    group('convertToAuthorizationStatus()', () {
+      test('returns correct AuthorizationStatus for status value', () {
+        expect(convertToAuthorizationStatus(-1),
+            AuthorizationStatus.notDetermined);
+        expect(convertToAuthorizationStatus(0), AuthorizationStatus.denied);
+        expect(convertToAuthorizationStatus(1), AuthorizationStatus.authorized);
+        expect(
+            convertToAuthorizationStatus(2), AuthorizationStatus.provisional);
+      });
+
+      test(
+          'returns AuthorizationStatus.notDetermined '
+          'if status is no a possible value', () {
+        expect(convertToAuthorizationStatus(-2),
+            AuthorizationStatus.notDetermined);
+        expect(
+            convertToAuthorizationStatus(3), AuthorizationStatus.notDetermined);
+      });
+
+      test(
+          'returns AuthorizationStatus.notDetermined '
+          'if status is null', () {
+        expect(convertToAuthorizationStatus(null),
+            AuthorizationStatus.notDetermined);
+      });
+    });
+
+    group('convertToAppleNotificationSetting', () {
+      test('returns correct AppleNotificationSetting for status value', () {
+        expect(convertToAppleNotificationSetting(-1),
+            AppleNotificationSetting.notSupported);
+        expect(convertToAppleNotificationSetting(0),
+            AppleNotificationSetting.disabled);
+        expect(convertToAppleNotificationSetting(1),
+            AppleNotificationSetting.enabled);
+      });
+
+      test(
+          'returns AppleNotificationSetting.notSupported '
+          'if status is no a possible value', () {
+        expect(convertToAppleNotificationSetting(-2),
+            AppleNotificationSetting.notSupported);
+        expect(convertToAppleNotificationSetting(2),
+            AppleNotificationSetting.notSupported);
+      });
+
+      test(
+          'returns AppleNotificationSetting.notSupported '
+          'if status is null', () {
+        expect(convertToAppleNotificationSetting(null),
+            AppleNotificationSetting.notSupported);
+      });
+    });
+
+    group('convertToAppleShowPreviewSetting', () {
+      test('returns correct AppleShowPreviewSetting for status value', () {
+        expect(convertToAppleShowPreviewSetting(-1),
+            AppleShowPreviewSetting.notSupported);
+        expect(
+            convertToAppleShowPreviewSetting(0), AppleShowPreviewSetting.never);
+        expect(convertToAppleShowPreviewSetting(1),
+            AppleShowPreviewSetting.always);
+        expect(convertToAppleShowPreviewSetting(2),
+            AppleShowPreviewSetting.whenAuthenticated);
+      });
+
+      test(
+          'returns AppleShowPreviewSetting.notSupported '
+          'if status is no a possible value', () {
+        expect(convertToAppleShowPreviewSetting(-2),
+            AppleShowPreviewSetting.notSupported);
+        expect(convertToAppleShowPreviewSetting(3),
+            AppleShowPreviewSetting.notSupported);
+      });
+
+      test(
+          'returns AppleShowPreviewSetting.notSupported '
+          'if status is null', () {
+        expect(convertToAppleShowPreviewSetting(null),
+            AppleShowPreviewSetting.notSupported);
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

This PR allows users of `firebase_messaging` to convert a `RemoteMessage` to a Map by calling its `toMap()` method. 

A use case could be if the user wants to send a received background message via a `SendPort` to the application while the application is running in the background and is not terminated. Since a  `SendPort` is only allowe to send primitive data types, Maps and Lists, one have to convert the message to a Map. 

## Related Issues

No related issues.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
