### PR TITLE
fix(firebase_dynamic_links): `getInitialLink()` returns `null` on 2nd call.

### DIFF
--- a/packages/firebase_dynamic_links/firebase_dynamic_links/ios/Classes/FLTFirebaseDynamicLinksPlugin.m
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/ios/Classes/FLTFirebaseDynamicLinksPlugin.m
@@ -89,6 +89,7 @@ static NSDictionary *getDictionaryFromNSError(NSError *error) {
     [[FLTFirebasePluginRegistry sharedInstance] registerFirebasePlugin:self];
     _binaryMessenger = messenger;
     _channel = channel;
+    _initiated = NO;
   }
   return self;
 }
@@ -222,13 +223,18 @@ static NSDictionary *getDictionaryFromNSError(NSError *error) {
 }
 
 - (void)getInitialLink:(FLTFirebaseMethodCallResult *)result {
-  _initiated = YES;
+  if (_initiated == YES) {
+    result.success(nil);
+    return;
+  }
+
   NSMutableDictionary *dict = getDictionaryFromDynamicLink(_initialLink);
   if (dict == nil && self.initialError != nil) {
     result.error(nil, nil, nil, self.initialError);
   } else {
     result.success(dict);
   }
+  _initiated = YES;
 }
 
 - (void)getDynamicLink:(id)arguments withMethodCallResult:(FLTFirebaseMethodCallResult *)result {
@@ -334,7 +340,7 @@ static NSDictionary *getDictionaryFromNSError(NSError *error) {
     }
   }
 
-  if (_initialLink == nil && dynamicLink.url != nil) {
+  if (_initialLink == nil && _initiated == NO && dynamicLink.url != nil) {
     _initialLink = dynamicLink;
   }
 


### PR DESCRIPTION
## Description

See title

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/8556

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
