### PR TITLE
docs(firebase_auth): explicit mention that `refreshToken` is empty string on native platforms on the `User`instance

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/user.dart
@@ -73,8 +73,8 @@ class User {
 
   /// Returns a JWT refresh token for the user.
   ///
-  /// This property maybe `null` or empty if the underlying platform does not
-  /// support providing refresh tokens.
+  /// This property will be an empty string for native platforms (android, iOS & macOS) as they do not
+  /// support refresh tokens.
   String? get refreshToken {
     return _delegate.refreshToken;
   }

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_user.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_user.dart
@@ -89,8 +89,8 @@ abstract class UserPlatform extends PlatformInterface {
 
   /// Returns a JWT refresh token for the user.
   ///
-  /// This property maybe `null` or empty if the underlying platform does not
-  /// support providing refresh tokens.
+  /// This property will be an empty string for native platforms (android, iOS & macOS) as they do not
+  /// support refresh tokens.
   String? get refreshToken {
     return _user['refreshToken'];
   }


### PR DESCRIPTION
## Description

see title.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/8171
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
