### PR TITLE
fix(analytics, web): use jsify with user properties

### DIFF
--- a/packages/firebase_analytics/firebase_analytics_web/lib/interop/analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/interop/analytics.dart
@@ -41,7 +41,11 @@ class Analytics extends JsObjectWrapper<analytics_interop.AnalyticsJsImpl> {
     AnalyticsCallOptions? callOptions,
   }) {
     return analytics_interop.logEvent(
-        jsObject, name, util.jsify(parameters ?? {}), callOptions);
+      jsObject,
+      name,
+      util.jsify(parameters ?? {}),
+      callOptions,
+    );
   }
 
   void setAnalyticsCollectionEnabled({required bool enabled}) {
@@ -77,7 +81,7 @@ class Analytics extends JsObjectWrapper<analytics_interop.AnalyticsJsImpl> {
   }) {
     return analytics_interop.setUserProperties(
       jsObject,
-      {name: value},
+      util.jsify({name: value}),
       callOptions,
     );
   }

--- a/packages/firebase_analytics/firebase_analytics_web/lib/interop/analytics_interop.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/interop/analytics_interop.dart
@@ -31,7 +31,9 @@ external void logEvent(
 
 @JS()
 external void setAnalyticsCollectionEnabled(
-    AnalyticsJsImpl analytics, bool enabled);
+  AnalyticsJsImpl analytics,
+  bool enabled,
+);
 
 @JS()
 external void setCurrentScreen(
@@ -50,7 +52,7 @@ external void setUserId(
 @JS()
 external void setUserProperties(
   AnalyticsJsImpl analytics,
-  Map<String, Object?> property,
+  dynamic property,
   AnalyticsCallOptions? callOptions,
 );
 


### PR DESCRIPTION
## Description

Modify the way Dart sends user properties to native Javascript with the setUserProperties() method. Now using jsify() in the same way that it's used in logEvent() method.

## Related Issues

Fixes [firebase/flutterfire#8757](https://github.com/firebase/flutterfire/issues/8757)

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
