### PR TITLE
docs(firebase_messaging): fix missing `await` for `getToken()`

### DIFF
--- a/docs/cloud-messaging/first-message.md
+++ b/docs/cloud-messaging/first-message.md
@@ -52,7 +52,7 @@ ask the user for notification permissions. Otherwise, it returns a token or
 rejects the future due to an error.
 
 ```dart
-final fcmToken = FirebaseMessaging.instance.getToken();
+final fcmToken = await FirebaseMessaging.instance.getToken();
 ```
 
 


### PR DESCRIPTION
## Description

https://github.com/firebase/flutterfire/blob/2854cbcb5a2e604ace8dc55993893e5ffdbff5a8/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart#L112

`getToken()` is a `Future` so you should `await` when getting the token.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
