### PR TITLE
refactor: use "firebase" instead of "FirebaseExtended" as organisation in all links for this repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature Request
-    url: https://github.com/FirebaseExtended/flutterfire/discussions/new?category=feature-request
+    url: https://github.com/firebase/flutterfire/discussions/new?category=feature-request
     about: Share ideas for new features.
   - name: Ask a Question
-    url: https://github.com/FirebaseExtended/flutterfire/discussions/new?category=q-a
+    url: https://github.com/firebase/flutterfire/discussions/new?category=q-a
     about: Ask the community for help.
   - name: Show and tell
-    url: https://github.com/FirebaseExtended/flutterfire/discussions/new?category=show-and-tell
+    url: https://github.com/firebase/flutterfire/discussions/new?category=show-and-tell
     about: Share what you've built with FlutterFire.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,7 +29,7 @@ Does your PR require plugin users to manually update their apps to accommodate y
 
 <!-- Links -->
 [issue database]: https://github.com/flutter/flutter/issues
-[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
+[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
 [Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
 [pub versioning philosophy]: https://dart.dev/tools/pub/versioning
 [CLA]: https://cla.developers.google.com/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,56 +102,56 @@ Packages with dependency updates only:
 
 #### `cloud_functions` - `v3.2.16`
 
- - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8746). ([53813627](https://github.com/FirebaseExtended/flutterfire/commit/53813627720e1e1ad729839519f7374ebc91470f))
+ - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8746). ([53813627](https://github.com/firebase/flutterfire/commit/53813627720e1e1ad729839519f7374ebc91470f))
 
 #### `firebase_app_check` - `v0.0.6+13`
 
- - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8747). ([e2a022d7](https://github.com/FirebaseExtended/flutterfire/commit/e2a022d7427817002e4114eb7434aa6e53384891))
+ - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8747). ([e2a022d7](https://github.com/firebase/flutterfire/commit/e2a022d7427817002e4114eb7434aa6e53384891))
 
 #### `firebase_auth` - `v3.3.19`
 
- - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8748). ([c6ff0b21](https://github.com/FirebaseExtended/flutterfire/commit/c6ff0b21352eb0f9a9a576ca7ef737d203292a58))
+ - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8748). ([c6ff0b21](https://github.com/firebase/flutterfire/commit/c6ff0b21352eb0f9a9a576ca7ef737d203292a58))
 
 #### `firebase_core` - `v1.17.1`
 
- - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8749). ([41462a42](https://github.com/FirebaseExtended/flutterfire/commit/41462a423ad783d20e5d303ed41898b061bccc48))
+ - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8749). ([41462a42](https://github.com/firebase/flutterfire/commit/41462a423ad783d20e5d303ed41898b061bccc48))
 
 #### `firebase_crashlytics` - `v2.8.1`
 
- - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8750). ([e9e1c1bf](https://github.com/FirebaseExtended/flutterfire/commit/e9e1c1bf19d32e5b8967da162b03d0254843a836))
+ - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8750). ([e9e1c1bf](https://github.com/firebase/flutterfire/commit/e9e1c1bf19d32e5b8967da162b03d0254843a836))
 
 #### `firebase_database` - `v9.0.15`
 
- - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8732). ([63aa1011](https://github.com/FirebaseExtended/flutterfire/commit/63aa10118e3fa541b276fed5828bd7db368c5ebd))
+ - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8732). ([63aa1011](https://github.com/firebase/flutterfire/commit/63aa10118e3fa541b276fed5828bd7db368c5ebd))
 
 #### `firebase_dynamic_links` - `v4.2.5`
 
- - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8733). ([a11bd602](https://github.com/FirebaseExtended/flutterfire/commit/a11bd6021a3e915bf36f0db295b45ee8a3f16517))
+ - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8733). ([a11bd602](https://github.com/firebase/flutterfire/commit/a11bd6021a3e915bf36f0db295b45ee8a3f16517))
 
 #### `firebase_in_app_messaging` - `v0.6.0+15`
 
- - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8734). ([9ce47865](https://github.com/FirebaseExtended/flutterfire/commit/9ce47865e4fcba0aaf1a4558ba7ede13abcde21d))
+ - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8734). ([9ce47865](https://github.com/firebase/flutterfire/commit/9ce47865e4fcba0aaf1a4558ba7ede13abcde21d))
 
 #### `firebase_messaging` - `v11.4.1`
 
- - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8735). ([b2cf87a5](https://github.com/FirebaseExtended/flutterfire/commit/b2cf87a5d96457bf49b9dd04d6087768bfe6ad95))
- - **FIX**: check `userInfo` for "aps.notification" property presence for firing data only messages. (#8759). ([9eb99674](https://github.com/FirebaseExtended/flutterfire/commit/9eb996748f4ddae8a34a2306b51af10b4c066039))
+ - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8735). ([b2cf87a5](https://github.com/firebase/flutterfire/commit/b2cf87a5d96457bf49b9dd04d6087768bfe6ad95))
+ - **FIX**: check `userInfo` for "aps.notification" property presence for firing data only messages. (#8759). ([9eb99674](https://github.com/firebase/flutterfire/commit/9eb996748f4ddae8a34a2306b51af10b4c066039))
 
 #### `firebase_ml_model_downloader` - `v0.1.0+14`
 
- - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8751). ([e1e42eb9](https://github.com/FirebaseExtended/flutterfire/commit/e1e42eb97772a86bf5e35d0f3be0376225a5f1d6))
+ - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8751). ([e1e42eb9](https://github.com/firebase/flutterfire/commit/e1e42eb97772a86bf5e35d0f3be0376225a5f1d6))
 
 #### `firebase_remote_config` - `v2.0.8`
 
- - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8738). ([f5ca08b2](https://github.com/FirebaseExtended/flutterfire/commit/f5ca08b2ca68e674f6c59c458ec26126c9e1b002))
+ - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8738). ([f5ca08b2](https://github.com/firebase/flutterfire/commit/f5ca08b2ca68e674f6c59c458ec26126c9e1b002))
 
 #### `firebase_storage` - `v10.2.17`
 
- - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8752). ([5c5dcaf1](https://github.com/FirebaseExtended/flutterfire/commit/5c5dcaf1909dacf293fec5e79461d43468a13279))
+ - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8752). ([5c5dcaf1](https://github.com/firebase/flutterfire/commit/5c5dcaf1909dacf293fec5e79461d43468a13279))
 
 #### `flutterfire_ui` - `v0.4.1+2`
 
- - **FIX**: correctly fix lint error from issue #8651 for dart `2.16` (#8713). ([666b1973](https://github.com/FirebaseExtended/flutterfire/commit/666b1973c68cd5e60ba254a889136c922fd73500))
+ - **FIX**: correctly fix lint error from issue #8651 for dart `2.16` (#8713). ([666b1973](https://github.com/firebase/flutterfire/commit/666b1973c68cd5e60ba254a889136c922fd73500))
 
 
 ## 2022-05-19
@@ -184,11 +184,11 @@ Packages with dependency updates only:
 
 #### `cloud_firestore` - `v3.1.16`
 
- - **REFACTOR**: remove deprecated `Tasks.call` for android and replace with `TaskCompletionSource`. (#8522). ([45e27201](https://github.com/FirebaseExtended/flutterfire/commit/45e27201480088fab71af60963001baeae61d80d))
+ - **REFACTOR**: remove deprecated `Tasks.call` for android and replace with `TaskCompletionSource`. (#8522). ([45e27201](https://github.com/firebase/flutterfire/commit/45e27201480088fab71af60963001baeae61d80d))
 
 #### `firebase_dynamic_links` - `v4.2.4`
 
- - **FIX**: `getInitialLink()` returns `null` on 2nd call. (#8621). ([a83ee58e](https://github.com/FirebaseExtended/flutterfire/commit/a83ee58e56879b88b2886a6e5f5be549ee403b23))
+ - **FIX**: `getInitialLink()` returns `null` on 2nd call. (#8621). ([a83ee58e](https://github.com/firebase/flutterfire/commit/a83ee58e56879b88b2886a6e5f5be549ee403b23))
 
 
 ## 2022-05-13
@@ -294,65 +294,65 @@ Packages with dependency updates only:
 
 #### `cloud_firestore_odm` - `v1.0.0-dev.15`
 
- - **FEAT**: Assert that collection.doc(id) does not point to a separate collection ([#8676](https://github.com/FirebaseExtended/flutterfire/issues/8676)). ([0808205b](https://github.com/FirebaseExtended/flutterfire/commit/0808205bdca03fc913015f00f5ffc2e1d018adb9))
+ - **FEAT**: Assert that collection.doc(id) does not point to a separate collection ([#8676](https://github.com/firebase/flutterfire/issues/8676)). ([0808205b](https://github.com/firebase/flutterfire/commit/0808205bdca03fc913015f00f5ffc2e1d018adb9))
 
 #### `cloud_firestore_odm_generator` - `v1.0.0-dev.15`
 
- - **FIX**: ODM should no-longer generates update/query functions for nested objects ([#8661](https://github.com/FirebaseExtended/flutterfire/issues/8661)). ([84eeed2e](https://github.com/FirebaseExtended/flutterfire/commit/84eeed2ec8da3aac87befd2028f8052005319730))
- - **FEAT**: Assert that collection.doc(id) does not point to a separate collection ([#8676](https://github.com/FirebaseExtended/flutterfire/issues/8676)). ([0808205b](https://github.com/FirebaseExtended/flutterfire/commit/0808205bdca03fc913015f00f5ffc2e1d018adb9))
+ - **FIX**: ODM should no-longer generates update/query functions for nested objects ([#8661](https://github.com/firebase/flutterfire/issues/8661)). ([84eeed2e](https://github.com/firebase/flutterfire/commit/84eeed2ec8da3aac87befd2028f8052005319730))
+ - **FEAT**: Assert that collection.doc(id) does not point to a separate collection ([#8676](https://github.com/firebase/flutterfire/issues/8676)). ([0808205b](https://github.com/firebase/flutterfire/commit/0808205bdca03fc913015f00f5ffc2e1d018adb9))
 
 #### `cloud_firestore_platform_interface` - `v5.5.6`
 
- - **REFACTOR**: fix analyzer issues introduced in Flutter 3.0.0 ([#8655](https://github.com/FirebaseExtended/flutterfire/issues/8655)). ([b05d7fa1](https://github.com/FirebaseExtended/flutterfire/commit/b05d7fa1ed56ab1bbceb02fec299800bce68a703))
+ - **REFACTOR**: fix analyzer issues introduced in Flutter 3.0.0 ([#8655](https://github.com/firebase/flutterfire/issues/8655)). ([b05d7fa1](https://github.com/firebase/flutterfire/commit/b05d7fa1ed56ab1bbceb02fec299800bce68a703))
 
 #### `firebase_auth_platform_interface` - `v6.2.6`
 
- - **REFACTOR**: fix analyzer issues introduced in Flutter 3.0.0 ([#8653](https://github.com/FirebaseExtended/flutterfire/issues/8653)). ([74e58171](https://github.com/FirebaseExtended/flutterfire/commit/74e5817159f18934ed0cd803f410ec96b372316a))
+ - **REFACTOR**: fix analyzer issues introduced in Flutter 3.0.0 ([#8653](https://github.com/firebase/flutterfire/issues/8653)). ([74e58171](https://github.com/firebase/flutterfire/commit/74e5817159f18934ed0cd803f410ec96b372316a))
 
 #### `firebase_core` - `v1.17.0`
 
- - **REFACTOR**: remove deprecated `Tasks.call` for android and replace with `TaskCompletionSource`. ([#8581](https://github.com/FirebaseExtended/flutterfire/issues/8581)). ([374c9df3](https://github.com/FirebaseExtended/flutterfire/commit/374c9df33bbb6b354ea526dcc6cc7812fa4452c0))
- - **FEAT**: bump Firebase Android SDK to 30.0.0 ([#8617](https://github.com/FirebaseExtended/flutterfire/issues/8617)). ([72158aaf](https://github.com/FirebaseExtended/flutterfire/commit/72158aaf9721dbf5f20c362f0c99853273507538))
- - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android ([#8566](https://github.com/FirebaseExtended/flutterfire/issues/8566)). ([30216c4a](https://github.com/FirebaseExtended/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
+ - **REFACTOR**: remove deprecated `Tasks.call` for android and replace with `TaskCompletionSource`. ([#8581](https://github.com/firebase/flutterfire/issues/8581)). ([374c9df3](https://github.com/firebase/flutterfire/commit/374c9df33bbb6b354ea526dcc6cc7812fa4452c0))
+ - **FEAT**: bump Firebase Android SDK to 30.0.0 ([#8617](https://github.com/firebase/flutterfire/issues/8617)). ([72158aaf](https://github.com/firebase/flutterfire/commit/72158aaf9721dbf5f20c362f0c99853273507538))
+ - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android ([#8566](https://github.com/firebase/flutterfire/issues/8566)). ([30216c4a](https://github.com/firebase/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
 
 #### `firebase_core_platform_interface` - `v4.4.0`
 
- - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android ([#8566](https://github.com/FirebaseExtended/flutterfire/issues/8566)). ([30216c4a](https://github.com/FirebaseExtended/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
+ - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android ([#8566](https://github.com/firebase/flutterfire/issues/8566)). ([30216c4a](https://github.com/firebase/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
 
 #### `firebase_crashlytics` - `v2.8.0`
 
- - **REFACTOR**: remove deprecated `Tasks.call` for android and replace with `TaskCompletionSource`. ([#8582](https://github.com/FirebaseExtended/flutterfire/issues/8582)). ([9539c92a](https://github.com/FirebaseExtended/flutterfire/commit/9539c92a53f73bf57b9c61ae9e0ce5042b4b8ca4))
- - **FIX**: symlink `ExceptionModel_Platform.h` to macOS. ([#8570](https://github.com/FirebaseExtended/flutterfire/issues/8570)). ([9991b7a5](https://github.com/FirebaseExtended/flutterfire/commit/9991b7a5389738a7bbba8f2210f8379b887d90e7))
- - **FEAT**: bump Firebase Android SDK to 30.0.0 ([#8617](https://github.com/FirebaseExtended/flutterfire/issues/8617)). ([72158aaf](https://github.com/FirebaseExtended/flutterfire/commit/72158aaf9721dbf5f20c362f0c99853273507538))
+ - **REFACTOR**: remove deprecated `Tasks.call` for android and replace with `TaskCompletionSource`. ([#8582](https://github.com/firebase/flutterfire/issues/8582)). ([9539c92a](https://github.com/firebase/flutterfire/commit/9539c92a53f73bf57b9c61ae9e0ce5042b4b8ca4))
+ - **FIX**: symlink `ExceptionModel_Platform.h` to macOS. ([#8570](https://github.com/firebase/flutterfire/issues/8570)). ([9991b7a5](https://github.com/firebase/flutterfire/commit/9991b7a5389738a7bbba8f2210f8379b887d90e7))
+ - **FEAT**: bump Firebase Android SDK to 30.0.0 ([#8617](https://github.com/firebase/flutterfire/issues/8617)). ([72158aaf](https://github.com/firebase/flutterfire/commit/72158aaf9721dbf5f20c362f0c99853273507538))
 
 #### `firebase_database_platform_interface` - `v0.2.1+6`
 
- - **REFACTOR**: fix analyzer issue introduced in Flutter 3.0.0 ([#8652](https://github.com/FirebaseExtended/flutterfire/issues/8652)). ([b781153a](https://github.com/FirebaseExtended/flutterfire/commit/b781153ac65df629c0a181219bf0b01999a5fa59))
+ - **REFACTOR**: fix analyzer issue introduced in Flutter 3.0.0 ([#8652](https://github.com/firebase/flutterfire/issues/8652)). ([b781153a](https://github.com/firebase/flutterfire/commit/b781153ac65df629c0a181219bf0b01999a5fa59))
 
 #### `firebase_dynamic_links_platform_interface` - `v0.2.3+2`
 
- - **REFACTOR**: fix analyzer issue introduced in Flutter 3.0.0 ([#8654](https://github.com/FirebaseExtended/flutterfire/issues/8654)). ([55d8fb59](https://github.com/FirebaseExtended/flutterfire/commit/55d8fb593acc8e50b3cbd98ab9645ca73e7af936))
+ - **REFACTOR**: fix analyzer issue introduced in Flutter 3.0.0 ([#8654](https://github.com/firebase/flutterfire/issues/8654)). ([55d8fb59](https://github.com/firebase/flutterfire/commit/55d8fb593acc8e50b3cbd98ab9645ca73e7af936))
 
 #### `firebase_messaging` - `v11.4.0`
 
- - **FIX**: ensure silent foreground messages for iOS are called via event channel. ([#8635](https://github.com/FirebaseExtended/flutterfire/issues/8635)). ([abb91e48](https://github.com/FirebaseExtended/flutterfire/commit/abb91e4861b769485878a0f165d6ba8a9604de5a))
- - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. ([#8532](https://github.com/FirebaseExtended/flutterfire/issues/8532)). ([14b38da3](https://github.com/FirebaseExtended/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
+ - **FIX**: ensure silent foreground messages for iOS are called via event channel. ([#8635](https://github.com/firebase/flutterfire/issues/8635)). ([abb91e48](https://github.com/firebase/flutterfire/commit/abb91e4861b769485878a0f165d6ba8a9604de5a))
+ - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. ([#8532](https://github.com/firebase/flutterfire/issues/8532)). ([14b38da3](https://github.com/firebase/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
 
 #### `firebase_messaging_platform_interface` - `v3.5.0`
 
- - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. ([#8532](https://github.com/FirebaseExtended/flutterfire/issues/8532)). ([14b38da3](https://github.com/FirebaseExtended/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
+ - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. ([#8532](https://github.com/firebase/flutterfire/issues/8532)). ([14b38da3](https://github.com/firebase/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
 
 #### `firebase_messaging_web` - `v2.4.0`
 
- - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. ([#8532](https://github.com/FirebaseExtended/flutterfire/issues/8532)). ([14b38da3](https://github.com/FirebaseExtended/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
+ - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. ([#8532](https://github.com/firebase/flutterfire/issues/8532)). ([14b38da3](https://github.com/firebase/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
 
 #### `flutterfire_ui` - `v0.4.1`
 
- - **FIX**: flutterfire_ui README links ([#8630](https://github.com/FirebaseExtended/flutterfire/issues/8630)). ([ba5b58af](https://github.com/FirebaseExtended/flutterfire/commit/ba5b58af354c762a4d4e4fe11e4017730bfa6c9e))
- - **FIX**: use `EmailVerificationScreen.actionCodeSettings` & and fix `flutter analyze` with Flutter 3.0.0 ([#8651](https://github.com/FirebaseExtended/flutterfire/issues/8651)). ([f12f1e24](https://github.com/FirebaseExtended/flutterfire/commit/f12f1e24e85dcea014374752a9d58142db33a5ab))
- - **FIX**: set the default variant of LoadingButton to outlined ([#8443](https://github.com/FirebaseExtended/flutterfire/issues/8443)) ([#8545](https://github.com/FirebaseExtended/flutterfire/issues/8545)). ([518cdcee](https://github.com/FirebaseExtended/flutterfire/commit/518cdcee7c43c995b4067857c38bff0a023302ee))
- - **FEAT**: add styling APIs `FlutterFireUITheme` and `FlutterFireUIStyle` ([#8580](https://github.com/FirebaseExtended/flutterfire/issues/8580)). ([83e2d455](https://github.com/FirebaseExtended/flutterfire/commit/83e2d455d3a083886168b4c115191b06e307a41f))
- - **DOCS**: Copy FlutterFire UI & ODM docs to package dirs ([#8574](https://github.com/FirebaseExtended/flutterfire/issues/8574)). ([c76f0d9b](https://github.com/FirebaseExtended/flutterfire/commit/c76f0d9bf954497923464e045671fd73be9b88c4))
+ - **FIX**: flutterfire_ui README links ([#8630](https://github.com/firebase/flutterfire/issues/8630)). ([ba5b58af](https://github.com/firebase/flutterfire/commit/ba5b58af354c762a4d4e4fe11e4017730bfa6c9e))
+ - **FIX**: use `EmailVerificationScreen.actionCodeSettings` & and fix `flutter analyze` with Flutter 3.0.0 ([#8651](https://github.com/firebase/flutterfire/issues/8651)). ([f12f1e24](https://github.com/firebase/flutterfire/commit/f12f1e24e85dcea014374752a9d58142db33a5ab))
+ - **FIX**: set the default variant of LoadingButton to outlined ([#8443](https://github.com/firebase/flutterfire/issues/8443)) ([#8545](https://github.com/firebase/flutterfire/issues/8545)). ([518cdcee](https://github.com/firebase/flutterfire/commit/518cdcee7c43c995b4067857c38bff0a023302ee))
+ - **FEAT**: add styling APIs `FlutterFireUITheme` and `FlutterFireUIStyle` ([#8580](https://github.com/firebase/flutterfire/issues/8580)). ([83e2d455](https://github.com/firebase/flutterfire/commit/83e2d455d3a083886168b4c115191b06e307a41f))
+ - **DOCS**: Copy FlutterFire UI & ODM docs to package dirs ([#8574](https://github.com/firebase/flutterfire/issues/8574)). ([c76f0d9b](https://github.com/firebase/flutterfire/commit/c76f0d9bf954497923464e045671fd73be9b88c4))
 
 
 ## 2022-05-03
@@ -466,23 +466,23 @@ Packages with dependency updates only:
 
 #### `firebase_core` - `v1.16.0`
 
- - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android (#8566). ([30216c4a](https://github.com/FirebaseExtended/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
+ - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android (#8566). ([30216c4a](https://github.com/firebase/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
 
 #### `firebase_core_platform_interface` - `v4.3.0`
 
- - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android (#8566). ([30216c4a](https://github.com/FirebaseExtended/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
+ - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android (#8566). ([30216c4a](https://github.com/firebase/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
 
 #### `firebase_messaging` - `v11.3.0`
 
- - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. (#8532). ([14b38da3](https://github.com/FirebaseExtended/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
+ - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. (#8532). ([14b38da3](https://github.com/firebase/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
 
 #### `firebase_messaging_platform_interface` - `v3.4.0`
 
- - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. (#8532). ([14b38da3](https://github.com/FirebaseExtended/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
+ - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. (#8532). ([14b38da3](https://github.com/firebase/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
 
 #### `firebase_messaging_web` - `v2.3.0`
 
- - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. (#8532). ([14b38da3](https://github.com/FirebaseExtended/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
+ - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. (#8532). ([14b38da3](https://github.com/firebase/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
 
 
 ## 2022-04-29
@@ -503,7 +503,7 @@ Packages with other changes:
 
 #### `firebase_crashlytics` - `v2.7.1`
 
- - **FIX**: re-add support for `recordFlutterFatalError` method from previous EAP API (#8550). ([8ef8b55c](https://github.com/FirebaseExtended/flutterfire/commit/8ef8b55c113f24abac783170723c7f784f5d1fe5))
+ - **FIX**: re-add support for `recordFlutterFatalError` method from previous EAP API (#8550). ([8ef8b55c](https://github.com/firebase/flutterfire/commit/8ef8b55c113f24abac783170723c7f784f5d1fe5))
 
 
 ## 2022-04-29
@@ -524,7 +524,7 @@ Packages with other changes:
 
 #### `firebase_crashlytics` - `v2.7.0`
 
- - **FEAT**: add support for on-demand exception reporting (#8540). ([dfec7d60](https://github.com/FirebaseExtended/flutterfire/commit/dfec7d60592abe0a5c6523e13feabffb8b03020b))
+ - **FEAT**: add support for on-demand exception reporting (#8540). ([dfec7d60](https://github.com/firebase/flutterfire/commit/dfec7d60592abe0a5c6523e13feabffb8b03020b))
 
 
 ## 2022-04-27
@@ -558,23 +558,23 @@ Packages with dependency updates only:
 
 #### `firebase_auth` - `v3.3.16`
 
- - **REFACTOR**: remove deprecated `Tasks.call()` API from Android. (#8452). ([3e92496b](https://github.com/FirebaseExtended/flutterfire/commit/3e92496b2783ec149258c22d3167c5388dcb1c40))
+ - **REFACTOR**: remove deprecated `Tasks.call()` API from Android. (#8452). ([3e92496b](https://github.com/firebase/flutterfire/commit/3e92496b2783ec149258c22d3167c5388dcb1c40))
 
 #### `firebase_dynamic_links` - `v4.2.1`
 
- - **REFACTOR**: Update deprecated API for dynamic links example app. (#8519). ([c5d288b3](https://github.com/FirebaseExtended/flutterfire/commit/c5d288b388cfd4180896ef9fc2a004c84ccbc017))
+ - **REFACTOR**: Update deprecated API for dynamic links example app. (#8519). ([c5d288b3](https://github.com/firebase/flutterfire/commit/c5d288b388cfd4180896ef9fc2a004c84ccbc017))
 
 #### `firebase_messaging` - `v11.2.15`
 
- - **REFACTOR**: Remove deprecated `Tasks.call()` API from android. (#8449). ([0510d113](https://github.com/FirebaseExtended/flutterfire/commit/0510d113dd279d6f55d889e522e74781d8fbb845))
+ - **REFACTOR**: Remove deprecated `Tasks.call()` API from android. (#8449). ([0510d113](https://github.com/firebase/flutterfire/commit/0510d113dd279d6f55d889e522e74781d8fbb845))
 
 #### `firebase_messaging_platform_interface` - `v3.3.1`
 
- - **FIX**: prevent isolate callback removal during split debug symbols (#8521). ([45ca7aeb](https://github.com/FirebaseExtended/flutterfire/commit/45ca7aeb50920cea0ba5784e16a5b78adac014f3))
+ - **FIX**: prevent isolate callback removal during split debug symbols (#8521). ([45ca7aeb](https://github.com/firebase/flutterfire/commit/45ca7aeb50920cea0ba5784e16a5b78adac014f3))
 
 #### `firebase_storage` - `v10.2.14`
 
- - **REFACTOR**: Remove deprecated `Tasks.call()` API from android. (#8421). ([461bba5a](https://github.com/FirebaseExtended/flutterfire/commit/461bba5a510b341b3b9bd414c9412944714e9305))
+ - **REFACTOR**: Remove deprecated `Tasks.call()` API from android. (#8421). ([461bba5a](https://github.com/firebase/flutterfire/commit/461bba5a510b341b3b9bd414c9412944714e9305))
 
 
 ## 2022-04-21
@@ -680,41 +680,41 @@ Packages with dependency updates only:
 
 #### `cloud_firestore_odm` - `v1.0.0-dev.13`
 
- - **FEAT**: upgrade analyzer, freezed_annotation and json_serializable dependencies (#8465). ([8a27ab21](https://github.com/FirebaseExtended/flutterfire/commit/8a27ab21279d72998e80aa17b8ec39a9e4a08ec8))
+ - **FEAT**: upgrade analyzer, freezed_annotation and json_serializable dependencies (#8465). ([8a27ab21](https://github.com/firebase/flutterfire/commit/8a27ab21279d72998e80aa17b8ec39a9e4a08ec8))
 
 #### `cloud_firestore_odm_generator` - `v1.0.0-dev.13`
 
- - **FEAT**: upgrade analyzer, freezed_annotation and json_serializable dependencies (#8465). ([8a27ab21](https://github.com/FirebaseExtended/flutterfire/commit/8a27ab21279d72998e80aa17b8ec39a9e4a08ec8))
+ - **FEAT**: upgrade analyzer, freezed_annotation and json_serializable dependencies (#8465). ([8a27ab21](https://github.com/firebase/flutterfire/commit/8a27ab21279d72998e80aa17b8ec39a9e4a08ec8))
 
 #### `firebase_analytics` - `v9.1.6`
 
- - **REFACTOR**: Update deployment target to `10.0` for Firebase Analytics podspec. (#8371). ([fe709da9](https://github.com/FirebaseExtended/flutterfire/commit/fe709da998162a3b884070df6666690ae560d0d1))
+ - **REFACTOR**: Update deployment target to `10.0` for Firebase Analytics podspec. (#8371). ([fe709da9](https://github.com/firebase/flutterfire/commit/fe709da998162a3b884070df6666690ae560d0d1))
 
 #### `firebase_auth` - `v3.3.15`
 
- - **FIX**: Use iterator instead of enhanced for loop on android. (#8498). ([027c75a6](https://github.com/FirebaseExtended/flutterfire/commit/027c75a60b39a40e6a3edc12edc51487cc954503))
+ - **FIX**: Use iterator instead of enhanced for loop on android. (#8498). ([027c75a6](https://github.com/firebase/flutterfire/commit/027c75a60b39a40e6a3edc12edc51487cc954503))
 
 #### `firebase_core` - `v1.15.0`
 
- - **FEAT**: bump Firebase Android SDK to `29.3.1` (#8494). ([17b9c289](https://github.com/FirebaseExtended/flutterfire/commit/17b9c2894ee901afd2631664b01829cd4df1dd16))
- - **FEAT**: Update Firebase iOS SDK to `8.15.0` (#8454). ([faaf4496](https://github.com/FirebaseExtended/flutterfire/commit/faaf449624ff4081cbbc0f241fec3134492cbdb3))
+ - **FEAT**: bump Firebase Android SDK to `29.3.1` (#8494). ([17b9c289](https://github.com/firebase/flutterfire/commit/17b9c2894ee901afd2631664b01829cd4df1dd16))
+ - **FEAT**: Update Firebase iOS SDK to `8.15.0` (#8454). ([faaf4496](https://github.com/firebase/flutterfire/commit/faaf449624ff4081cbbc0f241fec3134492cbdb3))
 
 #### `firebase_dynamic_links` - `v4.2.0`
 
- - **REFACTOR**: Remove deprecated Tasks.call() API from android. (#8450). ([fdb24c8d](https://github.com/FirebaseExtended/flutterfire/commit/fdb24c8d2cf4c51b20ffdb6c8898b7eced16aa64))
- - **FEAT**: `matchType` for pending Dynamic Link data for `iOS`. (#8464). ([d3dda125](https://github.com/FirebaseExtended/flutterfire/commit/d3dda12563eb28e565c2c01d348183d558e25335))
+ - **REFACTOR**: Remove deprecated Tasks.call() API from android. (#8450). ([fdb24c8d](https://github.com/firebase/flutterfire/commit/fdb24c8d2cf4c51b20ffdb6c8898b7eced16aa64))
+ - **FEAT**: `matchType` for pending Dynamic Link data for `iOS`. (#8464). ([d3dda125](https://github.com/firebase/flutterfire/commit/d3dda12563eb28e565c2c01d348183d558e25335))
 
 #### `firebase_dynamic_links_platform_interface` - `v0.2.3`
 
- - **FEAT**: `matchType` for pending Dynamic Link data for `iOS`. (#8464). ([d3dda125](https://github.com/FirebaseExtended/flutterfire/commit/d3dda12563eb28e565c2c01d348183d558e25335))
+ - **FEAT**: `matchType` for pending Dynamic Link data for `iOS`. (#8464). ([d3dda125](https://github.com/firebase/flutterfire/commit/d3dda12563eb28e565c2c01d348183d558e25335))
 
 #### `firebase_messaging_platform_interface` - `v3.3.0`
 
- - **FEAT**: add `toMap()` method to `RemoteMessage` and its properties (#8453). ([047cccda](https://github.com/FirebaseExtended/flutterfire/commit/047cccda6fe8e53c77e8e1f368e5f2c5d7d297e1))
+ - **FEAT**: add `toMap()` method to `RemoteMessage` and its properties (#8453). ([047cccda](https://github.com/firebase/flutterfire/commit/047cccda6fe8e53c77e8e1f368e5f2c5d7d297e1))
 
 #### `flutterfire_ui` - `v0.4.0+3`
 
- - **FIX**: Bump `twitter_login` version to fix Android build failure. (#8475). ([4a7f47ed](https://github.com/FirebaseExtended/flutterfire/commit/4a7f47edbe9d421e385efbd2be05a01a24b22a69))
+ - **FIX**: Bump `twitter_login` version to fix Android build failure. (#8475). ([4a7f47ed](https://github.com/firebase/flutterfire/commit/4a7f47edbe9d421e385efbd2be05a01a24b22a69))
 
 
 ## 2022-04-13
@@ -830,7 +830,7 @@ Packages with dependency updates only:
 
 #### `firebase_core_web` - `v1.6.2`
 
- - **DOCS**: Fix typo in "firebase_core_web.dart" documentation. ([658c1db7](https://github.com/FirebaseExtended/flutterfire/commit/658c1db71cc47b3eddec3a1f33d5d55d1a6ff98a))
+ - **DOCS**: Fix typo in "firebase_core_web.dart" documentation. ([658c1db7](https://github.com/firebase/flutterfire/commit/658c1db71cc47b3eddec3a1f33d5d55d1a6ff98a))
 
 
 ## 2022-04-07
@@ -864,24 +864,24 @@ Packages with dependency updates only:
 
 #### `firebase_analytics` - `v9.1.4`
 
- - **FIX**: Send default parameters for iOS when using `setDefaultEventParameters()` API. (#8402). ([7d3e5ba6](https://github.com/FirebaseExtended/flutterfire/commit/7d3e5ba6e4ee0bff178c5cfb73d34cdd3a7064e0))
+ - **FIX**: Send default parameters for iOS when using `setDefaultEventParameters()` API. (#8402). ([7d3e5ba6](https://github.com/firebase/flutterfire/commit/7d3e5ba6e4ee0bff178c5cfb73d34cdd3a7064e0))
 
 #### `firebase_auth_web` - `v3.3.11`
 
- - **FIX**: Allow `rawNonce` to be passed through on web via the `OAuthCredential`. (#8410). ([0df32f61](https://github.com/FirebaseExtended/flutterfire/commit/0df32f6106ca41cdb95c36c7816e6487124937d4))
+ - **FIX**: Allow `rawNonce` to be passed through on web via the `OAuthCredential`. (#8410). ([0df32f61](https://github.com/firebase/flutterfire/commit/0df32f6106ca41cdb95c36c7816e6487124937d4))
 
 #### `firebase_database_web` - `v0.2.0+9`
 
- - **FIX**: Remove sync as `true` on Stream broadcast for web platform. (#8420). ([4336e047](https://github.com/FirebaseExtended/flutterfire/commit/4336e0478a927385e676b069f354bd3cc2f932ab))
+ - **FIX**: Remove sync as `true` on Stream broadcast for web platform. (#8420). ([4336e047](https://github.com/firebase/flutterfire/commit/4336e0478a927385e676b069f354bd3cc2f932ab))
 
 #### `firebase_storage` - `v10.2.11`
 
- - **FIX**: Fix `UploadTask.cancel()` so that it completes when called. (#8417). ([19ee62c3](https://github.com/FirebaseExtended/flutterfire/commit/19ee62c33f34278dac082c11bf7574785e60abb5))
+ - **FIX**: Fix `UploadTask.cancel()` so that it completes when called. (#8417). ([19ee62c3](https://github.com/firebase/flutterfire/commit/19ee62c33f34278dac082c11bf7574785e60abb5))
 
 #### `flutterfire_ui` - `v0.4.0+1`
 
- - **FIX**: filter out whitespaces in email with input formatter (#8393). ([1da9dc15](https://github.com/FirebaseExtended/flutterfire/commit/1da9dc1539367641a43df053c243fe262e087bd2))
- - **FIX**: fix phone linking on web (#8395). ([b8ac0a20](https://github.com/FirebaseExtended/flutterfire/commit/b8ac0a202958864f793791877e556624f9b7c487))
+ - **FIX**: filter out whitespaces in email with input formatter (#8393). ([1da9dc15](https://github.com/firebase/flutterfire/commit/1da9dc1539367641a43df053c243fe262e087bd2))
+ - **FIX**: fix phone linking on web (#8395). ([b8ac0a20](https://github.com/firebase/flutterfire/commit/b8ac0a202958864f793791877e556624f9b7c487))
 
 
 ## 2022-04-05
@@ -902,7 +902,7 @@ Packages with other changes:
 
 #### `firebase_crashlytics` - `v2.6.1`
 
- - **FIX**: Exit the add crashlytics upload-symbols script if the required json isn't present. ([94077929](https://github.com/FirebaseExtended/flutterfire/commit/940779290a3039181a92567fe8492a720af899e1))
+ - **FIX**: Exit the add crashlytics upload-symbols script if the required json isn't present. ([94077929](https://github.com/firebase/flutterfire/commit/940779290a3039181a92567fe8492a720af899e1))
 
 
 ## 2022-03-31
@@ -1009,43 +1009,43 @@ Packages with dependency updates only:
 
 #### `flutterfire_ui` - `v0.4.0`
 
- - **REFACTOR**: refactor platform specific widget styling (#8333). ([ecbff15c](https://github.com/FirebaseExtended/flutterfire/commit/ecbff15cf657a1d451db39bb8a5b4f3419780228))
- - **FIX**: respect autocorrect property on `UniversalTextFormField` (#8367). ([ad942c34](https://github.com/FirebaseExtended/flutterfire/commit/ad942c349c3232f1946575fdab2b8b27e1c14215))
- - **FIX**: trim email before submitting (#8369). ([4f9b8855](https://github.com/FirebaseExtended/flutterfire/commit/4f9b8855504d5ae85d5904f4663fa93fa871e32a))
- - **FIX**: allow passing oauth scopes for google sign in (#8368). ([7edbf5e6](https://github.com/FirebaseExtended/flutterfire/commit/7edbf5e692499feb7b3c1b29dab67479917df21f))
- - **FIX**: Avoid layout jumps when editing user name. (#8334). ([1937f278](https://github.com/FirebaseExtended/flutterfire/commit/1937f27817acc59dedd85a6d1e0624f49685ef5e))
- - **FIX**: fix sign out issue on desktop and web (#8331). ([f1dae735](https://github.com/FirebaseExtended/flutterfire/commit/f1dae735483bf293c4b18a8ff7c3ab6ca3cbe6e7))
- - **FIX**: Fix Flutter Cupertino button color bug. (#8315). ([47dc6d09](https://github.com/FirebaseExtended/flutterfire/commit/47dc6d09112db8d1398908895b387795722eaaba))
- - **FEAT**: Allow setting `resizeToAvoidBottomInset` from LoginScreen and set as default `false` for backwards compatibility. (#8365). ([3e884f2f](https://github.com/FirebaseExtended/flutterfire/commit/3e884f2f7cb498c6dff23ff6ac2bd9a25a73034d))
- - **FEAT**: Add Japanese localization language support. (#8110). ([c9c7f828](https://github.com/FirebaseExtended/flutterfire/commit/c9c7f8281fbfb2cd2872eb1b71fbd5e46c8002d8))
- - **BREAKING** **FEAT**: add email verification and allow to unlink social providers from profile screen (#8358). ([89f97047](https://github.com/FirebaseExtended/flutterfire/commit/89f97047e34d5023f2c41312767f626cb662702f))
+ - **REFACTOR**: refactor platform specific widget styling (#8333). ([ecbff15c](https://github.com/firebase/flutterfire/commit/ecbff15cf657a1d451db39bb8a5b4f3419780228))
+ - **FIX**: respect autocorrect property on `UniversalTextFormField` (#8367). ([ad942c34](https://github.com/firebase/flutterfire/commit/ad942c349c3232f1946575fdab2b8b27e1c14215))
+ - **FIX**: trim email before submitting (#8369). ([4f9b8855](https://github.com/firebase/flutterfire/commit/4f9b8855504d5ae85d5904f4663fa93fa871e32a))
+ - **FIX**: allow passing oauth scopes for google sign in (#8368). ([7edbf5e6](https://github.com/firebase/flutterfire/commit/7edbf5e692499feb7b3c1b29dab67479917df21f))
+ - **FIX**: Avoid layout jumps when editing user name. (#8334). ([1937f278](https://github.com/firebase/flutterfire/commit/1937f27817acc59dedd85a6d1e0624f49685ef5e))
+ - **FIX**: fix sign out issue on desktop and web (#8331). ([f1dae735](https://github.com/firebase/flutterfire/commit/f1dae735483bf293c4b18a8ff7c3ab6ca3cbe6e7))
+ - **FIX**: Fix Flutter Cupertino button color bug. (#8315). ([47dc6d09](https://github.com/firebase/flutterfire/commit/47dc6d09112db8d1398908895b387795722eaaba))
+ - **FEAT**: Allow setting `resizeToAvoidBottomInset` from LoginScreen and set as default `false` for backwards compatibility. (#8365). ([3e884f2f](https://github.com/firebase/flutterfire/commit/3e884f2f7cb498c6dff23ff6ac2bd9a25a73034d))
+ - **FEAT**: Add Japanese localization language support. (#8110). ([c9c7f828](https://github.com/firebase/flutterfire/commit/c9c7f8281fbfb2cd2872eb1b71fbd5e46c8002d8))
+ - **BREAKING** **FEAT**: add email verification and allow to unlink social providers from profile screen (#8358). ([89f97047](https://github.com/firebase/flutterfire/commit/89f97047e34d5023f2c41312767f626cb662702f))
 
 #### `cloud_firestore` - `v3.1.11`
 
- - **REFACTOR**: recreate ios, android, web and macOS folders for example app (#8255). ([cdae0613](https://github.com/FirebaseExtended/flutterfire/commit/cdae0613a359da41013721f601c20169807d214f))
- - **DOCS**: Fix method name typo in code documentation (#8291). ([7b4e06db](https://github.com/FirebaseExtended/flutterfire/commit/7b4e06db305ff9f785a1bfcf1888fec1a53970c4))
+ - **REFACTOR**: recreate ios, android, web and macOS folders for example app (#8255). ([cdae0613](https://github.com/firebase/flutterfire/commit/cdae0613a359da41013721f601c20169807d214f))
+ - **DOCS**: Fix method name typo in code documentation (#8291). ([7b4e06db](https://github.com/firebase/flutterfire/commit/7b4e06db305ff9f785a1bfcf1888fec1a53970c4))
 
 #### `cloud_firestore_platform_interface` - `v5.5.2`
 
- - **DOCS**: Fix method name typo in code documentation (#8291). ([7b4e06db](https://github.com/FirebaseExtended/flutterfire/commit/7b4e06db305ff9f785a1bfcf1888fec1a53970c4))
+ - **DOCS**: Fix method name typo in code documentation (#8291). ([7b4e06db](https://github.com/firebase/flutterfire/commit/7b4e06db305ff9f785a1bfcf1888fec1a53970c4))
 
 #### `firebase_auth_web` - `v3.3.10`
 
- - **FIX**: Check if `UserMetadata` properties are `null` before parsing. (#8313). ([cac41fb9](https://github.com/FirebaseExtended/flutterfire/commit/cac41fb9ddd5462b57f9d17615f387478f10d3dc))
+ - **FIX**: Check if `UserMetadata` properties are `null` before parsing. (#8313). ([cac41fb9](https://github.com/firebase/flutterfire/commit/cac41fb9ddd5462b57f9d17615f387478f10d3dc))
 
 #### `firebase_core` - `v1.14.0`
 
- - **FEAT**: Bump Firebase iOS SDK to `8.14.0`. (#8370). ([41bb9800](https://github.com/FirebaseExtended/flutterfire/commit/41bb98004327013f90c93709513c419d04382475))
- - **FEAT**: bump Firebase Android SDK to `29.3.0` (#8283). ([a6c646a0](https://github.com/FirebaseExtended/flutterfire/commit/a6c646a0d23600e5e4ae6d40ca4b23c7e73fc257))
- - **DOCS**: Update inline code documentation for initializing Firebase app. (#8329). ([19727798](https://github.com/FirebaseExtended/flutterfire/commit/19727798a8dcfde103665eb8209b714e49327a11))
+ - **FEAT**: Bump Firebase iOS SDK to `8.14.0`. (#8370). ([41bb9800](https://github.com/firebase/flutterfire/commit/41bb98004327013f90c93709513c419d04382475))
+ - **FEAT**: bump Firebase Android SDK to `29.3.0` (#8283). ([a6c646a0](https://github.com/firebase/flutterfire/commit/a6c646a0d23600e5e4ae6d40ca4b23c7e73fc257))
+ - **DOCS**: Update inline code documentation for initializing Firebase app. (#8329). ([19727798](https://github.com/firebase/flutterfire/commit/19727798a8dcfde103665eb8209b714e49327a11))
 
 #### `firebase_crashlytics` - `v2.6.0`
 
- - **FEAT**: add automatic Crashlytics symbol uploads for iOS & macOS apps (#8157). ([c4a3eaa7](https://github.com/FirebaseExtended/flutterfire/commit/c4a3eaa7200d924f9ec71370dd3c875813804935))
+ - **FEAT**: add automatic Crashlytics symbol uploads for iOS & macOS apps (#8157). ([c4a3eaa7](https://github.com/firebase/flutterfire/commit/c4a3eaa7200d924f9ec71370dd3c875813804935))
 
 #### `firebase_dynamic_links` - `v4.1.2`
 
- - **REFACTOR**: recreate ios, android, web and macOS folders for example app (#8255). ([cdae0613](https://github.com/FirebaseExtended/flutterfire/commit/cdae0613a359da41013721f601c20169807d214f))
+ - **REFACTOR**: recreate ios, android, web and macOS folders for example app (#8255). ([cdae0613](https://github.com/firebase/flutterfire/commit/cdae0613a359da41013721f601c20169807d214f))
 
 
 ## 2022-03-15
@@ -1077,15 +1077,15 @@ Packages with dependency updates only:
 
 #### `firebase_auth` - `v3.3.11`
 
- - **FIX**: Update APN token once auth plugin has been initialized on `iOS`. (#8201). ([ab6239dd](https://github.com/FirebaseExtended/flutterfire/commit/ab6239ddf5cb14211b76bced04ec52203919a57a))
+ - **FIX**: Update APN token once auth plugin has been initialized on `iOS`. (#8201). ([ab6239dd](https://github.com/firebase/flutterfire/commit/ab6239ddf5cb14211b76bced04ec52203919a57a))
 
 #### `firebase_dynamic_links_platform_interface` - `v0.2.2+1`
 
- - **FIX**: Properly type cast utmParameters coming from native side. (#8280). ([22bbd807](https://github.com/FirebaseExtended/flutterfire/commit/22bbd807d2b3c3f9d9cc8ba817ccb4da931ae887))
+ - **FIX**: Properly type cast utmParameters coming from native side. (#8280). ([22bbd807](https://github.com/firebase/flutterfire/commit/22bbd807d2b3c3f9d9cc8ba817ccb4da931ae887))
 
 #### `firebase_messaging` - `v11.2.11`
 
- - **FIX**: Ensure `onMessage` callback is consistently called on `iOS` platform. (#8202). ([54f5555e](https://github.com/FirebaseExtended/flutterfire/commit/54f5555edbedc553df30d7e32747e3b305fbe643))
+ - **FIX**: Ensure `onMessage` callback is consistently called on `iOS` platform. (#8202). ([54f5555e](https://github.com/firebase/flutterfire/commit/54f5555edbedc553df30d7e32747e3b305fbe643))
 
 
 ## 2022-03-10
@@ -1106,7 +1106,7 @@ Packages with other changes:
 
 #### `firebase_messaging` - `v11.2.10`
 
- - **FIX**: Update notification key to `NSApplicationLaunchUserNotificationKey` for macOS. (#8251). ([46b54ccd](https://github.com/FirebaseExtended/flutterfire/commit/46b54ccd4aee61654e36396b86ed373939569d00))
+ - **FIX**: Update notification key to `NSApplicationLaunchUserNotificationKey` for macOS. (#8251). ([46b54ccd](https://github.com/firebase/flutterfire/commit/46b54ccd4aee61654e36396b86ed373939569d00))
 
 
 ## 2022-03-10
@@ -1132,30 +1132,30 @@ Packages with other changes:
 
 #### `cloud_functions` - `v3.2.10`
 
- - **FIX**: Allow raw data arguments to be passed as data to Cloud Function for `Android` & `iOS`. (#7994). ([8288b811](https://github.com/FirebaseExtended/flutterfire/commit/8288b811f2b82df263a092428905960960e537c6))
+ - **FIX**: Allow raw data arguments to be passed as data to Cloud Function for `Android` & `iOS`. (#7994). ([8288b811](https://github.com/firebase/flutterfire/commit/8288b811f2b82df263a092428905960960e537c6))
 
 #### `firebase_auth` - `v3.3.10`
 
- - **FIX**: return correct error code for linkWithCredential `provider-already-linked` on Android (#8245). ([ae090719](https://github.com/FirebaseExtended/flutterfire/commit/ae090719ebbb0873cf227f76004feeae9a7d0580))
- - **FIX**: Fixed bug that sets email to `nil` on `iOS` when the `User` has no provider. (#8209). ([fb646438](https://github.com/FirebaseExtended/flutterfire/commit/fb646438f219b0f0f7c6a8c52e2b9daa4afc833e))
+ - **FIX**: return correct error code for linkWithCredential `provider-already-linked` on Android (#8245). ([ae090719](https://github.com/firebase/flutterfire/commit/ae090719ebbb0873cf227f76004feeae9a7d0580))
+ - **FIX**: Fixed bug that sets email to `nil` on `iOS` when the `User` has no provider. (#8209). ([fb646438](https://github.com/firebase/flutterfire/commit/fb646438f219b0f0f7c6a8c52e2b9daa4afc833e))
 
 #### `firebase_dynamic_links` - `v4.1.0`
 
- - **FIX**: pass through `utmParameters` on `iOS` and make property on `PendingDynamicLinkData`. (#8232). ([32d06e79](https://github.com/FirebaseExtended/flutterfire/commit/32d06e793b4fc1bc1dad9b9071f94b28c5d477ca))
- - **FEAT**: add additional `longDynamicLink` parameter for creating a short Dynamic Link enabling additional parameters to be appended such as "ofl". (#7796). ([433a08ea](https://github.com/FirebaseExtended/flutterfire/commit/433a08eaacfaabb109a0185a5e494d87f9334d75))
+ - **FIX**: pass through `utmParameters` on `iOS` and make property on `PendingDynamicLinkData`. (#8232). ([32d06e79](https://github.com/firebase/flutterfire/commit/32d06e793b4fc1bc1dad9b9071f94b28c5d477ca))
+ - **FEAT**: add additional `longDynamicLink` parameter for creating a short Dynamic Link enabling additional parameters to be appended such as "ofl". (#7796). ([433a08ea](https://github.com/firebase/flutterfire/commit/433a08eaacfaabb109a0185a5e494d87f9334d75))
 
 #### `firebase_dynamic_links_platform_interface` - `v0.2.2`
 
- - **FIX**: pass through `utmParameters` on `iOS` and make property on `PendingDynamicLinkData`. (#8232). ([32d06e79](https://github.com/FirebaseExtended/flutterfire/commit/32d06e793b4fc1bc1dad9b9071f94b28c5d477ca))
- - **FEAT**: add additional `longDynamicLink` parameter for creating a short Dynamic Link enabling additional parameters to be appended such as "ofl". (#7796). ([433a08ea](https://github.com/FirebaseExtended/flutterfire/commit/433a08eaacfaabb109a0185a5e494d87f9334d75))
+ - **FIX**: pass through `utmParameters` on `iOS` and make property on `PendingDynamicLinkData`. (#8232). ([32d06e79](https://github.com/firebase/flutterfire/commit/32d06e793b4fc1bc1dad9b9071f94b28c5d477ca))
+ - **FEAT**: add additional `longDynamicLink` parameter for creating a short Dynamic Link enabling additional parameters to be appended such as "ofl". (#7796). ([433a08ea](https://github.com/firebase/flutterfire/commit/433a08eaacfaabb109a0185a5e494d87f9334d75))
 
 #### `firebase_messaging` - `v11.2.9`
 
- - **FIX**: `getInitialMessage` returns notification once & only if pressed for `iOS`. (#7634). ([85739b4c](https://github.com/FirebaseExtended/flutterfire/commit/85739b4cc2f75c6f7017de0e69160fa07477eb1e))
+ - **FIX**: `getInitialMessage` returns notification once & only if pressed for `iOS`. (#7634). ([85739b4c](https://github.com/firebase/flutterfire/commit/85739b4cc2f75c6f7017de0e69160fa07477eb1e))
 
 #### `flutterfire_ui` - `v0.3.6`
 
- - **FEAT**: Add German localization language support (#8195). ([9976d9d6](https://github.com/FirebaseExtended/flutterfire/commit/9976d9d66b870143227b08af068da3bc2efc5411))
+ - **FEAT**: Add German localization language support (#8195). ([9976d9d6](https://github.com/firebase/flutterfire/commit/9976d9d66b870143227b08af068da3bc2efc5411))
 
 
 ## 2022-02-25
@@ -1222,191 +1222,191 @@ Packages with other changes:
 
 #### `cloud_firestore` - `v3.1.10`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `cloud_firestore_odm` - `v1.0.0-dev.10`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `cloud_firestore_odm_generator` - `v1.0.0-dev.10`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `cloud_firestore_platform_interface` - `v5.5.1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `cloud_firestore_web` - `v2.6.10`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `cloud_functions` - `v3.2.9`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `cloud_functions_platform_interface` - `v5.1.1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `cloud_functions_web` - `v4.2.9`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_analytics` - `v9.1.2`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_analytics_platform_interface` - `v3.1.1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_analytics_web` - `v0.4.0+8`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_app_check` - `v0.0.6+7`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_app_check_platform_interface` - `v0.0.4+1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_app_check_web` - `v0.0.5+7`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_app_installations` - `v0.1.0+8`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_app_installations_platform_interface` - `v0.1.1+1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_app_installations_web` - `v0.1.0+8`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_auth` - `v3.3.9`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_auth_platform_interface` - `v6.2.1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_auth_web` - `v3.3.9`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_core` - `v1.13.1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_core_platform_interface` - `v4.2.5`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_core_web` - `v1.6.1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_crashlytics` - `v2.5.3`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_crashlytics_platform_interface` - `v3.2.1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_database` - `v9.0.8`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_database_platform_interface` - `v0.2.1+1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_database_web` - `v0.2.0+7`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_dynamic_links` - `v4.0.8`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_dynamic_links_platform_interface` - `v0.2.1+1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_in_app_messaging` - `v0.6.0+9`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_in_app_messaging_platform_interface` - `v0.2.1+1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_messaging` - `v11.2.8`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_messaging_platform_interface` - `v3.2.1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_messaging_web` - `v2.2.9`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_ml_model_downloader` - `v0.1.0+8`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_ml_model_downloader_platform_interface` - `v0.1.1+1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_performance` - `v0.8.0+7`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_performance_platform_interface` - `v0.1.1+1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_performance_web` - `v0.1.0+7`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_remote_config` - `v2.0.2`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_remote_config_platform_interface` - `v1.1.1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_remote_config_web` - `v1.0.7`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_storage` - `v10.2.9`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_storage_platform_interface` - `v4.1.1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `firebase_storage_web` - `v3.2.10`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 #### `flutterfire_ui` - `v0.3.5+1`
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 
 ## 2022-02-24
@@ -1500,101 +1500,101 @@ Packages with dependency updates only:
 
 #### `cloud_firestore_odm_generator` - `v1.0.0-dev.9`
 
- - **FIX**: Use descending in orderBy* (#8159). ([0b7b8811](https://github.com/FirebaseExtended/flutterfire/commit/0b7b88117ac65a0ab164ffcaa0ca7fa69633fcb2))
+ - **FIX**: Use descending in orderBy* (#8159). ([0b7b8811](https://github.com/firebase/flutterfire/commit/0b7b88117ac65a0ab164ffcaa0ca7fa69633fcb2))
 
 #### `cloud_firestore_platform_interface` - `v5.5.0`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `cloud_functions_platform_interface` - `v5.1.0`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `firebase_analytics` - `v9.1.1`
 
- - **DOCS**: code comment typo - `logAdImpression` mentions wrong event (#8180). ([960a75a7](https://github.com/FirebaseExtended/flutterfire/commit/960a75a77dc8c575e7f8f9c4350ad564a3814eb8))
+ - **DOCS**: code comment typo - `logAdImpression` mentions wrong event (#8180). ([960a75a7](https://github.com/firebase/flutterfire/commit/960a75a77dc8c575e7f8f9c4350ad564a3814eb8))
 
 #### `firebase_analytics_platform_interface` - `v3.1.0`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `firebase_app_check_platform_interface` - `v0.0.4`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `firebase_app_installations_platform_interface` - `v0.1.1`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `firebase_auth_platform_interface` - `v6.2.0`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `firebase_core` - `v1.13.0`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `firebase_core_web` - `v1.6.0`
 
- - **FEAT**: Bump Firebase Web SDK version to 8.10.1 (CVE-2022-0235) for security patch purposes. (#8162). ([7624f777](https://github.com/FirebaseExtended/flutterfire/commit/7624f7779f4a49f2353f3f593b31be9139197028))
+ - **FEAT**: Bump Firebase Web SDK version to 8.10.1 (CVE-2022-0235) for security patch purposes. (#8162). ([7624f777](https://github.com/firebase/flutterfire/commit/7624f7779f4a49f2353f3f593b31be9139197028))
 
 #### `firebase_crashlytics_platform_interface` - `v3.2.0`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `firebase_database_platform_interface` - `v0.2.1`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `firebase_dynamic_links_platform_interface` - `v0.2.1`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `firebase_in_app_messaging_platform_interface` - `v0.2.1`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `firebase_messaging` - `v11.2.7`
 
- - **FIX**: Stream new token via onTokenRefresh when getToken invoked for iOS. (#8166). ([28b396b8](https://github.com/FirebaseExtended/flutterfire/commit/28b396b84e019a5247e70d0abeb1ba24bdff4bcb))
+ - **FIX**: Stream new token via onTokenRefresh when getToken invoked for iOS. (#8166). ([28b396b8](https://github.com/firebase/flutterfire/commit/28b396b84e019a5247e70d0abeb1ba24bdff4bcb))
 
 #### `firebase_messaging_platform_interface` - `v3.2.0`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `firebase_ml_model_downloader_platform_interface` - `v0.1.1`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `firebase_performance` - `v0.8.0+6`
 
- - **FIX**: Fix firebase_performance not recording response payload size on Android. (#8154). ([46d8bc0f](https://github.com/FirebaseExtended/flutterfire/commit/46d8bc0f205f24b1e160333ddb76200543f48c89))
+ - **FIX**: Fix firebase_performance not recording response payload size on Android. (#8154). ([46d8bc0f](https://github.com/firebase/flutterfire/commit/46d8bc0f205f24b1e160333ddb76200543f48c89))
 
 #### `firebase_performance_platform_interface` - `v0.1.1`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `firebase_remote_config` - `v2.0.1`
 
- - **FIX**: add missing `default_package` entry for web in `pubspec.yaml` (#8139). ([5e6b570f](https://github.com/FirebaseExtended/flutterfire/commit/5e6b570f8445b0bd2eac8b112a2a6b35ff69b7b6))
+ - **FIX**: add missing `default_package` entry for web in `pubspec.yaml` (#8139). ([5e6b570f](https://github.com/firebase/flutterfire/commit/5e6b570f8445b0bd2eac8b112a2a6b35ff69b7b6))
 
 #### `firebase_remote_config_platform_interface` - `v1.1.0`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `firebase_storage_platform_interface` - `v4.1.0`
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 #### `flutterfire_ui` - `v0.3.5`
 
- - **FIX**: Upgrade `desktop_webview_auth` - v`0.0.5` (#8164). ([123fa6b1](https://github.com/FirebaseExtended/flutterfire/commit/123fa6b132183a4d6886c8be0595104752724532))
- - **FIX**: Upgrade `desktop_webview_auth` package causing a problem on macOS. (#8151). ([da4a1c5e](https://github.com/FirebaseExtended/flutterfire/commit/da4a1c5e074cb5af71983a3ae49c4838402b726f))
- - **FEAT**: Add support for configuring authentication providers globally (additionally fixes #7801) (#8120). ([ebde7d27](https://github.com/FirebaseExtended/flutterfire/commit/ebde7d27938d7a36a67973df4b33c21bbd7dea1a))
- - **FEAT**: Add Hindi localization language support (#7778). ([b584ce0f](https://github.com/FirebaseExtended/flutterfire/commit/b584ce0f254dcb195f9a31f279fb3871d01182c1))
- - **FEAT**: Add Turkish language localization support. (#7790). ([c47f6075](https://github.com/FirebaseExtended/flutterfire/commit/c47f60757ccbfcee1eaa5d7ed6ee01258f3b9d4f))
- - **FEAT**: Add Bahasa Indonesia localization language support (#7709). ([be0eb27f](https://github.com/FirebaseExtended/flutterfire/commit/be0eb27f4f4d85a4e4a2468768c166a701325a8c))
- - **FEAT**: Enhance the oauth provider button widget by showing error text underneath. (#8032). ([2b47f5a1](https://github.com/FirebaseExtended/flutterfire/commit/2b47f5a12747e3437dfc42d331684e798372beaf))
+ - **FIX**: Upgrade `desktop_webview_auth` - v`0.0.5` (#8164). ([123fa6b1](https://github.com/firebase/flutterfire/commit/123fa6b132183a4d6886c8be0595104752724532))
+ - **FIX**: Upgrade `desktop_webview_auth` package causing a problem on macOS. (#8151). ([da4a1c5e](https://github.com/firebase/flutterfire/commit/da4a1c5e074cb5af71983a3ae49c4838402b726f))
+ - **FEAT**: Add support for configuring authentication providers globally (additionally fixes #7801) (#8120). ([ebde7d27](https://github.com/firebase/flutterfire/commit/ebde7d27938d7a36a67973df4b33c21bbd7dea1a))
+ - **FEAT**: Add Hindi localization language support (#7778). ([b584ce0f](https://github.com/firebase/flutterfire/commit/b584ce0f254dcb195f9a31f279fb3871d01182c1))
+ - **FEAT**: Add Turkish language localization support. (#7790). ([c47f6075](https://github.com/firebase/flutterfire/commit/c47f60757ccbfcee1eaa5d7ed6ee01258f3b9d4f))
+ - **FEAT**: Add Bahasa Indonesia localization language support (#7709). ([be0eb27f](https://github.com/firebase/flutterfire/commit/be0eb27f4f4d85a4e4a2468768c166a701325a8c))
+ - **FEAT**: Enhance the oauth provider button widget by showing error text underneath. (#8032). ([2b47f5a1](https://github.com/firebase/flutterfire/commit/2b47f5a12747e3437dfc42d331684e798372beaf))
 
 
 ## 2022-02-10
@@ -1630,23 +1630,23 @@ Packages with dependency updates only:
 
 #### `cloud_firestore_odm` - `v1.0.0-dev.8`
 
- - **DOCS**: Update code snippets by removing incorrect forward slash for `@Collection` annotations. (#8044). ([292f20c6](https://github.com/FirebaseExtended/flutterfire/commit/292f20c61c0a479e5effcbf45a07f7fb782ba23e))
+ - **DOCS**: Update code snippets by removing incorrect forward slash for `@Collection` annotations. (#8044). ([292f20c6](https://github.com/firebase/flutterfire/commit/292f20c61c0a479e5effcbf45a07f7fb782ba23e))
 
 #### `cloud_firestore_platform_interface` - `v5.4.13`
 
- - **FIX**: Export enum `LoadBundleTaskState` from Platform Interface package. (#8027). ([7fa461e4](https://github.com/FirebaseExtended/flutterfire/commit/7fa461e4476db3ac255877db93b6ccf493d0e1cf))
+ - **FIX**: Export enum `LoadBundleTaskState` from Platform Interface package. (#8027). ([7fa461e4](https://github.com/firebase/flutterfire/commit/7fa461e4476db3ac255877db93b6ccf493d0e1cf))
 
 #### `firebase_auth` - `v3.3.7`
 
- - **DOCS**: Update documentation for `currentUser` property to make expectations clearer. (#7843). ([59bb47c2](https://github.com/FirebaseExtended/flutterfire/commit/59bb47c2490fbd641a1fcc26f2f888e8f4f02671))
+ - **DOCS**: Update documentation for `currentUser` property to make expectations clearer. (#7843). ([59bb47c2](https://github.com/firebase/flutterfire/commit/59bb47c2490fbd641a1fcc26f2f888e8f4f02671))
 
 #### `firebase_dynamic_links` - `v4.0.6`
 
- - **FIX**: Ensure Dynamic link is retrieved from the Intent just once for `getInitialLink()` on Android as per the documentation. (#7743). ([67cc6647](https://github.com/FirebaseExtended/flutterfire/commit/67cc66471046822463f326c05e732313dbaa9560))
+ - **FIX**: Ensure Dynamic link is retrieved from the Intent just once for `getInitialLink()` on Android as per the documentation. (#7743). ([67cc6647](https://github.com/firebase/flutterfire/commit/67cc66471046822463f326c05e732313dbaa9560))
 
 #### `flutterfire_ui` - `v0.3.4`
 
- - **FEAT**: Add Italian localization language support. (#7823). ([c3a1a839](https://github.com/FirebaseExtended/flutterfire/commit/c3a1a839a3963a75cc17e931a3eee6e091df40ac))
+ - **FEAT**: Add Italian localization language support. (#7823). ([c3a1a839](https://github.com/firebase/flutterfire/commit/c3a1a839a3963a75cc17e931a3eee6e091df40ac))
 
 
 ## 2022-02-08

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to FlutterFire
 
-<a href="https://github.com/FirebaseExtended/flutterfire/actions?query=workflow%3Aall_plugins">
-  <img src="https://github.com/FirebaseExtended/flutterfire/workflows/all_plugins/badge.svg" alt="all_plugins GitHub Workflow Status"/>
+<a href="https://github.com/firebase/flutterfire/actions?query=workflow%3Aall_plugins">
+  <img src="https://github.com/firebase/flutterfire/workflows/all_plugins/badge.svg" alt="all_plugins GitHub Workflow Status"/>
 </a>
 
 _See also: [Flutter's code of conduct](https://flutter.io/design-principles/#code-of-conduct)_
@@ -18,7 +18,7 @@ _See also: [Flutter's code of conduct](https://flutter.io/design-principles/#cod
 ## 2. Forking & cloning the repository
 
 - Ensure all the dependencies described in the previous section are installed.
-- Fork `https://github.com/FirebaseExtended/flutterfire` into your own GitHub account. If
+- Fork `https://github.com/firebase/flutterfire` into your own GitHub account. If
   you already have a fork, and are now installing a development environment on
   a new machine, make sure you've updated your fork so that you don't use stale
   configuration options from long ago.
@@ -26,7 +26,7 @@ _See also: [Flutter's code of conduct](https://flutter.io/design-principles/#cod
   follow [GitHub's directions](https://help.github.com/articles/generating-ssh-keys/)
   to generate an SSH key.
 - `git clone git@github.com:<your_name_here>/flutterfire.git`
-- `git remote add upstream git@github.com:FirebaseExtended/flutterfire.git` (So that you
+- `git remote add upstream git@github.com:firebase/flutterfire.git` (So that you
   fetch from the master repository, not your clone, when running `git fetch`
   et al.)
 
@@ -113,7 +113,7 @@ run the following command from the root of your cloned repository:
 melos run test:e2e
 ```
 
-A full list of all commands can be found within the [`melos.yaml`](https://github.com/FirebaseExtended/flutterfire/blob/master/melos.yaml)
+A full list of all commands can be found within the [`melos.yaml`](https://github.com/firebase/flutterfire/blob/master/melos.yaml)
 file.
 
 ## 5. Contributing code
@@ -151,7 +151,7 @@ Assuming all is successful, commit and push your code:
 To send us a pull request:
 
 - `git pull-request` (if you are using [Hub](http://github.com/github/hub/)) or
-  go to `https://github.com/FirebaseExtended/flutterfire` and click the
+  go to `https://github.com/firebase/flutterfire` and click the
   "Compare & pull request" button
 
 Please make sure all your check-ins have detailed commit messages explaining the patch.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ and open source.
 ## Issues
 
 Please file FlutterFire specific issues, bugs, or feature requests in
-our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new/choose).
+our [issue tracker](https://github.com/firebase/flutterfire/issues/new/choose).
 
 Plugin issues that are not specific to FlutterFire can be filed in
 the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
@@ -53,8 +53,8 @@ the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 **Note about contributing to Docs**: We're in the process of updating documentation for the Firebase SDK for Flutter. Please hold your PRs for docs until May 5th, 2022.
 
 If you wish to contribute a change to any of the existing plugins in this repo, please review
-our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).
 
 ## Status
 

--- a/docs/auth/federated-auth.md
+++ b/docs/auth/federated-auth.md
@@ -166,7 +166,7 @@ with the Facebook App ID and Secret set.
 
 Note: Firebase will not set the `User.emailVerified` property
 to `true` if your user logs in with Facebook. Should your user login using a provider that verifies email (e.g. Google sign-in) then this will be set to true.
-For further information, see this [issue](https://github.com/FirebaseExtended/flutterfire/issues/4612#issuecomment-782107867).
+For further information, see this [issue](https://github.com/firebase/flutterfire/issues/4612#issuecomment-782107867).
 
 
 ## Apple

--- a/docs/auth/password-auth.md
+++ b/docs/auth/password-auth.md
@@ -84,7 +84,7 @@ try {
 Caution: When a user uninstalls your app on iOS or macOS, the user's authentication
 state can persist between app re-installs, as the Firebase iOS SDK persists
 authentication state to the system keychain.
-See issue [#4661](https://github.com/FirebaseExtended/flutterfire/issues/4661)
+See issue [#4661](https://github.com/firebase/flutterfire/issues/4661)
 for more information.
 
 

--- a/docs/setup/_setup_main.md
+++ b/docs/setup/_setup_main.md
@@ -204,7 +204,7 @@ Product                                          | Plugin name                  
 ## Try out an example app with {{analytics}} {: #try-analytics-example-app}
 
 Like all packages, the `firebase_analytics` plugin comes with an
-[example program](//github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics/example){: .external}.
+[example program](//github.com/firebase/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics/example){: .external}.
 
 1.  Open a Flutter app that you've already configured to use Firebase (see
     instructions on this page).
@@ -213,7 +213,7 @@ Like all packages, the `firebase_analytics` plugin comes with an
     file.
 
 1.  From the {{firebase_analytics}}
-    [example program repository](//github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics/example/lib){: .external},
+    [example program repository](//github.com/firebase/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics/example/lib){: .external},
     copy-paste the following two files into your app's `lib` directory:
 
       * `main.dart`

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,5 +1,5 @@
 name: FlutterFire
-repository: https://github.com/FirebaseExtended/flutterfire
+repository: https://github.com/firebase/flutterfire
 
 packages:
   - packages/**

--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 3.1.16
 
- - **REFACTOR**: remove deprecated `Tasks.call` for android and replace with `TaskCompletionSource`. (#8522). ([45e27201](https://github.com/FirebaseExtended/flutterfire/commit/45e27201480088fab71af60963001baeae61d80d))
+ - **REFACTOR**: remove deprecated `Tasks.call` for android and replace with `TaskCompletionSource`. (#8522). ([45e27201](https://github.com/firebase/flutterfire/commit/45e27201480088fab71af60963001baeae61d80d))
 
 ## 3.1.15
 
@@ -24,12 +24,12 @@
 
 ## 3.1.11
 
- - **REFACTOR**: recreate ios, android, web and macOS folders for example app (#8255). ([cdae0613](https://github.com/FirebaseExtended/flutterfire/commit/cdae0613a359da41013721f601c20169807d214f))
- - **DOCS**: Fix method name typo in code documentation (#8291). ([7b4e06db](https://github.com/FirebaseExtended/flutterfire/commit/7b4e06db305ff9f785a1bfcf1888fec1a53970c4))
+ - **REFACTOR**: recreate ios, android, web and macOS folders for example app (#8255). ([cdae0613](https://github.com/firebase/flutterfire/commit/cdae0613a359da41013721f601c20169807d214f))
+ - **DOCS**: Fix method name typo in code documentation (#8291). ([7b4e06db](https://github.com/firebase/flutterfire/commit/7b4e06db305ff9f785a1bfcf1888fec1a53970c4))
 
 ## 3.1.10
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 3.1.9
 
@@ -41,7 +41,7 @@
 
 ## 3.1.7
 
- - **FIX**: Fix Android Firestore transaction crash when running in background caused by `null` `Activity`. (#7627). ([8d60d474](https://github.com/FirebaseExtended/flutterfire/commit/8d60d474438fccc5d6dcb41b840221ae385a853c))
+ - **FIX**: Fix Android Firestore transaction crash when running in background caused by `null` `Activity`. (#7627). ([8d60d474](https://github.com/firebase/flutterfire/commit/8d60d474438fccc5d6dcb41b840221ae385a853c))
 
 ## 3.1.6
 
@@ -49,7 +49,7 @@
 
 ## 3.1.5
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 3.1.4
 
@@ -325,7 +325,7 @@
 * Fixed issue #3210 (`Query.orderBy(FieldPath.documentId)` throws exception).
 * Fixed issue #3237 (`DocumentReference` not being parsed correctly).
 * Bump `cloud_firestore_web` dependency.
-* Bump `cloud_firestore_platform_interface` dependency to fix 2 race conditions. [(#3251)](https://github.com/FirebaseExtended/flutterfire/pull/3251)
+* Bump `cloud_firestore_platform_interface` dependency to fix 2 race conditions. [(#3251)](https://github.com/firebase/flutterfire/pull/3251)
 
 ## 0.14.0
 

--- a/packages/cloud_firestore/cloud_firestore/README.md
+++ b/packages/cloud_firestore/cloud_firestore/README.md
@@ -1,4 +1,4 @@
-[<img src="https://raw.githubusercontent.com/FirebaseExtended/flutterfire/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
+[<img src="https://raw.githubusercontent.com/firebase/flutterfire/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
 
 # Cloud Firestore Plugin for Flutter
 
@@ -18,10 +18,10 @@ To use this plugin, please visit the [Firestore Usage documentation](https://fir
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database with
   live synchronization and offline support on Android and iOS.
 homepage: https://firebase.flutter.dev/docs/firestore/overview
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore
+repository: https://github.com/firebase/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore
 version: 3.1.17
 
 false_secrets:

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 5.5.6
 
- - **REFACTOR**: fix analyzer issues introduced in Flutter 3.0.0 ([#8655](https://github.com/FirebaseExtended/flutterfire/issues/8655)). ([b05d7fa1](https://github.com/FirebaseExtended/flutterfire/commit/b05d7fa1ed56ab1bbceb02fec299800bce68a703))
+ - **REFACTOR**: fix analyzer issues introduced in Flutter 3.0.0 ([#8655](https://github.com/firebase/flutterfire/issues/8655)). ([b05d7fa1](https://github.com/firebase/flutterfire/commit/b05d7fa1ed56ab1bbceb02fec299800bce68a703))
 
 ## 5.5.5
 
@@ -20,19 +20,19 @@
 
 ## 5.5.2
 
- - **DOCS**: Fix method name typo in code documentation (#8291). ([7b4e06db](https://github.com/FirebaseExtended/flutterfire/commit/7b4e06db305ff9f785a1bfcf1888fec1a53970c4))
+ - **DOCS**: Fix method name typo in code documentation (#8291). ([7b4e06db](https://github.com/firebase/flutterfire/commit/7b4e06db305ff9f785a1bfcf1888fec1a53970c4))
 
 ## 5.5.1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 5.5.0
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 5.4.13
 
- - **FIX**: Export enum `LoadBundleTaskState` from Platform Interface package. (#8027). ([7fa461e4](https://github.com/FirebaseExtended/flutterfire/commit/7fa461e4476db3ac255877db93b6ccf493d0e1cf))
+ - **FIX**: Export enum `LoadBundleTaskState` from Platform Interface package. (#8027). ([7fa461e4](https://github.com/firebase/flutterfire/commit/7fa461e4476db3ac255877db93b6ccf493d0e1cf))
 
 ## 5.4.12
 
@@ -44,7 +44,7 @@
 
 ## 5.4.10
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 5.4.9
 
@@ -193,7 +193,7 @@
 
 ## 2.0.1
 
- - Fixed 2 race conditions. [(#3251)](https://github.com/FirebaseExtended/flutterfire/pull/3251)
+ - Fixed 2 race conditions. [(#3251)](https://github.com/firebase/flutterfire/pull/3251)
    - When a snapshot stream unsubscribes, the Dart Stream is removed at the same time an async request to remove the native listener is sent. In some cases, an event is sent from native before the native listener has been removed, but after the Dart Stream is removed, causing an assertion error.
    - If a widget updates in a very short period of time, the `onCancel` stream handler is called pretty much straight away. Since setting up the stream handler takes longer than removing, in some edge cases it's trying to remove a listener which hasn't been created.
 

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
@@ -1,8 +1,8 @@
 name: cloud_firestore_platform_interface
 description: A common platform interface for the cloud_firestore plugin.
 version: 5.5.7
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_platform_interface
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_platform_interface
+repository: https://github.com/firebase/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_platform_interface
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/timestamp_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/timestamp_test.dart
@@ -31,7 +31,7 @@ void main() {
       expect(t.nanoseconds, equals(456));
     });
 
-    // https://github.com/FirebaseExtended/flutterfire/issues/1222
+    // https://github.com/firebase/flutterfire/issues/1222
     test('does not exceed range', () {
       Timestamp maxTimestamp = Timestamp(_kEndOfTime - 1, _kBillion - 1);
       Timestamp.fromMicrosecondsSinceEpoch(maxTimestamp.microsecondsSinceEpoch);

--- a/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ## 2.6.10
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 2.6.9
 
@@ -44,7 +44,7 @@
 
 ## 2.6.5
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 2.6.4
 
@@ -184,7 +184,7 @@
 
 ## 1.0.1
 
- - **FIX**: Fix wrong cast (FirebaseExtended#5050) (#5242).
+ - **FIX**: Fix wrong cast (firebase#5050) (#5242).
 
 ## 1.0.0
 

--- a/packages/cloud_firestore/cloud_firestore_web/ios/cloud_firestore_web.podspec
+++ b/packages/cloud_firestore/cloud_firestore_web/ios/cloud_firestore_web.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
     s.description      = <<-DESC
   temp fake firebase_auth_web plugin
                          DESC
-    s.homepage         = 'https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_web'
+    s.homepage         = 'https://github.com/firebase/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_web'
     s.license          = { :file => '../LICENSE' }
     s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
     s.source           = { :path => '.' }

--- a/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cloud_firestore_web
 description: The web implementation of cloud_firestore
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_web
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_web
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_web
+repository: https://github.com/firebase/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_web
 
 version: 2.6.16
 

--- a/packages/cloud_firestore_odm/README.md
+++ b/packages/cloud_firestore_odm/README.md
@@ -4,7 +4,7 @@
 
 The Cloud Firestore ODM package enables developers to build fully type-safe applications for Flutter using the FlutterFire Cloud Firestore plugin.
 
-> The Cloud Firestore ODM is currently in **alpha**. Expect breaking changes, API changes and more. The documentation is still a work in progress. See the [discussion](https://github.com/FirebaseExtended/flutterfire/discussions/7475) for more details.
+> The Cloud Firestore ODM is currently in **alpha**. Expect breaking changes, API changes and more. The documentation is still a work in progress. See the [discussion](https://github.com/firebase/flutterfire/discussions/7475) for more details.
 
 ## What is an ODM?
 
@@ -80,10 +80,10 @@ Once installed, read the documentation on [defining models](./doc/defining-model
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/CHANGELOG.md
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## 1.0.0-dev.15
 
- - **FEAT**: Assert that collection.doc(id) does not point to a separate collection ([#8676](https://github.com/FirebaseExtended/flutterfire/issues/8676)). ([0808205b](https://github.com/FirebaseExtended/flutterfire/commit/0808205bdca03fc913015f00f5ffc2e1d018adb9))
+ - **FEAT**: Assert that collection.doc(id) does not point to a separate collection ([#8676](https://github.com/firebase/flutterfire/issues/8676)). ([0808205b](https://github.com/firebase/flutterfire/commit/0808205bdca03fc913015f00f5ffc2e1d018adb9))
 
 ## 1.0.0-dev.14
 
@@ -16,7 +16,7 @@
 
 ## 1.0.0-dev.13
 
- - **FEAT**: upgrade analyzer, freezed_annotation and json_serializable dependencies (#8465). ([8a27ab21](https://github.com/FirebaseExtended/flutterfire/commit/8a27ab21279d72998e80aa17b8ec39a9e4a08ec8))
+ - **FEAT**: upgrade analyzer, freezed_annotation and json_serializable dependencies (#8465). ([8a27ab21](https://github.com/firebase/flutterfire/commit/8a27ab21279d72998e80aa17b8ec39a9e4a08ec8))
 
 ## 1.0.0-dev.12
 
@@ -28,7 +28,7 @@
 
 ## 1.0.0-dev.10
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 1.0.0-dev.9
 
@@ -36,7 +36,7 @@
 
 ## 1.0.0-dev.8
 
- - **DOCS**: Update code snippets by removing incorrect forward slash for `@Collection` annotations. (#8044). ([292f20c6](https://github.com/FirebaseExtended/flutterfire/commit/292f20c61c0a479e5effcbf45a07f7fb782ba23e))
+ - **DOCS**: Update code snippets by removing incorrect forward slash for `@Collection` annotations. (#8044). ([292f20c6](https://github.com/firebase/flutterfire/commit/292f20c61c0a479e5effcbf45a07f7fb782ba23e))
 
 ## 1.0.0-dev.7
 

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/README.md
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/README.md
@@ -17,10 +17,10 @@ To use this package, please visit the [Firestore Usage documentation](https://fi
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/pubspec.yaml
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cloud_firestore_odm
 description: An ODM for Firebase Cloud Firestore (cloud_firestore).
 homepage: https://github.com/firebase/flutterfire/tree/master/packages/cloud_firestore_odm
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore_odm/cloud_firestore_odm
+repository: https://github.com/firebase/flutterfire/tree/master/packages/cloud_firestore_odm/cloud_firestore_odm
 version: 1.0.0-dev.17
 
 false_secrets:

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/CHANGELOG.md
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ## 1.0.0-dev.15
 
- - **FIX**: ODM should no-longer generates update/query functions for nested objects ([#8661](https://github.com/FirebaseExtended/flutterfire/issues/8661)). ([84eeed2e](https://github.com/FirebaseExtended/flutterfire/commit/84eeed2ec8da3aac87befd2028f8052005319730))
- - **FEAT**: Assert that collection.doc(id) does not point to a separate collection ([#8676](https://github.com/FirebaseExtended/flutterfire/issues/8676)). ([0808205b](https://github.com/FirebaseExtended/flutterfire/commit/0808205bdca03fc913015f00f5ffc2e1d018adb9))
+ - **FIX**: ODM should no-longer generates update/query functions for nested objects ([#8661](https://github.com/firebase/flutterfire/issues/8661)). ([84eeed2e](https://github.com/firebase/flutterfire/commit/84eeed2ec8da3aac87befd2028f8052005319730))
+ - **FEAT**: Assert that collection.doc(id) does not point to a separate collection ([#8676](https://github.com/firebase/flutterfire/issues/8676)). ([0808205b](https://github.com/firebase/flutterfire/commit/0808205bdca03fc913015f00f5ffc2e1d018adb9))
 
 ## 1.0.0-dev.14
 
@@ -17,7 +17,7 @@
 
 ## 1.0.0-dev.13
 
- - **FEAT**: upgrade analyzer, freezed_annotation and json_serializable dependencies (#8465). ([8a27ab21](https://github.com/FirebaseExtended/flutterfire/commit/8a27ab21279d72998e80aa17b8ec39a9e4a08ec8))
+ - **FEAT**: upgrade analyzer, freezed_annotation and json_serializable dependencies (#8465). ([8a27ab21](https://github.com/firebase/flutterfire/commit/8a27ab21279d72998e80aa17b8ec39a9e4a08ec8))
 
 ## 1.0.0-dev.12
 
@@ -29,11 +29,11 @@
 
 ## 1.0.0-dev.10
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 1.0.0-dev.9
 
- - **FIX**: Use descending in orderBy* (#8159). ([0b7b8811](https://github.com/FirebaseExtended/flutterfire/commit/0b7b88117ac65a0ab164ffcaa0ca7fa69633fcb2))
+ - **FIX**: Use descending in orderBy* (#8159). ([0b7b8811](https://github.com/firebase/flutterfire/commit/0b7b88117ac65a0ab164ffcaa0ca7fa69633fcb2))
 
 ## 1.0.0-dev.8
 
@@ -41,7 +41,7 @@
 
 ## 1.0.0-dev.7
 
- - **FEAT**: Added error handling for when the Firestore reference and the Model class are defined in two separate files. (#7885). ([43cb91c9](https://github.com/FirebaseExtended/flutterfire/commit/43cb91c9f22c7b61d7170305b9007c5beccfbdae))
+ - **FEAT**: Added error handling for when the Firestore reference and the Model class are defined in two separate files. (#7885). ([43cb91c9](https://github.com/firebase/flutterfire/commit/43cb91c9f22c7b61d7170305b9007c5beccfbdae))
 
 ## 1.0.0-dev.6
 

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/README.md
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/README.md
@@ -17,10 +17,10 @@ To use this package, please visit the [Firestore Usage documentation](https://fi
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/pubspec.yaml
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cloud_firestore_odm_generator
 description: A code generator for cloud_firestore_odm.
 homepage: https://firebase.flutter.dev/docs/firestore/odm
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator
+repository: https://github.com/firebase/flutterfire/tree/master/packages/cloud_firestore_odm_generator/cloud_firestore_odm_generator
 version: 1.0.0-dev.17
 
 environment:

--- a/packages/cloud_firestore_odm/doc/code-generation.md
+++ b/packages/cloud_firestore_odm/doc/code-generation.md
@@ -1,6 +1,6 @@
 # Code Generation
 
-> The Cloud Firestore ODM is currently in **alpha**. Expect breaking changes, API changes and more. The documentation is still a work in progress. See the [discussion](https://github.com/FirebaseExtended/flutterfire/discussions/7475) for more details.
+> The Cloud Firestore ODM is currently in **alpha**. Expect breaking changes, API changes and more. The documentation is still a work in progress. See the [discussion](https://github.com/firebase/flutterfire/discussions/7475) for more details.
 
 The power of the ODM comes from code generation. The models created need to be run through
 code generation to allow for the full type safety which the ODM offers.

--- a/packages/cloud_firestore_odm/doc/defining-models.md
+++ b/packages/cloud_firestore_odm/doc/defining-models.md
@@ -1,6 +1,6 @@
 # Defining Models
 
-> The Cloud Firestore ODM is currently in **alpha**. Expect breaking changes, API changes and more. The documentation is still a work in progress. See the [discussion](https://github.com/FirebaseExtended/flutterfire/discussions/7475) for more details.
+> The Cloud Firestore ODM is currently in **alpha**. Expect breaking changes, API changes and more. The documentation is still a work in progress. See the [discussion](https://github.com/firebase/flutterfire/discussions/7475) for more details.
 
 A model represents exactly what data we expect to both receive and mutate on Firestore. The ODM
 ensures that all data is validated against a model, and if the model is not valid an error will be

--- a/packages/cloud_firestore_odm/doc/references.md
+++ b/packages/cloud_firestore_odm/doc/references.md
@@ -1,6 +1,6 @@
 # Using References
 
-> The Cloud Firestore ODM is currently in **alpha**. Expect breaking changes, API changes and more. The documentation is still a work in progress. See the [discussion](https://github.com/FirebaseExtended/flutterfire/discussions/7475) for more details.
+> The Cloud Firestore ODM is currently in **alpha**. Expect breaking changes, API changes and more. The documentation is still a work in progress. See the [discussion](https://github.com/firebase/flutterfire/discussions/7475) for more details.
 
 A [reference](./defining-models.md#creating-references) provides full type-safe access to a Firestore
 Collection and Documents.

--- a/packages/cloud_firestore_odm/doc/subcollections.md
+++ b/packages/cloud_firestore_odm/doc/subcollections.md
@@ -1,6 +1,6 @@
 # Working with Subcollections
 
-> The Cloud Firestore ODM is currently in **alpha**. Expect breaking changes, API changes and more. The documentation is still a work in progress. See the [discussion](https://github.com/FirebaseExtended/flutterfire/discussions/7475) for more details.
+> The Cloud Firestore ODM is currently in **alpha**. Expect breaking changes, API changes and more. The documentation is still a work in progress. See the [discussion](https://github.com/firebase/flutterfire/discussions/7475) for more details.
 
 The ODM provides support for subcollections via the `Collection` annotation. For example, first define
 the root collection as normal:

--- a/packages/cloud_functions/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.2.16
 
- - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8746). ([53813627](https://github.com/FirebaseExtended/flutterfire/commit/53813627720e1e1ad729839519f7374ebc91470f))
+ - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8746). ([53813627](https://github.com/firebase/flutterfire/commit/53813627720e1e1ad729839519f7374ebc91470f))
 
 ## 3.2.15
 
@@ -24,11 +24,11 @@
 
 ## 3.2.10
 
- - **FIX**: Allow raw data arguments to be passed as data to Cloud Function for `Android` & `iOS`. (#7994). ([8288b811](https://github.com/FirebaseExtended/flutterfire/commit/8288b811f2b82df263a092428905960960e537c6))
+ - **FIX**: Allow raw data arguments to be passed as data to Cloud Function for `Android` & `iOS`. (#7994). ([8288b811](https://github.com/firebase/flutterfire/commit/8288b811f2b82df263a092428905960960e537c6))
 
 ## 3.2.9
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 3.2.8
 
@@ -36,7 +36,7 @@
 
 ## 3.2.7
 
-- **REFACTOR**: remove deprecated Android API usages (#7986). ([232e5f89](https://github.com/FirebaseExtended/flutterfire/commit/232e5f8972df8ef22bfb76ce8cf1e631d823a1b5))
+- **REFACTOR**: remove deprecated Android API usages (#7986). ([232e5f89](https://github.com/firebase/flutterfire/commit/232e5f8972df8ef22bfb76ce8cf1e631d823a1b5))
 
 ## 3.2.6
 
@@ -44,11 +44,11 @@
 
 ## 3.2.5
 
- - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/FirebaseExtended/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
+ - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/firebase/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
 
 ## 3.2.4
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 3.2.3
 

--- a/packages/cloud_functions/cloud_functions/README.md
+++ b/packages/cloud_functions/cloud_functions/README.md
@@ -1,4 +1,4 @@
-[<img src="https://raw.githubusercontent.com/FirebaseExtended/flutterfire/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
+[<img src="https://raw.githubusercontent.com/firebase/flutterfire/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
 
 # Firebase Cloud Functions for Flutter
 [![pub package](https://img.shields.io/pub/v/cloud_functions.svg)](https://pub.dev/packages/cloud_functions)
@@ -17,10 +17,10 @@ To use this plugin, please visit the [Functions Usage documentation](https://fir
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -2,7 +2,7 @@ name: cloud_functions
 description: A Flutter plugin allowing you to use Firebase Cloud Functions.
 version: 3.2.16
 homepage: https://firebase.flutter.dev/docs/functions/overview
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions
+repository: https://github.com/firebase/flutterfire/tree/master/packages/cloud_functions/cloud_functions
 
 false_secrets:
   - example/**

--- a/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
@@ -24,11 +24,11 @@
 
 ## 5.1.1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 5.1.0
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 5.0.21
 
@@ -40,7 +40,7 @@
 
 ## 5.0.19
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 5.0.18
 

--- a/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cloud_functions_platform_interface
 description: A common platform interface for the cloud_functions plugin.
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_platform_interface
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/cloud_functions/cloud_functions_platform_interface
+repository: https://github.com/firebase/flutterfire/tree/master/packages/cloud_functions/cloud_functions_platform_interface
 
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes

--- a/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ## 4.2.9
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 4.2.8
 

--- a/packages/cloud_functions/cloud_functions_web/ios/cloud_functions_web.podspec
+++ b/packages/cloud_functions/cloud_functions_web/ios/cloud_functions_web.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description      = <<-DESC
 Stub/fake cloud_functions_web plugin
                        DESC
-  s.homepage         = 'https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_web'
+  s.homepage         = 'https://github.com/firebase/flutterfire/tree/master/packages/cloud_functions/cloud_functions_web'
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :path => '.' }

--- a/packages/cloud_functions/cloud_functions_web/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cloud_functions_web
 description: The web implementation of cloud_functions
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_web
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_web
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/cloud_functions/cloud_functions_web
+repository: https://github.com/firebase/flutterfire/tree/master/packages/cloud_functions/cloud_functions_web
 
 version: 4.2.15
 

--- a/packages/firebase_admob/README.md
+++ b/packages/firebase_admob/README.md
@@ -1,4 +1,4 @@
 > **This package is now discontinued** in favor of [Google Mobile Ads SDK for
 Flutter](https://pub.dev/packages/google_mobile_ads).
 
-Source for the original package can be found [here](https://github.com/FirebaseExtended/flutterfire/tree/admob_backup/packages/firebase_admob).
+Source for the original package can be found [here](https://github.com/firebase/flutterfire/tree/admob_backup/packages/firebase_admob).

--- a/packages/firebase_analytics/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ## 9.1.6
 
- - **REFACTOR**: Update deployment target to `10.0` for Firebase Analytics podspec. (#8371). ([fe709da9](https://github.com/FirebaseExtended/flutterfire/commit/fe709da998162a3b884070df6666690ae560d0d1))
+ - **REFACTOR**: Update deployment target to `10.0` for Firebase Analytics podspec. (#8371). ([fe709da9](https://github.com/firebase/flutterfire/commit/fe709da998162a3b884070df6666690ae560d0d1))
 
 ## 9.1.5
 
@@ -20,7 +20,7 @@
 
 ## 9.1.4
 
- - **FIX**: Send default parameters for iOS when using `setDefaultEventParameters()` API. (#8402). ([7d3e5ba6](https://github.com/FirebaseExtended/flutterfire/commit/7d3e5ba6e4ee0bff178c5cfb73d34cdd3a7064e0))
+ - **FIX**: Send default parameters for iOS when using `setDefaultEventParameters()` API. (#8402). ([7d3e5ba6](https://github.com/firebase/flutterfire/commit/7d3e5ba6e4ee0bff178c5cfb73d34cdd3a7064e0))
 
 ## 9.1.3
 
@@ -28,32 +28,32 @@
 
 ## 9.1.2
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 9.1.1
 
- - **DOCS**: code comment typo - `logAdImpression` mentions wrong event (#8180). ([960a75a7](https://github.com/FirebaseExtended/flutterfire/commit/960a75a77dc8c575e7f8f9c4350ad564a3814eb8))
+ - **DOCS**: code comment typo - `logAdImpression` mentions wrong event (#8180). ([960a75a7](https://github.com/firebase/flutterfire/commit/960a75a77dc8c575e7f8f9c4350ad564a3814eb8))
 
 ## 9.1.0
 
- - **FEAT**: Improve `FirebaseAnalyticsObserver` so that it also fires events when the modal route changes. (#7711). ([f3bb2055](https://github.com/FirebaseExtended/flutterfire/commit/f3bb205594b3920f37eb4476c324e463f942c451))
+ - **FEAT**: Improve `FirebaseAnalyticsObserver` so that it also fires events when the modal route changes. (#7711). ([f3bb2055](https://github.com/firebase/flutterfire/commit/f3bb205594b3920f37eb4476c324e463f942c451))
 
 ## 9.0.5
 
- - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/FirebaseExtended/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
- - **FIX**: user id and user properties can be null so `NSNull` should be converted to `nil` on iOS/macOS (#7810). ([f588cf38](https://github.com/FirebaseExtended/flutterfire/commit/f588cf381135c6d51d472e7f744e72d7f6a69240))
- - **FIX**: `setUserProperty` should now accept null as a valid value on Android (#7735). ([c2237acb](https://github.com/FirebaseExtended/flutterfire/commit/c2237acb25903d2466db76a9c4fd2f14701369b6))
- - **DOCS**: example app initialization and docs support status (#7745). ([ac21f485](https://github.com/FirebaseExtended/flutterfire/commit/ac21f4855359d9c8452e60917b1992d8ad0f7a5e))
+ - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/firebase/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
+ - **FIX**: user id and user properties can be null so `NSNull` should be converted to `nil` on iOS/macOS (#7810). ([f588cf38](https://github.com/firebase/flutterfire/commit/f588cf381135c6d51d472e7f744e72d7f6a69240))
+ - **FIX**: `setUserProperty` should now accept null as a valid value on Android (#7735). ([c2237acb](https://github.com/firebase/flutterfire/commit/c2237acb25903d2466db76a9c4fd2f14701369b6))
+ - **DOCS**: example app initialization and docs support status (#7745). ([ac21f485](https://github.com/firebase/flutterfire/commit/ac21f4855359d9c8452e60917b1992d8ad0f7a5e))
 
 ## 9.0.4
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 9.0.3
 
- - **FIX**: ensure `setDefaultEventParameters()` API throws stating not supported on web. (#7522). ([9a83f121](https://github.com/FirebaseExtended/flutterfire/commit/9a83f1219e33090bc8dbdd9bf26316e7fc6e7979))
- - **FIX**: reinstate Analytics screen navigation observer. (#7529). ([caf2986e](https://github.com/FirebaseExtended/flutterfire/commit/caf2986ec76b0d761c2ef863af4c16f02fc4638f))
- - **FIX**: userId can be null (#7545). ([0d3b523c](https://github.com/FirebaseExtended/flutterfire/commit/0d3b523c3a2d1cd1d8c1ec17f7579727e88e5cb6))
+ - **FIX**: ensure `setDefaultEventParameters()` API throws stating not supported on web. (#7522). ([9a83f121](https://github.com/firebase/flutterfire/commit/9a83f1219e33090bc8dbdd9bf26316e7fc6e7979))
+ - **FIX**: reinstate Analytics screen navigation observer. (#7529). ([caf2986e](https://github.com/firebase/flutterfire/commit/caf2986ec76b0d761c2ef863af4c16f02fc4638f))
+ - **FIX**: userId can be null (#7545). ([0d3b523c](https://github.com/firebase/flutterfire/commit/0d3b523c3a2d1cd1d8c1ec17f7579727e88e5cb6))
 
 ## 9.0.2
 
@@ -67,7 +67,7 @@
 
 > Note: This release has breaking changes.
 
-As part of our on-going work for [#6769](https://github.com/FirebaseExtended/flutterfire/issues/6979) this is our Firebase Analytics rework changes.
+As part of our on-going work for [#6769](https://github.com/firebase/flutterfire/issues/6979) this is our Firebase Analytics rework changes.
 
 Overall, Firebase Analytics has been heavily reworked to bring it inline with the federated plugin setup along with adding new features,
 documentation and updating unit and end-to-end tests.

--- a/packages/firebase_analytics/firebase_analytics/README.md
+++ b/packages/firebase_analytics/firebase_analytics/README.md
@@ -16,10 +16,10 @@ To use this plugin, please visit the [Analytics Usage documentation](https://fir
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/firebase_analytics/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   Flutter plugin for Google Analytics for Firebase, an app measurement
   solution that provides insight on app usage and user engagement on Android and iOS.
 homepage: https://firebase.flutter.dev/docs/analytics/overview
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics
 version: 9.1.9
 
 false_secrets:

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/CHANGELOG.md
@@ -24,11 +24,11 @@
 
 ## 3.1.1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 3.1.0
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 3.0.5
 
@@ -40,7 +40,7 @@
 
 ## 3.0.3
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 3.0.2
 

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_analytics_platform_interface
 description: A common platform interface for the firebase_analytics plugin.
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics_platform_interface
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics_platform_interface
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics_platform_interface
 version: 3.1.7
 
 environment:

--- a/packages/firebase_analytics/firebase_analytics_web/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics_web/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ## 0.4.0+8
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.4.0+7
 
@@ -44,7 +44,7 @@
 
 ## 0.4.0+3
 
- - **FIX**: ensure `setDefaultEventParameters()` API throws stating not supported on web. (#7522). ([9a83f121](https://github.com/FirebaseExtended/flutterfire/commit/9a83f1219e33090bc8dbdd9bf26316e7fc6e7979))
+ - **FIX**: ensure `setDefaultEventParameters()` API throws stating not supported on web. (#7522). ([9a83f121](https://github.com/firebase/flutterfire/commit/9a83f1219e33090bc8dbdd9bf26316e7fc6e7979))
 
 ## 0.4.0+2
 

--- a/packages/firebase_analytics/firebase_analytics_web/ios/firebase_analytics_web.podspec
+++ b/packages/firebase_analytics/firebase_analytics_web/ios/firebase_analytics_web.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
     s.description      = <<-DESC
   temp fake firebase_auth_web plugin
                          DESC
-    s.homepage         = 'https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics_web'
+    s.homepage         = 'https://github.com/firebase/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics_web'
     s.license          = { :file => '../LICENSE' }
     s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
     s.source           = { :path => '.' }

--- a/packages/firebase_analytics/firebase_analytics_web/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_analytics_web
 description: The web implementation of firebase_analytics
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics_web
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics_web
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics_web
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics_web
 version: 0.4.0+14
 
 environment:

--- a/packages/firebase_app_check/firebase_app_check/CHANGELOG.md
+++ b/packages/firebase_app_check/firebase_app_check/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.6+13
 
- - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8747). ([e2a022d7](https://github.com/FirebaseExtended/flutterfire/commit/e2a022d7427817002e4114eb7434aa6e53384891))
+ - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8747). ([e2a022d7](https://github.com/firebase/flutterfire/commit/e2a022d7427817002e4114eb7434aa6e53384891))
 
 ## 0.0.6+12
 
@@ -24,7 +24,7 @@
 
 ## 0.0.6+7
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.0.6+6
 
@@ -32,15 +32,15 @@
 
 ## 0.0.6+5
 
- - **FIX**: workaround iOS build issue when targetting platforms < iOS 11. ([c78e0b79](https://github.com/FirebaseExtended/flutterfire/commit/c78e0b79bde479e78c558d3df92988c130280e81))
+ - **FIX**: workaround iOS build issue when targetting platforms < iOS 11. ([c78e0b79](https://github.com/firebase/flutterfire/commit/c78e0b79bde479e78c558d3df92988c130280e81))
 
 ## 0.0.6+4
 
- - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/FirebaseExtended/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
+ - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/firebase/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
 
 ## 0.0.6+3
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 0.0.6+2
 

--- a/packages/firebase_app_check/firebase_app_check/README.md
+++ b/packages/firebase_app_check/firebase_app_check/README.md
@@ -15,10 +15,10 @@ To use this plugin, please visit the [App Check Usage documentation](https://fir
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/firebase_app_check/firebase_app_check/pubspec.yaml
+++ b/packages/firebase_app_check/firebase_app_check/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_app_check
 description: App Check works alongside other Firebase services to help protect your backend resources from abuse, such as billing fraud or phishing.
 homepage: https://firebase.flutter.dev/docs/app-check/overview
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_app_check/firebase_app_check
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_app_check/firebase_app_check
 version: 0.0.6+13
 
 false_secrets:

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/CHANGELOG.md
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/CHANGELOG.md
@@ -24,11 +24,11 @@
 
 ## 0.0.4+1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.0.4
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 0.0.3+5
 
@@ -40,7 +40,7 @@
 
 ## 0.0.3+3
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 0.0.3+2
 

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/pubspec.yaml
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_app_check_platform_interface
 description: A common platform interface for the firebase_app_check plugin.
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_app_check/firebase_app_check_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_app_check/firebase_app_check_platform_interface
 version: 0.0.4+7
 
 environment:

--- a/packages/firebase_app_check/firebase_app_check_web/CHANGELOG.md
+++ b/packages/firebase_app_check/firebase_app_check_web/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ## 0.0.5+7
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.0.5+6
 

--- a/packages/firebase_app_check/firebase_app_check_web/pubspec.yaml
+++ b/packages/firebase_app_check/firebase_app_check_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_app_check_web
 description: The web implementation of firebase_auth
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_app_check/firebase_app_check_web
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_app_check/firebase_app_check_web
 version: 0.0.5+13
 
 environment:

--- a/packages/firebase_app_installations/firebase_app_installations/CHANGELOG.md
+++ b/packages/firebase_app_installations/firebase_app_installations/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ## 0.1.0+8
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.1.0+7
 
@@ -32,11 +32,11 @@
 
 ## 0.1.0+6
 
- - **FIX**: setup missing Firebase internal SDK headers (#7513). ([4c9d84cd](https://github.com/FirebaseExtended/flutterfire/commit/4c9d84cdc3f491c7d9c1421e7651742e5c2ccc1e))
+ - **FIX**: setup missing Firebase internal SDK headers (#7513). ([4c9d84cd](https://github.com/firebase/flutterfire/commit/4c9d84cdc3f491c7d9c1421e7651742e5c2ccc1e))
 
 ## 0.1.0+5
 
- - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/FirebaseExtended/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
+ - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/firebase/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
 
 ## 0.1.0+4
 

--- a/packages/firebase_app_installations/firebase_app_installations/README.md
+++ b/packages/firebase_app_installations/firebase_app_installations/README.md
@@ -14,10 +14,10 @@ To use this plugin, please visit the [Installations Usage documentation](https:/
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/firebase_app_installations/firebase_app_installations/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_app_installations
 description: A Flutter plugin allowing you to use Firebase Installations.
 version: 0.1.0+14
 homepage: https://firebase.flutter.dev/docs/installations/overview
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_app_installations/firebase_app_installations
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_app_installations/firebase_app_installations
 
 false_secrets:
   - example/**

--- a/packages/firebase_app_installations/firebase_app_installations_platform_interface/CHANGELOG.md
+++ b/packages/firebase_app_installations/firebase_app_installations_platform_interface/CHANGELOG.md
@@ -24,11 +24,11 @@
 
 ## 0.1.1+1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.1.1
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 0.1.0+6
 

--- a/packages/firebase_app_installations/firebase_app_installations_platform_interface/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations_platform_interface/pubspec.yaml
@@ -1,8 +1,8 @@
 name: firebase_app_installations_platform_interface
 description: A common platform interface for the firebase_app_installations plugin.
 version: 0.1.1+7
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_app_installations/firebase_app_installations_platform_interface
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_app_installations/firebase_app_installations_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_app_installations/firebase_app_installations_platform_interface
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_app_installations/firebase_app_installations_platform_interface
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/packages/firebase_app_installations/firebase_app_installations_web/CHANGELOG.md
+++ b/packages/firebase_app_installations/firebase_app_installations_web/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ## 0.1.0+8
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.1.0+7
 

--- a/packages/firebase_app_installations/firebase_app_installations_web/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations_web/pubspec.yaml
@@ -1,8 +1,8 @@
 name: firebase_app_installations_web
 description: The web implementation of firebase_app_installations.
 version: 0.1.0+14
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_app_installations/firebase_app_installations_web
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_app_installations/firebase_app_installations_web
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_app_installations/firebase_app_installations_web
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_app_installations/firebase_app_installations_web
 
 environment:
   sdk: '>=2.16.0 <3.0.0'

--- a/packages/firebase_auth/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.3.19
 
- - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8748). ([c6ff0b21](https://github.com/FirebaseExtended/flutterfire/commit/c6ff0b21352eb0f9a9a576ca7ef737d203292a58))
+ - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8748). ([c6ff0b21](https://github.com/firebase/flutterfire/commit/c6ff0b21352eb0f9a9a576ca7ef737d203292a58))
 
 ## 3.3.18
 
@@ -12,11 +12,11 @@
 
 ## 3.3.16
 
- - **REFACTOR**: remove deprecated `Tasks.call()` API from Android. (#8452). ([3e92496b](https://github.com/FirebaseExtended/flutterfire/commit/3e92496b2783ec149258c22d3167c5388dcb1c40))
+ - **REFACTOR**: remove deprecated `Tasks.call()` API from Android. (#8452). ([3e92496b](https://github.com/firebase/flutterfire/commit/3e92496b2783ec149258c22d3167c5388dcb1c40))
 
 ## 3.3.15
 
- - **FIX**: Use iterator instead of enhanced for loop on android. (#8498). ([027c75a6](https://github.com/FirebaseExtended/flutterfire/commit/027c75a60b39a40e6a3edc12edc51487cc954503))
+ - **FIX**: Use iterator instead of enhanced for loop on android. (#8498). ([027c75a6](https://github.com/firebase/flutterfire/commit/027c75a60b39a40e6a3edc12edc51487cc954503))
 
 ## 3.3.14
 
@@ -32,16 +32,16 @@
 
 ## 3.3.11
 
- - **FIX**: Update APN token once auth plugin has been initialized on `iOS`. (#8201). ([ab6239dd](https://github.com/FirebaseExtended/flutterfire/commit/ab6239ddf5cb14211b76bced04ec52203919a57a))
+ - **FIX**: Update APN token once auth plugin has been initialized on `iOS`. (#8201). ([ab6239dd](https://github.com/firebase/flutterfire/commit/ab6239ddf5cb14211b76bced04ec52203919a57a))
 
 ## 3.3.10
 
- - **FIX**: return correct error code for linkWithCredential `provider-already-linked` on Android (#8245). ([ae090719](https://github.com/FirebaseExtended/flutterfire/commit/ae090719ebbb0873cf227f76004feeae9a7d0580))
- - **FIX**: Fixed bug that sets email to `nil` on `iOS` when the `User` has no provider. (#8209). ([fb646438](https://github.com/FirebaseExtended/flutterfire/commit/fb646438f219b0f0f7c6a8c52e2b9daa4afc833e))
+ - **FIX**: return correct error code for linkWithCredential `provider-already-linked` on Android (#8245). ([ae090719](https://github.com/firebase/flutterfire/commit/ae090719ebbb0873cf227f76004feeae9a7d0580))
+ - **FIX**: Fixed bug that sets email to `nil` on `iOS` when the `User` has no provider. (#8209). ([fb646438](https://github.com/firebase/flutterfire/commit/fb646438f219b0f0f7c6a8c52e2b9daa4afc833e))
 
 ## 3.3.9
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 3.3.8
 
@@ -49,7 +49,7 @@
 
 ## 3.3.7
 
- - **DOCS**: Update documentation for `currentUser` property to make expectations clearer. (#7843). ([59bb47c2](https://github.com/FirebaseExtended/flutterfire/commit/59bb47c2490fbd641a1fcc26f2f888e8f4f02671))
+ - **DOCS**: Update documentation for `currentUser` property to make expectations clearer. (#7843). ([59bb47c2](https://github.com/firebase/flutterfire/commit/59bb47c2490fbd641a1fcc26f2f888e8f4f02671))
 
 ## 3.3.6
 
@@ -57,11 +57,11 @@
 
 ## 3.3.5
 
- - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/FirebaseExtended/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
+ - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/firebase/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
 
 ## 3.3.4
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 3.3.3
 
@@ -320,7 +320,7 @@
 
 ## 0.18.0+1
 
-* Fixed an Android issue where certain network related Firebase Auth error codes would come through as `unknown`. [(#3217)](https://github.com/FirebaseExtended/flutterfire/pull/3217)
+* Fixed an Android issue where certain network related Firebase Auth error codes would come through as `unknown`. [(#3217)](https://github.com/firebase/flutterfire/pull/3217)
 * Added missing deprecations: `FirebaseUser` class and `photoUrl` getter.
 * Bump `firebase_auth_platform_interface` dependency to fix an assertion issue when creating Google sign-in credentials.
 * Bump `firebase_auth_web` dependency to `^0.3.0+1`.

--- a/packages/firebase_auth/firebase_auth/README.md
+++ b/packages/firebase_auth/firebase_auth/README.md
@@ -1,4 +1,4 @@
-[<img src="https://raw.githubusercontent.com/FirebaseExtended/flutterfire/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
+[<img src="https://raw.githubusercontent.com/firebase/flutterfire/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
 
 # Firebase Auth for Flutter
 [![pub package](https://img.shields.io/pub/v/firebase_auth.svg)](https://pub.dev/packages/firebase_auth)
@@ -17,10 +17,10 @@ To use this plugin, please visit the [Authentication Usage documentation](https:
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -321,7 +321,7 @@ public class FlutterFirebaseAuthPlugin
     output.put(Constants.IS_ANONYMOUS, firebaseUser.isAnonymous());
 
     // TODO(Salakar): add an integration test to check for null, if possible
-    // See https://github.com/FirebaseExtended/flutterfire/issues/3643
+    // See https://github.com/firebase/flutterfire/issues/3643
     final FirebaseUserMetadata userMetadata = firebaseUser.getMetadata();
     if (userMetadata != null) {
       metadata.put(Constants.CREATION_TIME, firebaseUser.getMetadata().getCreationTimestamp());

--- a/packages/firebase_auth/firebase_auth/example/test_driver/instance_e2e.dart
+++ b/packages/firebase_auth/firebase_auth/example/test_driver/instance_e2e.dart
@@ -123,12 +123,12 @@ void runInstanceTests() {
       });
 
       test('fires once on first initialization of FirebaseAuth', () async {
-        // Fixes a very specific bug: https://github.com/FirebaseExtended/flutterfire/issues/3628
+        // Fixes a very specific bug: https://github.com/firebase/flutterfire/issues/3628
         // If the first initialization of FirebaseAuth involves the listeners userChanges() or idTokenChanges()
         // the user will receive two events. Why? The native SDK listener will always fire an event upon initial
         // listen. FirebaseAuth also sends an initial synthetic event. We send a synthetic event because, ordinarily, the user will
         // not use a listener as the first occurrence of FirebaseAuth. We, therefore, mimic native behavior by sending an
-        // event. This test proves the logic of PR: https://github.com/FirebaseExtended/flutterfire/pull/6560
+        // event. This test proves the logic of PR: https://github.com/firebase/flutterfire/pull/6560
 
         // Requires a fresh app.
         FirebaseApp second = await Firebase.initializeApp(

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   authentication using passwords, phone numbers and identity providers
   like Google, Facebook and Twitter.
 homepage: https://firebase.flutter.dev/docs/auth/overview
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_auth/firebase_auth
 version: 3.3.19
 
 false_secrets:

--- a/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 6.2.6
 
- - **REFACTOR**: fix analyzer issues introduced in Flutter 3.0.0 ([#8653](https://github.com/FirebaseExtended/flutterfire/issues/8653)). ([74e58171](https://github.com/FirebaseExtended/flutterfire/commit/74e5817159f18934ed0cd803f410ec96b372316a))
+ - **REFACTOR**: fix analyzer issues introduced in Flutter 3.0.0 ([#8653](https://github.com/firebase/flutterfire/issues/8653)). ([74e58171](https://github.com/firebase/flutterfire/commit/74e5817159f18934ed0cd803f410ec96b372316a))
 
 ## 6.2.5
 
@@ -24,11 +24,11 @@
 
 ## 6.2.1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 6.2.0
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 6.1.11
 
@@ -40,7 +40,7 @@
 
 ## 6.1.9
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 6.1.8
 
@@ -221,7 +221,7 @@ Migrated to null safety (#4633)
 
 ## 2.0.1
 
-* Fixed an incorrect assert when creating a `GoogleAuthCredential` instance. [(#3216)](https://github.com/FirebaseExtended/flutterfire/pull/3216/files#diff-be71096f90f1a879f17b7c94607b0885)
+* Fixed an incorrect assert when creating a `GoogleAuthCredential` instance. [(#3216)](https://github.com/firebase/flutterfire/pull/3216/files#diff-be71096f90f1a879f17b7c94607b0885)
 
 ## 2.0.0
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_auth_platform_interface
 description: A common platform interface for the firebase_auth plugin.
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_platform_interface
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_auth/firebase_auth_platform_interface
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_auth/firebase_auth_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
 version: 6.2.7

--- a/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
@@ -20,15 +20,15 @@
 
 ## 3.3.11
 
- - **FIX**: Allow `rawNonce` to be passed through on web via the `OAuthCredential`. (#8410). ([0df32f61](https://github.com/FirebaseExtended/flutterfire/commit/0df32f6106ca41cdb95c36c7816e6487124937d4))
+ - **FIX**: Allow `rawNonce` to be passed through on web via the `OAuthCredential`. (#8410). ([0df32f61](https://github.com/firebase/flutterfire/commit/0df32f6106ca41cdb95c36c7816e6487124937d4))
 
 ## 3.3.10
 
- - **FIX**: Check if `UserMetadata` properties are `null` before parsing. (#8313). ([cac41fb9](https://github.com/FirebaseExtended/flutterfire/commit/cac41fb9ddd5462b57f9d17615f387478f10d3dc))
+ - **FIX**: Check if `UserMetadata` properties are `null` before parsing. (#8313). ([cac41fb9](https://github.com/firebase/flutterfire/commit/cac41fb9ddd5462b57f9d17615f387478f10d3dc))
 
 ## 3.3.9
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 3.3.8
 
@@ -36,7 +36,7 @@
 
 ## 3.3.7
 
- - **FIX**: Add support for`dynamicLinkDomain` property to `ActionCodeSetting` for web. (#7683). ([3b0bf76e](https://github.com/FirebaseExtended/flutterfire/commit/3b0bf76e015c95840b2d38eec7f12c001d3bd47c))
+ - **FIX**: Add support for`dynamicLinkDomain` property to `ActionCodeSetting` for web. (#7683). ([3b0bf76e](https://github.com/firebase/flutterfire/commit/3b0bf76e015c95840b2d38eec7f12c001d3bd47c))
 
 ## 3.3.6
 

--- a/packages/firebase_auth/firebase_auth_web/ios/firebase_auth_web.podspec
+++ b/packages/firebase_auth/firebase_auth_web/ios/firebase_auth_web.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
     s.description      = <<-DESC
   temp fake firebase_auth_web plugin
                          DESC
-    s.homepage         = 'https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_web'
+    s.homepage         = 'https://github.com/firebase/flutterfire/tree/master/packages/firebase_auth/firebase_auth_web'
     s.license          = { :file => '../LICENSE' }
     s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
     s.source           = { :path => '.' }

--- a/packages/firebase_auth/firebase_auth_web/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_auth_web
 description: The web implementation of firebase_auth
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_web
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_web
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_auth/firebase_auth_web
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_auth/firebase_auth_web
 version: 3.3.16
 
 environment:

--- a/packages/firebase_core/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core/CHANGELOG.md
@@ -1,21 +1,21 @@
 ## 1.17.1
 
- - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8749). ([41462a42](https://github.com/FirebaseExtended/flutterfire/commit/41462a423ad783d20e5d303ed41898b061bccc48))
+ - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8749). ([41462a42](https://github.com/firebase/flutterfire/commit/41462a423ad783d20e5d303ed41898b061bccc48))
 
 ## 1.17.0
 
- - **REFACTOR**: remove deprecated `Tasks.call` for android and replace with `TaskCompletionSource`. ([#8581](https://github.com/FirebaseExtended/flutterfire/issues/8581)). ([374c9df3](https://github.com/FirebaseExtended/flutterfire/commit/374c9df33bbb6b354ea526dcc6cc7812fa4452c0))
- - **FEAT**: bump Firebase Android SDK to 30.0.0 ([#8617](https://github.com/FirebaseExtended/flutterfire/issues/8617)). ([72158aaf](https://github.com/FirebaseExtended/flutterfire/commit/72158aaf9721dbf5f20c362f0c99853273507538))
- - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android ([#8566](https://github.com/FirebaseExtended/flutterfire/issues/8566)). ([30216c4a](https://github.com/FirebaseExtended/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
+ - **REFACTOR**: remove deprecated `Tasks.call` for android and replace with `TaskCompletionSource`. ([#8581](https://github.com/firebase/flutterfire/issues/8581)). ([374c9df3](https://github.com/firebase/flutterfire/commit/374c9df33bbb6b354ea526dcc6cc7812fa4452c0))
+ - **FEAT**: bump Firebase Android SDK to 30.0.0 ([#8617](https://github.com/firebase/flutterfire/issues/8617)). ([72158aaf](https://github.com/firebase/flutterfire/commit/72158aaf9721dbf5f20c362f0c99853273507538))
+ - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android ([#8566](https://github.com/firebase/flutterfire/issues/8566)). ([30216c4a](https://github.com/firebase/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
 
 ## 1.16.0
 
- - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android (#8566). ([30216c4a](https://github.com/FirebaseExtended/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
+ - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android (#8566). ([30216c4a](https://github.com/firebase/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
 
 ## 1.15.0
 
- - **FEAT**: bump Firebase Android SDK to `29.3.1` (#8494). ([17b9c289](https://github.com/FirebaseExtended/flutterfire/commit/17b9c2894ee901afd2631664b01829cd4df1dd16))
- - **FEAT**: Update Firebase iOS SDK to `8.15.0` (#8454). ([faaf4496](https://github.com/FirebaseExtended/flutterfire/commit/faaf449624ff4081cbbc0f241fec3134492cbdb3))
+ - **FEAT**: bump Firebase Android SDK to `29.3.1` (#8494). ([17b9c289](https://github.com/firebase/flutterfire/commit/17b9c2894ee901afd2631664b01829cd4df1dd16))
+ - **FEAT**: Update Firebase iOS SDK to `8.15.0` (#8454). ([faaf4496](https://github.com/firebase/flutterfire/commit/faaf449624ff4081cbbc0f241fec3134492cbdb3))
 
 ## 1.14.1
 
@@ -23,32 +23,32 @@
 
 ## 1.14.0
 
- - **FEAT**: Bump Firebase iOS SDK to `8.14.0`. (#8370). ([41bb9800](https://github.com/FirebaseExtended/flutterfire/commit/41bb98004327013f90c93709513c419d04382475))
- - **FEAT**: bump Firebase Android SDK to `29.3.0` (#8283). ([a6c646a0](https://github.com/FirebaseExtended/flutterfire/commit/a6c646a0d23600e5e4ae6d40ca4b23c7e73fc257))
- - **DOCS**: Update inline code documentation for initializing Firebase app. (#8329). ([19727798](https://github.com/FirebaseExtended/flutterfire/commit/19727798a8dcfde103665eb8209b714e49327a11))
+ - **FEAT**: Bump Firebase iOS SDK to `8.14.0`. (#8370). ([41bb9800](https://github.com/firebase/flutterfire/commit/41bb98004327013f90c93709513c419d04382475))
+ - **FEAT**: bump Firebase Android SDK to `29.3.0` (#8283). ([a6c646a0](https://github.com/firebase/flutterfire/commit/a6c646a0d23600e5e4ae6d40ca4b23c7e73fc257))
+ - **DOCS**: Update inline code documentation for initializing Firebase app. (#8329). ([19727798](https://github.com/firebase/flutterfire/commit/19727798a8dcfde103665eb8209b714e49327a11))
 
 ## 1.13.1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 1.13.0
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 1.12.0
 
- - **FEAT**: bump Firebase iOS SDK to `8.11.0` & Android SDK to `29.0.4` (#7942). ([c23adf08](https://github.com/FirebaseExtended/flutterfire/commit/c23adf0853466941d0afb174dd425a43b44ce501))
+ - **FEAT**: bump Firebase iOS SDK to `8.11.0` & Android SDK to `29.0.4` (#7942). ([c23adf08](https://github.com/firebase/flutterfire/commit/c23adf0853466941d0afb174dd425a43b44ce501))
 
 ## 1.11.0
 
- - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/FirebaseExtended/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
- - **FIX**: bump Firebase Android SDK version to `29.0.3` (from `29.0.0`). ([2ab4abaf](https://github.com/FirebaseExtended/flutterfire/commit/2ab4abafbed279183d298f129cd14aebb588c86d))
- - **FIX**: workaround an SDK issue on Android where calling `initializeApp` when having `In App Messaging` installed causes a crash. ([8f5204e7](https://github.com/FirebaseExtended/flutterfire/commit/8f5204e7e59e92869d61764c051e5687e118282d))
- - **FEAT**: bump Firebase iOS SDK version to `8.10.0`. (#7775). ([ac9709e0](https://github.com/FirebaseExtended/flutterfire/commit/ac9709e00a0e3d1706b793750ed2e65d9ae9440b))
+ - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/firebase/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
+ - **FIX**: bump Firebase Android SDK version to `29.0.3` (from `29.0.0`). ([2ab4abaf](https://github.com/firebase/flutterfire/commit/2ab4abafbed279183d298f129cd14aebb588c86d))
+ - **FIX**: workaround an SDK issue on Android where calling `initializeApp` when having `In App Messaging` installed causes a crash. ([8f5204e7](https://github.com/firebase/flutterfire/commit/8f5204e7e59e92869d61764c051e5687e118282d))
+ - **FEAT**: bump Firebase iOS SDK version to `8.10.0`. (#7775). ([ac9709e0](https://github.com/firebase/flutterfire/commit/ac9709e00a0e3d1706b793750ed2e65d9ae9440b))
 
 ## 1.10.6
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 1.10.5
 

--- a/packages/firebase_core/firebase_core/README.md
+++ b/packages/firebase_core/firebase_core/README.md
@@ -1,4 +1,4 @@
-[<img src="https://raw.githubusercontent.com/FirebaseExtended/flutterfire/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
+[<img src="https://raw.githubusercontent.com/firebase/flutterfire/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
 
 # Firebase Core for Flutter
 
@@ -18,11 +18,11 @@ To use this plugin, please visit the [Core Usage documentation](https://firebase
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).
 

--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_core
 description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 homepage: https://firebase.flutter.dev/docs/core/usage
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_core/firebase_core
 version: 1.17.1
 
 false_secrets:

--- a/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
@@ -1,27 +1,27 @@
 ## 4.4.0
 
- - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android ([#8566](https://github.com/FirebaseExtended/flutterfire/issues/8566)). ([30216c4a](https://github.com/FirebaseExtended/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
+ - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android ([#8566](https://github.com/firebase/flutterfire/issues/8566)). ([30216c4a](https://github.com/firebase/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
 
 ## 4.3.0
 
- - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android (#8566). ([30216c4a](https://github.com/FirebaseExtended/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
+ - **FEAT**: allow initializing default Firebase apps via `FirebaseOptions.fromResource` on Android (#8566). ([30216c4a](https://github.com/firebase/flutterfire/commit/30216c4a4c06c20f9c4c2b9a235a4aa9a48816a0))
 
 ## 4.2.5
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 4.2.4
 
- - **FIX**: allow secondary Firebase App initialization without duplicate app error on hot restart (#7953). ([f4a2c2e6](https://github.com/FirebaseExtended/flutterfire/commit/f4a2c2e63e4dd4f888583110cc65ec84dec14dd7))
- - **FIX**: Fix `FirebaseException` error code bug by making default value: "unknown". (#6897). ([48fed37c](https://github.com/FirebaseExtended/flutterfire/commit/48fed37c8e09b4c1c70f97488215fd39ff2f0616))
+ - **FIX**: allow secondary Firebase App initialization without duplicate app error on hot restart (#7953). ([f4a2c2e6](https://github.com/firebase/flutterfire/commit/f4a2c2e63e4dd4f888583110cc65ec84dec14dd7))
+ - **FIX**: Fix `FirebaseException` error code bug by making default value: "unknown". (#6897). ([48fed37c](https://github.com/firebase/flutterfire/commit/48fed37c8e09b4c1c70f97488215fd39ff2f0616))
 
 ## 4.2.3
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 4.2.2
 
- - **FIX**: correctly detect `not-initialized` errors and provide a better error message. ([0578423e](https://github.com/FirebaseExtended/flutterfire/commit/0578423e9868352556bfdd326eef1cca8dbe04aa))
+ - **FIX**: correctly detect `not-initialized` errors and provide a better error message. ([0578423e](https://github.com/firebase/flutterfire/commit/0578423e9868352556bfdd326eef1cca8dbe04aa))
 
 ## 4.2.1
 

--- a/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_core_platform_interface
 description: A common platform interface for the firebase_core plugin.
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core_platform_interface
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_core/firebase_core_platform_interface
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_core/firebase_core_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
 version: 4.4.0

--- a/packages/firebase_core/firebase_core_web/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_web/CHANGELOG.md
@@ -8,15 +8,15 @@
 
 ## 1.6.2
 
- - **DOCS**: Fix typo in "firebase_core_web.dart" documentation. ([658c1db7](https://github.com/FirebaseExtended/flutterfire/commit/658c1db71cc47b3eddec3a1f33d5d55d1a6ff98a))
+ - **DOCS**: Fix typo in "firebase_core_web.dart" documentation. ([658c1db7](https://github.com/firebase/flutterfire/commit/658c1db71cc47b3eddec3a1f33d5d55d1a6ff98a))
 
 ## 1.6.1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 1.6.0
 
- - **FEAT**: Bump Firebase Web SDK version to 8.10.1 (CVE-2022-0235) for security patch purposes. (#8162). ([7624f777](https://github.com/FirebaseExtended/flutterfire/commit/7624f7779f4a49f2353f3f593b31be9139197028))
+ - **FEAT**: Bump Firebase Web SDK version to 8.10.1 (CVE-2022-0235) for security patch purposes. (#8162). ([7624f777](https://github.com/firebase/flutterfire/commit/7624f7779f4a49f2353f3f593b31be9139197028))
 
 ## 1.5.4
 
@@ -28,7 +28,7 @@
 
 ## 1.5.2
 
- - **FIX**: correctly detect `not-initialized` errors and provide a better error message. ([0578423e](https://github.com/FirebaseExtended/flutterfire/commit/0578423e9868352556bfdd326eef1cca8dbe04aa))
+ - **FIX**: correctly detect `not-initialized` errors and provide a better error message. ([0578423e](https://github.com/firebase/flutterfire/commit/0578423e9868352556bfdd326eef1cca8dbe04aa))
 
 ## 1.5.1
 
@@ -72,7 +72,7 @@
 
 ## 1.0.1
 
- - **FIX**: Fix wrong cast (FirebaseExtended#5050) (#5242).
+ - **FIX**: Fix wrong cast (firebase#5050) (#5242).
 
 ## 1.0.0
 

--- a/packages/firebase_core/firebase_core_web/ios/firebase_core_web.podspec
+++ b/packages/firebase_core/firebase_core_web/ios/firebase_core_web.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
     s.description      = <<-DESC
   temp fake firebase_core_web plugin
                          DESC
-    s.homepage         = 'https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core_web'
+    s.homepage         = 'https://github.com/firebase/flutterfire/tree/master/packages/firebase_core/firebase_core_web'
     s.license          = { :file => '../LICENSE' }
     s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
     s.source           = { :path => '.' }

--- a/packages/firebase_core/firebase_core_web/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_core_web
 description: The web implementation of firebase_core
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core_web
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core_web
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_core/firebase_core_web
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_core/firebase_core_web
 version: 1.6.4
 
 environment:

--- a/packages/firebase_crashlytics/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/firebase_crashlytics/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## 2.8.1
 
- - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8750). ([e9e1c1bf](https://github.com/FirebaseExtended/flutterfire/commit/e9e1c1bf19d32e5b8967da162b03d0254843a836))
+ - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8750). ([e9e1c1bf](https://github.com/firebase/flutterfire/commit/e9e1c1bf19d32e5b8967da162b03d0254843a836))
 
 ## 2.8.0
 
- - **REFACTOR**: remove deprecated `Tasks.call` for android and replace with `TaskCompletionSource`. ([#8582](https://github.com/FirebaseExtended/flutterfire/issues/8582)). ([9539c92a](https://github.com/FirebaseExtended/flutterfire/commit/9539c92a53f73bf57b9c61ae9e0ce5042b4b8ca4))
- - **FIX**: symlink `ExceptionModel_Platform.h` to macOS. ([#8570](https://github.com/FirebaseExtended/flutterfire/issues/8570)). ([9991b7a5](https://github.com/FirebaseExtended/flutterfire/commit/9991b7a5389738a7bbba8f2210f8379b887d90e7))
- - **FEAT**: bump Firebase Android SDK to 30.0.0 ([#8617](https://github.com/FirebaseExtended/flutterfire/issues/8617)). ([72158aaf](https://github.com/FirebaseExtended/flutterfire/commit/72158aaf9721dbf5f20c362f0c99853273507538))
+ - **REFACTOR**: remove deprecated `Tasks.call` for android and replace with `TaskCompletionSource`. ([#8582](https://github.com/firebase/flutterfire/issues/8582)). ([9539c92a](https://github.com/firebase/flutterfire/commit/9539c92a53f73bf57b9c61ae9e0ce5042b4b8ca4))
+ - **FIX**: symlink `ExceptionModel_Platform.h` to macOS. ([#8570](https://github.com/firebase/flutterfire/issues/8570)). ([9991b7a5](https://github.com/firebase/flutterfire/commit/9991b7a5389738a7bbba8f2210f8379b887d90e7))
+ - **FEAT**: bump Firebase Android SDK to 30.0.0 ([#8617](https://github.com/firebase/flutterfire/issues/8617)). ([72158aaf](https://github.com/firebase/flutterfire/commit/72158aaf9721dbf5f20c362f0c99853273507538))
 
 ## 2.7.2
 
@@ -14,11 +14,11 @@
 
 ## 2.7.1
 
- - **FIX**: re-add support for `recordFlutterFatalError` method from previous EAP API (#8550). ([8ef8b55c](https://github.com/FirebaseExtended/flutterfire/commit/8ef8b55c113f24abac783170723c7f784f5d1fe5))
+ - **FIX**: re-add support for `recordFlutterFatalError` method from previous EAP API (#8550). ([8ef8b55c](https://github.com/firebase/flutterfire/commit/8ef8b55c113f24abac783170723c7f784f5d1fe5))
 
 ## 2.7.0
 
- - **FEAT**: add support for on-demand exception reporting (#8540). ([dfec7d60](https://github.com/FirebaseExtended/flutterfire/commit/dfec7d60592abe0a5c6523e13feabffb8b03020b))
+ - **FEAT**: add support for on-demand exception reporting (#8540). ([dfec7d60](https://github.com/firebase/flutterfire/commit/dfec7d60592abe0a5c6523e13feabffb8b03020b))
 
 ## 2.6.3
 
@@ -30,15 +30,15 @@
 
 ## 2.6.1
 
- - **FIX**: Exit the add crashlytics upload-symbols script if the required json isn't present. ([94077929](https://github.com/FirebaseExtended/flutterfire/commit/940779290a3039181a92567fe8492a720af899e1))
+ - **FIX**: Exit the add crashlytics upload-symbols script if the required json isn't present. ([94077929](https://github.com/firebase/flutterfire/commit/940779290a3039181a92567fe8492a720af899e1))
 
 ## 2.6.0
 
- - **FEAT**: add automatic Crashlytics symbol uploads for iOS & macOS apps (#8157). ([c4a3eaa7](https://github.com/FirebaseExtended/flutterfire/commit/c4a3eaa7200d924f9ec71370dd3c875813804935))
+ - **FEAT**: add automatic Crashlytics symbol uploads for iOS & macOS apps (#8157). ([c4a3eaa7](https://github.com/firebase/flutterfire/commit/c4a3eaa7200d924f9ec71370dd3c875813804935))
 
 ## 2.5.3
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 2.5.2
 
@@ -50,17 +50,17 @@
 
 ## 2.5.0
 
- - **FEAT**: Set the dSYM file format through the Crashlytic's podspec to allow symbolicating crash reports. (#7872). ([d5d7e26a](https://github.com/FirebaseExtended/flutterfire/commit/d5d7e26a4828963f375b656c6e1a397d26aac980))
+ - **FEAT**: Set the dSYM file format through the Crashlytic's podspec to allow symbolicating crash reports. (#7872). ([d5d7e26a](https://github.com/firebase/flutterfire/commit/d5d7e26a4828963f375b656c6e1a397d26aac980))
 
 ## 2.4.5
 
- - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/FirebaseExtended/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
+ - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/firebase/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
 
 ## 2.4.4
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
- - **FIX**: set build id as not required, to allow Dart default app initialization (#7594). ([c15fdda3](https://github.com/FirebaseExtended/flutterfire/commit/c15fdda33b447ddd0c8e066e9c9ec7cabf9cd6fd))
- - **FIX**: Return app constants for default app only on `Android`. (#7592). ([b803c425](https://github.com/FirebaseExtended/flutterfire/commit/b803c425b420acae155fea93a62ab9b3de4556a5))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **FIX**: set build id as not required, to allow Dart default app initialization (#7594). ([c15fdda3](https://github.com/firebase/flutterfire/commit/c15fdda33b447ddd0c8e066e9c9ec7cabf9cd6fd))
+ - **FIX**: Return app constants for default app only on `Android`. (#7592). ([b803c425](https://github.com/firebase/flutterfire/commit/b803c425b420acae155fea93a62ab9b3de4556a5))
 
 ## 2.4.3
 

--- a/packages/firebase_crashlytics/firebase_crashlytics/README.md
+++ b/packages/firebase_crashlytics/firebase_crashlytics/README.md
@@ -1,4 +1,4 @@
-[<img src="https://raw.githubusercontent.com/FirebaseExtended/flutterfire/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
+[<img src="https://raw.githubusercontent.com/firebase/flutterfire/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
 
 # Firebase Crashlytics for Flutter
 
@@ -18,10 +18,10 @@ To use this plugin, please visit the [Crashlytics Usage documentation](https://f
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
@@ -4,7 +4,7 @@ description:
   Firebase console.
 version: 2.8.1
 homepage: https://firebase.flutter.dev/docs/crashlytics/overview
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics/firebase_crashlytics
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_crashlytics/firebase_crashlytics
 
 false_secrets:
   - example/**

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/CHANGELOG.md
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/CHANGELOG.md
@@ -24,11 +24,11 @@
 
 ## 3.2.1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 3.2.0
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 3.1.13
 
@@ -40,7 +40,7 @@
 
 ## 3.1.11
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 3.1.10
 

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pubspec.yaml
@@ -1,8 +1,8 @@
 name: firebase_crashlytics_platform_interface
 description: A common platform interface for the firebase_crashlytics plugin.
 version: 3.2.7
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics/firebase_crashlytics_platform_interface
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics/firebase_crashlytics_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_crashlytics/firebase_crashlytics_platform_interface
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_crashlytics/firebase_crashlytics_platform_interface
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/packages/firebase_database/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/firebase_database/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 9.0.15
 
- - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8732). ([63aa1011](https://github.com/FirebaseExtended/flutterfire/commit/63aa10118e3fa541b276fed5828bd7db368c5ebd))
+ - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8732). ([63aa1011](https://github.com/firebase/flutterfire/commit/63aa10118e3fa541b276fed5828bd7db368c5ebd))
 
 ## 9.0.14
 
@@ -28,7 +28,7 @@
 
 ## 9.0.8
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 9.0.7
 
@@ -36,25 +36,25 @@
 
 ## 9.0.6
 
- - **FIX**: Fix `MissingPluginException` caused by malformed EventChannel name. (#7859). ([b69be414](https://github.com/FirebaseExtended/flutterfire/commit/b69be414d46afa047d44d96bb46878e48db594d8))
+ - **FIX**: Fix `MissingPluginException` caused by malformed EventChannel name. (#7859). ([b69be414](https://github.com/firebase/flutterfire/commit/b69be414d46afa047d44d96bb46878e48db594d8))
 
 ## 9.0.5
 
- - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/FirebaseExtended/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
+ - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/firebase/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
 
 ## 9.0.4
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
- - **FIX**: remove trailing `/` from `databaseUrl` if present. (#7601). ([abe4c2c7](https://github.com/FirebaseExtended/flutterfire/commit/abe4c2c7e3c9828ffc508d3be5da576e79eb3e73))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **FIX**: remove trailing `/` from `databaseUrl` if present. (#7601). ([abe4c2c7](https://github.com/firebase/flutterfire/commit/abe4c2c7e3c9828ffc508d3be5da576e79eb3e73))
 
 ## 9.0.3
 
- - **FIX**: downgrade the Android min SDK to 19 (#7533). ([c657adec](https://github.com/FirebaseExtended/flutterfire/commit/c657adeca078a83ad7157eba91179f3e3ddb5001))
+ - **FIX**: downgrade the Android min SDK to 19 (#7533). ([c657adec](https://github.com/firebase/flutterfire/commit/c657adeca078a83ad7157eba91179f3e3ddb5001))
 
 ## 9.0.2
 
- - **FIX**: web reference `path` should now correctly return a path string. ([f9995ce0](https://github.com/FirebaseExtended/flutterfire/commit/f9995ce043d8d60d1e74077064f0df2226291738))
- - **FIX**: database path should default to `/` if no path specified rather than an empty string (fixes #7515). ([c33c3c93](https://github.com/FirebaseExtended/flutterfire/commit/c33c3c931d7e4c654dd0b2cd23d800b43192d95d))
+ - **FIX**: web reference `path` should now correctly return a path string. ([f9995ce0](https://github.com/firebase/flutterfire/commit/f9995ce043d8d60d1e74077064f0df2226291738))
+ - **FIX**: database path should default to `/` if no path specified rather than an empty string (fixes #7515). ([c33c3c93](https://github.com/firebase/flutterfire/commit/c33c3c931d7e4c654dd0b2cd23d800b43192d95d))
 
 ## 9.0.1
 

--- a/packages/firebase_database/firebase_database/README.md
+++ b/packages/firebase_database/firebase_database/README.md
@@ -16,10 +16,10 @@ To use this plugin, please visit the [Firebase Database Usage documentation](htt
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/firebase_database/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/firebase_database/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_database
 description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 homepage: https://firebase.google.com/docs/database
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_database/firebase_database
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_database/firebase_database
 version: 9.0.15
 
 false_secrets:

--- a/packages/firebase_database/firebase_database_platform_interface/CHANGELOG.md
+++ b/packages/firebase_database/firebase_database_platform_interface/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.2.1+6
 
- - **REFACTOR**: fix analyzer issue introduced in Flutter 3.0.0 ([#8652](https://github.com/FirebaseExtended/flutterfire/issues/8652)). ([b781153a](https://github.com/FirebaseExtended/flutterfire/commit/b781153ac65df629c0a181219bf0b01999a5fa59))
+ - **REFACTOR**: fix analyzer issue introduced in Flutter 3.0.0 ([#8652](https://github.com/firebase/flutterfire/issues/8652)). ([b781153a](https://github.com/firebase/flutterfire/commit/b781153ac65df629c0a181219bf0b01999a5fa59))
 
 ## 0.2.1+5
 
@@ -24,15 +24,15 @@
 
 ## 0.2.1+1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.2.1
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 0.2.0+5
 
- - **FIX**: Fixed transaction bug by removing duplicate arguments when they are already set as defaults. (#7839). ([df6568c2](https://github.com/FirebaseExtended/flutterfire/commit/df6568c2f5f58f1c93abebca4df477114ed7a68e))
+ - **FIX**: Fixed transaction bug by removing duplicate arguments when they are already set as defaults. (#7839). ([df6568c2](https://github.com/firebase/flutterfire/commit/df6568c2f5f58f1c93abebca4df477114ed7a68e))
 
 ## 0.2.0+4
 
@@ -44,7 +44,7 @@
 
 ## 0.2.0+2
 
- - **FIX**: database path should default to `/` if no path specified rather than an empty string (fixes #7515). ([c33c3c93](https://github.com/FirebaseExtended/flutterfire/commit/c33c3c931d7e4c654dd0b2cd23d800b43192d95d))
+ - **FIX**: database path should default to `/` if no path specified rather than an empty string (fixes #7515). ([c33c3c93](https://github.com/firebase/flutterfire/commit/c33c3c931d7e4c654dd0b2cd23d800b43192d95d))
 
 ## 0.2.0+1
 

--- a/packages/firebase_database/firebase_database_platform_interface/pubspec.yaml
+++ b/packages/firebase_database/firebase_database_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_database_platform_interface
 description: A common platform interface for the firebase_database plugin.
 version: 0.2.1+7
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_database/firebase_database_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_database/firebase_database_platform_interface
 
 dependencies:
   collection: ^1.14.3

--- a/packages/firebase_database/firebase_database_web/CHANGELOG.md
+++ b/packages/firebase_database/firebase_database_web/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ## 0.2.0+9
 
- - **FIX**: Remove sync as `true` on Stream broadcast for web platform. (#8420). ([4336e047](https://github.com/FirebaseExtended/flutterfire/commit/4336e0478a927385e676b069f354bd3cc2f932ab))
+ - **FIX**: Remove sync as `true` on Stream broadcast for web platform. (#8420). ([4336e047](https://github.com/firebase/flutterfire/commit/4336e0478a927385e676b069f354bd3cc2f932ab))
 
 ## 0.2.0+8
 
@@ -28,7 +28,7 @@
 
 ## 0.2.0+7
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.2.0+6
 
@@ -48,7 +48,7 @@
 
 ## 0.2.0+2
 
- - **FIX**: web reference `path` should now correctly return a path string. ([f9995ce0](https://github.com/FirebaseExtended/flutterfire/commit/f9995ce043d8d60d1e74077064f0df2226291738))
+ - **FIX**: web reference `path` should now correctly return a path string. ([f9995ce0](https://github.com/firebase/flutterfire/commit/f9995ce043d8d60d1e74077064f0df2226291738))
 
 ## 0.2.0+1
 

--- a/packages/firebase_database/firebase_database_web/pubspec.yaml
+++ b/packages/firebase_database/firebase_database_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_database_web
 description: The web implementation of firebase_database
 version: 0.2.0+14
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_database/firebase_database_web
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_database/firebase_database_web
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 4.2.5
 
- - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8733). ([a11bd602](https://github.com/FirebaseExtended/flutterfire/commit/a11bd6021a3e915bf36f0db295b45ee8a3f16517))
+ - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8733). ([a11bd602](https://github.com/firebase/flutterfire/commit/a11bd6021a3e915bf36f0db295b45ee8a3f16517))
 
 ## 4.2.4
 
- - **FIX**: `getInitialLink()` returns `null` on 2nd call. (#8621). ([a83ee58e](https://github.com/FirebaseExtended/flutterfire/commit/a83ee58e56879b88b2886a6e5f5be549ee403b23))
+ - **FIX**: `getInitialLink()` returns `null` on 2nd call. (#8621). ([a83ee58e](https://github.com/firebase/flutterfire/commit/a83ee58e56879b88b2886a6e5f5be549ee403b23))
 
 ## 4.2.3
 
@@ -16,12 +16,12 @@
 
 ## 4.2.1
 
- - **REFACTOR**: Update deprecated API for dynamic links example app. (#8519). ([c5d288b3](https://github.com/FirebaseExtended/flutterfire/commit/c5d288b388cfd4180896ef9fc2a004c84ccbc017))
+ - **REFACTOR**: Update deprecated API for dynamic links example app. (#8519). ([c5d288b3](https://github.com/firebase/flutterfire/commit/c5d288b388cfd4180896ef9fc2a004c84ccbc017))
 
 ## 4.2.0
 
- - **REFACTOR**: Remove deprecated Tasks.call() API from android. (#8450). ([fdb24c8d](https://github.com/FirebaseExtended/flutterfire/commit/fdb24c8d2cf4c51b20ffdb6c8898b7eced16aa64))
- - **FEAT**: `matchType` for pending Dynamic Link data for `iOS`. (#8464). ([d3dda125](https://github.com/FirebaseExtended/flutterfire/commit/d3dda12563eb28e565c2c01d348183d558e25335))
+ - **REFACTOR**: Remove deprecated Tasks.call() API from android. (#8450). ([fdb24c8d](https://github.com/firebase/flutterfire/commit/fdb24c8d2cf4c51b20ffdb6c8898b7eced16aa64))
+ - **FEAT**: `matchType` for pending Dynamic Link data for `iOS`. (#8464). ([d3dda125](https://github.com/firebase/flutterfire/commit/d3dda12563eb28e565c2c01d348183d558e25335))
 
 ## 4.1.3
 
@@ -29,7 +29,7 @@
 
 ## 4.1.2
 
- - **REFACTOR**: recreate ios, android, web and macOS folders for example app (#8255). ([cdae0613](https://github.com/FirebaseExtended/flutterfire/commit/cdae0613a359da41013721f601c20169807d214f))
+ - **REFACTOR**: recreate ios, android, web and macOS folders for example app (#8255). ([cdae0613](https://github.com/firebase/flutterfire/commit/cdae0613a359da41013721f601c20169807d214f))
 
 ## 4.1.1
 
@@ -37,12 +37,12 @@
 
 ## 4.1.0
 
- - **FIX**: pass through `utmParameters` on `iOS` and make property on `PendingDynamicLinkData`. (#8232). ([32d06e79](https://github.com/FirebaseExtended/flutterfire/commit/32d06e793b4fc1bc1dad9b9071f94b28c5d477ca))
- - **FEAT**: add additional `longDynamicLink` parameter for creating a short Dynamic Link enabling additional parameters to be appended such as "ofl". (#7796). ([433a08ea](https://github.com/FirebaseExtended/flutterfire/commit/433a08eaacfaabb109a0185a5e494d87f9334d75))
+ - **FIX**: pass through `utmParameters` on `iOS` and make property on `PendingDynamicLinkData`. (#8232). ([32d06e79](https://github.com/firebase/flutterfire/commit/32d06e793b4fc1bc1dad9b9071f94b28c5d477ca))
+ - **FEAT**: add additional `longDynamicLink` parameter for creating a short Dynamic Link enabling additional parameters to be appended such as "ofl". (#7796). ([433a08ea](https://github.com/firebase/flutterfire/commit/433a08eaacfaabb109a0185a5e494d87f9334d75))
 
 ## 4.0.8
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 4.0.7
 
@@ -50,7 +50,7 @@
 
 ## 4.0.6
 
- - **FIX**: Ensure Dynamic link is retrieved from the Intent just once for `getInitialLink()` on Android as per the documentation. (#7743). ([67cc6647](https://github.com/FirebaseExtended/flutterfire/commit/67cc66471046822463f326c05e732313dbaa9560))
+ - **FIX**: Ensure Dynamic link is retrieved from the Intent just once for `getInitialLink()` on Android as per the documentation. (#7743). ([67cc6647](https://github.com/firebase/flutterfire/commit/67cc66471046822463f326c05e732313dbaa9560))
 
 ## 4.0.5
 
@@ -62,7 +62,7 @@
 
 ## 4.0.3
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 4.0.2
 

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/README.md
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/README.md
@@ -17,10 +17,10 @@ To use this plugin, please visit the [Dynamic Links Usage documentation](https:/
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/pubspec.yaml
@@ -4,7 +4,7 @@ description:
   and handling links across multiple platforms.
 version: 4.2.5
 homepage: https://firebase.google.com/docs/dynamic-links
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_dynamic_links
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_dynamic_links
 
 false_secrets:
   - example/**

--- a/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.2.3+2
 
- - **REFACTOR**: fix analyzer issue introduced in Flutter 3.0.0 ([#8654](https://github.com/FirebaseExtended/flutterfire/issues/8654)). ([55d8fb59](https://github.com/FirebaseExtended/flutterfire/commit/55d8fb593acc8e50b3cbd98ab9645ca73e7af936))
+ - **REFACTOR**: fix analyzer issue introduced in Flutter 3.0.0 ([#8654](https://github.com/firebase/flutterfire/issues/8654)). ([55d8fb59](https://github.com/firebase/flutterfire/commit/55d8fb593acc8e50b3cbd98ab9645ca73e7af936))
 
 ## 0.2.3+1
 
@@ -12,7 +12,7 @@
 
 ## 0.2.3
 
- - **FEAT**: `matchType` for pending Dynamic Link data for `iOS`. (#8464). ([d3dda125](https://github.com/FirebaseExtended/flutterfire/commit/d3dda12563eb28e565c2c01d348183d558e25335))
+ - **FEAT**: `matchType` for pending Dynamic Link data for `iOS`. (#8464). ([d3dda125](https://github.com/firebase/flutterfire/commit/d3dda12563eb28e565c2c01d348183d558e25335))
 
 ## 0.2.2+3
 
@@ -24,20 +24,20 @@
 
 ## 0.2.2+1
 
- - **FIX**: Properly type cast utmParameters coming from native side. (#8280). ([22bbd807](https://github.com/FirebaseExtended/flutterfire/commit/22bbd807d2b3c3f9d9cc8ba817ccb4da931ae887))
+ - **FIX**: Properly type cast utmParameters coming from native side. (#8280). ([22bbd807](https://github.com/firebase/flutterfire/commit/22bbd807d2b3c3f9d9cc8ba817ccb4da931ae887))
 
 ## 0.2.2
 
- - **FIX**: pass through `utmParameters` on `iOS` and make property on `PendingDynamicLinkData`. (#8232). ([32d06e79](https://github.com/FirebaseExtended/flutterfire/commit/32d06e793b4fc1bc1dad9b9071f94b28c5d477ca))
- - **FEAT**: add additional `longDynamicLink` parameter for creating a short Dynamic Link enabling additional parameters to be appended such as "ofl". (#7796). ([433a08ea](https://github.com/FirebaseExtended/flutterfire/commit/433a08eaacfaabb109a0185a5e494d87f9334d75))
+ - **FIX**: pass through `utmParameters` on `iOS` and make property on `PendingDynamicLinkData`. (#8232). ([32d06e79](https://github.com/firebase/flutterfire/commit/32d06e793b4fc1bc1dad9b9071f94b28c5d477ca))
+ - **FEAT**: add additional `longDynamicLink` parameter for creating a short Dynamic Link enabling additional parameters to be appended such as "ofl". (#7796). ([433a08ea](https://github.com/firebase/flutterfire/commit/433a08eaacfaabb109a0185a5e494d87f9334d75))
 
 ## 0.2.1+1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.2.1
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 0.2.0+5
 
@@ -45,7 +45,7 @@
 
 ## 0.2.0+4
 
- - **FIX**: PendingDynamicLinkData.asString() prints out instance type with mapped values. (#7727). ([7d4013fc](https://github.com/FirebaseExtended/flutterfire/commit/7d4013fcdada2cfebc74cc3bb90734a2fcad1a5c))
+ - **FIX**: PendingDynamicLinkData.asString() prints out instance type with mapped values. (#7727). ([7d4013fc](https://github.com/firebase/flutterfire/commit/7d4013fcdada2cfebc74cc3bb90734a2fcad1a5c))
 
 ## 0.2.0+3
 

--- a/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface/pubspec.yaml
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface/pubspec.yaml
@@ -1,8 +1,8 @@
 name: firebase_dynamic_links_platform_interface
 description: A common platform interface for the firebase_dynamic_links plugin.
 version: 0.2.3+3
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/CHANGELOG.md
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.0+15
 
- - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8734). ([9ce47865](https://github.com/FirebaseExtended/flutterfire/commit/9ce47865e4fcba0aaf1a4558ba7ede13abcde21d))
+ - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8734). ([9ce47865](https://github.com/firebase/flutterfire/commit/9ce47865e4fcba0aaf1a4558ba7ede13abcde21d))
 
 ## 0.6.0+14
 
@@ -24,7 +24,7 @@
 
 ## 0.6.0+9
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.6.0+8
 
@@ -32,14 +32,14 @@
 
 ## 0.6.0+7
 
- - **FIX**: issue where Boolean value was always `true` for `setMessagesSuppressed ()` & `setAutomaticDataCollectionEnabled()` on iOS. (#7954). ([e397add5](https://github.com/FirebaseExtended/flutterfire/commit/e397add52fc30d08bccad000237962ca3c903e49))
- - **FIX**: setup missing Firebase internal SDK headers (#7513). ([4c9d84cd](https://github.com/FirebaseExtended/flutterfire/commit/4c9d84cdc3f491c7d9c1421e7651742e5c2ccc1e))
+ - **FIX**: issue where Boolean value was always `true` for `setMessagesSuppressed ()` & `setAutomaticDataCollectionEnabled()` on iOS. (#7954). ([e397add5](https://github.com/firebase/flutterfire/commit/e397add52fc30d08bccad000237962ca3c903e49))
+ - **FIX**: setup missing Firebase internal SDK headers (#7513). ([4c9d84cd](https://github.com/firebase/flutterfire/commit/4c9d84cdc3f491c7d9c1421e7651742e5c2ccc1e))
 
 ## 0.6.0+6
 
- - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/FirebaseExtended/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
- - **FIX**: lazily get the default `FirebaseInAppMessaging` instance on Android to allow for Firebase initialization via Dart only. ([88cfa0c8](https://github.com/FirebaseExtended/flutterfire/commit/88cfa0c81543f639eb14c75a0d655806d9683bbf))
- - **FIX**: issue where Dart only initialization did not function correctly on iOS. ([5c6feb72](https://github.com/FirebaseExtended/flutterfire/commit/5c6feb72c446cbe9632ff4ad6b963b63d92aec76))
+ - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/firebase/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
+ - **FIX**: lazily get the default `FirebaseInAppMessaging` instance on Android to allow for Firebase initialization via Dart only. ([88cfa0c8](https://github.com/firebase/flutterfire/commit/88cfa0c81543f639eb14c75a0d655806d9683bbf))
+ - **FIX**: issue where Dart only initialization did not function correctly on iOS. ([5c6feb72](https://github.com/firebase/flutterfire/commit/5c6feb72c446cbe9632ff4ad6b963b63d92aec76))
 
 ## 0.6.0+5
 

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/README.md
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/README.md
@@ -16,10 +16,10 @@ To use this plugin, please visit the [Firebase In-App Messaging Usage documentat
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_in_app_messaging
 description: Flutter plugin for Firebase In-App Messaging.
 version: 0.6.0+15
 homepage: https://firebase.google.com/docs/in-app-messaging
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_in_app_messaging
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_in_app_messaging
 
 false_secrets:
   - example/**

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/CHANGELOG.md
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/CHANGELOG.md
@@ -24,11 +24,11 @@
 
 ## 0.2.1+1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.2.1
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 0.2.0+7
 

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_in_app_messaging_platform_interface
 description: A common platform interface for the firebase_in_app_messaging plugin.
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_in_app_messaging/firebase_in_app_messagin_platform_interface
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_in_app_messaging/firebase_in_app_messagin_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_in_app_messaging/firebase_in_app_messagin_platform_interface
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_in_app_messaging/firebase_in_app_messagin_platform_interface
 
 version: 0.2.1+7
 

--- a/packages/firebase_messaging/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/firebase_messaging/CHANGELOG.md
@@ -1,20 +1,20 @@
 ## 11.4.1
 
- - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8735). ([b2cf87a5](https://github.com/FirebaseExtended/flutterfire/commit/b2cf87a5d96457bf49b9dd04d6087768bfe6ad95))
- - **FIX**: check `userInfo` for "aps.notification" property presence for firing data only messages. (#8759). ([9eb99674](https://github.com/FirebaseExtended/flutterfire/commit/9eb996748f4ddae8a34a2306b51af10b4c066039))
+ - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8735). ([b2cf87a5](https://github.com/firebase/flutterfire/commit/b2cf87a5d96457bf49b9dd04d6087768bfe6ad95))
+ - **FIX**: check `userInfo` for "aps.notification" property presence for firing data only messages. (#8759). ([9eb99674](https://github.com/firebase/flutterfire/commit/9eb996748f4ddae8a34a2306b51af10b4c066039))
 
 ## 11.4.0
 
- - **FIX**: ensure silent foreground messages for iOS are called via event channel. ([#8635](https://github.com/FirebaseExtended/flutterfire/issues/8635)). ([abb91e48](https://github.com/FirebaseExtended/flutterfire/commit/abb91e4861b769485878a0f165d6ba8a9604de5a))
- - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. ([#8532](https://github.com/FirebaseExtended/flutterfire/issues/8532)). ([14b38da3](https://github.com/FirebaseExtended/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
+ - **FIX**: ensure silent foreground messages for iOS are called via event channel. ([#8635](https://github.com/firebase/flutterfire/issues/8635)). ([abb91e48](https://github.com/firebase/flutterfire/commit/abb91e4861b769485878a0f165d6ba8a9604de5a))
+ - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. ([#8532](https://github.com/firebase/flutterfire/issues/8532)). ([14b38da3](https://github.com/firebase/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
 
 ## 11.3.0
 
- - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. (#8532). ([14b38da3](https://github.com/FirebaseExtended/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
+ - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. (#8532). ([14b38da3](https://github.com/firebase/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
 
 ## 11.2.15
 
- - **REFACTOR**: Remove deprecated `Tasks.call()` API from android. (#8449). ([0510d113](https://github.com/FirebaseExtended/flutterfire/commit/0510d113dd279d6f55d889e522e74781d8fbb845))
+ - **REFACTOR**: Remove deprecated `Tasks.call()` API from android. (#8449). ([0510d113](https://github.com/firebase/flutterfire/commit/0510d113dd279d6f55d889e522e74781d8fbb845))
 
 ## 11.2.14
 
@@ -30,36 +30,36 @@
 
 ## 11.2.11
 
- - **FIX**: Ensure `onMessage` callback is consistently called on `iOS` platform. (#8202). ([54f5555e](https://github.com/FirebaseExtended/flutterfire/commit/54f5555edbedc553df30d7e32747e3b305fbe643))
+ - **FIX**: Ensure `onMessage` callback is consistently called on `iOS` platform. (#8202). ([54f5555e](https://github.com/firebase/flutterfire/commit/54f5555edbedc553df30d7e32747e3b305fbe643))
 
 ## 11.2.10
 
- - **FIX**: Update notification key to `NSApplicationLaunchUserNotificationKey` for macOS. (#8251). ([46b54ccd](https://github.com/FirebaseExtended/flutterfire/commit/46b54ccd4aee61654e36396b86ed373939569d00))
+ - **FIX**: Update notification key to `NSApplicationLaunchUserNotificationKey` for macOS. (#8251). ([46b54ccd](https://github.com/firebase/flutterfire/commit/46b54ccd4aee61654e36396b86ed373939569d00))
 
 ## 11.2.9
 
- - **FIX**: `getInitialMessage` returns notification once & only if pressed for `iOS`. (#7634). ([85739b4c](https://github.com/FirebaseExtended/flutterfire/commit/85739b4cc2f75c6f7017de0e69160fa07477eb1e))
+ - **FIX**: `getInitialMessage` returns notification once & only if pressed for `iOS`. (#7634). ([85739b4c](https://github.com/firebase/flutterfire/commit/85739b4cc2f75c6f7017de0e69160fa07477eb1e))
 
 ## 11.2.8
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 11.2.7
 
- - **FIX**: Stream new token via onTokenRefresh when getToken invoked for iOS. (#8166). ([28b396b8](https://github.com/FirebaseExtended/flutterfire/commit/28b396b84e019a5247e70d0abeb1ba24bdff4bcb))
+ - **FIX**: Stream new token via onTokenRefresh when getToken invoked for iOS. (#8166). ([28b396b8](https://github.com/firebase/flutterfire/commit/28b396b84e019a5247e70d0abeb1ba24bdff4bcb))
 
 ## 11.2.6
 
- - **FIX**: Set APNS token if user initializes Firebase app from Flutter. (#7610). ([dc4c2c1d](https://github.com/FirebaseExtended/flutterfire/commit/dc4c2c1d249abf214c8ec7d835af18c86d64b2f5))
+ - **FIX**: Set APNS token if user initializes Firebase app from Flutter. (#7610). ([dc4c2c1d](https://github.com/firebase/flutterfire/commit/dc4c2c1d249abf214c8ec7d835af18c86d64b2f5))
 
 ## 11.2.5
 
- - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/FirebaseExtended/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
- - **DOCS**: Provide fallback for `messageId` field for web as JS SDK does not have. (#7234). ([4571abeb](https://github.com/FirebaseExtended/flutterfire/commit/4571abeb859124b8daa520583a8f23fd8e1182d6))
+ - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/firebase/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
+ - **DOCS**: Provide fallback for `messageId` field for web as JS SDK does not have. (#7234). ([4571abeb](https://github.com/firebase/flutterfire/commit/4571abeb859124b8daa520583a8f23fd8e1182d6))
 
 ## 11.2.4
 
- - **FIX**: Return app constants for default app only on `Android`. (#7592). ([b803c425](https://github.com/FirebaseExtended/flutterfire/commit/b803c425b420acae155fea93a62ab9b3de4556a5))
+ - **FIX**: Return app constants for default app only on `Android`. (#7592). ([b803c425](https://github.com/firebase/flutterfire/commit/b803c425b420acae155fea93a62ab9b3de4556a5))
 
 ## 11.2.3
 
@@ -749,7 +749,7 @@ In FirebaseMessagingPlugin.m:
 ## 0.0.2+1
 
 * Added workaround for https://github.com/flutter/flutter/issues/9694 to README
-* Moved code to https://github.com/FirebaseExtended/flutterfire
+* Moved code to https://github.com/firebase/flutterfire
 
 ## 0.0.2
 

--- a/packages/firebase_messaging/firebase_messaging/README.md
+++ b/packages/firebase_messaging/firebase_messaging/README.md
@@ -1,4 +1,4 @@
-[<img src="https://raw.githubusercontent.com/FirebaseExtended/flutterfire/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
+[<img src="https://raw.githubusercontent.com/firebase/flutterfire/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
 
 # Firebase Messaging Plugin for Flutter
 
@@ -18,10 +18,10 @@ To use this plugin, please visit the [Cloud Messaging Usage documentation](https
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -244,7 +244,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
       // addApplicationDelegate:self];` will automatically delegate calls to this plugin. If we
       // replace it, it will cause a stack overflow as our original delegate forwarding handler
       // below causes an infinite loop of forwarding. See
-      // https://github.com/FirebaseExtended/flutterfire/issues/4026.
+      // https://github.com/firebasefire/issues/4026.
       if ([GULApplication sharedApplication].delegate != nil &&
           [[GULApplication sharedApplication].delegate
               conformsToProtocol:@protocol(UNUserNotificationCenterDelegate)]) {

--- a/packages/firebase_messaging/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_messaging
 description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 homepage: https://firebase.google.com/docs/cloud-messaging
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging
 version: 11.4.1
 
 false_secrets:

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/CHANGELOG.md
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/CHANGELOG.md
@@ -4,19 +4,19 @@
 
 ## 3.5.0
 
- - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. ([#8532](https://github.com/FirebaseExtended/flutterfire/issues/8532)). ([14b38da3](https://github.com/FirebaseExtended/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
+ - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. ([#8532](https://github.com/firebase/flutterfire/issues/8532)). ([14b38da3](https://github.com/firebase/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
 
 ## 3.4.0
 
- - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. (#8532). ([14b38da3](https://github.com/FirebaseExtended/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
+ - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. (#8532). ([14b38da3](https://github.com/firebase/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
 
 ## 3.3.1
 
- - **FIX**: prevent isolate callback removal during split debug symbols (#8521). ([45ca7aeb](https://github.com/FirebaseExtended/flutterfire/commit/45ca7aeb50920cea0ba5784e16a5b78adac014f3))
+ - **FIX**: prevent isolate callback removal during split debug symbols (#8521). ([45ca7aeb](https://github.com/firebase/flutterfire/commit/45ca7aeb50920cea0ba5784e16a5b78adac014f3))
 
 ## 3.3.0
 
- - **FEAT**: add `toMap()` method to `RemoteMessage` and its properties (#8453). ([047cccda](https://github.com/FirebaseExtended/flutterfire/commit/047cccda6fe8e53c77e8e1f368e5f2c5d7d297e1))
+ - **FEAT**: add `toMap()` method to `RemoteMessage` and its properties (#8453). ([047cccda](https://github.com/firebase/flutterfire/commit/047cccda6fe8e53c77e8e1f368e5f2c5d7d297e1))
 
 ## 3.2.3
 
@@ -28,11 +28,11 @@
 
 ## 3.2.1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 3.2.0
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 3.1.6
 

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/pubspec.yaml
@@ -1,8 +1,8 @@
 name: firebase_messaging_platform_interface
 description: A common platform interface for the firebase_messaging plugin.
 version: 3.5.1
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging_platform_interface
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging_platform_interface
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging_platform_interface
 
 environment:
   sdk: '>=2.16.0 <3.0.0'

--- a/packages/firebase_messaging/firebase_messaging_web/CHANGELOG.md
+++ b/packages/firebase_messaging/firebase_messaging_web/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ## 2.4.0
 
- - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. ([#8532](https://github.com/FirebaseExtended/flutterfire/issues/8532)). ([14b38da3](https://github.com/FirebaseExtended/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
+ - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. ([#8532](https://github.com/firebase/flutterfire/issues/8532)). ([14b38da3](https://github.com/firebase/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
 
 ## 2.3.0
 
- - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. (#8532). ([14b38da3](https://github.com/FirebaseExtended/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
+ - **FEAT**: retrieve `timeSensitiveSetting` for iOS 15+. (#8532). ([14b38da3](https://github.com/firebase/flutterfire/commit/14b38da31f364ad35be20c5df9cd633c613d8067))
 
 ## 2.2.13
 
@@ -28,7 +28,7 @@
 
 ## 2.2.9
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 2.2.8
 
@@ -36,7 +36,7 @@
 
 ## 2.2.7
 
- - **FIX**: Make Web `deleteToken()` API a Future so it resolves only when completed. (#7687). ([cf59bd38](https://github.com/FirebaseExtended/flutterfire/commit/cf59bd380a495a0390d8c14a63498ba1600f9f12))
+ - **FIX**: Make Web `deleteToken()` API a Future so it resolves only when completed. (#7687). ([cf59bd38](https://github.com/firebase/flutterfire/commit/cf59bd380a495a0390d8c14a63498ba1600f9f12))
 
 ## 2.2.6
 
@@ -48,7 +48,7 @@
 
 ## 2.2.4
 
- - **FIX**: messaging `isSupported()` check on web should be used lazily in `_delegate` (fixes #7511). ([9a3d1d93](https://github.com/FirebaseExtended/flutterfire/commit/9a3d1d9300c49ccdffa90b8193269badd79d2c9b))
+ - **FIX**: messaging `isSupported()` check on web should be used lazily in `_delegate` (fixes #7511). ([9a3d1d93](https://github.com/firebase/flutterfire/commit/9a3d1d9300c49ccdffa90b8193269badd79d2c9b))
 
 ## 2.2.3
 

--- a/packages/firebase_messaging/firebase_messaging_web/ios/firebase_messaging_web.podspec
+++ b/packages/firebase_messaging/firebase_messaging_web/ios/firebase_messaging_web.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
     s.description      = <<-DESC
   temp fake firebase_messaging_web plugin
                          DESC
-    s.homepage         = 'https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging_web'
+    s.homepage         = 'https://github.com/firebase/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging_web'
     s.license          = { :file => '../LICENSE' }
     s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
     s.source           = { :path => '.' }

--- a/packages/firebase_messaging/firebase_messaging_web/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_messaging_web
 description: The web implementation of firebase_messaging
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging_web
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging_web
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging_web
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging_web
 version: 2.4.1
 
 environment:

--- a/packages/firebase_ml_custom/README.md
+++ b/packages/firebase_ml_custom/README.md
@@ -2,4 +2,4 @@
 
 As an alternative, use Firebase ML Model Downloader to manage your models and tflite to run your models.
 
-Source for the original package can be found [here](https://github.com/FirebaseExtended/flutterfire/tree/ml_custom_backup/packages/firebase_ml_custom).
+Source for the original package can be found [here](https://github.com/firebase/flutterfire/tree/ml_custom_backup/packages/firebase_ml_custom).

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/CHANGELOG.md
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.0+14
 
- - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8751). ([e1e42eb9](https://github.com/FirebaseExtended/flutterfire/commit/e1e42eb97772a86bf5e35d0f3be0376225a5f1d6))
+ - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8751). ([e1e42eb9](https://github.com/firebase/flutterfire/commit/e1e42eb97772a86bf5e35d0f3be0376225a5f1d6))
 
 ## 0.1.0+13
 
@@ -24,7 +24,7 @@
 
 ## 0.1.0+8
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.1.0+7
 
@@ -32,7 +32,7 @@
 
 ## 0.1.0+6
 
- - **FIX**: fixed an issue where macOS builds failed due to bug with missing pod subspec in Firebase SDK (added a workaround until issue fixed upstream). ([acc6afab](https://github.com/FirebaseExtended/flutterfire/commit/acc6afab3e1bc66baa13a35c968df45de36e64bf))
+ - **FIX**: fixed an issue where macOS builds failed due to bug with missing pod subspec in Firebase SDK (added a workaround until issue fixed upstream). ([acc6afab](https://github.com/firebase/flutterfire/commit/acc6afab3e1bc66baa13a35c968df45de36e64bf))
 
 ## 0.1.0+5
 
@@ -40,7 +40,7 @@
 
 ## 0.1.0+4
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 0.1.0+3
 

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/README.md
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/README.md
@@ -13,10 +13,10 @@ To use this plugin, please visit the [Firebase ML Model Downloader Usage documen
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/pubspec.yaml
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_ml_model_downloader
 description: A Flutter plugin allowing you to use Firebase Ml Model Downloader.
 version: 0.1.0+14
 homepage: https://firebase.flutter.dev/docs/ml/overview
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_ml_model_downloader/firebase_ml_model_downloader
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_ml_model_downloader/firebase_ml_model_downloader
 
 false_secrets:
   - example/**

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/CHANGELOG.md
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/CHANGELOG.md
@@ -24,11 +24,11 @@
 
 ## 0.1.1+1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.1.1
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 0.1.0+6
 
@@ -40,7 +40,7 @@
 
 ## 0.1.0+4
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 0.1.0+3
 

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/pubspec.yaml
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/pubspec.yaml
@@ -1,8 +1,8 @@
 name: firebase_ml_model_downloader_platform_interface
 description: A common platform interface for the firebase_ml_model_downloader plugin.
 version: 0.1.1+7
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/packages/firebase_ml_vision/README.md
+++ b/packages/firebase_ml_vision/README.md
@@ -4,4 +4,4 @@
 > Authentication and Functions, which gives you a managed, serverless gateway to Google Cloud Vision APIs. For an example
 > Functions project see the [vision-annotate-images](https://github.com/firebase/functions-samples/tree/master/vision-annotate-images) sample project.
 
-Source for the original package can be found [here](https://github.com/FirebaseExtended/flutterfire/tree/ml_vision_backup/packages/firebase_ml_vision).
+Source for the original package can be found [here](https://github.com/firebase/flutterfire/tree/ml_vision_backup/packages/firebase_ml_vision).

--- a/packages/firebase_performance/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/firebase_performance/CHANGELOG.md
@@ -24,11 +24,11 @@
 
 ## 0.8.0+7
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.8.0+6
 
- - **FIX**: Fix firebase_performance not recording response payload size on Android. (#8154). ([46d8bc0f](https://github.com/FirebaseExtended/flutterfire/commit/46d8bc0f205f24b1e160333ddb76200543f48c89))
+ - **FIX**: Fix firebase_performance not recording response payload size on Android. (#8154). ([46d8bc0f](https://github.com/firebase/flutterfire/commit/46d8bc0f205f24b1e160333ddb76200543f48c89))
 
 ## 0.8.0+5
 
@@ -36,7 +36,7 @@
 
 ## 0.8.0+4
 
- - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/FirebaseExtended/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
+ - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/firebase/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
 
 ## 0.8.0+3
 

--- a/packages/firebase_performance/firebase_performance/README.md
+++ b/packages/firebase_performance/firebase_performance/README.md
@@ -16,10 +16,10 @@ To use this plugin, please visit the [Firebase Performance Usage documentation](
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/firebase_performance/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/firebase_performance/pubspec.yaml
@@ -4,7 +4,7 @@ description:
   measurement solution that monitors traces and HTTP/S network requests on Android and
   iOS.
 homepage: https://firebase.flutter.dev/docs/performance/overview
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_performance
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_performance
 version: 0.8.0+13
 
 false_secrets:

--- a/packages/firebase_performance/firebase_performance_platform_interface/CHANGELOG.md
+++ b/packages/firebase_performance/firebase_performance_platform_interface/CHANGELOG.md
@@ -24,11 +24,11 @@
 
 ## 0.1.1+1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.1.1
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 0.1.0+5
 
@@ -40,8 +40,8 @@
 
 ## 0.1.0+3
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
- - **FIX**: `HttpMetric` send only non-null values on `stop()` (#7593). ([16ec31e4](https://github.com/FirebaseExtended/flutterfire/commit/16ec31e4720935c80e70b76e10de7a263622cc15))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **FIX**: `HttpMetric` send only non-null values on `stop()` (#7593). ([16ec31e4](https://github.com/firebase/flutterfire/commit/16ec31e4720935c80e70b76e10de7a263622cc15))
 
 ## 0.1.0+2
 

--- a/packages/firebase_performance/firebase_performance_web/CHANGELOG.md
+++ b/packages/firebase_performance/firebase_performance_web/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ## 0.1.0+7
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.1.0+6
 

--- a/packages/firebase_performance/firebase_performance_web/pubspec.yaml
+++ b/packages/firebase_performance/firebase_performance_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_performance_web
 description: Web implementation of Firebase Performance monitoring.
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_performance/firebase_performance_web
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_performance/firebase_performance_web
 version: 0.1.0+13
 
 environment:

--- a/packages/firebase_remote_config/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/firebase_remote_config/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.8
 
- - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8738). ([f5ca08b2](https://github.com/FirebaseExtended/flutterfire/commit/f5ca08b2ca68e674f6c59c458ec26126c9e1b002))
+ - **REFACTOR**: use `firebase.google.com` link for `homepage` in `pubspec.yaml` (#8738). ([f5ca08b2](https://github.com/firebase/flutterfire/commit/f5ca08b2ca68e674f6c59c458ec26126c9e1b002))
 
 ## 2.0.7
 
@@ -24,21 +24,21 @@
 
 ## 2.0.2
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 2.0.1
 
- - **FIX**: add missing `default_package` entry for web in `pubspec.yaml` (#8139). ([5e6b570f](https://github.com/FirebaseExtended/flutterfire/commit/5e6b570f8445b0bd2eac8b112a2a6b35ff69b7b6))
+ - **FIX**: add missing `default_package` entry for web in `pubspec.yaml` (#8139). ([5e6b570f](https://github.com/firebase/flutterfire/commit/5e6b570f8445b0bd2eac8b112a2a6b35ff69b7b6))
 
 ## 2.0.0
 
 > Note: This release has breaking changes.
 
- - **BREAKING** **REFACTOR**: deprecated `RemoteConfig` in favour of `FirebaseRemoteConfig` to align Firebase services naming with other plugins. ([99b932be](https://github.com/FirebaseExtended/flutterfire/commit/99b932bea6d604d500bb29841ad59177165dee60))
+ - **BREAKING** **REFACTOR**: deprecated `RemoteConfig` in favour of `FirebaseRemoteConfig` to align Firebase services naming with other plugins. ([99b932be](https://github.com/firebase/flutterfire/commit/99b932bea6d604d500bb29841ad59177165dee60))
 
 ## 1.0.4
 
- - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/FirebaseExtended/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
+ - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/firebase/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
 
 ## 1.0.3
 

--- a/packages/firebase_remote_config/firebase_remote_config/README.md
+++ b/packages/firebase_remote_config/firebase_remote_config/README.md
@@ -17,10 +17,10 @@ To use this plugin, please visit the [Firebase Remote Config Usage documentation
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/firebase_remote_config/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   Flutter plugin for Firebase Remote Config. Update your application look and feel and behavior without
   re-releasing.
 homepage: https://firebase.google.com/docs/remote-config
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_remote_config/firebase_remote_config
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_remote_config/firebase_remote_config
 version: 2.0.8
 
 false_secrets:

--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/CHANGELOG.md
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/CHANGELOG.md
@@ -24,11 +24,11 @@
 
 ## 1.1.1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 1.1.0
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 1.0.5
 

--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_remote_config_platform_interface
 description: A common platform interface for the firebase_remote_config plugin.
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_remote_config/firebase_remote_config_platform_interface
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_remote_config/firebase_remote_config_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_remote_config/firebase_remote_config_platform_interface
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_remote_config/firebase_remote_config_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
 version: 1.1.7

--- a/packages/firebase_remote_config/firebase_remote_config_web/CHANGELOG.md
+++ b/packages/firebase_remote_config/firebase_remote_config_web/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ## 1.0.7
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 1.0.6
 

--- a/packages/firebase_remote_config/firebase_remote_config_web/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_remote_config_web
 description: The web implementation of firebase_remote_config
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_remote_config/firebase_remote_config_web
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_remote_config/firebase_remote_config_web
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_remote_config/firebase_remote_config_web
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_remote_config/firebase_remote_config_web
 
 version: 1.0.13
 

--- a/packages/firebase_storage/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/firebase_storage/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 10.2.17
 
- - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8752). ([5c5dcaf1](https://github.com/FirebaseExtended/flutterfire/commit/5c5dcaf1909dacf293fec5e79461d43468a13279))
+ - **DOCS**: use camel case style for "FlutterFire" in `README.md` (#8752). ([5c5dcaf1](https://github.com/firebase/flutterfire/commit/5c5dcaf1909dacf293fec5e79461d43468a13279))
 
 ## 10.2.16
 
@@ -12,7 +12,7 @@
 
 ## 10.2.14
 
- - **REFACTOR**: Remove deprecated `Tasks.call()` API from android. (#8421). ([461bba5a](https://github.com/FirebaseExtended/flutterfire/commit/461bba5a510b341b3b9bd414c9412944714e9305))
+ - **REFACTOR**: Remove deprecated `Tasks.call()` API from android. (#8421). ([461bba5a](https://github.com/firebase/flutterfire/commit/461bba5a510b341b3b9bd414c9412944714e9305))
 
 ## 10.2.13
 
@@ -24,7 +24,7 @@
 
 ## 10.2.11
 
- - **FIX**: Fix `UploadTask.cancel()` so that it completes when called. (#8417). ([19ee62c3](https://github.com/FirebaseExtended/flutterfire/commit/19ee62c33f34278dac082c11bf7574785e60abb5))
+ - **FIX**: Fix `UploadTask.cancel()` so that it completes when called. (#8417). ([19ee62c3](https://github.com/firebase/flutterfire/commit/19ee62c33f34278dac082c11bf7574785e60abb5))
 
 ## 10.2.10
 
@@ -32,7 +32,7 @@
 
 ## 10.2.9
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 10.2.8
 
@@ -48,11 +48,11 @@
 
 ## 10.2.5
 
- - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/FirebaseExtended/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
+ - **FIX**: bump Android `compileSdkVersion` to 31 (#7726). ([a9562bac](https://github.com/firebase/flutterfire/commit/a9562bac60ba927fb3664a47a7f7eaceb277dca6))
 
 ## 10.2.4
 
- - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/FirebaseExtended/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
+ - **REFACTOR**: fix all `unnecessary_import` analyzer issues introduced with Flutter 2.8. ([7f0e82c9](https://github.com/firebase/flutterfire/commit/7f0e82c978a3f5a707dd95c7e9136a3e106ff75e))
 
 ## 10.2.3
 
@@ -238,7 +238,7 @@
 
 ## 5.0.0-dev.1
 
-As part of our on-going work for [#2582](https://github.com/FirebaseExtended/flutterfire/issues/2582) this is our Firebase Storage rework changes.
+As part of our on-going work for [#2582](https://github.com/firebase/flutterfire/issues/2582) this is our Firebase Storage rework changes.
 
 Overall, Firebase Storage has been heavily reworked to bring it inline with the federated plugin setup along with adding new features,
 documentation and many more unit and end-to-end tests (tested on Android, iOS & MacOS).

--- a/packages/firebase_storage/firebase_storage/README.md
+++ b/packages/firebase_storage/firebase_storage/README.md
@@ -1,4 +1,4 @@
-[<img src="https://raw.githubusercontent.com/FirebaseExtended/flutterfire/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
+[<img src="https://raw.githubusercontent.com/firebase/flutterfire/master/resources/flutter_favorite.png" width="200" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
 
 # Cloud Storage for Flutter
 [![pub package](https://img.shields.io/pub/v/firebase_storage.svg)](https://pub.dev/packages/firebase_storage)
@@ -17,10 +17,10 @@ To use this plugin, please visit the [Storage Usage documentation](https://fireb
 
 ## Issues and feedback
 
-Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).
+Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).
 
 Plugin issues that are not specific to FlutterFire can be filed in the [Flutter issue tracker](https://github.com/flutter/flutter/issues/new).
 
 To contribute a change to this plugin,
-please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md)
-and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md)
+and open a [pull request](https://github.com/firebase/flutterfire/pulls).

--- a/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.java
+++ b/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.java
@@ -70,7 +70,7 @@ class FlutterFirebaseStorageTask {
           task = inProgressTasks.valueAt(i);
         } catch (ArrayIndexOutOfBoundsException e) {
           // TODO(Salakar): Why does this happen? Race condition / multiple destroy calls?
-          // Can safely ignore exception for now, see https://github.com/FirebaseExtended/flutterfire/issues/4334
+          // Can safely ignore exception for now, see https://github.com/firebase/flutterfire/issues/4334
         }
         if (task != null) {
           task.destroy();
@@ -148,7 +148,7 @@ class FlutterFirebaseStorageTask {
         inProgressTasks.remove(handle);
       } catch (ArrayIndexOutOfBoundsException e) {
         // TODO(Salakar): Why does this happen? Race condition / multiple destroy calls?
-        // Can safely ignore exception for now, see https://github.com/FirebaseExtended/flutterfire/issues/4334
+        // Can safely ignore exception for now, see https://github.com/firebase/flutterfire/issues/4334
       }
     }
 

--- a/packages/firebase_storage/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_storage
 description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 homepage: https://firebase.flutter.dev/docs/storage/overview
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_storage/firebase_storage
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_storage/firebase_storage
 version: 10.2.17
 
 false_secrets:

--- a/packages/firebase_storage/firebase_storage/test/firebase_storage_test.dart
+++ b/packages/firebase_storage/firebase_storage/test/firebase_storage_test.dart
@@ -145,7 +145,7 @@ void main() {
         verify(kMockStoragePlatform.ref(testPath));
       });
 
-      // https://github.com/FirebaseExtended/flutterfire/issues/5673
+      // https://github.com/firebase/flutterfire/issues/5673
       test('verify delegate method is called for http urls with + symbol', () {
         const String customBucket = 'test.appspot.com';
         const String testPath = 'foo+bar/file.gif';

--- a/packages/firebase_storage/firebase_storage_platform_interface/CHANGELOG.md
+++ b/packages/firebase_storage/firebase_storage_platform_interface/CHANGELOG.md
@@ -24,11 +24,11 @@
 
 ## 4.1.1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 4.1.0
 
- - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/FirebaseExtended/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
+ - **FEAT**: refactor error handling to preserve stack traces on platform exceptions (#8156). ([6ac77d99](https://github.com/firebase/flutterfire/commit/6ac77d99042de2a1950f89b35972e3ee1116dc9f))
 
 ## 4.0.14
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage_platform_interface/pubspec.yaml
@@ -1,8 +1,8 @@
 name: firebase_storage_platform_interface
 description: A common platform interface for the firebase_storage plugin.
 version: 4.1.7
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_storage/firebase_storage_platform_interface
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_storage/firebase_storage_platform_interface
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_storage/firebase_storage_platform_interface
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_storage/firebase_storage_platform_interface
 environment:
   sdk: '>=2.16.0 <3.0.0'
   flutter: ">=1.9.1+hotfix.5"

--- a/packages/firebase_storage/firebase_storage_web/CHANGELOG.md
+++ b/packages/firebase_storage/firebase_storage_web/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ## 3.2.10
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 3.2.9
 

--- a/packages/firebase_storage/firebase_storage_web/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_storage_web
 description: The web implementation of firebase_storage
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_storage/firebase_storage_web
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_storage/firebase_storage_web
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_storage/firebase_storage_web
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_storage/firebase_storage_web
 version: 3.2.16
 
 environment:

--- a/packages/flutterfire_ui/CHANGELOG.md
+++ b/packages/flutterfire_ui/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.1+2
 
- - **FIX**: correctly fix lint error from issue #8651 for dart `2.16` (#8713). ([666b1973](https://github.com/FirebaseExtended/flutterfire/commit/666b1973c68cd5e60ba254a889136c922fd73500))
+ - **FIX**: correctly fix lint error from issue #8651 for dart `2.16` (#8713). ([666b1973](https://github.com/firebase/flutterfire/commit/666b1973c68cd5e60ba254a889136c922fd73500))
 
 ## 0.4.1+1
 
@@ -8,11 +8,11 @@
 
 ## 0.4.1
 
- - **FIX**: flutterfire_ui README links ([#8630](https://github.com/FirebaseExtended/flutterfire/issues/8630)). ([ba5b58af](https://github.com/FirebaseExtended/flutterfire/commit/ba5b58af354c762a4d4e4fe11e4017730bfa6c9e))
- - **FIX**: use `EmailVerificationScreen.actionCodeSettings` & and fix `flutter analyze` with Flutter 3.0.0 ([#8651](https://github.com/FirebaseExtended/flutterfire/issues/8651)). ([f12f1e24](https://github.com/FirebaseExtended/flutterfire/commit/f12f1e24e85dcea014374752a9d58142db33a5ab))
- - **FIX**: set the default variant of LoadingButton to outlined ([#8443](https://github.com/FirebaseExtended/flutterfire/issues/8443)) ([#8545](https://github.com/FirebaseExtended/flutterfire/issues/8545)). ([518cdcee](https://github.com/FirebaseExtended/flutterfire/commit/518cdcee7c43c995b4067857c38bff0a023302ee))
- - **FEAT**: add styling APIs `FlutterFireUITheme` and `FlutterFireUIStyle` ([#8580](https://github.com/FirebaseExtended/flutterfire/issues/8580)). ([83e2d455](https://github.com/FirebaseExtended/flutterfire/commit/83e2d455d3a083886168b4c115191b06e307a41f))
- - **DOCS**: Copy FlutterFire UI & ODM docs to package dirs ([#8574](https://github.com/FirebaseExtended/flutterfire/issues/8574)). ([c76f0d9b](https://github.com/FirebaseExtended/flutterfire/commit/c76f0d9bf954497923464e045671fd73be9b88c4))
+ - **FIX**: flutterfire_ui README links ([#8630](https://github.com/firebase/flutterfire/issues/8630)). ([ba5b58af](https://github.com/firebase/flutterfire/commit/ba5b58af354c762a4d4e4fe11e4017730bfa6c9e))
+ - **FIX**: use `EmailVerificationScreen.actionCodeSettings` & and fix `flutter analyze` with Flutter 3.0.0 ([#8651](https://github.com/firebase/flutterfire/issues/8651)). ([f12f1e24](https://github.com/firebase/flutterfire/commit/f12f1e24e85dcea014374752a9d58142db33a5ab))
+ - **FIX**: set the default variant of LoadingButton to outlined ([#8443](https://github.com/firebase/flutterfire/issues/8443)) ([#8545](https://github.com/firebase/flutterfire/issues/8545)). ([518cdcee](https://github.com/firebase/flutterfire/commit/518cdcee7c43c995b4067857c38bff0a023302ee))
+ - **FEAT**: add styling APIs `FlutterFireUITheme` and `FlutterFireUIStyle` ([#8580](https://github.com/firebase/flutterfire/issues/8580)). ([83e2d455](https://github.com/firebase/flutterfire/commit/83e2d455d3a083886168b4c115191b06e307a41f))
+ - **DOCS**: Copy FlutterFire UI & ODM docs to package dirs ([#8574](https://github.com/firebase/flutterfire/issues/8574)). ([c76f0d9b](https://github.com/firebase/flutterfire/commit/c76f0d9bf954497923464e045671fd73be9b88c4))
 
 ## 0.4.0+5
 
@@ -24,7 +24,7 @@
 
 ## 0.4.0+3
 
- - **FIX**: Bump `twitter_login` version to fix Android build failure. (#8475). ([4a7f47ed](https://github.com/FirebaseExtended/flutterfire/commit/4a7f47edbe9d421e385efbd2be05a01a24b22a69))
+ - **FIX**: Bump `twitter_login` version to fix Android build failure. (#8475). ([4a7f47ed](https://github.com/firebase/flutterfire/commit/4a7f47edbe9d421e385efbd2be05a01a24b22a69))
 
 ## 0.4.0+2
 
@@ -32,23 +32,23 @@
 
 ## 0.4.0+1
 
- - **FIX**: filter out whitespaces in email with input formatter (#8393). ([1da9dc15](https://github.com/FirebaseExtended/flutterfire/commit/1da9dc1539367641a43df053c243fe262e087bd2))
- - **FIX**: fix phone linking on web (#8395). ([b8ac0a20](https://github.com/FirebaseExtended/flutterfire/commit/b8ac0a202958864f793791877e556624f9b7c487))
+ - **FIX**: filter out whitespaces in email with input formatter (#8393). ([1da9dc15](https://github.com/firebase/flutterfire/commit/1da9dc1539367641a43df053c243fe262e087bd2))
+ - **FIX**: fix phone linking on web (#8395). ([b8ac0a20](https://github.com/firebase/flutterfire/commit/b8ac0a202958864f793791877e556624f9b7c487))
 
 ## 0.4.0
 
 > Note: This release has breaking changes.
 
- - **REFACTOR**: refactor platform specific widget styling (#8333). ([ecbff15c](https://github.com/FirebaseExtended/flutterfire/commit/ecbff15cf657a1d451db39bb8a5b4f3419780228))
- - **FIX**: respect autocorrect property on `UniversalTextFormField` (#8367). ([ad942c34](https://github.com/FirebaseExtended/flutterfire/commit/ad942c349c3232f1946575fdab2b8b27e1c14215))
- - **FIX**: trim email before submitting (#8369). ([4f9b8855](https://github.com/FirebaseExtended/flutterfire/commit/4f9b8855504d5ae85d5904f4663fa93fa871e32a))
- - **FIX**: allow passing oauth scopes for google sign in (#8368). ([7edbf5e6](https://github.com/FirebaseExtended/flutterfire/commit/7edbf5e692499feb7b3c1b29dab67479917df21f))
- - **FIX**: Avoid layout jumps when editing user name. (#8334). ([1937f278](https://github.com/FirebaseExtended/flutterfire/commit/1937f27817acc59dedd85a6d1e0624f49685ef5e))
- - **FIX**: fix sign out issue on desktop and web (#8331). ([f1dae735](https://github.com/FirebaseExtended/flutterfire/commit/f1dae735483bf293c4b18a8ff7c3ab6ca3cbe6e7))
- - **FIX**: Fix Flutter Cupertino button color bug. (#8315). ([47dc6d09](https://github.com/FirebaseExtended/flutterfire/commit/47dc6d09112db8d1398908895b387795722eaaba))
- - **FEAT**: Allow setting `resizeToAvoidBottomInset` from LoginScreen and set as default `false` for backwards compatibility. (#8365). ([3e884f2f](https://github.com/FirebaseExtended/flutterfire/commit/3e884f2f7cb498c6dff23ff6ac2bd9a25a73034d))
- - **FEAT**: Add Japanese localization language support. (#8110). ([c9c7f828](https://github.com/FirebaseExtended/flutterfire/commit/c9c7f8281fbfb2cd2872eb1b71fbd5e46c8002d8))
- - **BREAKING** **FEAT**: add email verification and allow to unlink social providers from profile screen (#8358). ([89f97047](https://github.com/FirebaseExtended/flutterfire/commit/89f97047e34d5023f2c41312767f626cb662702f))
+ - **REFACTOR**: refactor platform specific widget styling (#8333). ([ecbff15c](https://github.com/firebase/flutterfire/commit/ecbff15cf657a1d451db39bb8a5b4f3419780228))
+ - **FIX**: respect autocorrect property on `UniversalTextFormField` (#8367). ([ad942c34](https://github.com/firebase/flutterfire/commit/ad942c349c3232f1946575fdab2b8b27e1c14215))
+ - **FIX**: trim email before submitting (#8369). ([4f9b8855](https://github.com/firebase/flutterfire/commit/4f9b8855504d5ae85d5904f4663fa93fa871e32a))
+ - **FIX**: allow passing oauth scopes for google sign in (#8368). ([7edbf5e6](https://github.com/firebase/flutterfire/commit/7edbf5e692499feb7b3c1b29dab67479917df21f))
+ - **FIX**: Avoid layout jumps when editing user name. (#8334). ([1937f278](https://github.com/firebase/flutterfire/commit/1937f27817acc59dedd85a6d1e0624f49685ef5e))
+ - **FIX**: fix sign out issue on desktop and web (#8331). ([f1dae735](https://github.com/firebase/flutterfire/commit/f1dae735483bf293c4b18a8ff7c3ab6ca3cbe6e7))
+ - **FIX**: Fix Flutter Cupertino button color bug. (#8315). ([47dc6d09](https://github.com/firebase/flutterfire/commit/47dc6d09112db8d1398908895b387795722eaaba))
+ - **FEAT**: Allow setting `resizeToAvoidBottomInset` from LoginScreen and set as default `false` for backwards compatibility. (#8365). ([3e884f2f](https://github.com/firebase/flutterfire/commit/3e884f2f7cb498c6dff23ff6ac2bd9a25a73034d))
+ - **FEAT**: Add Japanese localization language support. (#8110). ([c9c7f828](https://github.com/firebase/flutterfire/commit/c9c7f8281fbfb2cd2872eb1b71fbd5e46c8002d8))
+ - **BREAKING** **FEAT**: add email verification and allow to unlink social providers from profile screen (#8358). ([89f97047](https://github.com/firebase/flutterfire/commit/89f97047e34d5023f2c41312767f626cb662702f))
 
 ## 0.3.6+1
 
@@ -56,60 +56,60 @@
 
 ## 0.3.6
 
- - **FEAT**: Add German localization language support (#8195). ([9976d9d6](https://github.com/FirebaseExtended/flutterfire/commit/9976d9d66b870143227b08af068da3bc2efc5411))
+ - **FEAT**: Add German localization language support (#8195). ([9976d9d6](https://github.com/firebase/flutterfire/commit/9976d9d66b870143227b08af068da3bc2efc5411))
 
 ## 0.3.5+1
 
- - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/FirebaseExtended/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
+ - **FIX**: update all Dart SDK version constraints to Dart >= 2.16.0 (#8184). ([df4a5bab](https://github.com/firebase/flutterfire/commit/df4a5bab3c029399b4f257a5dd658d302efe3908))
 
 ## 0.3.5
 
- - **FIX**: Upgrade `desktop_webview_auth` - v`0.0.5` (#8164). ([123fa6b1](https://github.com/FirebaseExtended/flutterfire/commit/123fa6b132183a4d6886c8be0595104752724532))
- - **FIX**: Upgrade `desktop_webview_auth` package causing a problem on macOS. (#8151). ([da4a1c5e](https://github.com/FirebaseExtended/flutterfire/commit/da4a1c5e074cb5af71983a3ae49c4838402b726f))
- - **FEAT**: Add support for configuring authentication providers globally (additionally fixes #7801) (#8120). ([ebde7d27](https://github.com/FirebaseExtended/flutterfire/commit/ebde7d27938d7a36a67973df4b33c21bbd7dea1a))
- - **FEAT**: Add Hindi localization language support (#7778). ([b584ce0f](https://github.com/FirebaseExtended/flutterfire/commit/b584ce0f254dcb195f9a31f279fb3871d01182c1))
- - **FEAT**: Add Turkish language localization support. (#7790). ([c47f6075](https://github.com/FirebaseExtended/flutterfire/commit/c47f60757ccbfcee1eaa5d7ed6ee01258f3b9d4f))
- - **FEAT**: Add Bahasa Indonesia localization language support (#7709). ([be0eb27f](https://github.com/FirebaseExtended/flutterfire/commit/be0eb27f4f4d85a4e4a2468768c166a701325a8c))
- - **FEAT**: Enhance the oauth provider button widget by showing error text underneath. (#8032). ([2b47f5a1](https://github.com/FirebaseExtended/flutterfire/commit/2b47f5a12747e3437dfc42d331684e798372beaf))
+ - **FIX**: Upgrade `desktop_webview_auth` - v`0.0.5` (#8164). ([123fa6b1](https://github.com/firebase/flutterfire/commit/123fa6b132183a4d6886c8be0595104752724532))
+ - **FIX**: Upgrade `desktop_webview_auth` package causing a problem on macOS. (#8151). ([da4a1c5e](https://github.com/firebase/flutterfire/commit/da4a1c5e074cb5af71983a3ae49c4838402b726f))
+ - **FEAT**: Add support for configuring authentication providers globally (additionally fixes #7801) (#8120). ([ebde7d27](https://github.com/firebase/flutterfire/commit/ebde7d27938d7a36a67973df4b33c21bbd7dea1a))
+ - **FEAT**: Add Hindi localization language support (#7778). ([b584ce0f](https://github.com/firebase/flutterfire/commit/b584ce0f254dcb195f9a31f279fb3871d01182c1))
+ - **FEAT**: Add Turkish language localization support. (#7790). ([c47f6075](https://github.com/firebase/flutterfire/commit/c47f60757ccbfcee1eaa5d7ed6ee01258f3b9d4f))
+ - **FEAT**: Add Bahasa Indonesia localization language support (#7709). ([be0eb27f](https://github.com/firebase/flutterfire/commit/be0eb27f4f4d85a4e4a2468768c166a701325a8c))
+ - **FEAT**: Enhance the oauth provider button widget by showing error text underneath. (#8032). ([2b47f5a1](https://github.com/firebase/flutterfire/commit/2b47f5a12747e3437dfc42d331684e798372beaf))
 
 ## 0.3.4
 
- - **FEAT**: Add Italian localization language support. (#7823). ([c3a1a839](https://github.com/FirebaseExtended/flutterfire/commit/c3a1a839a3963a75cc17e931a3eee6e091df40ac))
+ - **FEAT**: Add Italian localization language support. (#7823). ([c3a1a839](https://github.com/firebase/flutterfire/commit/c3a1a839a3963a75cc17e931a3eee6e091df40ac))
 
 ## 0.3.3
 
-- **FIX**: prompt user to select google account on web (#8007). ([b3db0213](https://github.com/FirebaseExtended/flutterfire/commit/b3db0213ae949435f74d8193cfb5c8a65ed7f601))
-- **FIX**: bump flutter_facebook_auth version (#8031). ([82c1fe11](https://github.com/FirebaseExtended/flutterfire/commit/82c1fe111d00b499e9587d235e4499b03cfe17bd))
-- **FIX**: make breakpoints of all screens configurable (#7996). ([6557740c](https://github.com/FirebaseExtended/flutterfire/commit/6557740cf68dbd79da7bd03c65f92479c3ff435b))
-- **FEAT**: add Dutch localization support (#7782). ([751104b6](https://github.com/FirebaseExtended/flutterfire/commit/751104b6ec282592e209ee57f130aae68a752ba5))
-- **FEAT**: add autofillhints (#7668). ([dd94e935](https://github.com/FirebaseExtended/flutterfire/commit/dd94e935828d2de873a08eb26801541ca68f0696))
-- **DOCS**: Fixes "infinite" typo (#8039). ([c2cf325d](https://github.com/FirebaseExtended/flutterfire/commit/c2cf325dfd52194c68b70d17a91bb9e1158840b6))
+- **FIX**: prompt user to select google account on web (#8007). ([b3db0213](https://github.com/firebase/flutterfire/commit/b3db0213ae949435f74d8193cfb5c8a65ed7f601))
+- **FIX**: bump flutter_facebook_auth version (#8031). ([82c1fe11](https://github.com/firebase/flutterfire/commit/82c1fe111d00b499e9587d235e4499b03cfe17bd))
+- **FIX**: make breakpoints of all screens configurable (#7996). ([6557740c](https://github.com/firebase/flutterfire/commit/6557740cf68dbd79da7bd03c65f92479c3ff435b))
+- **FEAT**: add Dutch localization support (#7782). ([751104b6](https://github.com/firebase/flutterfire/commit/751104b6ec282592e209ee57f130aae68a752ba5))
+- **FEAT**: add autofillhints (#7668). ([dd94e935](https://github.com/firebase/flutterfire/commit/dd94e935828d2de873a08eb26801541ca68f0696))
+- **DOCS**: Fixes "infinite" typo (#8039). ([c2cf325d](https://github.com/firebase/flutterfire/commit/c2cf325dfd52194c68b70d17a91bb9e1158840b6))
 
 ## 0.3.2
 
- - **FEAT**: add Portuguese localization support (#7830). ([5152692f](https://github.com/FirebaseExtended/flutterfire/commit/5152692f22fe61a95e9dd19eb3bdf87547760d72))
+ - **FEAT**: add Portuguese localization support (#7830). ([5152692f](https://github.com/firebase/flutterfire/commit/5152692f22fe61a95e9dd19eb3bdf87547760d72))
 
 ## 0.3.1
 
- - **FIX**: fix `ResponsivePage` overflow issue (#7792). ([4c633737](https://github.com/FirebaseExtended/flutterfire/commit/4c633737926f114ef32a409a1b0df6e262ba4816))
- - **FIX**: export DifferentSignInMethodsFound auth state and make sure to add it to the list of provided actions (#7789). ([0ebc382f](https://github.com/FirebaseExtended/flutterfire/commit/0ebc382f18039660d0d5a52c596155a58e201820))
- - **FIX**: validate email with the library instead of the RegExp (#7772). ([b271b7fc](https://github.com/FirebaseExtended/flutterfire/commit/b271b7fc8aa648d436041d0c6092a7de4b7f48d0))
- - **FIX**: not working onTap in OAuthProviderButtonWidget (#7641). ([d3b81eab](https://github.com/FirebaseExtended/flutterfire/commit/d3b81eabf9a2a9d10133a44d23a48997c776764f))
- - **FIX**: pass auth down to LoginView (#7645). ([e8926702](https://github.com/FirebaseExtended/flutterfire/commit/e8926702674cc41e019b3f5277683446b4106a31))
- - **FEAT**: add Spanish localization support (#7716). ([4e8931c8](https://github.com/FirebaseExtended/flutterfire/commit/4e8931c8b68290f3f9f16fceb5d345f34d4183b6))
- - **FEAT**: add French localization support (#7797). ([a1837a28](https://github.com/FirebaseExtended/flutterfire/commit/a1837a283d16d1e0d15a1f43ae2ead2b93470e64))
- - **FEAT**: add Arabic localization support (#7771). ([9e2959ec](https://github.com/FirebaseExtended/flutterfire/commit/9e2959ec04710b97a7f9d910a9ecd9c3aa879e13))
- - **DOCS**: update repository and homepage url (#7781). ([5034d699](https://github.com/FirebaseExtended/flutterfire/commit/5034d69926cb5da2a7da1a690021f92762188d03))
- - **DOCS**: add missing providerConfigs in example (#7724). ([8649f83d](https://github.com/FirebaseExtended/flutterfire/commit/8649f83dd38e8bce95fffd66870747ee0f70776f))
+ - **FIX**: fix `ResponsivePage` overflow issue (#7792). ([4c633737](https://github.com/firebase/flutterfire/commit/4c633737926f114ef32a409a1b0df6e262ba4816))
+ - **FIX**: export DifferentSignInMethodsFound auth state and make sure to add it to the list of provided actions (#7789). ([0ebc382f](https://github.com/firebase/flutterfire/commit/0ebc382f18039660d0d5a52c596155a58e201820))
+ - **FIX**: validate email with the library instead of the RegExp (#7772). ([b271b7fc](https://github.com/firebase/flutterfire/commit/b271b7fc8aa648d436041d0c6092a7de4b7f48d0))
+ - **FIX**: not working onTap in OAuthProviderButtonWidget (#7641). ([d3b81eab](https://github.com/firebase/flutterfire/commit/d3b81eabf9a2a9d10133a44d23a48997c776764f))
+ - **FIX**: pass auth down to LoginView (#7645). ([e8926702](https://github.com/firebase/flutterfire/commit/e8926702674cc41e019b3f5277683446b4106a31))
+ - **FEAT**: add Spanish localization support (#7716). ([4e8931c8](https://github.com/firebase/flutterfire/commit/4e8931c8b68290f3f9f16fceb5d345f34d4183b6))
+ - **FEAT**: add French localization support (#7797). ([a1837a28](https://github.com/firebase/flutterfire/commit/a1837a283d16d1e0d15a1f43ae2ead2b93470e64))
+ - **FEAT**: add Arabic localization support (#7771). ([9e2959ec](https://github.com/firebase/flutterfire/commit/9e2959ec04710b97a7f9d910a9ecd9c3aa879e13))
+ - **DOCS**: update repository and homepage url (#7781). ([5034d699](https://github.com/firebase/flutterfire/commit/5034d69926cb5da2a7da1a690021f92762188d03))
+ - **DOCS**: add missing providerConfigs in example (#7724). ([8649f83d](https://github.com/firebase/flutterfire/commit/8649f83dd38e8bce95fffd66870747ee0f70776f))
 
 ## 0.3.0
 
 > Note: This release has breaking changes.
 
- - **FIX**: add missing export for `ProviderConfiguration` (#7585). ([050ed837](https://github.com/FirebaseExtended/flutterfire/commit/050ed837884a8945b31f60098eba7a0eb500a3d2))
- - **FIX**: some OAuth providers now work on macOS & web (#7576). ([a4315731](https://github.com/FirebaseExtended/flutterfire/commit/a43157316787edcdefb10f9534800692b76e92c3))
- - **FIX**: fix various typos in i10n text (#7624). ([504f7056](https://github.com/FirebaseExtended/flutterfire/commit/504f7056f74e4a7bb7800ed45e10910a373e9d29))
- - **BREAKING** **FEAT**: update all dependencies to use latest releases (#7549). ([051ff77b](https://github.com/FirebaseExtended/flutterfire/commit/051ff77b7e95c376dc2c5014877dd0a5a7856de8))
+ - **FIX**: add missing export for `ProviderConfiguration` (#7585). ([050ed837](https://github.com/firebase/flutterfire/commit/050ed837884a8945b31f60098eba7a0eb500a3d2))
+ - **FIX**: some OAuth providers now work on macOS & web (#7576). ([a4315731](https://github.com/firebase/flutterfire/commit/a43157316787edcdefb10f9534800692b76e92c3))
+ - **FIX**: fix various typos in i10n text (#7624). ([504f7056](https://github.com/firebase/flutterfire/commit/504f7056f74e4a7bb7800ed45e10910a373e9d29))
+ - **BREAKING** **FEAT**: update all dependencies to use latest releases (#7549). ([051ff77b](https://github.com/firebase/flutterfire/commit/051ff77b7e95c376dc2c5014877dd0a5a7856de8))
    - Note this has no breaking public API changes, however if you additionally also depend on some of the same dependencies in your app, e.g. `flutter_svg` then you may need to update your versions of these packages as well in your app `pubspec.yaml` to 
    avoid version resolution issues when running `pub get`.
 

--- a/packages/flutterfire_ui/README.md
+++ b/packages/flutterfire_ui/README.md
@@ -4,7 +4,7 @@
 
 FlutterFire UI is a set of Flutter widgets and utilities designed to help you build and integrate your user interface with Firebase.
 
-> FlutterFire UI is still in beta and is subject to change. Please contribute to the [discussion](https://github.com/FirebaseExtended/flutterfire/discussions/6978) with feedback.
+> FlutterFire UI is still in beta and is subject to change. Please contribute to the [discussion](https://github.com/firebase/flutterfire/discussions/6978) with feedback.
 
 ## Installation
 
@@ -61,11 +61,11 @@ Learn more in the [Integrating your first screen section](doc/auth/integrating-y
 
 FlutterFire UI is still in active development.
 
-- For issues, please create a new [issue on the repository](https://github.com/FirebaseExtended/flutterfire/issues).
-- For feature requests, & questions, please participate on the [discussion](https://github.com/FirebaseExtended/flutterfire/discussions/6978) thread.
-- To contribute a change to this plugin, please review our [contribution guide](https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md) and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls).
+- For issues, please create a new [issue on the repository](https://github.com/firebase/flutterfire/issues).
+- For feature requests, & questions, please participate on the [discussion](https://github.com/firebase/flutterfire/discussions/6978) thread.
+- To contribute a change to this plugin, please review our [contribution guide](https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md) and open a [pull request](https://github.com/firebase/flutterfire/pulls).
 
-Please contribute to the [discussion](https://github.com/FirebaseExtended/flutterfire/discussions/6978) with feedback.
+Please contribute to the [discussion](https://github.com/firebase/flutterfire/discussions/6978) with feedback.
 
 ## Next Steps
 

--- a/packages/flutterfire_ui/pubspec.yaml
+++ b/packages/flutterfire_ui/pubspec.yaml
@@ -1,8 +1,8 @@
 name: flutterfire_ui
 description: UI library built on top of firebase services
 version: 0.4.1+2
-repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/flutterfire_ui
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/flutterfire_ui
+repository: https://github.com/firebase/flutterfire/tree/master/packages/flutterfire_ui
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/flutterfire_ui
 
 false_secrets:
   - example/**

--- a/tests/test_driver/firebase_auth/firebase_auth_instance_e2e.dart
+++ b/tests/test_driver/firebase_auth/firebase_auth_instance_e2e.dart
@@ -134,12 +134,12 @@ void setupTests() {
       });
 
       test('fires once on first initialization of FirebaseAuth', () async {
-        // Fixes a very specific bug: https://github.com/FirebaseExtended/flutterfire/issues/3628
+        // Fixes a very specific bug: https://github.com/firebase/flutterfire/issues/3628
         // If the first initialization of FirebaseAuth involves the listeners userChanges() or idTokenChanges()
         // the user will receive two events. Why? The native SDK listener will always fire an event upon initial
         // listen. FirebaseAuth also sends an initial synthetic event. We send a synthetic event because, ordinarily, the user will
         // not use a listener as the first occurrence of FirebaseAuth. We, therefore, mimic native behavior by sending an
-        // event. This test proves the logic of PR: https://github.com/FirebaseExtended/flutterfire/pull/6560
+        // event. This test proves the logic of PR: https://github.com/firebase/flutterfire/pull/6560
 
         // Requires a fresh app.
         FirebaseApp second = await Firebase.initializeApp(

--- a/tests/test_driver/firebase_messaging/firebase_messaging_e2e.dart
+++ b/tests/test_driver/firebase_messaging/firebase_messaging_e2e.dart
@@ -41,7 +41,7 @@ void setupTests() {
 
       group('onMessage', () {
         test('can listen multiple times', () async {
-          // regression test for https://github.com/FirebaseExtended/flutterfire/issues/6009
+          // regression test for https://github.com/firebase/flutterfire/issues/6009
 
           StreamSubscription<RemoteMessage> _onMessageSubscription;
           StreamSubscription<RemoteMessage> _onMessageOpenedAppSubscription;


### PR DESCRIPTION
## Description

All links of the repository in the codebase are using "FirebaseExtended" instead of "firebase" as GitHub organization. The reason for is this that this repository moved to the [Firebase](https://github.com/firebase) organization.

The old links are still working, because GitHub redirects to the new organization. But this has some disadvantages:
* Confusing for new developers
* Can easily break a new repository with name "FlutterFire" will be created inside the [FirebaseExtended](https://github.com/FirebaseExtended) organization (e. g. forking this repository).

Therefore, it's a good idea to just update the links.

## Related Issues

Closes #8790

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x]  I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/