### PR TITLE
test(firebase_crashlytics): migrate tests to `integration_test` package

### DIFF
--- a/tests/integration_test/e2e_test.dart
+++ b/tests/integration_test/e2e_test.dart
@@ -6,12 +6,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'firebase_core/firebase_core_e2e_test.dart' as firebase_core;
+import 'firebase_crashlytics/firebase_crashlytics_e2e_test.dart'
+    as firebase_crashlytics;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  // ignore: unnecessary_lambdas
   group('FlutterFire', () {
     firebase_core.main();
+    firebase_crashlytics.main();
   });
 }

--- a/tests/integration_test/firebase_crashlytics/firebase_crashlytics_e2e_test.dart
+++ b/tests/integration_test/firebase_crashlytics/firebase_crashlytics_e2e_test.dart
@@ -1,0 +1,150 @@
+// Copyright 2019, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tests/firebase_options.dart';
+
+void main() {
+  group(
+    'firebase_crashlytics',
+    () {
+      setUpAll(() async {
+        await Firebase.initializeApp(
+          options: DefaultFirebaseOptions.currentPlatform,
+        );
+      });
+
+      group('checkForUnsentReports', () {
+        test('should throw if automatic crash report is enabled', () async {
+          await FirebaseCrashlytics.instance
+              .setCrashlyticsCollectionEnabled(true);
+
+          await expectLater(
+            FirebaseCrashlytics.instance.checkForUnsentReports,
+            throwsA(isA<StateError>()),
+          );
+        });
+
+        test('checks device cache for unsent crashlytics reports', () async {
+          await FirebaseCrashlytics.instance
+              .setCrashlyticsCollectionEnabled(false);
+          var unsentReports =
+              await FirebaseCrashlytics.instance.checkForUnsentReports();
+
+          expect(unsentReports, isFalse);
+        });
+      });
+
+      group('deleteUnsentReports', () {
+        // This is currently only testing that we can delete reports without crashing.
+        test('deletes unsent crashlytics reports', () async {
+          await FirebaseCrashlytics.instance.deleteUnsentReports();
+        });
+      });
+
+      group('didCrashOnPreviousExecution', () {
+        test('checks if app crashed on previous execution', () async {
+          var didCrash =
+              await FirebaseCrashlytics.instance.didCrashOnPreviousExecution();
+          expect(didCrash, isFalse);
+        });
+      });
+
+      group('recordError', () {
+        // This is currently only testing that we can log errors without crashing.
+        test('should log error', () async {
+          await FirebaseCrashlytics.instance.recordError(
+            'foo exception',
+            StackTrace.fromString('during testing'),
+          );
+        });
+
+        // This is currently only testing that we can log flutter errors without crashing.
+        test('should record flutter error', () async {
+          await FirebaseCrashlytics.instance.recordFlutterError(
+            FlutterErrorDetails(
+              exception: 'foo exception',
+              stack: StackTrace.fromString(''),
+              context: DiagnosticsNode.message('bar reason'),
+              informationCollector: () => <DiagnosticsNode>[
+                DiagnosticsNode.message('first message'),
+                DiagnosticsNode.message('second message')
+              ],
+            ),
+          );
+        });
+      });
+
+      group('log', () {
+        // This is currently only testing that we can log without crashing.
+        test('accepts any value', () async {
+          await FirebaseCrashlytics.instance.log('flutter');
+        });
+      });
+
+      group('sendUnsentReports', () {
+        // This is currently only testing that we can send unsent reports without crashing.
+        test('sends unsent reports to crashlytics server', () async {
+          await FirebaseCrashlytics.instance.sendUnsentReports();
+        });
+      });
+
+      group('setCrashlyticsCollectionEnabled', () {
+        // This is currently only testing that we can send unsent reports without crashing.
+        test('should update to true', () async {
+          await FirebaseCrashlytics.instance
+              .setCrashlyticsCollectionEnabled(true);
+        });
+
+        // This is currently only testing that we can send unsent reports without crashing.
+        test('should update to false', () async {
+          await FirebaseCrashlytics.instance
+              .setCrashlyticsCollectionEnabled(false);
+        });
+      });
+
+      group('setUserIdentifier', () {
+        // This is currently only testing that we can log errors without crashing.
+        test('should update', () async {
+          await FirebaseCrashlytics.instance.setUserIdentifier('foo');
+        });
+      });
+
+      group('setCustomKey', () {
+        test('should throw if null', () async {
+          // expect(
+          //   () => FirebaseCrashlytics.instance.setCustomKey(null, null),
+          //   throwsAssertionError,
+          // );
+          // expect(
+          //   () => FirebaseCrashlytics.instance.setCustomKey('foo', null),
+          //   throwsAssertionError,
+          // );
+          expect(
+            () => FirebaseCrashlytics.instance.setCustomKey('foo', []),
+            throwsAssertionError,
+          );
+          expect(
+            () => FirebaseCrashlytics.instance.setCustomKey('foo', {}),
+            throwsAssertionError,
+          );
+        });
+
+        // This is currently only testing that we can log errors without crashing.
+        test('should update', () async {
+          await FirebaseCrashlytics.instance.setCustomKey('fooString', 'bar');
+          await FirebaseCrashlytics.instance.setCustomKey('fooBool', true);
+          await FirebaseCrashlytics.instance.setCustomKey('fooInt', 42);
+          await FirebaseCrashlytics.instance.setCustomKey('fooDouble', 42.0);
+        });
+      });
+    },
+    // Only supported on Android & iOS/macOS.
+    skip: kIsWeb,
+  );
+}


### PR DESCRIPTION
## Description

Migrates the Flutter Driver tests to Flutter Integration tests. I just copied the Flutter Driver. So I have not changed any test.  

## Related Issues

Part of #6829 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
