### PR TITLE
docs: contributing hold note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,7 @@
 
 _See also: [Flutter's code of conduct](https://flutter.io/design-principles/#code-of-conduct)_
 
-**Note about contributing to Docs**: We're in the process of updating documentation for the FlutterFire SDK. Please hold your PRs for docs until May 5th.
-
+**Note about contributing to Docs**: We're in the process of updating documentation for the Firebase SDK for Flutter. Please hold your PRs for docs until May 5th.
 ## 1. Things you will need
 
 - Linux, Mac OS X, or Windows.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 _See also: [Flutter's code of conduct](https://flutter.io/design-principles/#code-of-conduct)_
 
-**Note about contributing to Docs**: We're in the process of updating documentation for the Firebase SDK for Flutter. Please hold your PRs for docs until May 5th.
+**Note about contributing to Docs**: We're in the process of updating documentation for the Firebase SDK for Flutter. Please hold your PRs for docs until May 5th, 2022.
 ## 1. Things you will need
 
 - Linux, Mac OS X, or Windows.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@
 
 _See also: [Flutter's code of conduct](https://flutter.io/design-principles/#code-of-conduct)_
 
+**Note about contributing to Docs**: We're in the process of updating documentation for the FlutterFire SDK. Please hold your PRs for docs until May 5th.
+
 ## 1. Things you will need
 
 - Linux, Mac OS X, or Windows.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 ## Contributing
 
-**Note about contributing to Docs**: We're in the process of updating documentation for the Firebase SDK for Flutter. Please hold your PRs for docs until May 5th.
+**Note about contributing to Docs**: We're in the process of updating documentation for the Firebase SDK for Flutter. Please hold your PRs for docs until May 5th, 2022.
 
 If you wish to contribute a change to any of the existing plugins in this repo, please review
 our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 ## Contributing
 
+**Note about contributing to Docs**: We're in the process of updating documentation for the FlutterFire SDK. Please hold your PRs for docs until May 5th.
+
 If you wish to contribute a change to any of the existing plugins in this repo, please review
 our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
 and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 ## Contributing
 
-**Note about contributing to Docs**: We're in the process of updating documentation for the FlutterFire SDK. Please hold your PRs for docs until May 5th.
+**Note about contributing to Docs**: We're in the process of updating documentation for the Firebase SDK for Flutter. Please hold your PRs for docs until May 5th.
 
 If you wish to contribute a change to any of the existing plugins in this repo, please review
 our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
## Description

This PR just adds a sentence to the README and CONTRIBUTING files, in order to deter 3P contributors from contributing to docs while we migrate.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
