### PR TITLE
docs(firebase_dynamic_links): adjust wording for adding Associated Domains

### DIFF
--- a/docs/dynamic-links/receive.md
+++ b/docs/dynamic-links/receive.md
@@ -71,8 +71,12 @@ start the activity with this intent filter to handle the link.
     1.  On the Signing & Capabilities page, ensure your Team is registered, and
         your Provisioning Profile is set.
 
-    1.  Add the domain you created in the Firebase console to the Associated
-        Domains, prefixed with `applinks:` (for example, `applinks:example.page.link`).
+    1.  On the Signing & Capabilities page, enable **Associated Domains** and
+        add the following to the Associated Domains list:
+        
+        ```
+        applinks:example.page.link
+        ```
 
     1.  On the Info page, add a URL Type to your project. Set the URL Schemes
         field to your app's bundle ID. (The Identifier can be `Bundle ID` or


### PR DESCRIPTION
## Description

As in #8990 described, I think the step 4) c) in the [Firebase Dynamic Links docs](https://firebase.google.com/docs/dynamic-links/flutter/receive) is wrong. There is not a for Associated Domains in the Firebase Console. The step should say that you need to add the Associated Domains in XCode (like shown in the [iOS Firebase Dynamic Links](https://firebase.google.com/docs/dynamic-links/ios/receive#open-dynamic-links-in-your-app)).

## Related Issues

Fixes #8990

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
