### PR TITLE
fix(firebase_messaging): Swizzle check for FlutterAppLifeCycleProvider instead of UNUserNotificationCenterDelegate

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -245,9 +245,8 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
       // replace it, it will cause a stack overflow as our original delegate forwarding handler
       // below causes an infinite loop of forwarding. See
       // https://github.com/firebasefire/issues/4026.
-      if ([GULApplication sharedApplication].delegate != nil &&
-          [[GULApplication sharedApplication].delegate
-              conformsToProtocol:@protocol(UNUserNotificationCenterDelegate)]) {
+      if ([notificationCenter.delegate
+              conformsToProtocol:@protocol(FlutterAppLifeCycleProvider)]) {
         // Note this one only executes if Firebase swizzling is **enabled**.
         shouldReplaceDelegate = NO;
       }

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -239,11 +239,11 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 
     if (notificationCenter.delegate != nil) {
 #if !TARGET_OS_OSX
-      // If the App delegate exists and it conforms to UNUserNotificationCenterDelegate then we
-      // don't want to replace it on iOS as the earlier call to `[_registrar
-      // addApplicationDelegate:self];` will automatically delegate calls to this plugin. If we
-      // replace it, it will cause a stack overflow as our original delegate forwarding handler
-      // below causes an infinite loop of forwarding. See
+      // If a UNUserNotificationCenterDelegate is set and it conforms to
+      // FlutterAppLifeCycleProvider then we don't want to replace it on iOS as the earlier
+      // call to `[_registrar addApplicationDelegate:self];` will automatically delegate calls
+      // to this plugin. If we replace it, it will cause a stack overflow as our original
+      // delegate forwarding handler below causes an infinite loop of forwarding. See
       // https://github.com/firebasefire/issues/4026.
       if ([notificationCenter.delegate
               conformsToProtocol:@protocol(FlutterAppLifeCycleProvider)]) {

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -245,8 +245,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
       // to this plugin. If we replace it, it will cause a stack overflow as our original
       // delegate forwarding handler below causes an infinite loop of forwarding. See
       // https://github.com/firebasefire/issues/4026.
-      if ([notificationCenter.delegate
-              conformsToProtocol:@protocol(FlutterAppLifeCycleProvider)]) {
+      if ([notificationCenter.delegate conformsToProtocol:@protocol(FlutterAppLifeCycleProvider)]) {
         // Note this one only executes if Firebase swizzling is **enabled**.
         shouldReplaceDelegate = NO;
       }


### PR DESCRIPTION
## Description
### One Line Summary
Fix `FirebaseMessaging.onMessage` not firing on iOS if `UNUserNotificationCenterDelegate` is assigned to `UNUserNotificationCenter.currentNotificationCenter.delegate` by the app developer or another plugin / SDK.

### Details
The shouldReplaceDelegate was originally added to prevent an infinite
loop due to double swizzling. This only happens however if the app
developer set UNUserNotificationCenterDelegate to the AppDelegate. This
check was added in PR #4043. However this check does not consider if the
non-nil was set to something else, either by the app developer or
another SDK. FluterFire should swizzle in this case, so it does not miss
these events.

To address the above this commit checks if notificationCenter.delegate
conformsToProtocol FlutterAppLifeCycleProvider. This forwards events so
this is the true protocol that should be checked to prevent the infinite
loop the PR #4043 was addressing.

## Testing
Tested sending a push notification from the Firebase console ensuring `FirebaseMessaging.onMessage` fires and does not cause an infinite swizzling loop:
The following `AppDelegate.m` changes under `didFinishLaunchingWithOptions`:
1. Setting `UNUserNotificationCenter.currentNotificationCenter.delegate = self;`
2. Setting to a different delegate `UNUserNotificationCenter.currentNotificationCenter.delegate = myNotifDelegate;`
3. Adding another notification SDK to the project, `onesignal_flutter`.
    - This SDK sets a `UNUserNotificationCenterDelegate` and also swizzles.

## Related Issues
* Fixes issue firebase/flutterfire#8792
* Relates to PR firebase/flutterfire#4043

## Checklist
- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
   - No existing test for this
- [ ] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
Does your PR require plugin users to manually update their apps to accommodate your change?
- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
