### PR TITLE
refactor(firebase_dynamic_links_platform_interface): fix analyzer issue introduced in Flutter 3.0.0

### DIFF
--- a/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface/test/mock.dart
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface/test/mock.dart
@@ -75,7 +75,7 @@ Future<void> injectEventChannelResponse(
   String channelName,
   Map<String, dynamic> event,
 ) async {
-  await ServicesBinding.instance!.defaultBinaryMessenger.handlePlatformMessage(
+  await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
     channelName,
     MethodChannelFirebaseDynamicLinks.channel.codec
         .encodeSuccessEnvelope(event),


### PR DESCRIPTION
## Description
Flutter 3.0.0 caused failing the CI: https://github.com/firebase/flutterfire/runs/6398175458?check_suite_focus=true

```
Nils-MBP-13-M1-3:firebase_dynamic_links_platform_interface nils$ flutter analyze
Running "flutter pub get" in firebase_dynamic_links_platform_interface...      1,220ms
Analyzing firebase_dynamic_links_platform_interface...                  

warning • The '!' will have no effect because the receiver can't be null • test/mock.dart:78:33 • unnecessary_non_null_assertion

1 issue found. (ran in 2.5s)
```

## Related Issues
Closes #8646
Part of #8644 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
