### PR TITLE
docs(firestore_odm): fix Firestore ODM readme broken link.

### DIFF
--- a/packages/cloud_firestore_odm/README.md
+++ b/packages/cloud_firestore_odm/README.md
@@ -76,7 +76,7 @@ flutter pub add --dev json_serializable
 
 ## Next Steps
 
-Once installed, read the documentation on [defining models](./docs/defining-models.md).
+Once installed, read the documentation on [defining models](./doc/defining-models.md).
 
 ## Issues and feedback
 


### PR DESCRIPTION
Fix path do doc `doc/defining-models.md` which is located on `/doc` instead of `./docs`.

## Description

Fix path do doc `doc/defining-models.md` which is located on `/doc` instead of `./docs`.

## Related Issues

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [N/A] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [N/A] All existing and new tests are passing.
- [N/A] I updated/added relevant documentation (doc comments with `///`).
- [N/A] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
