### PR TITLE
docs(crashlytics): rm double quotes from scripts for deobfuscated stack traces on iOS

### DIFF
--- a/docs/crashlytics/_deobfuscated.md
+++ b/docs/crashlytics/_deobfuscated.md
@@ -60,9 +60,9 @@ If you have this issue, first make sure that you have the run script installed:
     These scripts process your project's dSYM files and upload the files to
     {{crashlytics}}.
 
-    <pre class="devsite-click-to-copy">"$PODS_ROOT/FirebaseCrashlytics/upload-symbols --build-phase --validate -ai <var>FIREBASE_APPLE_APP_ID</var>"</pre>
+    <pre class="devsite-click-to-copy">$PODS_ROOT/FirebaseCrashlytics/upload-symbols --build-phase --validate -ai <var>FIREBASE_APPLE_APP_ID</var></pre>
 
-    <pre class="devsite-click-to-copy">"$PODS_ROOT/FirebaseCrashlytics/upload-symbols --build-phase -ai <var>FIREBASE_APPLE_APP_ID</var>"</pre>
+    <pre class="devsite-click-to-copy">$PODS_ROOT/FirebaseCrashlytics/upload-symbols --build-phase -ai <var>FIREBASE_APPLE_APP_ID</var></pre>
 
 1.  In the _Input Files_ section, add the paths for the locations of the
     following files:


### PR DESCRIPTION
## Description

see title.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/8744

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
