### PR TITLE
feat(firebase_messaging): retrieve `timeSensitiveSetting` for iOS 15+.

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -688,6 +688,16 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     }
   }
 
+  NSNumber *timeSensitive = @-1;
+  if (@available(iOS 15.0, macOS 12.0, *)) {
+    if (settings.timeSensitiveSetting == UNNotificationSettingDisabled) {
+      timeSensitive = @0;
+    }
+    if (settings.timeSensitiveSetting == UNNotificationSettingEnabled) {
+      timeSensitive = @1;
+    }
+  }
+
   NSNumber *showPreviews = @-1;
   if (@available(iOS 11.0, *)) {
     if (settings.showPreviewsSetting == UNShowPreviewsSettingNever) {
@@ -736,6 +746,8 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
       [FLTFirebaseMessagingPlugin NSNumberForUNNotificationSetting:settings.lockScreenSetting];
   settingsDictionary[@"notificationCenter"] = [FLTFirebaseMessagingPlugin
       NSNumberForUNNotificationSetting:settings.notificationCenterSetting];
+  settingsDictionary[@"timeSensitive"] = timeSensitive;
+
   return settingsDictionary;
 }
 

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/notification_settings.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/notification_settings.dart
@@ -17,6 +17,7 @@ class NotificationSettings {
       required this.lockScreen,
       required this.notificationCenter,
       required this.showPreviews,
+      required this.timeSensitive,
       required this.sound});
 
   /// Whether or not messages containing a notification will alert the user.
@@ -32,6 +33,11 @@ class NotificationSettings {
 
   /// The overall notification authorization status for the user.
   final AuthorizationStatus authorizationStatus;
+
+  /// The setting that indicates the system treats the notification as time-sensitive.
+  ///
+  /// Apple devices only.
+  final AppleNotificationSetting timeSensitive;
 
   /// Whether or not messages containing a notification can update the application badge.
   ///

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/utils.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/utils.dart
@@ -132,6 +132,7 @@ NotificationSettings convertToNotificationSettings(Map<String, int> map) {
   return NotificationSettings(
     authorizationStatus:
         convertToAuthorizationStatus(map['authorizationStatus']),
+    timeSensitive: convertToAppleNotificationSetting(map['timeSensitive']),
     alert: convertToAppleNotificationSetting(map['alert']),
     announcement: convertToAppleNotificationSetting(map['announcement']),
     badge: convertToAppleNotificationSetting(map['badge']),
@@ -155,4 +156,5 @@ const NotificationSettings defaultNotificationSettings = NotificationSettings(
   notificationCenter: AppleNotificationSetting.notSupported,
   showPreviews: AppleShowPreviewSetting.notSupported,
   sound: AppleNotificationSetting.notSupported,
+  timeSensitive: AppleNotificationSetting.notSupported,
 );

--- a/packages/firebase_messaging/firebase_messaging_web/lib/src/utils.dart
+++ b/packages/firebase_messaging/firebase_messaging_web/lib/src/utils.dart
@@ -36,6 +36,7 @@ NotificationSettings getNotificationSettings(String? status) {
     notificationCenter: AppleNotificationSetting.notSupported,
     showPreviews: AppleShowPreviewSetting.notSupported,
     sound: AppleNotificationSetting.notSupported,
+    timeSensitive: AppleNotificationSetting.notSupported,
   );
 }
 

--- a/packages/firebase_messaging/firebase_messaging_web/test/firebase_messaging_web_test.dart
+++ b/packages/firebase_messaging/firebase_messaging_web/test/firebase_messaging_web_test.dart
@@ -35,6 +35,7 @@ void main() {
       expect(notification.badge, AppleNotificationSetting.notSupported);
       expect(notification.carPlay, AppleNotificationSetting.notSupported);
       expect(notification.lockScreen, AppleNotificationSetting.notSupported);
+      expect(notification.timeSensitive, AppleNotificationSetting.notSupported);
       expect(
         notification.notificationCenter,
         AppleNotificationSetting.notSupported,


### PR DESCRIPTION
## Description

See title.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/8112

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
