### PR TITLE
test(firebase_messaging): migrate to `integration_test` package

### DIFF
--- a/tests/integration_test/e2e_test.dart
+++ b/tests/integration_test/e2e_test.dart
@@ -6,12 +6,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'firebase_core/firebase_core_e2e_test.dart' as firebase_core;
+import 'firebase_messaging/firebase_messaging_e2e_test.dart'
+    as firebase_messaging;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  // ignore: unnecessary_lambdas
   group('FlutterFire', () {
     firebase_core.main();
+    firebase_messaging.main();
   });
 }

--- a/tests/integration_test/firebase_messaging/firebase_messaging_e2e_test.dart
+++ b/tests/integration_test/firebase_messaging/firebase_messaging_e2e_test.dart
@@ -1,0 +1,186 @@
+// Copyright 2019, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tests/firebase_options.dart';
+
+// ignore: do_not_use_environment
+const bool skipManualTests = bool.fromEnvironment('CI');
+
+void main() {
+  group(
+    'firebase_messaging',
+    () {
+      late FirebaseApp app;
+      late FirebaseMessaging messaging;
+
+      setUpAll(() async {
+        app = await Firebase.initializeApp(
+          options: DefaultFirebaseOptions.currentPlatform,
+        );
+        messaging = FirebaseMessaging.instance;
+      });
+
+      test('instance', () {
+        expect(messaging, isA<FirebaseMessaging>());
+        expect(messaging.app, isA<FirebaseApp>());
+        expect(messaging.app.name, defaultFirebaseAppName);
+      });
+
+      test('.app accessible from messaging.app', () {
+        expect(messaging.app, isA<FirebaseApp>());
+        expect(messaging.app.name, app.name);
+      });
+
+      group('onMessage', () {
+        test('can listen multiple times', () async {
+          // regression test for https://github.com/firebase/flutterfire/issues/6009
+
+          StreamSubscription<RemoteMessage> _onMessageSubscription;
+          StreamSubscription<RemoteMessage> _onMessageOpenedAppSubscription;
+
+          _onMessageSubscription = FirebaseMessaging.onMessage.listen((_) {});
+          _onMessageOpenedAppSubscription =
+              FirebaseMessaging.onMessageOpenedApp.listen((_) {});
+
+          await _onMessageSubscription.cancel();
+          await _onMessageOpenedAppSubscription.cancel();
+
+          _onMessageSubscription = FirebaseMessaging.onMessage.listen((_) {});
+          _onMessageOpenedAppSubscription =
+              FirebaseMessaging.onMessageOpenedApp.listen((_) {});
+
+          await _onMessageSubscription.cancel();
+          await _onMessageOpenedAppSubscription.cancel();
+        });
+      });
+
+      group('setAutoInitEnabled()', () {
+        test(
+          'sets the value',
+          () async {
+            expect(messaging.isAutoInitEnabled, isTrue);
+            await messaging.setAutoInitEnabled(false);
+            expect(messaging.isAutoInitEnabled, isFalse);
+          },
+          skip: kIsWeb,
+        );
+      });
+
+      group('isSupported()', () {
+        test('returns "true" value', () {
+          expect(messaging.isSupported(), isTrue);
+        });
+      });
+
+      group('requestPermission', () {
+        test(
+          'authorizationStatus returns AuthorizationStatus.authorized on Android',
+          () async {
+            final result = await messaging.requestPermission();
+            expect(result, isA<NotificationSettings>());
+            expect(result.authorizationStatus, AuthorizationStatus.authorized);
+          },
+          skip: defaultTargetPlatform != TargetPlatform.android || kIsWeb,
+        );
+      });
+
+      group('requestPermission', () {
+        test(
+          'authorizationStatus returns AuthorizationStatus.notDetermined on Web',
+          () async {
+            final result = await messaging.requestPermission();
+            expect(result, isA<NotificationSettings>());
+            expect(
+              result.authorizationStatus,
+              AuthorizationStatus.notDetermined,
+            );
+          },
+          skip: !kIsWeb,
+        );
+      });
+
+      group('getAPNSToken', () {
+        test(
+          'resolves null on android',
+          () async {
+            expect(await messaging.getAPNSToken(), null);
+          },
+          skip: defaultTargetPlatform != TargetPlatform.android,
+        );
+
+        test(
+          'resolves null on ios if using simulator',
+          () async {
+            expect(await messaging.getAPNSToken(), null);
+          },
+          skip: !(defaultTargetPlatform == TargetPlatform.iOS ||
+              defaultTargetPlatform != TargetPlatform.macOS),
+        );
+      });
+
+      group('getInitialMessage', () {
+        test('returns null when no initial message', () async {
+          expect(await messaging.getInitialMessage(), null);
+        });
+      });
+
+      group(
+        'getToken()',
+        () {
+          test('returns a token', () async {
+            final result = await messaging.getToken();
+            expect(result, isA<String>());
+          });
+        },
+        skip: skipManualTests,
+      ); // only run for manual testing
+
+      group('deleteToken()', () {
+        test(
+          'generate a new token after deleting',
+          () async {
+            final token1 = await messaging.getToken();
+            await Future.delayed(const Duration(seconds: 3));
+            await messaging.deleteToken();
+            await Future.delayed(const Duration(seconds: 3));
+            final token2 = await messaging.getToken();
+            expect(token1, isA<String>());
+            expect(token2, isA<String>());
+            expect(token1, isNot(token2));
+          },
+          skip: skipManualTests,
+        ); // only run for manual testing
+      });
+
+      group('subscribeToTopic()', () {
+        test(
+          'successfully subscribes from topic',
+          () async {
+            const topic = 'test-topic';
+            await messaging.subscribeToTopic(topic);
+          },
+          skip: kIsWeb,
+        );
+      });
+
+      group('unsubscribeFromTopic()', () {
+        test(
+          'successfully unsubscribes from topic',
+          () async {
+            const topic = 'test-topic';
+            await messaging.unsubscribeFromTopic(topic);
+          },
+          skip: kIsWeb,
+        );
+      });
+    },
+  );
+}


### PR DESCRIPTION
## Description

Migrates the Flutter Driver tests to Flutter Integration tests. I just copied the Flutter Driver. So I have not changed any test.  

## Related Issues

Part of #6829 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
