### PR TITLE
refactor(firebase_crashlytics): use `firebase.google.com` link for `homepage` in `pubspec.yaml`

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
 version: 2.8.0
-homepage: https://firebase.flutter.dev/docs/crashlytics/overview
+homepage: https://firebase.google.com/docs/crashlytics
 repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics/firebase_crashlytics
 
 false_secrets:


### PR DESCRIPTION
## Description
`firebase.flutter.dev` docs is archived. Therefore, we should link to the new docs.

## Related Issues
Part of #8612

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
