### PR TITLE
test(cloud_functions): migrate to `integration_test` package

### DIFF
--- a/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
+++ b/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
@@ -1,0 +1,194 @@
+// Copyright 2021, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:typed_data';
+
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tests/firebase_options.dart';
+
+import 'sample_data.dart' as data;
+
+String kTestFunctionDefaultRegion = 'testFunctionDefaultRegion';
+String kTestFunctionCustomRegion = 'testFunctionCustomRegion';
+String kTestFunctionTimeout = 'testFunctionTimeout';
+String kTestMapConvertType = 'testMapConvertType';
+
+void main() {
+  group('cloud_functions', () {
+    late HttpsCallable callable;
+
+    setUpAll(() async {
+      await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform,
+      );
+      FirebaseFunctions.instance.useFunctionsEmulator('localhost', 5001);
+      callable =
+          FirebaseFunctions.instance.httpsCallable(kTestFunctionDefaultRegion);
+    });
+
+    group('HttpsCallable', () {
+      test('returns a [HttpsCallableResult]', () async {
+        var result = await callable();
+        expect(result, isA<HttpsCallableResult>());
+      });
+
+      test('accepts no arguments', () async {
+        HttpsCallableResult result = await callable();
+        expect(result.data, equals('null'));
+      });
+
+      test('accepts `null arguments', () async {
+        HttpsCallableResult result = await callable(null);
+        expect(result.data, equals('null'));
+      });
+
+      test('accepts a string value', () async {
+        HttpsCallableResult result = await callable('foo');
+        expect(result.data, equals('string'));
+      });
+
+      test('accepts a number value', () async {
+        HttpsCallableResult result = await callable(123);
+        expect(result.data, equals('number'));
+        HttpsCallableResult result2 = await callable(12.3);
+        expect(result2.data, equals('number'));
+      });
+
+      test('accepts a boolean value', () async {
+        HttpsCallableResult result = await callable(true);
+        expect(result.data, equals('boolean'));
+        HttpsCallableResult result2 = await callable(false);
+        expect(result2.data, equals('boolean'));
+      });
+
+      test('accepts a [List]', () async {
+        HttpsCallableResult result = await callable(data.list);
+        expect(result.data, equals('array'));
+      });
+
+      test('accepts a deeply nested [Map]', () async {
+        HttpsCallableResult result = await callable({
+          'type': 'deepMap',
+          'inputData': data.deepMap,
+        });
+        expect(result.data, equals(data.deepMap));
+      });
+
+      test('accepts a deeply nested [List]', () async {
+        HttpsCallableResult result = await callable({
+          'type': 'deepList',
+          'inputData': data.deepList,
+        });
+        expect(result.data, equals(data.deepList));
+      });
+
+      test(
+        'accepts raw data as arguments',
+        () async {
+          HttpsCallableResult result = await callable({
+            'type': 'rawData',
+            'list': Uint8List(100),
+            'int': Int32List(39),
+            'long': Int64List(45),
+            'float': Float32List(23),
+            'double': Float64List(1001),
+          });
+          final data = result.data;
+          expect(data['list'], isA<List>());
+          expect(data['int'], isA<List>());
+          expect(data['long'], isA<List>());
+          expect(data['float'], isA<List>());
+          expect(data['double'], isA<List>());
+        },
+        // Int64List is not supported on Web.
+        skip: kIsWeb,
+      );
+
+      test(
+        '[HttpsCallableResult.data] should return Map<String, dynamic> type for returned objects',
+        () async {
+          HttpsCallable callable =
+              FirebaseFunctions.instance.httpsCallable(kTestMapConvertType);
+
+          var result = await callable();
+
+          expect(result.data, isA<Map<String, dynamic>>());
+        },
+      );
+    });
+
+    group('FirebaseFunctionsException', () {
+      test('HttpsCallable returns a FirebaseFunctionsException on error',
+          () async {
+        try {
+          await callable({});
+          fail('Should have thrown');
+        } on FirebaseFunctionsException catch (e) {
+          expect(e.code, equals('invalid-argument'));
+          expect(e.message, equals('Invalid test requested.'));
+          return;
+        } catch (e) {
+          fail('$e');
+        }
+      });
+
+      test('it returns "details" value as part of the exception', () async {
+        try {
+          await callable({
+            'type': 'deepMap',
+            'inputData': data.deepMap,
+            'asError': true,
+          });
+          fail('Should have thrown');
+        } on FirebaseFunctionsException catch (e) {
+          expect(e.code, equals('cancelled'));
+          expect(
+            e.message,
+            equals(
+              'Response data was requested to be sent as part of an Error payload, so here we are!',
+            ),
+          );
+          expect(e.details, equals(data.deepMap));
+        } catch (e) {
+          fail('$e');
+        }
+      });
+    });
+
+    group('instanceFor', () {
+      test('accepts a custom region', () async {
+        final instance = FirebaseFunctions.instanceFor(region: 'europe-west1');
+        instance.useFunctionsEmulator('localhost', 5001);
+        final customRegionCallable =
+            instance.httpsCallable(kTestFunctionCustomRegion);
+        final result = await customRegionCallable();
+        expect(result.data, equals('europe-west1'));
+      });
+    });
+
+    group('HttpsCallableOptions', () {
+      test('times out when the provided timeout option is exceeded', () async {
+        final instance = FirebaseFunctions.instance;
+        instance.useFunctionsEmulator('localhost', 5001);
+        final timeoutCallable = FirebaseFunctions.instance.httpsCallable(
+          kTestFunctionTimeout,
+          options: HttpsCallableOptions(timeout: const Duration(seconds: 3)),
+        );
+        try {
+          await timeoutCallable({
+            'testTimeout': const Duration(seconds: 6).inMilliseconds.toString(),
+          });
+          fail('Should have thrown');
+        } on FirebaseFunctionsException catch (e) {
+          expect(e.code, equals('deadline-exceeded'));
+        } catch (e) {
+          fail('$e');
+        }
+      });
+    });
+  });
+}

--- a/tests/integration_test/cloud_functions/sample_data.dart
+++ b/tests/integration_test/cloud_functions/sample_data.dart
@@ -1,0 +1,25 @@
+// Copyright 2021, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+Map<String, dynamic> map = <String, dynamic>{
+  'number': 123,
+  'string': 'foo',
+  'booleanTrue': true,
+  'booleanFalse': false,
+  'null': null,
+};
+
+List<dynamic> list = ['1', 2, true, false];
+
+Map<String, dynamic> deepMap = <String, dynamic>{
+  ...map,
+  'list': list,
+  'map': map,
+};
+
+List<dynamic> deepList = [
+  ...list,
+  list,
+  map,
+];

--- a/tests/integration_test/e2e_test.dart
+++ b/tests/integration_test/e2e_test.dart
@@ -11,7 +11,6 @@ import 'firebase_core/firebase_core_e2e_test.dart' as firebase_core;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  // ignore: unnecessary_lambdas
   group('FlutterFire', () {
     cloud_functions.main();
     firebase_core.main();

--- a/tests/integration_test/e2e_test.dart
+++ b/tests/integration_test/e2e_test.dart
@@ -1,12 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import 'cloud_functions/cloud_functions_e2e_test.dart' as cloud_functions;
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
+  // ignore: unnecessary_lambdas
   group('FlutterFire', () {
-    test('dummy test', () {
-      expect(true, true);
-    });
+    cloud_functions.main();
   });
 }


### PR DESCRIPTION
## Description

Migrates the Flutter Driver tests to Flutter Integration tests. I just copied the Flutter Driver. So I have not changed any test.  

## Related Issues

Part of #6829 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
