### PR TITLE
test(firebase_app_check): enable tests

### DIFF
--- a/tests/pubspec.yaml
+++ b/tests/pubspec.yaml
@@ -27,13 +27,12 @@ dependencies:
     path: ../packages/firebase_analytics/firebase_analytics_platform_interface
   firebase_analytics_web:
     path: ../packages/firebase_analytics/firebase_analytics_web
-  # TODO RTDB emulator breaks just by including App Check
-  # firebase_app_check:
-  #   path: ../packages/firebase_app_check/firebase_app_check
-  # firebase_app_check_platform_interface:
-  #   path: ../packages/firebase_app_check/firebase_app_check_platform_interface
-  # firebase_app_check_web:
-  #   path: ../packages/firebase_app_check/firebase_app_check_web
+  firebase_app_check:
+    path: ../packages/firebase_app_check/firebase_app_check
+  firebase_app_check_platform_interface:
+    path: ../packages/firebase_app_check/firebase_app_check_platform_interface
+  firebase_app_check_web:
+    path: ../packages/firebase_app_check/firebase_app_check_web
   firebase_app_installations:
     path: ../packages/firebase_app_installations/firebase_app_installations
   firebase_app_installations_platform_interface:
@@ -123,12 +122,12 @@ dependency_overrides:
     path: ../packages/firebase_analytics/firebase_analytics_platform_interface
   firebase_analytics_web:
     path: ../packages/firebase_analytics/firebase_analytics_web
-  # firebase_app_check:
-  #   path: ../packages/firebase_app_check/firebase_app_check
-  # firebase_app_check_platform_interface:
-  #   path: ../packages/firebase_app_check/firebase_app_check_platform_interface
-  # firebase_app_check_web:
-  #   path: ../packages/firebase_app_check/firebase_app_check_web
+  firebase_app_check:
+    path: ../packages/firebase_app_check/firebase_app_check
+  firebase_app_check_platform_interface:
+    path: ../packages/firebase_app_check/firebase_app_check_platform_interface
+  firebase_app_check_web:
+    path: ../packages/firebase_app_check/firebase_app_check_web
   firebase_app_installations:
     path: ../packages/firebase_app_installations/firebase_app_installations
   firebase_app_installations_platform_interface:

--- a/tests/test_driver/firebase_app_check/firebase_app_check_e2e.dart
+++ b/tests/test_driver/firebase_app_check/firebase_app_check_e2e.dart
@@ -2,14 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_core/firebase_core.dart';
-// import 'package:firebase_app_check/firebase_app_check.dart';
-
 import 'package:drive/drive.dart';
-import '../firebase_default_options.dart';
-// import 'package:flutter/foundation.dart';
+import 'package:firebase_app_check/firebase_app_check.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
 
-// TODO RTDB emulator breaks just by including App Check
+import '../firebase_default_options.dart';
+
 void setupTests() {
   group(
     'firebase_app_check',
@@ -20,48 +19,41 @@ void setupTests() {
         );
       });
 
-      // test('activate', () async {
-      //   await expectLater(
-      //     FirebaseAppCheck.instance.activate(
-      //       webRecaptchaSiteKey: '6Lemcn0dAAAAABLkf6aiiHvpGD6x-zF3nOSDU2M8',
-      //     ),
-      //     completes,
-      //   );
-      // });
+      test('activate', () async {
+        await expectLater(
+          FirebaseAppCheck.instance.activate(
+            webRecaptchaSiteKey: '6Lemcn0dAAAAABLkf6aiiHvpGD6x-zF3nOSDU2M8',
+          ),
+          completes,
+        );
+      });
 
-      // test(
-      //   'getToken',
-      //   () async {
-      //     final token = await FirebaseAppCheck.instance.getToken(true);
-      //     expect(token, isA<String?>());
-      //   },
-      //   // TODO why is this Android/Web only?
-      //   skip: defaultTargetPlatform == TargetPlatform.iOS ||
-      //       defaultTargetPlatform == TargetPlatform.macOS,
-      // );
+      test(
+        'getToken',
+        () async {
+          final token = await FirebaseAppCheck.instance.getToken(true);
+          expect(token, isA<String?>());
+        },
+        // Is not working on iOS and macOS. Tracking issue:
+        // https://github.com/firebase/flutterfire/issues/8969
+        skip: defaultTargetPlatform == TargetPlatform.iOS ||
+            defaultTargetPlatform == TargetPlatform.macOS,
+      );
 
