### PR TITLE
fix: update firebase_auth example to not be dependent on an emulator

### DIFF
--- a/packages/firebase_auth/firebase_auth/example/lib/main.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/main.dart
@@ -7,6 +7,10 @@ import 'package:firebase_core/firebase_core.dart';
 import 'auth.dart';
 import 'profile.dart';
 
+/// Requires that a Firebase local emulator is running locally.
+/// See https://firebase.flutter.dev/docs/auth/start/#optional-prototype-and-test-with-firebase-local-emulator-suite
+bool shouldUseFirebaseEmulator = false;
+
 // Requires that the Firebase Auth emulator is running locally
 // e.g via `melos run firebase:emulator`.
 Future<void> main() async {
@@ -31,8 +35,9 @@ Future<void> main() async {
     );
   }
 
-  // Uncomment the line below if you are running the example from a emulator, otherwise this line will cause a connection error
-  //await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
+  if (shouldUseFirebaseEmulator) {
+    await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
+  }
 
   runApp(const AuthExampleApp());
 }

--- a/packages/firebase_auth/firebase_auth/example/lib/main.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/main.dart
@@ -31,7 +31,8 @@ Future<void> main() async {
     );
   }
 
-  await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
+  /* Uncomment the line below if you are running the example from a emulator, otherwise this line will cause a connection error */
+  // await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
 
   runApp(const AuthExampleApp());
 }

--- a/packages/firebase_auth/firebase_auth/example/lib/main.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/main.dart
@@ -31,8 +31,8 @@ Future<void> main() async {
     );
   }
 
-  /* Uncomment the line below if you are running the example from a emulator, otherwise this line will cause a connection error */
-  // await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
+  // Uncomment the line below if you are running the example from a emulator, otherwise this line will cause a connection error
+  //await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
 
   runApp(const AuthExampleApp());
 }


### PR DESCRIPTION
## Description

The main `flutterfire_auth example`, when compiled either on a device or through web will throw a connection error without this line commented out:

```
A network error (such as timeout, interrupted connection or unreachable host) has occurred.
```

removing the emulator setting, removes this error, helping people out there that are trying out this example.

## Related Issues

(https://github.com/firebase/firebase-ios-sdk/issues/7864)](https://github.com/firebase/firebase-ios-sdk/issues/7864)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
