### PR TITLE
docs: Clarify steps when adding FCM to existing apps

### DIFF
--- a/docs/messaging/apple-integration.mdx
+++ b/docs/messaging/apple-integration.mdx
@@ -124,6 +124,8 @@ Upload the downloaded file and enter the Key & Team IDs;
 For messaging to work when your app is built for production, you must create a new App Identifier which is linked to the
 application that you're developing.
 
+Note that if you're adding push notifications to an existing app that already has a registered App Identifier you don't need to create a new one. Just make sure the "Push Notifications" capability is checked. Once you've done that you can skip to [Step 3](#3-generating-a-provisioning-profile).
+
 On the Apple Developer portal:
 
 1. Click the "Identifiers" side menu item.
@@ -160,6 +162,9 @@ Save the identifier, it'll be used when creating a provisioning profile in the n
 A provisioning profile enables signed communicate between Apple and your application. Since messaging can only be used on
 real devices, a signed certificate ensures that the app being installed on a device is genuine and has the correct
 permissions enabled.
+
+Note that if you're adding push notifications to an existing app you may have already set up a provisioning profile. In which
+case you can skip this step.
 
 On the "Profiles" menu item, register a new Profile. Select the "iOS App Development" (or macOS) checkbox and click "Continue".
 


### PR DESCRIPTION
Steps 2 and 3 are currently confusing if you're adding FCM an existing,
already published application. Add a few notes about where things can
be skipped if you already have an App ID and provisioning profile.

Fixes #8557

## Description

Just clarifying the docs. It's a simple issue but I spun my wheels on it for a while...

## Related Issues

#8557

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [NA] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [NA] All existing and new tests are passing.
  - I actually couldn't get `melos bootstrap` to run without crashing my network connection :thinking:
- [X] I updated/added relevant documentation (doc comments with `///`).
- [NA] The analyzer (`melos run analyze`) does not report any problems on my PR.
  - It's failing pretty hard (lots of issues) but I suspect that's due to the fact that I couldn't get `melos bootstrap` to work. I think this is okay for this change.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
