### PR TITLE
fix: 'Flutter.initializeApp' error on Android

### DIFF
--- a/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseCorePlugin.java
+++ b/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseCorePlugin.java
@@ -135,14 +135,14 @@ public class FlutterFirebaseCorePlugin implements FlutterPlugin, MethodChannel.M
           } else {
             options =
               new FirebaseOptions.Builder()
-                .setApiKey(Objects.requireNonNull(optionsMap.get(KEY_API_KEY)))
-                .setApplicationId(Objects.requireNonNull(optionsMap.get(KEY_APP_ID)))
-                .setDatabaseUrl(optionsMap.get(KEY_DATABASE_URL))
-                .setGcmSenderId(optionsMap.get(KEY_MESSAGING_SENDER_ID))
-                .setProjectId(optionsMap.get(KEY_PROJECT_ID))
-                .setStorageBucket(optionsMap.get(KEY_STORAGE_BUCKET))
-                .setGaTrackingId(optionsMap.get(KEY_TRACKING_ID))
-                .build();
+                  .setApiKey(Objects.requireNonNull(optionsMap.get(KEY_API_KEY)))
+                  .setApplicationId(Objects.requireNonNull(optionsMap.get(KEY_APP_ID)))
+                  .setDatabaseUrl(optionsMap.get(KEY_DATABASE_URL))
+                  .setGcmSenderId(optionsMap.get(KEY_MESSAGING_SENDER_ID))
+                  .setProjectId(optionsMap.get(KEY_PROJECT_ID))
+                  .setStorageBucket(optionsMap.get(KEY_STORAGE_BUCKET))
+                  .setGaTrackingId(optionsMap.get(KEY_TRACKING_ID))
+                  .build();
           }
           // TODO(Salakar) hacky workaround a bug with FirebaseInAppMessaging causing the error:
           //    Can't create handler inside thread Thread[pool-3-thread-1,5,main] that has not called Looper.prepare()

--- a/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseCorePlugin.java
+++ b/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseCorePlugin.java
@@ -134,19 +134,21 @@ public class FlutterFirebaseCorePlugin implements FlutterPlugin, MethodChannel.M
             options = FirebaseOptions.fromResource(applicationContext);
           } else {
             options =
-              new FirebaseOptions.Builder()
-                .setApiKey(Objects.requireNonNull(optionsMap.get(KEY_API_KEY)))
-                .setApplicationId(Objects.requireNonNull(optionsMap.get(KEY_APP_ID)))
-                .setDatabaseUrl(optionsMap.get(KEY_DATABASE_URL))
-                .setGcmSenderId(optionsMap.get(KEY_MESSAGING_SENDER_ID))
-                .setProjectId(optionsMap.get(KEY_PROJECT_ID))
-                .setStorageBucket(optionsMap.get(KEY_STORAGE_BUCKET))
-                .setGaTrackingId(optionsMap.get(KEY_TRACKING_ID))
-                .build();
+                new FirebaseOptions.Builder()
+                    .setApiKey(Objects.requireNonNull(optionsMap.get(KEY_API_KEY)))
+                    .setApplicationId(Objects.requireNonNull(optionsMap.get(KEY_APP_ID)))
+                    .setDatabaseUrl(optionsMap.get(KEY_DATABASE_URL))
+                    .setGcmSenderId(optionsMap.get(KEY_MESSAGING_SENDER_ID))
+                    .setProjectId(optionsMap.get(KEY_PROJECT_ID))
+                    .setStorageBucket(optionsMap.get(KEY_STORAGE_BUCKET))
+                    .setGaTrackingId(optionsMap.get(KEY_TRACKING_ID))
+                    .build();
           }
           // TODO(Salakar) hacky workaround a bug with FirebaseInAppMessaging causing the error:
