### PR TITLE
test(firebase_core): migrate to `integration_test` package

### DIFF
--- a/tests/integration_test/e2e_test.dart
+++ b/tests/integration_test/e2e_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2019, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 

--- a/tests/integration_test/e2e_test.dart
+++ b/tests/integration_test/e2e_test.dart
@@ -1,12 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import 'firebase_core/firebase_core_e2e_test.dart' as firebase_core;
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
+  // ignore: unnecessary_lambdas
   group('FlutterFire', () {
-    test('dummy test', () {
-      expect(true, true);
-    });
+    firebase_core.main();
   });
 }

--- a/tests/integration_test/firebase_core/firebase_core_e2e_test.dart
+++ b/tests/integration_test/firebase_core/firebase_core_e2e_test.dart
@@ -1,0 +1,79 @@
+// Copyright 2019, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
+
+import 'package:drive/drive.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../test_driver/firebase_default_options.dart';
+
+void main() {
+  group('firebase_core', () {
+    String testAppName = '[DEFAULT]';
+
+    setUpAll(() async {
+      await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform,
+      );
+    });
+
+    test('Firebase.apps', () async {
+      List<FirebaseApp> apps = Firebase.apps;
+      expect(apps.length, 1);
+      expect(apps[0].name, testAppName);
+      expect(apps[0].options, DefaultFirebaseOptions.currentPlatform);
+    });
+
+    test('Firebase.app()', () async {
+      FirebaseApp app = Firebase.app(testAppName);
+
+      expect(app.name, testAppName);
+      expect(app.options, DefaultFirebaseOptions.currentPlatform);
+    });
+
+    test('Firebase.app() Exception', () async {
+      expect(
+        () => Firebase.app('NoApp'),
+        throwsA(noAppExists('NoApp')),
+      );
+    });
+
+    test(
+      'FirebaseApp.delete()',
+      () async {
+        await Firebase.initializeApp(
+          name: 'SecondaryApp',
+          options: DefaultFirebaseOptions.currentPlatform,
+        );
+
+        expect(Firebase.apps.length, 2);
+
+        FirebaseApp app = Firebase.app('SecondaryApp');
+
+        await app.delete();
+
+        expect(Firebase.apps.length, 1);
+        // TODO(russellwheatley): test randomly causes an auth sign-in failure due to duplicate accounts.
+      },
+      skip: TargetPlatform.android == defaultTargetPlatform,
+    );
+
+    test('FirebaseApp.setAutomaticDataCollectionEnabled()', () async {
+      FirebaseApp app = Firebase.app(testAppName);
+      bool enabled = app.isAutomaticDataCollectionEnabled;
+
+      await app.setAutomaticDataCollectionEnabled(!enabled);
+
+      expect(app.isAutomaticDataCollectionEnabled, !enabled);
+    });
+
+    test('FirebaseApp.setAutomaticResourceManagementEnabled()', () async {
+      FirebaseApp app = Firebase.app(testAppName);
+
+      await app.setAutomaticResourceManagementEnabled(true);
+    });
+  });
+}

--- a/tests/integration_test/firebase_core/firebase_core_e2e_test.dart
+++ b/tests/integration_test/firebase_core/firebase_core_e2e_test.dart
@@ -7,8 +7,7 @@ import 'package:firebase_core_platform_interface/firebase_core_platform_interfac
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-
-import '../../test_driver/firebase_default_options.dart';
+import 'package:tests/firebase_options.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/tests/integration_test/firebase_core/firebase_core_e2e_test.dart
+++ b/tests/integration_test/firebase_core/firebase_core_e2e_test.dart
@@ -2,10 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:drive/drive.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import '../../test_driver/firebase_default_options.dart';

--- a/tests/integration_test/firebase_core/firebase_core_e2e_test.dart
+++ b/tests/integration_test/firebase_core/firebase_core_e2e_test.dart
@@ -2,15 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:drive/drive.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
-
-import 'package:drive/drive.dart';
 import 'package:flutter/foundation.dart';
+import 'package:integration_test/integration_test.dart';
 
 import '../../test_driver/firebase_default_options.dart';
 
 void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
   group('firebase_core', () {
     String testAppName = '[DEFAULT]';
 


### PR DESCRIPTION
## Description

Migrates the Flutter Driver tests to Flutter Integration tests. I just copied the Flutter Driver. So have not changed any test.  

## Related Issues

Part of #6829 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
