### PR TITLE
docs: Change Facebook Typo to Twitter in the documentation

### DIFF
--- a/packages/flutterfire_ui/doc/auth/configuring-providers.md
+++ b/packages/flutterfire_ui/doc/auth/configuring-providers.md
@@ -144,7 +144,7 @@ The configuration requires the `clientId` property (which can be found in the Fi
 
 ## Twitter
 
-To support Facebook as a provider, first install the [`twitter_login`](https://pub.dev/packages/twitter_login)
+To support Twitter as a provider, first install the [`twitter_login`](https://pub.dev/packages/twitter_login)
 plugin to your project.
 
 Next, enable the "Twitter" provider in the Firebase Console:


### PR DESCRIPTION
## Description

In the Twitter section, Facebook was mistakenly referred to. So this corrects it back to Twitter.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
