### PR TITLE
docs(firebase_messaging): clarify when `vapidKey` parameter is needed when calling `getToken()`

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
@@ -110,7 +110,7 @@ class FirebaseMessaging extends FirebasePluginPlatform {
 
   /// Returns the default FCM token for this device.
   ///
-  /// On web is the [vapidKey] required.
+  /// On web, a [vapidKey] is required.
   Future<String?> getToken({
     String? vapidKey,
   }) {

--- a/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
@@ -110,7 +110,7 @@ class FirebaseMessaging extends FirebasePluginPlatform {
 
   /// Returns the default FCM token for this device.
   ///
-  /// On web you need to pass the [vapidKey].
+  /// On web is the [vapidKey] required.
   Future<String?> getToken({
     String? vapidKey,
   }) {

--- a/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
@@ -109,6 +109,8 @@ class FirebaseMessaging extends FirebasePluginPlatform {
   }
 
   /// Returns the default FCM token for this device.
+  ///
+  /// On web you need to pass the [vapidKey].
   Future<String?> getToken({
     String? vapidKey,
   }) {


### PR DESCRIPTION
## Description
Makes it more clear when you need to pass `vapidKey`

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
