### PR TITLE
test(firebase_app_installations): migrate to `integration_test` package

### DIFF
--- a/tests/integration_test/e2e_test.dart
+++ b/tests/integration_test/e2e_test.dart
@@ -12,7 +12,6 @@ import 'firebase_core/firebase_core_e2e_test.dart' as firebase_core;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  // ignore: unnecessary_lambdas
   group('FlutterFire', () {
     firebase_app_installations.main();
     firebase_core.main();

--- a/tests/integration_test/e2e_test.dart
+++ b/tests/integration_test/e2e_test.dart
@@ -1,12 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import 'firebase_app_installations/firebase_app_installations_e2e_test.dart'
+    as firebase_app_installations;
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
+  // ignore: unnecessary_lambdas
   group('FlutterFire', () {
-    test('dummy test', () {
-      expect(true, true);
-    });
+    firebase_app_installations.main();
   });
 }

--- a/tests/integration_test/firebase_app_installations/firebase_app_installations_e2e_test.dart
+++ b/tests/integration_test/firebase_app_installations/firebase_app_installations_e2e_test.dart
@@ -1,0 +1,46 @@
+// Copyright 2022, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:firebase_app_installations/firebase_app_installations.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tests/firebase_options.dart';
+
+void main() {
+  group(
+    'firebase_app_installations',
+    () {
+      setUpAll(() async {
+        await Firebase.initializeApp(
+          options: DefaultFirebaseOptions.currentPlatform,
+        );
+      });
+
+      test('.getId', () async {
+        final id = await FirebaseInstallations.instance.getId();
+        expect(id, isNotEmpty);
+      });
+
+      test('.delete', () async {
+        final id = await FirebaseInstallations.instance.getId();
+
+        // Wait a little so we don't get a delete-pending exception
+        await Future.delayed(const Duration(seconds: 8));
+
+        await FirebaseInstallations.instance.delete();
+
+        // Wait a little so we don't get a delete-pending exception
+        await Future.delayed(const Duration(seconds: 8));
+
+        final newId = await FirebaseInstallations.instance.getId();
+        expect(newId, isNot(equals(id)));
+      });
+
+      test('.getToken', () async {
+        final token = await FirebaseInstallations.instance.getId();
+        expect(token, isNotEmpty);
+      });
+    },
+  );
+}


### PR DESCRIPTION
## Description

Migrates the Flutter Driver tests to Flutter Integration tests. I just copied the Flutter Driver. So I have not changed any test.  

## Related Issues

Part of #6829 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