-          //    Can't create handler inside thread Thread[pool-3-thread-1,5,main] that has not called Looper.prepare()
-          //     at com.google.firebase.inappmessaging.internal.ForegroundNotifier.<init>(ForegroundNotifier.java:61)
+          //    Can't create handler inside thread Thread[pool-3-thread-1,5,main] that has not
+          // called Looper.prepare()
+          //     at
+          // com.google.firebase.inappmessaging.internal.ForegroundNotifier.<init>(ForegroundNotifier.java:61)
           try {
             Looper.prepare();
           } catch (Exception e) {

--- a/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseCorePlugin.java
+++ b/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseCorePlugin.java
@@ -126,19 +126,24 @@ public class FlutterFirebaseCorePlugin implements FlutterPlugin, MethodChannel.M
           String name = (String) Objects.requireNonNull(arguments.get(KEY_APP_NAME));
 
           @SuppressWarnings("unchecked")
-          Map<String, String> optionsMap =
-              (Map<String, String>) Objects.requireNonNull(arguments.get(KEY_OPTIONS));
+          Map<String, String> optionsMap = (Map<String, String>) arguments.get(KEY_OPTIONS);
 
-          FirebaseOptions options =
+          FirebaseOptions options;
+
+          if (optionsMap == null) {
+            options = FirebaseOptions.fromResource(applicationContext);
+          } else {
+            options =
               new FirebaseOptions.Builder()
-                  .setApiKey(Objects.requireNonNull(optionsMap.get(KEY_API_KEY)))
-                  .setApplicationId(Objects.requireNonNull(optionsMap.get(KEY_APP_ID)))
-                  .setDatabaseUrl(optionsMap.get(KEY_DATABASE_URL))
-                  .setGcmSenderId(optionsMap.get(KEY_MESSAGING_SENDER_ID))
-                  .setProjectId(optionsMap.get(KEY_PROJECT_ID))
-                  .setStorageBucket(optionsMap.get(KEY_STORAGE_BUCKET))
-                  .setGaTrackingId(optionsMap.get(KEY_TRACKING_ID))
-                  .build();
+                .setApiKey(Objects.requireNonNull(optionsMap.get(KEY_API_KEY)))
+                .setApplicationId(Objects.requireNonNull(optionsMap.get(KEY_APP_ID)))
+                .setDatabaseUrl(optionsMap.get(KEY_DATABASE_URL))
+                .setGcmSenderId(optionsMap.get(KEY_MESSAGING_SENDER_ID))
+                .setProjectId(optionsMap.get(KEY_PROJECT_ID))
+                .setStorageBucket(optionsMap.get(KEY_STORAGE_BUCKET))
+                .setGaTrackingId(optionsMap.get(KEY_TRACKING_ID))
+                .build();
+          }
           // TODO(Salakar) hacky workaround a bug with FirebaseInAppMessaging causing the error:
           //    Can't create handler inside thread Thread[pool-3-thread-1,5,main] that has not called Looper.prepare()
           //     at com.google.firebase.inappmessaging.internal.ForegroundNotifier.<init>(ForegroundNotifier.java:61)

--- a/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseCorePlugin.java
+++ b/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseCorePlugin.java
@@ -134,21 +134,19 @@ public class FlutterFirebaseCorePlugin implements FlutterPlugin, MethodChannel.M
             options = FirebaseOptions.fromResource(applicationContext);
           } else {
             options =
-                new FirebaseOptions.Builder()
-                    .setApiKey(Objects.requireNonNull(optionsMap.get(KEY_API_KEY)))
-                    .setApplicationId(Objects.requireNonNull(optionsMap.get(KEY_APP_ID)))
-                    .setDatabaseUrl(optionsMap.get(KEY_DATABASE_URL))
-                    .setGcmSenderId(optionsMap.get(KEY_MESSAGING_SENDER_ID))
-                    .setProjectId(optionsMap.get(KEY_PROJECT_ID))
-                    .setStorageBucket(optionsMap.get(KEY_STORAGE_BUCKET))
-                    .setGaTrackingId(optionsMap.get(KEY_TRACKING_ID))
-                    .build();
+              new FirebaseOptions.Builder()
+                .setApiKey(Objects.requireNonNull(optionsMap.get(KEY_API_KEY)))
+                .setApplicationId(Objects.requireNonNull(optionsMap.get(KEY_APP_ID)))
+                .setDatabaseUrl(optionsMap.get(KEY_DATABASE_URL))
+                .setGcmSenderId(optionsMap.get(KEY_MESSAGING_SENDER_ID))
+                .setProjectId(optionsMap.get(KEY_PROJECT_ID))
+                .setStorageBucket(optionsMap.get(KEY_STORAGE_BUCKET))
+                .setGaTrackingId(optionsMap.get(KEY_TRACKING_ID))
+                .build();
           }
           // TODO(Salakar) hacky workaround a bug with FirebaseInAppMessaging causing the error:
-          //    Can't create handler inside thread Thread[pool-3-thread-1,5,main] that has not
-          // called Looper.prepare()
-          //     at
-          // com.google.firebase.inappmessaging.internal.ForegroundNotifier.<init>(ForegroundNotifier.java:61)
+          //    Can't create handler inside thread Thread[pool-3-thread-1,5,main] that has not called Looper.prepare()
+          //     at com.google.firebase.inappmessaging.internal.ForegroundNotifier.<init>(ForegroundNotifier.java:61)
           try {
             Looper.prepare();
           } catch (Exception e) {

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase.dart
@@ -80,14 +80,14 @@ class MethodChannelFirebase extends FirebasePlatform {
       MethodChannelFirebaseApp? defaultApp =
           appInstances[defaultFirebaseAppName];
 
-      // If options are present & no default app has been setup, the user is
+      // If no default app has been setup, the user is
       // trying to initialize default from dart
-      if (defaultApp == null && options != null) {
+      if (defaultApp == null) {
         _initializeFirebaseAppFromMap((await channel.invokeMapMethod(
           'Firebase#initializeApp',
           <String, dynamic>{
             'appName': defaultFirebaseAppName,
-            'options': options.asMap
+            'options': options?.asMap
           },
         ))!);
         defaultApp = appInstances[defaultFirebaseAppName];


### PR DESCRIPTION
## Description

Error:
```
E/flutter ( 6109): [ERROR:flutter/runtime/dart_vm_initializer.cc(39)] Unhandled Exception: [core/not-initialized] Firebase has not been correctly initialized.
E/flutter ( 6109): 
E/flutter ( 6109): Usually this means you've attempted to use a Firebase service before calling `Firebase.initializeApp`.
E/flutter ( 6109): 
E/flutter ( 6109): View the documentation for more information: https://firebase.flutter.dev/docs/overview#initialization
E/flutter ( 6109):     
E/flutter ( 6109): #0      MethodChannelFirebase.initializeApp (package:*******.flutter_plugins.firebase_core.interface/src/method_channel/method_channel_firebase.dart:99:9)
E/flutter ( 6109): <asynchronous suspension>
E/flutter ( 6109): #1      Firebase.initializeApp (package:firebase_core/src/firebase.dart:40:31)
E/flutter ( 6109): <asynchronous suspension>
```

Bug explanation:
Default `FirebaseApp` is not created, if `FirebaseOptions` instance` is not passed directly to `Firebase.initializeApp` function.

Fix explanation:
- modify `MethodChannelFirebase` to create default app also if options are null
- modify `[FlutterFirebaseCorePlugin.java` to check whether `options` are null. If yes - retrieve firebase options from resource:
```
options = FirebaseOptions.fromResource(applicationContext);
```

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

