### PR TITLE
fix: flutterfire_ui README links

### DIFF
--- a/packages/flutterfire_ui/README.md
+++ b/packages/flutterfire_ui/README.md
@@ -55,7 +55,7 @@ class MyApp extends StatelessWidget {
 }
 ```
 
-Learn more in the [Integrating your first screen section](docs/auth/integrating-your-first-screen.md) of the documentation
+Learn more in the [Integrating your first screen section](doc/auth/integrating-your-first-screen.md) of the documentation
 
 ## Roadmap / Features
 

--- a/packages/flutterfire_ui/README.md
+++ b/packages/flutterfire_ui/README.md
@@ -6,7 +6,6 @@ FlutterFire UI is a set of Flutter widgets and utilities designed to help you bu
 
 > FlutterFire UI is still in beta and is subject to change. Please contribute to the [discussion](https://github.com/FirebaseExtended/flutterfire/discussions/6978) with feedback.
 
-
 ## Installation
 
 ```sh
@@ -72,6 +71,6 @@ Please contribute to the [discussion](https://github.com/FirebaseExtended/flutte
 
 Once installed, you can read the following documentation to learn more about the FlutterFire UI widgets and utilities:
 
-- [Authentication](docs/auth.md)
-- [Firestore](docs/firestore.md)
-- [Realtime Database](docs/database.md)
+- [Authentication](doc/auth.md)
+- [Firestore](doc/firestore.md)
+- [Realtime Database](doc/database.md)


### PR DESCRIPTION
## Description

The flutterfire_ui README file had some links broken, as they were pointing to a 'docs' folder instead of 'doc'. This PR intends to fix it. 

## Related Issues

#8628

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [*] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [NA] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [NA] All existing and new tests are passing.
- [NA] I updated/added relevant documentation (doc comments with `///`).
- [NA] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [*] I read and followed the [Flutter Style Guide].
- [*] I signed the [CLA].
- [*] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [*] No, this is *not* a breaking change.
