### PR TITLE
feat: Assert that collection.doc(id) does not point to a separate collection

### DIFF
--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/movie.g.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/movie.g.dart
@@ -71,6 +71,10 @@ class _$MovieCollectionReference extends _$MovieQuery
 
   @override
   MovieDocumentReference doc([String? id]) {
+    assert(
+      id == null || id.split('/').length == 1,
+      'The document ID cannot be from a different collection',
+    );
     return MovieDocumentReference(
       reference.doc(id),
     );
@@ -1058,6 +1062,10 @@ class _$CommentCollectionReference extends _$CommentQuery
 
   @override
   CommentDocumentReference doc([String? id]) {
+    assert(
+      id == null || id.split('/').length == 1,
+      'The document ID cannot be from a different collection',
+    );
     return CommentDocumentReference(
       reference.doc(id),
     );

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
@@ -73,6 +73,10 @@ class _$SplitFileModelCollectionReference extends _$SplitFileModelQuery
 
   @override
   SplitFileModelDocumentReference doc([String? id]) {
+    assert(
+      id == null || id.split('/').length == 1,
+      'The document ID cannot be from a different collection',
+    );
     return SplitFileModelDocumentReference(
       reference.doc(id),
     );
@@ -368,6 +372,10 @@ class _$EmptyModelCollectionReference extends _$EmptyModelQuery
 
   @override
   EmptyModelDocumentReference doc([String? id]) {
+    assert(
+      id == null || id.split('/').length == 1,
+      'The document ID cannot be from a different collection',
+    );
     return EmptyModelDocumentReference(
       reference.doc(id),
     );
@@ -659,6 +667,10 @@ class _$OptionalJsonCollectionReference extends _$OptionalJsonQuery
 
   @override
   OptionalJsonDocumentReference doc([String? id]) {
+    assert(
+      id == null || id.split('/').length == 1,
+      'The document ID cannot be from a different collection',
+    );
     return OptionalJsonDocumentReference(
       reference.doc(id),
     );
@@ -1061,6 +1073,10 @@ class _$MixedJsonCollectionReference extends _$MixedJsonQuery
 
   @override
   MixedJsonDocumentReference doc([String? id]) {
+    assert(
+      id == null || id.split('/').length == 1,
+      'The document ID cannot be from a different collection',
+    );
     return MixedJsonDocumentReference(
       reference.doc(id),
     );
@@ -1458,6 +1474,10 @@ class _$RootCollectionReference extends _$RootQuery
 
   @override
   RootDocumentReference doc([String? id]) {
+    assert(
+      id == null || id.split('/').length == 1,
+      'The document ID cannot be from a different collection',
+    );
     return RootDocumentReference(
       reference.doc(id),
     );
@@ -1986,6 +2006,10 @@ class _$SubCollectionReference extends _$SubQuery
 
   @override
   SubDocumentReference doc([String? id]) {
+    assert(
+      id == null || id.split('/').length == 1,
+      'The document ID cannot be from a different collection',
+    );
     return SubDocumentReference(
       reference.doc(id),
     );
@@ -2497,6 +2521,10 @@ class _$AsCamelCaseCollectionReference extends _$AsCamelCaseQuery
 
   @override
   AsCamelCaseDocumentReference doc([String? id]) {
+    assert(
+      id == null || id.split('/').length == 1,
+      'The document ID cannot be from a different collection',
+    );
     return AsCamelCaseDocumentReference(
       reference.doc(id),
     );
@@ -2917,6 +2945,10 @@ class _$CustomSubNameCollectionReference extends _$CustomSubNameQuery
 
   @override
   CustomSubNameDocumentReference doc([String? id]) {
+    assert(
+      id == null || id.split('/').length == 1,
+      'The document ID cannot be from a different collection',
+    );
     return CustomSubNameDocumentReference(
       reference.doc(id),
     );
@@ -3329,6 +3361,10 @@ class _$ExplicitPathCollectionReference extends _$ExplicitPathQuery
 
   @override
   ExplicitPathDocumentReference doc([String? id]) {
+    assert(
+      id == null || id.split('/').length == 1,
+      'The document ID cannot be from a different collection',
+    );
     return ExplicitPathDocumentReference(
       reference.doc(id),
     );
@@ -3749,6 +3785,10 @@ class _$ExplicitSubPathCollectionReference extends _$ExplicitSubPathQuery
 
   @override
   ExplicitSubPathDocumentReference doc([String? id]) {
+    assert(
+      id == null || id.split('/').length == 1,
+      'The document ID cannot be from a different collection',
+    );
     return ExplicitSubPathDocumentReference(
       reference.doc(id),
     );

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/test/collection_test.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/test/collection_test.dart
@@ -1,5 +1,4 @@
 import 'package:cloud_firestore_odm_generator_integration_test/simple.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'setup_firestore_mock.dart';
@@ -9,7 +8,6 @@ void main() {
 
   group('orderBy', () {
     testWidgets('applies `descending`', (tester) async {
-      await Firebase.initializeApp();
       expect(
         rootRef.orderByNullable(descending: true),
         rootRef.orderByNullable(descending: true),
@@ -21,6 +19,22 @@ void main() {
       expect(
         rootRef.orderByNullable(),
         rootRef.orderByNullable(),
+      );
+    });
+  });
+
+  group('doc', () {
+    test('asserts that the path does not point to a separate collection',
+        () async {
+      rootRef.doc('42');
+
+      expect(
+        () => rootRef.doc('42/123'),
+        throwsAssertionError,
+      );
+      expect(
+        () => rootRef.doc('42/123/456'),
+        throwsAssertionError,
       );
     });
   });

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/test/setup_firestore_mock.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/test/setup_firestore_mock.dart
@@ -1,9 +1,10 @@
 // ignore_for_file: avoid_dynamic_calls
 
+import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-void setupCloudFirestoreMocks() {
+Future<void> setupCloudFirestoreMocks() async {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   MethodChannelFirebase.channel.setMockMethodCallHandler((call) async {
@@ -32,4 +33,6 @@ void setupCloudFirestoreMocks() {
 
     return null;
   });
+
+  await Firebase.initializeApp();
 }

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/collection_reference.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/collection_reference.dart
@@ -53,6 +53,10 @@ ${_parentProperty(data)}
 
   @override
   ${data.documentReferenceName} doc([String? id]) {
+    assert(
+      id == null || id.split('/').length == 1,
+      'The document ID cannot be from a different collection',
+    );
     return ${data.documentReferenceName}(
       reference.doc(id),
     );


### PR DESCRIPTION
## Description

This prevents from writing `moviesRef.doc('foo/bar/baz')` as that is not something that makes sense in the ODM.
The document reference returned will be typed as if it's a movie, when it most definitely is something different.

Users should instead use nested collections:

```dart
@Collection<Movie>('movies')
@Collection<Comments>('movies/*/bar')
final moviesRef = MovieCollectionReference();


void main() {
  moviesRef.doc('123').comments.doc('baz');
}
```

## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
