### PR TITLE
fix(ui): fixed profile email modal overflow occurring on smaller devices

### DIFF
--- a/packages/flutterfire_ui/lib/src/auth/widgets/email_sign_up_dialog.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/email_sign_up_dialog.dart
@@ -21,33 +21,37 @@ class EmailSignUpDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final l = FlutterFireUILocalizations.labelsOf(context);
 
-    return Center(
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 500),
-        child: Dialog(
-          child: AuthStateListener<EmailFlowController>(
-            listener: (oldState, newState, ctrl) {
-              if (newState is CredentialLinked) {
-                Navigator.of(context).pop();
-              }
+    return SingleChildScrollView(
+      child: Center(
+        child: SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 500),
+            child: Dialog(
+              child: AuthStateListener<EmailFlowController>(
+                listener: (oldState, newState, ctrl) {
+                  if (newState is CredentialLinked) {
+                    Navigator.of(context).pop();
+                  }
 
-              return null;
-            },
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const SizedBox(height: 16),
-                  Title(text: l.provideEmail),
-                  const SizedBox(height: 32),
-                  EmailForm(
-                    auth: auth,
-                    action: action,
-                    config: config,
+                  return null;
+                },
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const SizedBox(height: 16),
+                      Title(text: l.provideEmail),
+                      const SizedBox(height: 32),
+                      EmailForm(
+                        auth: auth,
+                        action: action,
+                        config: config,
+                      ),
+                    ],
                   ),
-                ],
+                ),
               ),
             ),
           ),

--- a/packages/flutterfire_ui/lib/src/auth/widgets/email_sign_up_dialog.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/email_sign_up_dialog.dart
@@ -21,36 +21,34 @@ class EmailSignUpDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final l = FlutterFireUILocalizations.labelsOf(context);
 
-    return SingleChildScrollView(
-      child: Center(
-        child: SingleChildScrollView(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 500),
-            child: Dialog(
-              child: AuthStateListener<EmailFlowController>(
-                listener: (oldState, newState, ctrl) {
-                  if (newState is CredentialLinked) {
-                    Navigator.of(context).pop();
-                  }
+    return Center(
+      child: SingleChildScrollView(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 500),
+          child: Dialog(
+            child: AuthStateListener<EmailFlowController>(
+              listener: (oldState, newState, ctrl) {
+                if (newState is CredentialLinked) {
+                  Navigator.of(context).pop();
+                }
 
-                  return null;
-                },
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      const SizedBox(height: 16),
-                      Title(text: l.provideEmail),
-                      const SizedBox(height: 32),
-                      EmailForm(
-                        auth: auth,
-                        action: action,
-                        config: config,
-                      ),
-                    ],
-                  ),
+                return null;
+              },
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const SizedBox(height: 16),
+                    Title(text: l.provideEmail),
+                    const SizedBox(height: 32),
+                    EmailForm(
+                      auth: auth,
+                      action: action,
+                      config: config,
+                    ),
+                  ],
                 ),
               ),
             ),


### PR DESCRIPTION
## Description

On smaller devices the profile email linking modal would overflow. Adding a singleChildScrollView allows the user to scroll to be able to see the full modal and doesn't overflow.

I am willing to work more in order to fix the null safe checking which is currently failing the melos analyze, but that is out of scope for this PR. 

I haven't really messed with flutter testing, but would be willing to add testing on this feature if it's required.

## Related Issues
resolves #8682 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
