### PR TITLE
docs(firebase_messaging): add caution notice for old docs

### DIFF
--- a/docs/messaging/overview.mdx
+++ b/docs/messaging/overview.mdx
@@ -3,6 +3,19 @@ title: Firebase Cloud Messaging
 sidebar_label: Overview
 ---
 
+:::caution Notice
+
+This page is **archived** and might not reflect the latest version of the
+FlutterFire plugins. You can find the latest information on
+firebase.google.com:
+
+- Set up a Flutter client [https://firebase.google.com/docs/cloud-messaging/flutter/client](https://firebase.google.com/docs/cloud-messaging/flutter/client)
+- Send a test message [https://firebase.google.com/docs/cloud-messaging/flutter/first-message](https://firebase.google.com/docs/cloud-messaging/flutter/first-message)
+- Receive messages [https://firebase.google.com/docs/cloud-messaging/flutter/receive](https://firebase.google.com/docs/cloud-messaging/flutter/receive)
+- Subscribe to topics [https://firebase.google.com/docs/cloud-messaging/flutter/topic-messaging](https://firebase.google.com/docs/cloud-messaging/flutter/topic-messaging)
+
+:::
+
 ## What does it do?
 
 Firebase Cloud Messaging (FCM) is a cross-platform messaging solution that lets you reliably send messages at no cost.


### PR DESCRIPTION
## Description

Set caution notice for the old Firebase Messaging docs were missing. Therefore, I added them. I copied the style from the cloud functions notice.

## Related Issues

Fixes #8873

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/