### PR TITLE
feat(firebase_database): `ServerValue.increment()` now correctly accepts a `num`  to support both integers and doubles.

### DIFF
--- a/packages/firebase_database/firebase_database/example/pubspec.yaml
+++ b/packages/firebase_database/firebase_database/example/pubspec.yaml
@@ -22,6 +22,8 @@ dependency_overrides:
     path: ../../../firebase_core/firebase_core_web
   firebase_database:
     path: ../
+  firebase_database_platform_interface:
+    path: ../../firebase_database_platform_interface
   firebase_database_web:
     path: ../../firebase_database_web
 

--- a/packages/firebase_database/firebase_database_platform_interface/lib/src/server_value.dart
+++ b/packages/firebase_database/firebase_database_platform_interface/lib/src/server_value.dart
@@ -9,7 +9,7 @@ class ServerValue {
 
   /// Returns a placeholder value that can be used to atomically increment the
   /// current database value by the provided delta.
-  static Map<dynamic, dynamic> increment(int delta) {
+  static Map<dynamic, dynamic> increment(num delta) {
     return <dynamic, dynamic>{
       '.sv': {'increment': delta}
     };

--- a/tests/test_driver/firebase_database/database_reference_e2e.dart
+++ b/tests/test_driver/firebase_database/database_reference_e2e.dart
@@ -156,6 +156,11 @@ void setupDatabaseReferenceTests() {
         final snap = await ref.get();
         var value = snap.value;
         expect(value, 1.5);
+
+        await ref.set(ServerValue.increment(1));
+        final snap2 = await ref.get();
+        var value2 = snap2.value;
+        expect(value2, 2.5);
       });
     });
   });

--- a/tests/test_driver/firebase_database/database_reference_e2e.dart
+++ b/tests/test_driver/firebase_database/database_reference_e2e.dart
@@ -147,6 +147,16 @@ void setupDatabaseReferenceTests() {
         expect(value, isNotNull);
         expect(value['list'], data);
       });
+
+      test('Server.increment', () async {
+        final FirebaseDatabase database = FirebaseDatabase.instance;
+        final DatabaseReference ref = database.ref('tests/server-increment');
+        await ref.set(ServerValue.increment(1.5));
+
+        final snap = await ref.get();
+        var value = snap.value;
+        expect(value, 1.5);
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

See title.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/7933

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
