### PR TITLE
refactor(firebase_database): use `firebase.google.com` link for `homepage` in `pubspec.yaml`

### DIFF
--- a/packages/firebase_database/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/firebase_database/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_database
 description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
-homepage: https://firebase.flutter.dev/docs/database/overview
+homepage: https://firebase.google.com/docs/database
 repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_database/firebase_database
 version: 9.0.14
 


### PR DESCRIPTION
## Description
`firebase.flutter.dev` docs is archived. Therefore, we should link to the new docs.

## Related Issues
Part of #8612

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