-      // test(
-      //   'setTokenAutoRefreshEnabled',
-      //   () async {
-      //     await expectLater(
-      //       FirebaseAppCheck.instance.setTokenAutoRefreshEnabled(true),
-      //       completes,
-      //     );
-      //   },
-      // );
+      test(
+        'setTokenAutoRefreshEnabled',
+        () async {
+          await expectLater(
+            FirebaseAppCheck.instance.setTokenAutoRefreshEnabled(true),
+            completes,
+          );
+        },
+      );
 
-      // test('tokenChanges', () async {
-      //   final stream = FirebaseAppCheck.instance.onTokenChange;
-      //   expect(stream, isA<Stream>());
-
-      //   // TODO how to trigger event listener in e2e tests?
-      //   // await FirebaseAppCheck.instance.getToken(true);
-      //   //
-      //   // final result = await stream.first;
-      //   //
-      //   // expect(result, isA<AppCheckTokenResult>());
-      //   // expect(result.token, isA<String>());
-      // });
+      test('onTokenChange', () async {
+        final stream = FirebaseAppCheck.instance.onTokenChange;
+        expect(stream, isA<Stream<String?>>());
+      });
     },
   );
 }

--- a/tests/test_driver/firebase_app_check/firebase_app_check_e2e.dart
+++ b/tests/test_driver/firebase_app_check/firebase_app_check_e2e.dart
@@ -31,6 +31,11 @@ void setupTests() {
       test(
         'getToken',
         () async {
+          // Enable the App Check
+          FirebaseAppCheck.instance.activate(
+            webRecaptchaSiteKey: '6Lemcn0dAAAAABLkf6aiiHvpGD6x-zF3nOSDU2M8',
+          );
+
           final token = await FirebaseAppCheck.instance.getToken(true);
           expect(token, isA<String>());
         },

--- a/tests/test_driver/firebase_app_check/firebase_app_check_e2e.dart
+++ b/tests/test_driver/firebase_app_check/firebase_app_check_e2e.dart
@@ -32,7 +32,7 @@ void setupTests() {
         'getToken',
         () async {
           final token = await FirebaseAppCheck.instance.getToken(true);
-          expect(token, isA<String?>());
+          expect(token, isA<String>());
         },
         // Is not working on iOS and macOS. Tracking issue:
         // https://github.com/firebase/flutterfire/issues/8969

--- a/tests/test_driver/firebase_app_check/firebase_app_check_e2e.dart
+++ b/tests/test_driver/firebase_app_check/firebase_app_check_e2e.dart
@@ -31,17 +31,16 @@ void setupTests() {
       test(
         'getToken',
         () async {
-          // Enable the App Check
-          FirebaseAppCheck.instance.activate(
-            webRecaptchaSiteKey: '6Lemcn0dAAAAABLkf6aiiHvpGD6x-zF3nOSDU2M8',
-          );
-
           final token = await FirebaseAppCheck.instance.getToken(true);
           expect(token, isA<String>());
         },
+        // Getting "Fetch server returned an HTTP error status. HTTP status:
+        // 400" when running tests on web.
+        //
         // Is not working on iOS and macOS. Tracking issue:
         // https://github.com/firebase/flutterfire/issues/8969
-        skip: defaultTargetPlatform == TargetPlatform.iOS ||
+        skip: kIsWeb ||
+            defaultTargetPlatform == TargetPlatform.iOS ||
             defaultTargetPlatform == TargetPlatform.macOS,
       );
 


### PR DESCRIPTION
## Description

There was a comment that adding Firebase App Check to the app crashes the RTDB emulator. I tried it out again and it worked. Therefore, it has been fixed :)

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x]  I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
