### PR TITLE
docs(firebase_messaging): fix usage link to the documentation in the README.md

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/README.md
+++ b/packages/firebase_messaging/firebase_messaging/README.md
@@ -14,7 +14,7 @@ To get started with Firebase Cloud Messaging for Flutter, please [see the docume
 
 ## Usage
 
-To use this plugin, please visit the [Cloud Messaging Usage documentation](https://firebase.google.com/docs/firestore/quickstart)
+To use this plugin, please visit the [Cloud Messaging Usage documentation](https://firebase.google.com/docs/cloud-messaging)
 
 ## Issues and feedback
 


### PR DESCRIPTION


## Description

the Usage link in the README of `firebase_messaging` was pointing to the `firestore` documentation. this PR changes that link to point to the `firebase_messaging` documentation.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
