### PR TITLE
Fix link to docs.

### DIFF
--- a/packages/flutterfire_ui/README.md
+++ b/packages/flutterfire_ui/README.md
@@ -72,6 +72,6 @@ Please contribute to the [discussion](https://github.com/FirebaseExtended/flutte
 
 Once installed, you can read the following documentation to learn more about the FlutterFire UI widgets and utilities:
 
-- [Authentication](docs/auth.md)
-- [Firestore](docs/firestore.md)
-- [Realtime Database](docs/database.md)
+- [Authentication](doc/auth.md)
+- [Firestore](doc/firestore.md)
+- [Realtime Database](doc/database.md)


### PR DESCRIPTION
## Description

flutterfire_ui/README.md had broken links to docs in flutterfire_ui/doc/.   
Simple fix.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.
