### PR TITLE
fix(ui): set the default variant of LoadingButton to outlined (#8443)

### DIFF
--- a/packages/flutterfire_ui/lib/src/auth/widgets/internal/loading_button.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/internal/loading_button.dart
@@ -44,7 +44,7 @@ class LoadingButton extends StatelessWidget {
     this.isLoading = false,
     this.icon,
     this.color,
-    this.variant = ButtonVariant.text,
+    this.variant = ButtonVariant.outlined,
   }) : super(key: key);
 
   @override

--- a/packages/flutterfire_ui/pubspec.yaml
+++ b/packages/flutterfire_ui/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   twitter_login: ^4.2.2
 
 dev_dependencies:
+  firebase_auth_mocks: ^0.8.4
   flutter_test:
     sdk: flutter
 

--- a/packages/flutterfire_ui/test/auth/widgets/email_form_test.dart
+++ b/packages/flutterfire_ui/test/auth/widgets/email_form_test.dart
@@ -24,7 +24,9 @@ void main() {
       await tester.pumpWidget(widget);
       expect(
         find.descendant(
-          of: find.byWidgetPredicate((widget) => widget is LoadingButton && widget.variant == ButtonVariant.outlined),
+          of: find.byWidgetPredicate((widget) =>
+              widget is LoadingButton &&
+              widget.variant == ButtonVariant.outlined),
           matching: find.text('Sign in'),
         ),
         findsOneWidget,
@@ -35,7 +37,9 @@ void main() {
       await tester.pumpWidget(widget);
       expect(
         find.descendant(
-          of: find.byWidgetPredicate((widget) => widget is UniversalButton && widget.variant == ButtonVariant.text),
+          of: find.byWidgetPredicate((widget) =>
+              widget is UniversalButton &&
+              widget.variant == ButtonVariant.text),
           matching: find.text('Forgot password?'),
         ),
         findsOneWidget,

--- a/packages/flutterfire_ui/test/auth/widgets/email_form_test.dart
+++ b/packages/flutterfire_ui/test/auth/widgets/email_form_test.dart
@@ -1,0 +1,45 @@
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterfire_ui/auth.dart';
+import 'package:flutterfire_ui/src/auth/widgets/internal/loading_button.dart';
+import 'package:flutterfire_ui/src/auth/widgets/internal/universal_button.dart';
+
+import '../../test_utils.dart';
+
+void main() {
+  group('EmailForm', () {
+    late Widget widget;
+
+    setUp(() {
+      widget = TestMaterialApp(
+        child: EmailForm(
+          auth: MockFirebaseAuth(),
+          action: AuthAction.signIn,
+        ),
+      );
+    });
+
+    testWidgets('Has a Sign in button of outlined variant', (tester) async {
+      await tester.pumpWidget(widget);
+      expect(
+        find.descendant(
+          of: find.byWidgetPredicate((widget) => widget is LoadingButton && widget.variant == ButtonVariant.outlined),
+          matching: find.text('Sign in'),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('Has a Forgot password button of text variant', (tester) async {
+      await tester.pumpWidget(widget);
+      expect(
+        find.descendant(
+          of: find.byWidgetPredicate((widget) => widget is UniversalButton && widget.variant == ButtonVariant.text),
+          matching: find.text('Forgot password?'),
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/packages/flutterfire_ui/test/auth/widgets/email_form_test.dart
+++ b/packages/flutterfire_ui/test/auth/widgets/email_form_test.dart
@@ -24,9 +24,11 @@ void main() {
       await tester.pumpWidget(widget);
       expect(
         find.descendant(
-          of: find.byWidgetPredicate((widget) =>
-              widget is LoadingButton &&
-              widget.variant == ButtonVariant.outlined),
+          of: find.byWidgetPredicate(
+            (widget) =>
+                widget is LoadingButton &&
+                widget.variant == ButtonVariant.outlined,
+          ),
           matching: find.text('Sign in'),
         ),
         findsOneWidget,
@@ -37,9 +39,11 @@ void main() {
       await tester.pumpWidget(widget);
       expect(
         find.descendant(
-          of: find.byWidgetPredicate((widget) =>
-              widget is UniversalButton &&
-              widget.variant == ButtonVariant.text),
+          of: find.byWidgetPredicate(
+            (widget) =>
+                widget is UniversalButton &&
+                widget.variant == ButtonVariant.text,
+          ),
           matching: find.text('Forgot password?'),
         ),
         findsOneWidget,

--- a/packages/flutterfire_ui/test/test_utils.dart
+++ b/packages/flutterfire_ui/test/test_utils.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class TestMaterialApp extends StatelessWidget {
+  final Widget child;
+
+  const TestMaterialApp({Key? key, required this.child}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: child,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Description

The PR provides a fix for #8443, by setting the default buttonVariant of the LoadingButton to Outlined. This results in the UI-s using a LoadingButton to behave like they did before #8333 was merged. Before the #8333 was merged, the LoadingButton used to be an OutlinedButton, but in the current implementation it defaults to being a TextButton, which can not be overridden from composite UI elements using a LoadingButton (e.g. EmailForm or SignInScreen). This is poses a problem on these UI elements, because it makes it impossible to style the UI elements seperatly. (In the case of the EmailForm, the Sign in button and the Forgotton password button can only be styled together - Using TextButtonTheme).

## Related Issues

Resolves #8443 
Resolves #8480 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.