### PR TITLE
feat(firebase_analytics): provide isSupported for v9/analytics

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/example/test_driver/firebase_analytics_e2e.dart
+++ b/packages/firebase_analytics/firebase_analytics/example/test_driver/firebase_analytics_e2e.dart
@@ -25,6 +25,11 @@ void testsMain() {
       analytics = FirebaseAnalytics.instance;
     });
 
+    test('isSupported', () async {
+      final result = await FirebaseAnalytics.instance.isSupported();
+      expect(result, isA<bool>());
+    });
+
     test('logEvent', () async {
       await expectLater(analytics.logEvent(name: 'testing'), completes);
 

--- a/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
@@ -65,6 +65,10 @@ class FirebaseAnalytics extends FirebasePluginPlatform {
     return FirebaseAnalytics.instanceFor(app: defaultAppInstance);
   }
 
+  Future<bool> isSupported() {
+    return _delegate.isSupported();
+  }
+
   /// Logs a custom Flutter Analytics event with the given [name] and event [parameters].
   Future<void> logEvent({
     required String name,

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/lib/src/method_channel/method_channel_firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/lib/src/method_channel/method_channel_firebase_analytics.dart
@@ -38,6 +38,12 @@ class MethodChannelFirebaseAnalytics extends FirebaseAnalyticsPlatform {
     return MethodChannelFirebaseAnalytics(app: app);
   }
 
+  /// Returns "true" as this API is used to inform users of web browser support
+  @override
+  Future<bool> isSupported() {
+    return Future.value(true);
+  }
+
   @override
   Future<void> logEvent({
     required String name,

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/lib/src/platform_interface/platform_interface_firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/lib/src/platform_interface/platform_interface_firebase_analytics.dart
@@ -62,6 +62,12 @@ abstract class FirebaseAnalyticsPlatform extends PlatformInterface {
     throw UnimplementedError('delegateFor() is not implemented');
   }
 
+  /// isSupported() informs web users whether
+  /// the browser supports Firebase.Analytics
+  Future<bool> isSupported() {
+    throw UnimplementedError('isSupported() is not implemented');
+  }
+
   /// Logs the given event [name] with the given [parameters].
   Future<void> logEvent({
     required String name,

--- a/packages/firebase_analytics/firebase_analytics_web/lib/firebase_analytics_web.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/firebase_analytics_web.dart
@@ -39,6 +39,11 @@ class FirebaseAnalyticsWeb extends FirebaseAnalyticsPlatform {
   }
 
   @override
+  Future<bool> isSupported() {
+    return analytics_interop.Analytics.isSupported();
+  }
+
+  @override
   Future<void> logEvent({
     required String name,
     Map<String, Object?>? parameters,

--- a/packages/firebase_analytics/firebase_analytics_web/lib/interop/analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/interop/analytics.dart
@@ -32,6 +32,10 @@ class Analytics extends JsObjectWrapper<analytics_interop.AnalyticsJsImpl> {
     return _expando[jsObject] ??= Analytics._fromJsObject(jsObject);
   }
 
+  static Future<bool> isSupported() {
+    return handleThenable(analytics_interop.isSupported());
+  }
+
   /// Non-null App for this instance of analytics service.
   App get app => App.getInstance(jsObject.app);
 
@@ -41,7 +45,11 @@ class Analytics extends JsObjectWrapper<analytics_interop.AnalyticsJsImpl> {
     AnalyticsCallOptions? callOptions,
   }) {
     return analytics_interop.logEvent(
-        jsObject, name, util.jsify(parameters ?? {}), callOptions);
+      jsObject,
+      name,
+      util.jsify(parameters ?? {}),
+      callOptions,
+    );
   }
 
   void setAnalyticsCollectionEnabled({required bool enabled}) {

--- a/packages/firebase_analytics/firebase_analytics_web/lib/interop/analytics_interop.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/interop/analytics_interop.dart
@@ -19,7 +19,7 @@ external AnalyticsJsImpl getAnalytics([AppJsImpl? app]);
 external AnalyticsJsImpl initializeAnalytics([AppJsImpl app]);
 
 @JS()
-external bool isSupported();
+external PromiseJsImpl<bool> isSupported();
 
 @JS()
 external void logEvent(
@@ -31,7 +31,9 @@ external void logEvent(
 
 @JS()
 external void setAnalyticsCollectionEnabled(
-    AnalyticsJsImpl analytics, bool enabled);
+  AnalyticsJsImpl analytics,
+  bool enabled,
+);
 
 @JS()
 external void setCurrentScreen(

--- a/tests/test_driver/firebase_analytics/firebase_analytics_e2e.dart
+++ b/tests/test_driver/firebase_analytics/firebase_analytics_e2e.dart
@@ -17,6 +17,11 @@ void setupTests() {
       );
     });
 
+    test('isSupported', () async {
+      final result = await FirebaseAnalytics.instance.isSupported();
+      expect(result, isA<bool>());
+    });
+
     test('logEvent', () async {
       await expectLater(
         FirebaseAnalytics.instance.logEvent(name: 'testing'),


### PR DESCRIPTION
## Description

Similiar to [#8860](https://github.com/firebase/flutterfire/pull/8860) this PR implements isSupported() in Firebase Analytics. We need to check if the Browser supports Analytics in our Flutter Web app.

## Related Pull Request

- https://github.com/firebase/flutterfire/pull/8860

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

This PR changes the result type of isSupported in `analytics_interop.dart` from `bool` to `PromiseJsImpl<bool>`

