### PR TITLE
docs(firebase_core): fix link to new docs in the banner of the old docs

### DIFF
--- a/docs/core/usage.mdx
+++ b/docs/core/usage.mdx
@@ -9,7 +9,7 @@ This page is **archived** and might not reflect the latest version of the
 FlutterFire plugins. You can find the latest information on
 firebase.google.com:
 
-[https://firebase.google.com/docs/flutter/start](https://firebase.google.com/docs/flutter/start)
+[https://firebase.google.com/docs/flutter/setup](https://firebase.google.com/docs/flutter/setup)
 
 :::
 


### PR DESCRIPTION
## Description

https://user-images.githubusercontent.com/24459435/169665246-6c002e65-a3f0-4e3a-b106-35ed48726b82.mov

## Related Issues

Closes #8730

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
