### PR TITLE
chore: use `firebase.google.com` url in docs issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---documentation-feedback.md
+++ b/.github/ISSUE_TEMPLATE/---documentation-feedback.md
@@ -1,6 +1,6 @@
 ---
 name: "\U0001F4DA Documentation Feedback"
-about: Report an issue with the firebase.flutter.dev documentation or suggest an improvement.
+about: Report an issue with the firebase.google.com/docs/flutter documentation or suggest an improvement.
 title: "[\U0001F4DA] Your documentation feedback title (CHANGE ME)"
 labels: 'good first issue, type: documentation'
 assignees: ''


### PR DESCRIPTION
## Description
The documentation is now located under `firebase.google.com/docs/flutter`. Therefore, we should update in the issue template.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
