### PR TITLE
feat!: The low-level interface of Queries/Documentreferences are improved to no-longer use `Object?` in various situations

### DIFF
--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/integration.g.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/integration.g.dart
@@ -23,7 +23,7 @@ const _sentinel = _Sentinel();
 abstract class ManualJsonCollectionReference
     implements
         ManualJsonQuery,
-        FirestoreCollectionReference<ManualJsonQuerySnapshot> {
+        FirestoreCollectionReference<ManualJson, ManualJsonQuerySnapshot> {
   factory ManualJsonCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$ManualJsonCollectionReference;
@@ -104,7 +104,7 @@ class _$ManualJsonCollectionReference extends _$ManualJsonQuery
 }
 
 abstract class ManualJsonDocumentReference
-    extends FirestoreDocumentReference<ManualJsonDocumentSnapshot> {
+    extends FirestoreDocumentReference<ManualJson, ManualJsonDocumentSnapshot> {
   factory ManualJsonDocumentReference(DocumentReference<ManualJson> reference) =
       _$ManualJsonDocumentReference;
 
@@ -132,7 +132,7 @@ abstract class ManualJsonDocumentReference
 }
 
 class _$ManualJsonDocumentReference
-    extends FirestoreDocumentReference<ManualJsonDocumentSnapshot>
+    extends FirestoreDocumentReference<ManualJson, ManualJsonDocumentSnapshot>
     implements ManualJsonDocumentReference {
   _$ManualJsonDocumentReference(this.reference);
 
@@ -195,7 +195,7 @@ class _$ManualJsonDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class ManualJsonDocumentSnapshot extends FirestoreDocumentSnapshot {
+class ManualJsonDocumentSnapshot extends FirestoreDocumentSnapshot<ManualJson> {
   ManualJsonDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -216,7 +216,7 @@ class ManualJsonDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class ManualJsonQuery
-    implements QueryReference<ManualJsonQuerySnapshot> {
+    implements QueryReference<ManualJson, ManualJsonQuerySnapshot> {
   @override
   ManualJsonQuery limit(int limit);
 
@@ -336,7 +336,8 @@ abstract class ManualJsonQuery
   });
 }
 
-class _$ManualJsonQuery extends QueryReference<ManualJsonQuerySnapshot>
+class _$ManualJsonQuery
+    extends QueryReference<ManualJson, ManualJsonQuerySnapshot>
     implements ManualJsonQuery {
   _$ManualJsonQuery(
     this.reference,
@@ -624,8 +625,8 @@ class _$ManualJsonQuery extends QueryReference<ManualJsonQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-class ManualJsonQuerySnapshot
-    extends FirestoreQuerySnapshot<ManualJsonQueryDocumentSnapshot> {
+class ManualJsonQuerySnapshot extends FirestoreQuerySnapshot<ManualJson,
+    ManualJsonQueryDocumentSnapshot> {
   ManualJsonQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -641,7 +642,8 @@ class ManualJsonQuerySnapshot
   final List<FirestoreDocumentChange<ManualJsonDocumentSnapshot>> docChanges;
 }
 
-class ManualJsonQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class ManualJsonQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<ManualJson>
     implements ManualJsonDocumentSnapshot {
   ManualJsonQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -663,7 +665,7 @@ class ManualJsonQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 abstract class AdvancedJsonCollectionReference
     implements
         AdvancedJsonQuery,
-        FirestoreCollectionReference<AdvancedJsonQuerySnapshot> {
+        FirestoreCollectionReference<AdvancedJson, AdvancedJsonQuerySnapshot> {
   factory AdvancedJsonCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$AdvancedJsonCollectionReference;
@@ -745,8 +747,8 @@ class _$AdvancedJsonCollectionReference extends _$AdvancedJsonQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-abstract class AdvancedJsonDocumentReference
-    extends FirestoreDocumentReference<AdvancedJsonDocumentSnapshot> {
+abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
+    AdvancedJson, AdvancedJsonDocumentSnapshot> {
   factory AdvancedJsonDocumentReference(
           DocumentReference<AdvancedJson> reference) =
       _$AdvancedJsonDocumentReference;
@@ -776,9 +778,9 @@ abstract class AdvancedJsonDocumentReference
   Future<void> set(AdvancedJson value);
 }
 
-class _$AdvancedJsonDocumentReference
-    extends FirestoreDocumentReference<AdvancedJsonDocumentSnapshot>
-    implements AdvancedJsonDocumentReference {
+class _$AdvancedJsonDocumentReference extends FirestoreDocumentReference<
+    AdvancedJson,
+    AdvancedJsonDocumentSnapshot> implements AdvancedJsonDocumentReference {
   _$AdvancedJsonDocumentReference(this.reference);
 
   @override
@@ -844,7 +846,8 @@ class _$AdvancedJsonDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class AdvancedJsonDocumentSnapshot extends FirestoreDocumentSnapshot {
+class AdvancedJsonDocumentSnapshot
+    extends FirestoreDocumentSnapshot<AdvancedJson> {
   AdvancedJsonDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -865,7 +868,7 @@ class AdvancedJsonDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class AdvancedJsonQuery
-    implements QueryReference<AdvancedJsonQuerySnapshot> {
+    implements QueryReference<AdvancedJson, AdvancedJsonQuerySnapshot> {
   @override
   AdvancedJsonQuery limit(int limit);
 
@@ -1031,7 +1034,8 @@ abstract class AdvancedJsonQuery
   });
 }
 
-class _$AdvancedJsonQuery extends QueryReference<AdvancedJsonQuerySnapshot>
+class _$AdvancedJsonQuery
+    extends QueryReference<AdvancedJson, AdvancedJsonQuerySnapshot>
     implements AdvancedJsonQuery {
   _$AdvancedJsonQuery(
     this.reference,
@@ -1462,8 +1466,8 @@ class _$AdvancedJsonQuery extends QueryReference<AdvancedJsonQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-class AdvancedJsonQuerySnapshot
-    extends FirestoreQuerySnapshot<AdvancedJsonQueryDocumentSnapshot> {
+class AdvancedJsonQuerySnapshot extends FirestoreQuerySnapshot<AdvancedJson,
+    AdvancedJsonQueryDocumentSnapshot> {
   AdvancedJsonQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -1479,7 +1483,8 @@ class AdvancedJsonQuerySnapshot
   final List<FirestoreDocumentChange<AdvancedJsonDocumentSnapshot>> docChanges;
 }
 
-class AdvancedJsonQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class AdvancedJsonQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<AdvancedJson>
     implements AdvancedJsonDocumentSnapshot {
   AdvancedJsonQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -1501,7 +1506,8 @@ class AdvancedJsonQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 abstract class _PrivateAdvancedJsonCollectionReference
     implements
         _PrivateAdvancedJsonQuery,
-        FirestoreCollectionReference<_PrivateAdvancedJsonQuerySnapshot> {
+        FirestoreCollectionReference<_PrivateAdvancedJson,
+            _PrivateAdvancedJsonQuerySnapshot> {
   factory _PrivateAdvancedJsonCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$_PrivateAdvancedJsonCollectionReference;
@@ -1590,7 +1596,8 @@ class _$_PrivateAdvancedJsonCollectionReference
 }
 
 abstract class _PrivateAdvancedJsonDocumentReference
-    extends FirestoreDocumentReference<_PrivateAdvancedJsonDocumentSnapshot> {
+    extends FirestoreDocumentReference<_PrivateAdvancedJson,
+        _PrivateAdvancedJsonDocumentSnapshot> {
   factory _PrivateAdvancedJsonDocumentReference(
           DocumentReference<_PrivateAdvancedJson> reference) =
       _$_PrivateAdvancedJsonDocumentReference;
@@ -1621,7 +1628,8 @@ abstract class _PrivateAdvancedJsonDocumentReference
 }
 
 class _$_PrivateAdvancedJsonDocumentReference
-    extends FirestoreDocumentReference<_PrivateAdvancedJsonDocumentSnapshot>
+    extends FirestoreDocumentReference<_PrivateAdvancedJson,
+        _PrivateAdvancedJsonDocumentSnapshot>
     implements _PrivateAdvancedJsonDocumentReference {
   _$_PrivateAdvancedJsonDocumentReference(this.reference);
 
@@ -1688,7 +1696,8 @@ class _$_PrivateAdvancedJsonDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class _PrivateAdvancedJsonDocumentSnapshot extends FirestoreDocumentSnapshot {
+class _PrivateAdvancedJsonDocumentSnapshot
+    extends FirestoreDocumentSnapshot<_PrivateAdvancedJson> {
   _PrivateAdvancedJsonDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -1709,7 +1718,9 @@ class _PrivateAdvancedJsonDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class _PrivateAdvancedJsonQuery
-    implements QueryReference<_PrivateAdvancedJsonQuerySnapshot> {
+    implements
+        QueryReference<_PrivateAdvancedJson,
+            _PrivateAdvancedJsonQuerySnapshot> {
   @override
   _PrivateAdvancedJsonQuery limit(int limit);
 
@@ -1875,9 +1886,8 @@ abstract class _PrivateAdvancedJsonQuery
   });
 }
 
-class _$_PrivateAdvancedJsonQuery
-    extends QueryReference<_PrivateAdvancedJsonQuerySnapshot>
-    implements _PrivateAdvancedJsonQuery {
+class _$_PrivateAdvancedJsonQuery extends QueryReference<_PrivateAdvancedJson,
+    _PrivateAdvancedJsonQuerySnapshot> implements _PrivateAdvancedJsonQuery {
   _$_PrivateAdvancedJsonQuery(
     this.reference,
     this._collection,
@@ -2309,8 +2319,8 @@ class _$_PrivateAdvancedJsonQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-class _PrivateAdvancedJsonQuerySnapshot
-    extends FirestoreQuerySnapshot<_PrivateAdvancedJsonQueryDocumentSnapshot> {
+class _PrivateAdvancedJsonQuerySnapshot extends FirestoreQuerySnapshot<
+    _PrivateAdvancedJson, _PrivateAdvancedJsonQueryDocumentSnapshot> {
   _PrivateAdvancedJsonQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -2328,7 +2338,7 @@ class _PrivateAdvancedJsonQuerySnapshot
 }
 
 class _PrivateAdvancedJsonQueryDocumentSnapshot
-    extends FirestoreQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<_PrivateAdvancedJson>
     implements _PrivateAdvancedJsonDocumentSnapshot {
   _PrivateAdvancedJsonQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -2350,7 +2360,7 @@ class _PrivateAdvancedJsonQueryDocumentSnapshot
 abstract class EmptyModelCollectionReference
     implements
         EmptyModelQuery,
-        FirestoreCollectionReference<EmptyModelQuerySnapshot> {
+        FirestoreCollectionReference<EmptyModel, EmptyModelQuerySnapshot> {
   factory EmptyModelCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$EmptyModelCollectionReference;
@@ -2431,7 +2441,7 @@ class _$EmptyModelCollectionReference extends _$EmptyModelQuery
 }
 
 abstract class EmptyModelDocumentReference
-    extends FirestoreDocumentReference<EmptyModelDocumentSnapshot> {
+    extends FirestoreDocumentReference<EmptyModel, EmptyModelDocumentSnapshot> {
   factory EmptyModelDocumentReference(DocumentReference<EmptyModel> reference) =
       _$EmptyModelDocumentReference;
 
@@ -2455,7 +2465,7 @@ abstract class EmptyModelDocumentReference
 }
 
 class _$EmptyModelDocumentReference
-    extends FirestoreDocumentReference<EmptyModelDocumentSnapshot>
+    extends FirestoreDocumentReference<EmptyModel, EmptyModelDocumentSnapshot>
     implements EmptyModelDocumentReference {
   _$EmptyModelDocumentReference(this.reference);
 
@@ -2508,7 +2518,7 @@ class _$EmptyModelDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class EmptyModelDocumentSnapshot extends FirestoreDocumentSnapshot {
+class EmptyModelDocumentSnapshot extends FirestoreDocumentSnapshot<EmptyModel> {
   EmptyModelDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -2529,7 +2539,7 @@ class EmptyModelDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class EmptyModelQuery
-    implements QueryReference<EmptyModelQuerySnapshot> {
+    implements QueryReference<EmptyModel, EmptyModelQuerySnapshot> {
   @override
   EmptyModelQuery limit(int limit);
 
@@ -2626,7 +2636,8 @@ abstract class EmptyModelQuery
   });
 }
 
-class _$EmptyModelQuery extends QueryReference<EmptyModelQuerySnapshot>
+class _$EmptyModelQuery
+    extends QueryReference<EmptyModel, EmptyModelQuerySnapshot>
     implements EmptyModelQuery {
   _$EmptyModelQuery(
     this.reference,
@@ -2844,8 +2855,8 @@ class _$EmptyModelQuery extends QueryReference<EmptyModelQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-class EmptyModelQuerySnapshot
-    extends FirestoreQuerySnapshot<EmptyModelQueryDocumentSnapshot> {
+class EmptyModelQuerySnapshot extends FirestoreQuerySnapshot<EmptyModel,
+    EmptyModelQueryDocumentSnapshot> {
   EmptyModelQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -2861,7 +2872,8 @@ class EmptyModelQuerySnapshot
   final List<FirestoreDocumentChange<EmptyModelDocumentSnapshot>> docChanges;
 }
 
-class EmptyModelQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class EmptyModelQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<EmptyModel>
     implements EmptyModelDocumentSnapshot {
   EmptyModelQueryDocumentSnapshot._(this.snapshot, this.data);
 

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/integration/query.g.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/integration/query.g.dart
@@ -23,7 +23,8 @@ const _sentinel = _Sentinel();
 abstract class DateTimeQueryCollectionReference
     implements
         DateTimeQueryQuery,
-        FirestoreCollectionReference<DateTimeQueryQuerySnapshot> {
+        FirestoreCollectionReference<DateTimeQuery,
+            DateTimeQueryQuerySnapshot> {
   factory DateTimeQueryCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$DateTimeQueryCollectionReference;
@@ -106,7 +107,8 @@ class _$DateTimeQueryCollectionReference extends _$DateTimeQueryQuery
 }
 
 abstract class DateTimeQueryDocumentReference
-    extends FirestoreDocumentReference<DateTimeQueryDocumentSnapshot> {
+    extends FirestoreDocumentReference<DateTimeQuery,
+        DateTimeQueryDocumentSnapshot> {
   factory DateTimeQueryDocumentReference(
           DocumentReference<DateTimeQuery> reference) =
       _$DateTimeQueryDocumentReference;
@@ -134,9 +136,9 @@ abstract class DateTimeQueryDocumentReference
   Future<void> set(DateTimeQuery value);
 }
 
-class _$DateTimeQueryDocumentReference
-    extends FirestoreDocumentReference<DateTimeQueryDocumentSnapshot>
-    implements DateTimeQueryDocumentReference {
+class _$DateTimeQueryDocumentReference extends FirestoreDocumentReference<
+    DateTimeQuery,
+    DateTimeQueryDocumentSnapshot> implements DateTimeQueryDocumentReference {
   _$DateTimeQueryDocumentReference(this.reference);
 
   @override
@@ -198,7 +200,8 @@ class _$DateTimeQueryDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class DateTimeQueryDocumentSnapshot extends FirestoreDocumentSnapshot {
+class DateTimeQueryDocumentSnapshot
+    extends FirestoreDocumentSnapshot<DateTimeQuery> {
   DateTimeQueryDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -219,7 +222,7 @@ class DateTimeQueryDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class DateTimeQueryQuery
-    implements QueryReference<DateTimeQueryQuerySnapshot> {
+    implements QueryReference<DateTimeQuery, DateTimeQueryQuerySnapshot> {
   @override
   DateTimeQueryQuery limit(int limit);
 
@@ -339,7 +342,8 @@ abstract class DateTimeQueryQuery
   });
 }
 
-class _$DateTimeQueryQuery extends QueryReference<DateTimeQueryQuerySnapshot>
+class _$DateTimeQueryQuery
+    extends QueryReference<DateTimeQuery, DateTimeQueryQuerySnapshot>
     implements DateTimeQueryQuery {
   _$DateTimeQueryQuery(
     this.reference,
@@ -628,8 +632,8 @@ class _$DateTimeQueryQuery extends QueryReference<DateTimeQueryQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-class DateTimeQueryQuerySnapshot
-    extends FirestoreQuerySnapshot<DateTimeQueryQueryDocumentSnapshot> {
+class DateTimeQueryQuerySnapshot extends FirestoreQuerySnapshot<DateTimeQuery,
+    DateTimeQueryQueryDocumentSnapshot> {
   DateTimeQueryQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -645,7 +649,8 @@ class DateTimeQueryQuerySnapshot
   final List<FirestoreDocumentChange<DateTimeQueryDocumentSnapshot>> docChanges;
 }
 
-class DateTimeQueryQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class DateTimeQueryQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<DateTimeQuery>
     implements DateTimeQueryDocumentSnapshot {
   DateTimeQueryQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -667,7 +672,8 @@ class DateTimeQueryQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 abstract class TimestampQueryCollectionReference
     implements
         TimestampQueryQuery,
-        FirestoreCollectionReference<TimestampQueryQuerySnapshot> {
+        FirestoreCollectionReference<TimestampQuery,
+            TimestampQueryQuerySnapshot> {
   factory TimestampQueryCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$TimestampQueryCollectionReference;
@@ -752,7 +758,8 @@ class _$TimestampQueryCollectionReference extends _$TimestampQueryQuery
 }
 
 abstract class TimestampQueryDocumentReference
-    extends FirestoreDocumentReference<TimestampQueryDocumentSnapshot> {
+    extends FirestoreDocumentReference<TimestampQuery,
+        TimestampQueryDocumentSnapshot> {
   factory TimestampQueryDocumentReference(
           DocumentReference<TimestampQuery> reference) =
       _$TimestampQueryDocumentReference;
@@ -780,9 +787,9 @@ abstract class TimestampQueryDocumentReference
   Future<void> set(TimestampQuery value);
 }
 
-class _$TimestampQueryDocumentReference
-    extends FirestoreDocumentReference<TimestampQueryDocumentSnapshot>
-    implements TimestampQueryDocumentReference {
+class _$TimestampQueryDocumentReference extends FirestoreDocumentReference<
+    TimestampQuery,
+    TimestampQueryDocumentSnapshot> implements TimestampQueryDocumentReference {
   _$TimestampQueryDocumentReference(this.reference);
 
   @override
@@ -844,7 +851,8 @@ class _$TimestampQueryDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class TimestampQueryDocumentSnapshot extends FirestoreDocumentSnapshot {
+class TimestampQueryDocumentSnapshot
+    extends FirestoreDocumentSnapshot<TimestampQuery> {
   TimestampQueryDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -865,7 +873,7 @@ class TimestampQueryDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class TimestampQueryQuery
-    implements QueryReference<TimestampQueryQuerySnapshot> {
+    implements QueryReference<TimestampQuery, TimestampQueryQuerySnapshot> {
   @override
   TimestampQueryQuery limit(int limit);
 
@@ -985,7 +993,8 @@ abstract class TimestampQueryQuery
   });
 }
 
-class _$TimestampQueryQuery extends QueryReference<TimestampQueryQuerySnapshot>
+class _$TimestampQueryQuery
+    extends QueryReference<TimestampQuery, TimestampQueryQuerySnapshot>
     implements TimestampQueryQuery {
   _$TimestampQueryQuery(
     this.reference,
@@ -1274,8 +1283,8 @@ class _$TimestampQueryQuery extends QueryReference<TimestampQueryQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-class TimestampQueryQuerySnapshot
-    extends FirestoreQuerySnapshot<TimestampQueryQueryDocumentSnapshot> {
+class TimestampQueryQuerySnapshot extends FirestoreQuerySnapshot<TimestampQuery,
+    TimestampQueryQueryDocumentSnapshot> {
   TimestampQueryQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -1292,7 +1301,8 @@ class TimestampQueryQuerySnapshot
       docChanges;
 }
 
-class TimestampQueryQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class TimestampQueryQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<TimestampQuery>
     implements TimestampQueryDocumentSnapshot {
   TimestampQueryQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -1314,7 +1324,8 @@ class TimestampQueryQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 abstract class GeoPointQueryCollectionReference
     implements
         GeoPointQueryQuery,
-        FirestoreCollectionReference<GeoPointQueryQuerySnapshot> {
+        FirestoreCollectionReference<GeoPointQuery,
+            GeoPointQueryQuerySnapshot> {
   factory GeoPointQueryCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$GeoPointQueryCollectionReference;
@@ -1399,7 +1410,8 @@ class _$GeoPointQueryCollectionReference extends _$GeoPointQueryQuery
 }
 
 abstract class GeoPointQueryDocumentReference
-    extends FirestoreDocumentReference<GeoPointQueryDocumentSnapshot> {
+    extends FirestoreDocumentReference<GeoPointQuery,
+        GeoPointQueryDocumentSnapshot> {
   factory GeoPointQueryDocumentReference(
           DocumentReference<GeoPointQuery> reference) =
       _$GeoPointQueryDocumentReference;
@@ -1427,9 +1439,9 @@ abstract class GeoPointQueryDocumentReference
   Future<void> set(GeoPointQuery value);
 }
 
-class _$GeoPointQueryDocumentReference
-    extends FirestoreDocumentReference<GeoPointQueryDocumentSnapshot>
-    implements GeoPointQueryDocumentReference {
+class _$GeoPointQueryDocumentReference extends FirestoreDocumentReference<
+    GeoPointQuery,
+    GeoPointQueryDocumentSnapshot> implements GeoPointQueryDocumentReference {
   _$GeoPointQueryDocumentReference(this.reference);
 
   @override
@@ -1491,7 +1503,8 @@ class _$GeoPointQueryDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class GeoPointQueryDocumentSnapshot extends FirestoreDocumentSnapshot {
+class GeoPointQueryDocumentSnapshot
+    extends FirestoreDocumentSnapshot<GeoPointQuery> {
   GeoPointQueryDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -1512,7 +1525,7 @@ class GeoPointQueryDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class GeoPointQueryQuery
-    implements QueryReference<GeoPointQueryQuerySnapshot> {
+    implements QueryReference<GeoPointQuery, GeoPointQueryQuerySnapshot> {
   @override
   GeoPointQueryQuery limit(int limit);
 
@@ -1632,7 +1645,8 @@ abstract class GeoPointQueryQuery
   });
 }
 
-class _$GeoPointQueryQuery extends QueryReference<GeoPointQueryQuerySnapshot>
+class _$GeoPointQueryQuery
+    extends QueryReference<GeoPointQuery, GeoPointQueryQuerySnapshot>
     implements GeoPointQueryQuery {
   _$GeoPointQueryQuery(
     this.reference,
@@ -1921,8 +1935,8 @@ class _$GeoPointQueryQuery extends QueryReference<GeoPointQueryQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-class GeoPointQueryQuerySnapshot
-    extends FirestoreQuerySnapshot<GeoPointQueryQueryDocumentSnapshot> {
+class GeoPointQueryQuerySnapshot extends FirestoreQuerySnapshot<GeoPointQuery,
+    GeoPointQueryQueryDocumentSnapshot> {
   GeoPointQueryQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -1938,7 +1952,8 @@ class GeoPointQueryQuerySnapshot
   final List<FirestoreDocumentChange<GeoPointQueryDocumentSnapshot>> docChanges;
 }
 
-class GeoPointQueryQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class GeoPointQueryQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<GeoPointQuery>
     implements GeoPointQueryDocumentSnapshot {
   GeoPointQueryQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -1960,7 +1975,8 @@ class GeoPointQueryQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 abstract class DocumentReferenceQueryCollectionReference
     implements
         DocumentReferenceQueryQuery,
-        FirestoreCollectionReference<DocumentReferenceQueryQuerySnapshot> {
+        FirestoreCollectionReference<DocumentReferenceQuery,
+            DocumentReferenceQueryQuerySnapshot> {
   factory DocumentReferenceQueryCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$DocumentReferenceQueryCollectionReference;
@@ -2048,7 +2064,8 @@ class _$DocumentReferenceQueryCollectionReference
 }
 
 abstract class DocumentReferenceQueryDocumentReference
-    extends FirestoreDocumentReference<DocumentReferenceQueryDocumentSnapshot> {
+    extends FirestoreDocumentReference<DocumentReferenceQuery,
+        DocumentReferenceQueryDocumentSnapshot> {
   factory DocumentReferenceQueryDocumentReference(
           DocumentReference<DocumentReferenceQuery> reference) =
       _$DocumentReferenceQueryDocumentReference;
@@ -2077,7 +2094,8 @@ abstract class DocumentReferenceQueryDocumentReference
 }
 
 class _$DocumentReferenceQueryDocumentReference
-    extends FirestoreDocumentReference<DocumentReferenceQueryDocumentSnapshot>
+    extends FirestoreDocumentReference<DocumentReferenceQuery,
+        DocumentReferenceQueryDocumentSnapshot>
     implements DocumentReferenceQueryDocumentReference {
   _$DocumentReferenceQueryDocumentReference(this.reference);
 
@@ -2141,7 +2159,8 @@ class _$DocumentReferenceQueryDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class DocumentReferenceQueryDocumentSnapshot extends FirestoreDocumentSnapshot {
+class DocumentReferenceQueryDocumentSnapshot
+    extends FirestoreDocumentSnapshot<DocumentReferenceQuery> {
   DocumentReferenceQueryDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -2162,7 +2181,9 @@ class DocumentReferenceQueryDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class DocumentReferenceQueryQuery
-    implements QueryReference<DocumentReferenceQueryQuerySnapshot> {
+    implements
+        QueryReference<DocumentReferenceQuery,
+            DocumentReferenceQueryQuerySnapshot> {
   @override
   DocumentReferenceQueryQuery limit(int limit);
 
@@ -2282,8 +2303,8 @@ abstract class DocumentReferenceQueryQuery
   });
 }
 
-class _$DocumentReferenceQueryQuery
-    extends QueryReference<DocumentReferenceQueryQuerySnapshot>
+class _$DocumentReferenceQueryQuery extends QueryReference<
+        DocumentReferenceQuery, DocumentReferenceQueryQuerySnapshot>
     implements DocumentReferenceQueryQuery {
   _$DocumentReferenceQueryQuery(
     this.reference,
@@ -2575,7 +2596,7 @@ class _$DocumentReferenceQueryQuery
 }
 
 class DocumentReferenceQueryQuerySnapshot extends FirestoreQuerySnapshot<
-    DocumentReferenceQueryQueryDocumentSnapshot> {
+    DocumentReferenceQuery, DocumentReferenceQueryQueryDocumentSnapshot> {
   DocumentReferenceQueryQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -2593,7 +2614,7 @@ class DocumentReferenceQueryQuerySnapshot extends FirestoreQuerySnapshot<
 }
 
 class DocumentReferenceQueryQueryDocumentSnapshot
-    extends FirestoreQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<DocumentReferenceQuery>
     implements DocumentReferenceQueryDocumentSnapshot {
   DocumentReferenceQueryQueryDocumentSnapshot._(this.snapshot, this.data);
 

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/movie.g.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/movie.g.dart
@@ -21,7 +21,9 @@ const _sentinel = _Sentinel();
 /// getting document references, and querying for documents
 /// (using the methods inherited from Query).
 abstract class MovieCollectionReference
-    implements MovieQuery, FirestoreCollectionReference<MovieQuerySnapshot> {
+    implements
+        MovieQuery,
+        FirestoreCollectionReference<Movie, MovieQuerySnapshot> {
   factory MovieCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$MovieCollectionReference;
@@ -102,7 +104,7 @@ class _$MovieCollectionReference extends _$MovieQuery
 }
 
 abstract class MovieDocumentReference
-    extends FirestoreDocumentReference<MovieDocumentSnapshot> {
+    extends FirestoreDocumentReference<Movie, MovieDocumentSnapshot> {
   factory MovieDocumentReference(DocumentReference<Movie> reference) =
       _$MovieDocumentReference;
 
@@ -140,7 +142,7 @@ abstract class MovieDocumentReference
 }
 
 class _$MovieDocumentReference
-    extends FirestoreDocumentReference<MovieDocumentSnapshot>
+    extends FirestoreDocumentReference<Movie, MovieDocumentSnapshot>
     implements MovieDocumentReference {
   _$MovieDocumentReference(this.reference);
 
@@ -219,7 +221,7 @@ class _$MovieDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class MovieDocumentSnapshot extends FirestoreDocumentSnapshot {
+class MovieDocumentSnapshot extends FirestoreDocumentSnapshot<Movie> {
   MovieDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -239,7 +241,7 @@ class MovieDocumentSnapshot extends FirestoreDocumentSnapshot {
   final Movie? data;
 }
 
-abstract class MovieQuery implements QueryReference<MovieQuerySnapshot> {
+abstract class MovieQuery implements QueryReference<Movie, MovieQuerySnapshot> {
   @override
   MovieQuery limit(int limit);
 
@@ -496,7 +498,7 @@ abstract class MovieQuery implements QueryReference<MovieQuerySnapshot> {
   });
 }
 
-class _$MovieQuery extends QueryReference<MovieQuerySnapshot>
+class _$MovieQuery extends QueryReference<Movie, MovieQuerySnapshot>
     implements MovieQuery {
   _$MovieQuery(
     this.reference,
@@ -1210,7 +1212,7 @@ class _$MovieQuery extends QueryReference<MovieQuerySnapshot>
 }
 
 class MovieQuerySnapshot
-    extends FirestoreQuerySnapshot<MovieQueryDocumentSnapshot> {
+    extends FirestoreQuerySnapshot<Movie, MovieQueryDocumentSnapshot> {
   MovieQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -1226,7 +1228,7 @@ class MovieQuerySnapshot
   final List<FirestoreDocumentChange<MovieDocumentSnapshot>> docChanges;
 }
 
-class MovieQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class MovieQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot<Movie>
     implements MovieDocumentSnapshot {
   MovieQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -1248,7 +1250,7 @@ class MovieQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 abstract class CommentCollectionReference
     implements
         CommentQuery,
-        FirestoreCollectionReference<CommentQuerySnapshot> {
+        FirestoreCollectionReference<Comment, CommentQuerySnapshot> {
   factory CommentCollectionReference(
     DocumentReference<Movie> parent,
   ) = _$CommentCollectionReference;
@@ -1337,7 +1339,7 @@ class _$CommentCollectionReference extends _$CommentQuery
 }
 
 abstract class CommentDocumentReference
-    extends FirestoreDocumentReference<CommentDocumentSnapshot> {
+    extends FirestoreDocumentReference<Comment, CommentDocumentSnapshot> {
   factory CommentDocumentReference(DocumentReference<Comment> reference) =
       _$CommentDocumentReference;
 
@@ -1371,7 +1373,7 @@ abstract class CommentDocumentReference
 }
 
 class _$CommentDocumentReference
-    extends FirestoreDocumentReference<CommentDocumentSnapshot>
+    extends FirestoreDocumentReference<Comment, CommentDocumentSnapshot>
     implements CommentDocumentReference {
   _$CommentDocumentReference(this.reference);
 
@@ -1441,7 +1443,7 @@ class _$CommentDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class CommentDocumentSnapshot extends FirestoreDocumentSnapshot {
+class CommentDocumentSnapshot extends FirestoreDocumentSnapshot<Comment> {
   CommentDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -1461,7 +1463,8 @@ class CommentDocumentSnapshot extends FirestoreDocumentSnapshot {
   final Comment? data;
 }
 
-abstract class CommentQuery implements QueryReference<CommentQuerySnapshot> {
+abstract class CommentQuery
+    implements QueryReference<Comment, CommentQuerySnapshot> {
   @override
   CommentQuery limit(int limit);
 
@@ -1604,7 +1607,7 @@ abstract class CommentQuery implements QueryReference<CommentQuerySnapshot> {
   });
 }
 
-class _$CommentQuery extends QueryReference<CommentQuerySnapshot>
+class _$CommentQuery extends QueryReference<Comment, CommentQuerySnapshot>
     implements CommentQuery {
   _$CommentQuery(
     this.reference,
@@ -1965,7 +1968,7 @@ class _$CommentQuery extends QueryReference<CommentQuerySnapshot>
 }
 
 class CommentQuerySnapshot
-    extends FirestoreQuerySnapshot<CommentQueryDocumentSnapshot> {
+    extends FirestoreQuerySnapshot<Comment, CommentQueryDocumentSnapshot> {
   CommentQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -1981,7 +1984,8 @@ class CommentQuerySnapshot
   final List<FirestoreDocumentChange<CommentDocumentSnapshot>> docChanges;
 }
 
-class CommentQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class CommentQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<Comment>
     implements CommentDocumentSnapshot {
   CommentQueryDocumentSnapshot._(this.snapshot, this.data);
 

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/test_driver/common.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/test_driver/common.dart
@@ -9,7 +9,8 @@ import 'package:cloud_firestore_odm_example/movie.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:mockito/mockito.dart';
 
-Future<T> initializeTest<T extends FirestoreCollectionReference<Object?>>(
+Future<T>
+    initializeTest<T extends FirestoreCollectionReference<Object?, Object?>>(
   T ref,
 ) async {
   final snapshot = await ref.reference.get();

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/lib/src/firestore_reference.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/lib/src/firestore_reference.dart
@@ -41,8 +41,8 @@ abstract class FirestoreReference<Snapshot>
   );
 }
 
-abstract class FirestoreDocumentReference<
-        Snapshot extends FirestoreDocumentSnapshot>
+abstract class FirestoreDocumentReference<Model,
+        Snapshot extends FirestoreDocumentSnapshot<Model>>
     implements FirestoreReference<Snapshot> {
   @override
   FirestoreListenable<Selected> select<Selected>(
@@ -53,7 +53,7 @@ abstract class FirestoreDocumentReference<
 
   /// The original reference obtained from Firebase.
   @override
-  DocumentReference<Object?> get reference;
+  DocumentReference<Model> get reference;
 
   /// The document's identifier within its collection.
   String get id => reference.id;
@@ -77,10 +77,12 @@ abstract class FirestoreDocumentReference<
 }
 
 abstract class FirestoreCollectionReference<
-        Snapshot extends FirestoreQuerySnapshot>
+        Model,
+        Snapshot extends FirestoreQuerySnapshot<Model,
+            FirestoreDocumentSnapshot<Model>>>
     implements FirestoreReference<Snapshot> {
   @override
-  CollectionReference<Object?> get reference;
+  CollectionReference<Model> get reference;
 
   /// A string representing the path of the referenced collection
   /// (relative to the root of the database).
@@ -94,12 +96,13 @@ abstract class FirestoreCollectionReference<
   FirestoreDocumentReference doc([String? id]);
 }
 
-abstract class FirestoreDocumentSnapshot {
+abstract class FirestoreDocumentSnapshot<Model> {
   /// The reference for this document.
-  FirestoreDocumentReference get reference;
+  FirestoreDocumentReference<Model, FirestoreDocumentSnapshot<Model>>
+      get reference;
 
   /// The original [DocumentSnapshot] returned by Firebase.
-  DocumentSnapshot<Object?> get snapshot;
+  DocumentSnapshot<Model> get snapshot;
 
   /// Property of the DocumentSnapshot that provides the document's ID.
   String get id => snapshot.id;
@@ -113,23 +116,23 @@ abstract class FirestoreDocumentSnapshot {
   SnapshotMetadata get metadata => snapshot.metadata;
 
   /// Retrieves all fields in the document as an Object.
-  Object? get data;
+  Model? get data;
 }
 
-abstract class FirestoreQueryDocumentSnapshot
-    extends FirestoreDocumentSnapshot {
+abstract class FirestoreQueryDocumentSnapshot<Model>
+    extends FirestoreDocumentSnapshot<Model> {
   /// The original [QueryDocumentSnapshot] returned by Firebase.
   @override
-  QueryDocumentSnapshot<Object?> get snapshot;
+  QueryDocumentSnapshot<Model> get snapshot;
 
   @override
-  Object? get data;
+  Model get data;
 }
 
-abstract class FirestoreQuerySnapshot<
-    Snapshot extends FirestoreDocumentSnapshot> {
+abstract class FirestoreQuerySnapshot<Model,
+    Snapshot extends FirestoreDocumentSnapshot<Model>> {
   /// The original [QuerySnapshot] from Firebase.
-  QuerySnapshot<Object?> get snapshot;
+  QuerySnapshot<Model> get snapshot;
 
   /// Metadata about this snapshot, concerning its source and if it has
   /// local modifications.
@@ -140,7 +143,8 @@ abstract class FirestoreQuerySnapshot<
 
   /// An array of the documents that changed since the last snapshot. If this
   /// is the first snapshot, all documents will be in the list as Added changes.
-  List<FirestoreDocumentChange<Object?>> get docChanges;
+  List<FirestoreDocumentChange<FirestoreDocumentSnapshot<Model>>>
+      get docChanges;
 }
 
 /// A [DocumentChange] represents a change to the documents matching a query.
@@ -149,7 +153,7 @@ abstract class FirestoreQuerySnapshot<
 /// (added, modified, or removed).
 @sealed
 class FirestoreDocumentChange<
-    DocumentSnapshot extends FirestoreDocumentSnapshot> {
+    DocumentSnapshot extends FirestoreDocumentSnapshot<Object?>> {
   /// A [DocumentChange] represents a change to the documents matching a query.
   ///
   /// It contains the document affected and the type of change that occurred
@@ -182,7 +186,10 @@ class FirestoreDocumentChange<
   final DocumentSnapshot doc;
 }
 
-abstract class QueryReference<Snapshot extends FirestoreQuerySnapshot>
+abstract class QueryReference<
+        Model,
+        Snapshot extends FirestoreQuerySnapshot<Model,
+            FirestoreDocumentSnapshot<Model>>>
     implements FirestoreReference<Snapshot> {
   @override
   FirestoreListenable<Selected> select<Selected>(
@@ -192,7 +199,7 @@ abstract class QueryReference<Snapshot extends FirestoreQuerySnapshot>
   }
 
   @override
-  Query<Object?> get reference;
+  Query<Model> get reference;
 
   /// Executes the query and returns the results as a QuerySnapshot.
   ///
@@ -205,18 +212,18 @@ abstract class QueryReference<Snapshot extends FirestoreQuerySnapshot>
   Future<Snapshot> get([GetOptions options]);
 
   /// Creates and returns a new Query that only returns the first matching documents.
-  QueryReference<Snapshot> limit(int limit);
+  QueryReference<Model, Snapshot> limit(int limit);
 
   /// Creates and returns a new Query that only returns the last matching documents.
   ///
   /// You must specify at least one orderBy clause for limitToLast queries,
   /// otherwise an exception will be thrown during execution.
-  QueryReference<Snapshot> limitToLast(int limit);
+  QueryReference<Model, Snapshot> limitToLast(int limit);
 
   /// Filter a collection based on the documents' ID.
   ///
   /// This is similar to using [FieldPath.documentId].
-  QueryReference<Snapshot> whereDocumentId({
+  QueryReference<Model, Snapshot> whereDocumentId({
     String isEqualTo,
     String isNotEqualTo,
     String isLessThan,
@@ -231,7 +238,7 @@ abstract class QueryReference<Snapshot extends FirestoreQuerySnapshot>
   /// Sorts a collection based on the documents' ID.
   ///
   /// This is similar to using [FieldPath.documentId].
-  QueryReference<Snapshot> orderByDocumentId({
+  QueryReference<Model, Snapshot> orderByDocumentId({
     bool descending,
     String startAt,
     String startAfter,

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/test/common.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/test/common.dart
@@ -5,10 +5,15 @@ import 'package:cloud_firestore_odm/cloud_firestore_odm.dart';
 import 'package:flutter/foundation.dart';
 
 class FakeCollectionReference<Value>
-    extends QueryReference<FakeQuerySnapshot<Value>>
-    implements FirestoreCollectionReference<FakeQuerySnapshot<Value>> {
+    extends QueryReference<Value, FakeQuerySnapshot<Value>>
+    implements FirestoreCollectionReference<Value, FakeQuerySnapshot<Value>> {
   FakeCollectionReference(this.valueListenable);
   final ValueListenable<List<Value>> valueListenable;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnimplementedError();
+  }
 
   @override
   Future<FakeQuerySnapshot<Value>> get([GetOptions? options]) async {
@@ -18,9 +23,6 @@ class FakeCollectionReference<Value>
           .toList(),
     );
   }
-
-  @override
-  CollectionReference<Object?> get reference => throw UnimplementedError();
 
   @override
   Stream<FakeQuerySnapshot<Value>> snapshots([GetOptions? options]) {
@@ -50,93 +52,36 @@ class FakeCollectionReference<Value>
 
     return controller.stream;
   }
-
-  @override
-  String get path => throw UnimplementedError();
-
-  @override
-  FirestoreDocumentReference<FirestoreDocumentSnapshot> doc([String? id]) {
-    throw UnimplementedError();
-  }
-
-  @override
-  QueryReference<FakeQuerySnapshot<Value>> limit(int limit) {
-    throw UnimplementedError();
-  }
-
-  @override
-  QueryReference<FakeQuerySnapshot<Value>> limitToLast(int limit) {
-    throw UnimplementedError();
-  }
-
-  @override
-  QueryReference<FakeQuerySnapshot<Value>> orderByDocumentId({
-    bool? descending,
-    String? startAt,
-    String? startAfter,
-    String? endAt,
-    String? endBefore,
-    QuerySnapshot<FakeQuerySnapshot<Value>>? startAtDocument,
-    QuerySnapshot<FakeQuerySnapshot<Value>>? endAtDocument,
-    QuerySnapshot<FakeQuerySnapshot<Value>>? endBeforeDocument,
-    QuerySnapshot<FakeQuerySnapshot<Value>>? startAfterDocument,
-  }) {
-    throw UnimplementedError();
-  }
-
-  @override
-  QueryReference<FakeQuerySnapshot<Value>> whereDocumentId({
-    String? isEqualTo,
-    String? isNotEqualTo,
-    String? isLessThan,
-    String? isLessThanOrEqualTo,
-    String? isGreaterThan,
-    String? isGreaterThanOrEqualTo,
-    bool? isNull,
-    List<String>? whereIn,
-    List<String>? whereNotIn,
-  }) {
-    throw UnimplementedError();
-  }
 }
 
-class FakeQuerySnapshot<Value> extends FirestoreQuerySnapshot {
+class FakeQuerySnapshot<Value> extends FirestoreQuerySnapshot<Value,
+    FakeFirestoreQueryDocumentSnapshot<Value>> {
   FakeQuerySnapshot(this.docs);
-
-  @override
-  List<FirestoreDocumentChange<FirestoreQueryDocumentSnapshot>>
-      get docChanges => throw UnimplementedError();
 
   @override
   final List<FakeFirestoreQueryDocumentSnapshot<Value>> docs;
 
   @override
-  SnapshotMetadata get metadata => throw UnimplementedError();
-
-  @override
-  QuerySnapshot<Object?> get snapshot => throw UnimplementedError();
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnimplementedError();
+  }
 }
 
 class FakeFirestoreQueryDocumentSnapshot<Value>
-    extends FirestoreQueryDocumentSnapshot {
+    extends FirestoreQueryDocumentSnapshot<Value> {
   FakeFirestoreQueryDocumentSnapshot(this.data);
 
   @override
   final Value data;
 
   @override
-  FirestoreDocumentReference<FirestoreDocumentSnapshot> get reference =>
-      throw UnimplementedError();
-
-  @override
-  QueryDocumentSnapshot<Object?> get snapshot => throw UnimplementedError();
-
-  @override
-  SnapshotMetadata get metadata => throw UnimplementedError();
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnimplementedError();
+  }
 }
 
 class FakeDocumentReference<Value>
-    extends FirestoreDocumentReference<FakeDocumentSnapshot<Value>> {
+    extends FirestoreDocumentReference<Value, FakeDocumentSnapshot<Value>> {
   FakeDocumentReference(
     this.valueListenable, {
     this.errorListenable,
@@ -148,12 +93,14 @@ class FakeDocumentReference<Value>
   final bool emitCurrentValue;
 
   @override
-  Future<FakeDocumentSnapshot<Value>> get([GetOptions? options]) async {
-    return FakeDocumentSnapshot<Value>(valueListenable.value);
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnimplementedError();
   }
 
   @override
-  DocumentReference<Object?> get reference => throw UnimplementedError();
+  Future<FakeDocumentSnapshot<Value>> get([GetOptions? options]) async {
+    return FakeDocumentSnapshot<Value>(valueListenable.value);
+  }
 
   @override
   Stream<FakeDocumentSnapshot<Value>> snapshots([GetOptions? options]) {
@@ -183,30 +130,16 @@ class FakeDocumentReference<Value>
 
     return controller.stream;
   }
-
-  @override
-  Future<void> delete() => throw UnimplementedError();
-
-  @override
-  String get id => throw UnimplementedError();
-
-  @override
-  String get path => throw UnimplementedError();
 }
 
-class FakeDocumentSnapshot<Value> extends FirestoreDocumentSnapshot {
+class FakeDocumentSnapshot<Value> extends FirestoreDocumentSnapshot<Value> {
   FakeDocumentSnapshot(this.data);
 
   @override
   final Value data;
 
   @override
-  FirestoreDocumentReference<FirestoreDocumentSnapshot> get reference =>
-      throw UnimplementedError();
-
-  @override
-  DocumentSnapshot<Object?> get snapshot => throw UnimplementedError();
-
-  @override
-  SnapshotMetadata get metadata => throw UnimplementedError();
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnimplementedError();
+  }
 }

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
@@ -19,7 +19,9 @@ const _sentinel = _Sentinel();
 /// getting document references, and querying for documents
 /// (using the methods inherited from Query).
 abstract class ModelCollectionReference
-    implements ModelQuery, FirestoreCollectionReference<ModelQuerySnapshot> {
+    implements
+        ModelQuery,
+        FirestoreCollectionReference<Model, ModelQuerySnapshot> {
   factory ModelCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$ModelCollectionReference;
@@ -100,7 +102,7 @@ class _$ModelCollectionReference extends _$ModelQuery
 }
 
 abstract class ModelDocumentReference
-    extends FirestoreDocumentReference<ModelDocumentSnapshot> {
+    extends FirestoreDocumentReference<Model, ModelDocumentSnapshot> {
   factory ModelDocumentReference(DocumentReference<Model> reference) =
       _$ModelDocumentReference;
 
@@ -128,7 +130,7 @@ abstract class ModelDocumentReference
 }
 
 class _$ModelDocumentReference
-    extends FirestoreDocumentReference<ModelDocumentSnapshot>
+    extends FirestoreDocumentReference<Model, ModelDocumentSnapshot>
     implements ModelDocumentReference {
   _$ModelDocumentReference(this.reference);
 
@@ -191,7 +193,7 @@ class _$ModelDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class ModelDocumentSnapshot extends FirestoreDocumentSnapshot {
+class ModelDocumentSnapshot extends FirestoreDocumentSnapshot<Model> {
   ModelDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -211,7 +213,7 @@ class ModelDocumentSnapshot extends FirestoreDocumentSnapshot {
   final Model? data;
 }
 
-abstract class ModelQuery implements QueryReference<ModelQuerySnapshot> {
+abstract class ModelQuery implements QueryReference<Model, ModelQuerySnapshot> {
   @override
   ModelQuery limit(int limit);
 
@@ -331,7 +333,7 @@ abstract class ModelQuery implements QueryReference<ModelQuerySnapshot> {
   });
 }
 
-class _$ModelQuery extends QueryReference<ModelQuerySnapshot>
+class _$ModelQuery extends QueryReference<Model, ModelQuerySnapshot>
     implements ModelQuery {
   _$ModelQuery(
     this.reference,
@@ -621,7 +623,7 @@ class _$ModelQuery extends QueryReference<ModelQuerySnapshot>
 }
 
 class ModelQuerySnapshot
-    extends FirestoreQuerySnapshot<ModelQueryDocumentSnapshot> {
+    extends FirestoreQuerySnapshot<Model, ModelQueryDocumentSnapshot> {
   ModelQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -637,7 +639,7 @@ class ModelQuerySnapshot
   final List<FirestoreDocumentChange<ModelDocumentSnapshot>> docChanges;
 }
 
-class ModelQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class ModelQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot<Model>
     implements ModelDocumentSnapshot {
   ModelQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -657,7 +659,9 @@ class ModelQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 /// getting document references, and querying for documents
 /// (using the methods inherited from Query).
 abstract class NestedCollectionReference
-    implements NestedQuery, FirestoreCollectionReference<NestedQuerySnapshot> {
+    implements
+        NestedQuery,
+        FirestoreCollectionReference<Nested, NestedQuerySnapshot> {
   factory NestedCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$NestedCollectionReference;
@@ -738,7 +742,7 @@ class _$NestedCollectionReference extends _$NestedQuery
 }
 
 abstract class NestedDocumentReference
-    extends FirestoreDocumentReference<NestedDocumentSnapshot> {
+    extends FirestoreDocumentReference<Nested, NestedDocumentSnapshot> {
   factory NestedDocumentReference(DocumentReference<Nested> reference) =
       _$NestedDocumentReference;
 
@@ -770,7 +774,7 @@ abstract class NestedDocumentReference
 }
 
 class _$NestedDocumentReference
-    extends FirestoreDocumentReference<NestedDocumentSnapshot>
+    extends FirestoreDocumentReference<Nested, NestedDocumentSnapshot>
     implements NestedDocumentReference {
   _$NestedDocumentReference(this.reference);
 
@@ -842,7 +846,7 @@ class _$NestedDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class NestedDocumentSnapshot extends FirestoreDocumentSnapshot {
+class NestedDocumentSnapshot extends FirestoreDocumentSnapshot<Nested> {
   NestedDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -862,7 +866,8 @@ class NestedDocumentSnapshot extends FirestoreDocumentSnapshot {
   final Nested? data;
 }
 
-abstract class NestedQuery implements QueryReference<NestedQuerySnapshot> {
+abstract class NestedQuery
+    implements QueryReference<Nested, NestedQuerySnapshot> {
   @override
   NestedQuery limit(int limit);
 
@@ -1069,7 +1074,7 @@ abstract class NestedQuery implements QueryReference<NestedQuerySnapshot> {
   });
 }
 
-class _$NestedQuery extends QueryReference<NestedQuerySnapshot>
+class _$NestedQuery extends QueryReference<Nested, NestedQuerySnapshot>
     implements NestedQuery {
   _$NestedQuery(
     this.reference,
@@ -1633,7 +1638,7 @@ class _$NestedQuery extends QueryReference<NestedQuerySnapshot>
 }
 
 class NestedQuerySnapshot
-    extends FirestoreQuerySnapshot<NestedQueryDocumentSnapshot> {
+    extends FirestoreQuerySnapshot<Nested, NestedQueryDocumentSnapshot> {
   NestedQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -1649,7 +1654,7 @@ class NestedQuerySnapshot
   final List<FirestoreDocumentChange<NestedDocumentSnapshot>> docChanges;
 }
 
-class NestedQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class NestedQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot<Nested>
     implements NestedDocumentSnapshot {
   NestedQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -1671,7 +1676,8 @@ class NestedQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 abstract class SplitFileModelCollectionReference
     implements
         SplitFileModelQuery,
-        FirestoreCollectionReference<SplitFileModelQuerySnapshot> {
+        FirestoreCollectionReference<SplitFileModel,
+            SplitFileModelQuerySnapshot> {
   factory SplitFileModelCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$SplitFileModelCollectionReference;
@@ -1754,7 +1760,8 @@ class _$SplitFileModelCollectionReference extends _$SplitFileModelQuery
 }
 
 abstract class SplitFileModelDocumentReference
-    extends FirestoreDocumentReference<SplitFileModelDocumentSnapshot> {
+    extends FirestoreDocumentReference<SplitFileModel,
+        SplitFileModelDocumentSnapshot> {
   factory SplitFileModelDocumentReference(
           DocumentReference<SplitFileModel> reference) =
       _$SplitFileModelDocumentReference;
@@ -1778,9 +1785,9 @@ abstract class SplitFileModelDocumentReference
   Future<void> set(SplitFileModel value);
 }
 
-class _$SplitFileModelDocumentReference
-    extends FirestoreDocumentReference<SplitFileModelDocumentSnapshot>
-    implements SplitFileModelDocumentReference {
+class _$SplitFileModelDocumentReference extends FirestoreDocumentReference<
+    SplitFileModel,
+    SplitFileModelDocumentSnapshot> implements SplitFileModelDocumentReference {
   _$SplitFileModelDocumentReference(this.reference);
 
   @override
@@ -1832,7 +1839,8 @@ class _$SplitFileModelDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class SplitFileModelDocumentSnapshot extends FirestoreDocumentSnapshot {
+class SplitFileModelDocumentSnapshot
+    extends FirestoreDocumentSnapshot<SplitFileModel> {
   SplitFileModelDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -1853,7 +1861,7 @@ class SplitFileModelDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class SplitFileModelQuery
-    implements QueryReference<SplitFileModelQuerySnapshot> {
+    implements QueryReference<SplitFileModel, SplitFileModelQuerySnapshot> {
   @override
   SplitFileModelQuery limit(int limit);
 
@@ -1950,7 +1958,8 @@ abstract class SplitFileModelQuery
   });
 }
 
-class _$SplitFileModelQuery extends QueryReference<SplitFileModelQuerySnapshot>
+class _$SplitFileModelQuery
+    extends QueryReference<SplitFileModel, SplitFileModelQuerySnapshot>
     implements SplitFileModelQuery {
   _$SplitFileModelQuery(
     this.reference,
@@ -2168,8 +2177,8 @@ class _$SplitFileModelQuery extends QueryReference<SplitFileModelQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-class SplitFileModelQuerySnapshot
-    extends FirestoreQuerySnapshot<SplitFileModelQueryDocumentSnapshot> {
+class SplitFileModelQuerySnapshot extends FirestoreQuerySnapshot<SplitFileModel,
+    SplitFileModelQueryDocumentSnapshot> {
   SplitFileModelQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -2186,7 +2195,8 @@ class SplitFileModelQuerySnapshot
       docChanges;
 }
 
-class SplitFileModelQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class SplitFileModelQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<SplitFileModel>
     implements SplitFileModelDocumentSnapshot {
   SplitFileModelQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -2208,7 +2218,7 @@ class SplitFileModelQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 abstract class EmptyModelCollectionReference
     implements
         EmptyModelQuery,
-        FirestoreCollectionReference<EmptyModelQuerySnapshot> {
+        FirestoreCollectionReference<EmptyModel, EmptyModelQuerySnapshot> {
   factory EmptyModelCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$EmptyModelCollectionReference;
@@ -2289,7 +2299,7 @@ class _$EmptyModelCollectionReference extends _$EmptyModelQuery
 }
 
 abstract class EmptyModelDocumentReference
-    extends FirestoreDocumentReference<EmptyModelDocumentSnapshot> {
+    extends FirestoreDocumentReference<EmptyModel, EmptyModelDocumentSnapshot> {
   factory EmptyModelDocumentReference(DocumentReference<EmptyModel> reference) =
       _$EmptyModelDocumentReference;
 
@@ -2313,7 +2323,7 @@ abstract class EmptyModelDocumentReference
 }
 
 class _$EmptyModelDocumentReference
-    extends FirestoreDocumentReference<EmptyModelDocumentSnapshot>
+    extends FirestoreDocumentReference<EmptyModel, EmptyModelDocumentSnapshot>
     implements EmptyModelDocumentReference {
   _$EmptyModelDocumentReference(this.reference);
 
@@ -2366,7 +2376,7 @@ class _$EmptyModelDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class EmptyModelDocumentSnapshot extends FirestoreDocumentSnapshot {
+class EmptyModelDocumentSnapshot extends FirestoreDocumentSnapshot<EmptyModel> {
   EmptyModelDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -2387,7 +2397,7 @@ class EmptyModelDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class EmptyModelQuery
-    implements QueryReference<EmptyModelQuerySnapshot> {
+    implements QueryReference<EmptyModel, EmptyModelQuerySnapshot> {
   @override
   EmptyModelQuery limit(int limit);
 
@@ -2484,7 +2494,8 @@ abstract class EmptyModelQuery
   });
 }
 
-class _$EmptyModelQuery extends QueryReference<EmptyModelQuerySnapshot>
+class _$EmptyModelQuery
+    extends QueryReference<EmptyModel, EmptyModelQuerySnapshot>
     implements EmptyModelQuery {
   _$EmptyModelQuery(
     this.reference,
@@ -2702,8 +2713,8 @@ class _$EmptyModelQuery extends QueryReference<EmptyModelQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-class EmptyModelQuerySnapshot
-    extends FirestoreQuerySnapshot<EmptyModelQueryDocumentSnapshot> {
+class EmptyModelQuerySnapshot extends FirestoreQuerySnapshot<EmptyModel,
+    EmptyModelQueryDocumentSnapshot> {
   EmptyModelQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -2719,7 +2730,8 @@ class EmptyModelQuerySnapshot
   final List<FirestoreDocumentChange<EmptyModelDocumentSnapshot>> docChanges;
 }
 
-class EmptyModelQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class EmptyModelQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<EmptyModel>
     implements EmptyModelDocumentSnapshot {
   EmptyModelQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -2741,7 +2753,7 @@ class EmptyModelQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 abstract class OptionalJsonCollectionReference
     implements
         OptionalJsonQuery,
-        FirestoreCollectionReference<OptionalJsonQuerySnapshot> {
+        FirestoreCollectionReference<OptionalJson, OptionalJsonQuerySnapshot> {
   factory OptionalJsonCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$OptionalJsonCollectionReference;
@@ -2823,8 +2835,8 @@ class _$OptionalJsonCollectionReference extends _$OptionalJsonQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-abstract class OptionalJsonDocumentReference
-    extends FirestoreDocumentReference<OptionalJsonDocumentSnapshot> {
+abstract class OptionalJsonDocumentReference extends FirestoreDocumentReference<
+    OptionalJson, OptionalJsonDocumentSnapshot> {
   factory OptionalJsonDocumentReference(
           DocumentReference<OptionalJson> reference) =
       _$OptionalJsonDocumentReference;
@@ -2852,9 +2864,9 @@ abstract class OptionalJsonDocumentReference
   Future<void> set(OptionalJson value);
 }
 
-class _$OptionalJsonDocumentReference
-    extends FirestoreDocumentReference<OptionalJsonDocumentSnapshot>
-    implements OptionalJsonDocumentReference {
+class _$OptionalJsonDocumentReference extends FirestoreDocumentReference<
+    OptionalJson,
+    OptionalJsonDocumentSnapshot> implements OptionalJsonDocumentReference {
   _$OptionalJsonDocumentReference(this.reference);
 
   @override
@@ -2916,7 +2928,8 @@ class _$OptionalJsonDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class OptionalJsonDocumentSnapshot extends FirestoreDocumentSnapshot {
+class OptionalJsonDocumentSnapshot
+    extends FirestoreDocumentSnapshot<OptionalJson> {
   OptionalJsonDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -2937,7 +2950,7 @@ class OptionalJsonDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class OptionalJsonQuery
-    implements QueryReference<OptionalJsonQuerySnapshot> {
+    implements QueryReference<OptionalJson, OptionalJsonQuerySnapshot> {
   @override
   OptionalJsonQuery limit(int limit);
 
@@ -3057,7 +3070,8 @@ abstract class OptionalJsonQuery
   });
 }
 
-class _$OptionalJsonQuery extends QueryReference<OptionalJsonQuerySnapshot>
+class _$OptionalJsonQuery
+    extends QueryReference<OptionalJson, OptionalJsonQuerySnapshot>
     implements OptionalJsonQuery {
   _$OptionalJsonQuery(
     this.reference,
@@ -3346,8 +3360,8 @@ class _$OptionalJsonQuery extends QueryReference<OptionalJsonQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-class OptionalJsonQuerySnapshot
-    extends FirestoreQuerySnapshot<OptionalJsonQueryDocumentSnapshot> {
+class OptionalJsonQuerySnapshot extends FirestoreQuerySnapshot<OptionalJson,
+    OptionalJsonQueryDocumentSnapshot> {
   OptionalJsonQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -3363,7 +3377,8 @@ class OptionalJsonQuerySnapshot
   final List<FirestoreDocumentChange<OptionalJsonDocumentSnapshot>> docChanges;
 }
 
-class OptionalJsonQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class OptionalJsonQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<OptionalJson>
     implements OptionalJsonDocumentSnapshot {
   OptionalJsonQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -3385,7 +3400,7 @@ class OptionalJsonQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 abstract class MixedJsonCollectionReference
     implements
         MixedJsonQuery,
-        FirestoreCollectionReference<MixedJsonQuerySnapshot> {
+        FirestoreCollectionReference<MixedJson, MixedJsonQuerySnapshot> {
   factory MixedJsonCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$MixedJsonCollectionReference;
@@ -3466,7 +3481,7 @@ class _$MixedJsonCollectionReference extends _$MixedJsonQuery
 }
 
 abstract class MixedJsonDocumentReference
-    extends FirestoreDocumentReference<MixedJsonDocumentSnapshot> {
+    extends FirestoreDocumentReference<MixedJson, MixedJsonDocumentSnapshot> {
   factory MixedJsonDocumentReference(DocumentReference<MixedJson> reference) =
       _$MixedJsonDocumentReference;
 
@@ -3494,7 +3509,7 @@ abstract class MixedJsonDocumentReference
 }
 
 class _$MixedJsonDocumentReference
-    extends FirestoreDocumentReference<MixedJsonDocumentSnapshot>
+    extends FirestoreDocumentReference<MixedJson, MixedJsonDocumentSnapshot>
     implements MixedJsonDocumentReference {
   _$MixedJsonDocumentReference(this.reference);
 
@@ -3557,7 +3572,7 @@ class _$MixedJsonDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class MixedJsonDocumentSnapshot extends FirestoreDocumentSnapshot {
+class MixedJsonDocumentSnapshot extends FirestoreDocumentSnapshot<MixedJson> {
   MixedJsonDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -3578,7 +3593,7 @@ class MixedJsonDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class MixedJsonQuery
-    implements QueryReference<MixedJsonQuerySnapshot> {
+    implements QueryReference<MixedJson, MixedJsonQuerySnapshot> {
   @override
   MixedJsonQuery limit(int limit);
 
@@ -3698,7 +3713,7 @@ abstract class MixedJsonQuery
   });
 }
 
-class _$MixedJsonQuery extends QueryReference<MixedJsonQuerySnapshot>
+class _$MixedJsonQuery extends QueryReference<MixedJson, MixedJsonQuerySnapshot>
     implements MixedJsonQuery {
   _$MixedJsonQuery(
     this.reference,
@@ -3988,7 +4003,7 @@ class _$MixedJsonQuery extends QueryReference<MixedJsonQuerySnapshot>
 }
 
 class MixedJsonQuerySnapshot
-    extends FirestoreQuerySnapshot<MixedJsonQueryDocumentSnapshot> {
+    extends FirestoreQuerySnapshot<MixedJson, MixedJsonQueryDocumentSnapshot> {
   MixedJsonQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -4004,7 +4019,8 @@ class MixedJsonQuerySnapshot
   final List<FirestoreDocumentChange<MixedJsonDocumentSnapshot>> docChanges;
 }
 
-class MixedJsonQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class MixedJsonQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<MixedJson>
     implements MixedJsonDocumentSnapshot {
   MixedJsonQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -4024,7 +4040,9 @@ class MixedJsonQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 /// getting document references, and querying for documents
 /// (using the methods inherited from Query).
 abstract class RootCollectionReference
-    implements RootQuery, FirestoreCollectionReference<RootQuerySnapshot> {
+    implements
+        RootQuery,
+        FirestoreCollectionReference<Root, RootQuerySnapshot> {
   factory RootCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$RootCollectionReference;
@@ -4105,7 +4123,7 @@ class _$RootCollectionReference extends _$RootQuery
 }
 
 abstract class RootDocumentReference
-    extends FirestoreDocumentReference<RootDocumentSnapshot> {
+    extends FirestoreDocumentReference<Root, RootDocumentSnapshot> {
   factory RootDocumentReference(DocumentReference<Root> reference) =
       _$RootDocumentReference;
 
@@ -4148,7 +4166,7 @@ abstract class RootDocumentReference
 }
 
 class _$RootDocumentReference
-    extends FirestoreDocumentReference<RootDocumentSnapshot>
+    extends FirestoreDocumentReference<Root, RootDocumentSnapshot>
     implements RootDocumentReference {
   _$RootDocumentReference(this.reference);
 
@@ -4227,7 +4245,7 @@ class _$RootDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class RootDocumentSnapshot extends FirestoreDocumentSnapshot {
+class RootDocumentSnapshot extends FirestoreDocumentSnapshot<Root> {
   RootDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -4247,7 +4265,7 @@ class RootDocumentSnapshot extends FirestoreDocumentSnapshot {
   final Root? data;
 }
 
-abstract class RootQuery implements QueryReference<RootQuerySnapshot> {
+abstract class RootQuery implements QueryReference<Root, RootQuerySnapshot> {
   @override
   RootQuery limit(int limit);
 
@@ -4390,7 +4408,7 @@ abstract class RootQuery implements QueryReference<RootQuerySnapshot> {
   });
 }
 
-class _$RootQuery extends QueryReference<RootQuerySnapshot>
+class _$RootQuery extends QueryReference<Root, RootQuerySnapshot>
     implements RootQuery {
   _$RootQuery(
     this.reference,
@@ -4751,7 +4769,7 @@ class _$RootQuery extends QueryReference<RootQuerySnapshot>
 }
 
 class RootQuerySnapshot
-    extends FirestoreQuerySnapshot<RootQueryDocumentSnapshot> {
+    extends FirestoreQuerySnapshot<Root, RootQueryDocumentSnapshot> {
   RootQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -4767,7 +4785,7 @@ class RootQuerySnapshot
   final List<FirestoreDocumentChange<RootDocumentSnapshot>> docChanges;
 }
 
-class RootQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class RootQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot<Root>
     implements RootDocumentSnapshot {
   RootQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -4787,7 +4805,7 @@ class RootQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 /// getting document references, and querying for documents
 /// (using the methods inherited from Query).
 abstract class SubCollectionReference
-    implements SubQuery, FirestoreCollectionReference<SubQuerySnapshot> {
+    implements SubQuery, FirestoreCollectionReference<Sub, SubQuerySnapshot> {
   factory SubCollectionReference(
     DocumentReference<Root> parent,
   ) = _$SubCollectionReference;
@@ -4876,7 +4894,7 @@ class _$SubCollectionReference extends _$SubQuery
 }
 
 abstract class SubDocumentReference
-    extends FirestoreDocumentReference<SubDocumentSnapshot> {
+    extends FirestoreDocumentReference<Sub, SubDocumentSnapshot> {
   factory SubDocumentReference(DocumentReference<Sub> reference) =
       _$SubDocumentReference;
 
@@ -4910,7 +4928,7 @@ abstract class SubDocumentReference
 }
 
 class _$SubDocumentReference
-    extends FirestoreDocumentReference<SubDocumentSnapshot>
+    extends FirestoreDocumentReference<Sub, SubDocumentSnapshot>
     implements SubDocumentReference {
   _$SubDocumentReference(this.reference);
 
@@ -4980,7 +4998,7 @@ class _$SubDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class SubDocumentSnapshot extends FirestoreDocumentSnapshot {
+class SubDocumentSnapshot extends FirestoreDocumentSnapshot<Sub> {
   SubDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -5000,7 +5018,7 @@ class SubDocumentSnapshot extends FirestoreDocumentSnapshot {
   final Sub? data;
 }
 
-abstract class SubQuery implements QueryReference<SubQuerySnapshot> {
+abstract class SubQuery implements QueryReference<Sub, SubQuerySnapshot> {
   @override
   SubQuery limit(int limit);
 
@@ -5143,7 +5161,8 @@ abstract class SubQuery implements QueryReference<SubQuerySnapshot> {
   });
 }
 
-class _$SubQuery extends QueryReference<SubQuerySnapshot> implements SubQuery {
+class _$SubQuery extends QueryReference<Sub, SubQuerySnapshot>
+    implements SubQuery {
   _$SubQuery(
     this.reference,
     this._collection,
@@ -5503,7 +5522,7 @@ class _$SubQuery extends QueryReference<SubQuerySnapshot> implements SubQuery {
 }
 
 class SubQuerySnapshot
-    extends FirestoreQuerySnapshot<SubQueryDocumentSnapshot> {
+    extends FirestoreQuerySnapshot<Sub, SubQueryDocumentSnapshot> {
   SubQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -5519,7 +5538,7 @@ class SubQuerySnapshot
   final List<FirestoreDocumentChange<SubDocumentSnapshot>> docChanges;
 }
 
-class SubQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class SubQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot<Sub>
     implements SubDocumentSnapshot {
   SubQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -5541,7 +5560,7 @@ class SubQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 abstract class AsCamelCaseCollectionReference
     implements
         AsCamelCaseQuery,
-        FirestoreCollectionReference<AsCamelCaseQuerySnapshot> {
+        FirestoreCollectionReference<AsCamelCase, AsCamelCaseQuerySnapshot> {
   factory AsCamelCaseCollectionReference(
     DocumentReference<Root> parent,
   ) = _$AsCamelCaseCollectionReference;
@@ -5631,8 +5650,8 @@ class _$AsCamelCaseCollectionReference extends _$AsCamelCaseQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-abstract class AsCamelCaseDocumentReference
-    extends FirestoreDocumentReference<AsCamelCaseDocumentSnapshot> {
+abstract class AsCamelCaseDocumentReference extends FirestoreDocumentReference<
+    AsCamelCase, AsCamelCaseDocumentSnapshot> {
   factory AsCamelCaseDocumentReference(
           DocumentReference<AsCamelCase> reference) =
       _$AsCamelCaseDocumentReference;
@@ -5666,7 +5685,7 @@ abstract class AsCamelCaseDocumentReference
 }
 
 class _$AsCamelCaseDocumentReference
-    extends FirestoreDocumentReference<AsCamelCaseDocumentSnapshot>
+    extends FirestoreDocumentReference<AsCamelCase, AsCamelCaseDocumentSnapshot>
     implements AsCamelCaseDocumentReference {
   _$AsCamelCaseDocumentReference(this.reference);
 
@@ -5734,7 +5753,8 @@ class _$AsCamelCaseDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class AsCamelCaseDocumentSnapshot extends FirestoreDocumentSnapshot {
+class AsCamelCaseDocumentSnapshot
+    extends FirestoreDocumentSnapshot<AsCamelCase> {
   AsCamelCaseDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -5755,7 +5775,7 @@ class AsCamelCaseDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class AsCamelCaseQuery
-    implements QueryReference<AsCamelCaseQuerySnapshot> {
+    implements QueryReference<AsCamelCase, AsCamelCaseQuerySnapshot> {
   @override
   AsCamelCaseQuery limit(int limit);
 
@@ -5875,7 +5895,8 @@ abstract class AsCamelCaseQuery
   });
 }
 
-class _$AsCamelCaseQuery extends QueryReference<AsCamelCaseQuerySnapshot>
+class _$AsCamelCaseQuery
+    extends QueryReference<AsCamelCase, AsCamelCaseQuerySnapshot>
     implements AsCamelCaseQuery {
   _$AsCamelCaseQuery(
     this.reference,
@@ -6164,8 +6185,8 @@ class _$AsCamelCaseQuery extends QueryReference<AsCamelCaseQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-class AsCamelCaseQuerySnapshot
-    extends FirestoreQuerySnapshot<AsCamelCaseQueryDocumentSnapshot> {
+class AsCamelCaseQuerySnapshot extends FirestoreQuerySnapshot<AsCamelCase,
+    AsCamelCaseQueryDocumentSnapshot> {
   AsCamelCaseQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -6181,7 +6202,8 @@ class AsCamelCaseQuerySnapshot
   final List<FirestoreDocumentChange<AsCamelCaseDocumentSnapshot>> docChanges;
 }
 
-class AsCamelCaseQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class AsCamelCaseQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<AsCamelCase>
     implements AsCamelCaseDocumentSnapshot {
   AsCamelCaseQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -6203,7 +6225,8 @@ class AsCamelCaseQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 abstract class CustomSubNameCollectionReference
     implements
         CustomSubNameQuery,
-        FirestoreCollectionReference<CustomSubNameQuerySnapshot> {
+        FirestoreCollectionReference<CustomSubName,
+            CustomSubNameQuerySnapshot> {
   factory CustomSubNameCollectionReference(
     DocumentReference<Root> parent,
   ) = _$CustomSubNameCollectionReference;
@@ -6294,7 +6317,8 @@ class _$CustomSubNameCollectionReference extends _$CustomSubNameQuery
 }
 
 abstract class CustomSubNameDocumentReference
-    extends FirestoreDocumentReference<CustomSubNameDocumentSnapshot> {
+    extends FirestoreDocumentReference<CustomSubName,
+        CustomSubNameDocumentSnapshot> {
   factory CustomSubNameDocumentReference(
           DocumentReference<CustomSubName> reference) =
       _$CustomSubNameDocumentReference;
@@ -6327,9 +6351,9 @@ abstract class CustomSubNameDocumentReference
   Future<void> set(CustomSubName value);
 }
 
-class _$CustomSubNameDocumentReference
-    extends FirestoreDocumentReference<CustomSubNameDocumentSnapshot>
-    implements CustomSubNameDocumentReference {
+class _$CustomSubNameDocumentReference extends FirestoreDocumentReference<
+    CustomSubName,
+    CustomSubNameDocumentSnapshot> implements CustomSubNameDocumentReference {
   _$CustomSubNameDocumentReference(this.reference);
 
   @override
@@ -6396,7 +6420,8 @@ class _$CustomSubNameDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class CustomSubNameDocumentSnapshot extends FirestoreDocumentSnapshot {
+class CustomSubNameDocumentSnapshot
+    extends FirestoreDocumentSnapshot<CustomSubName> {
   CustomSubNameDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -6417,7 +6442,7 @@ class CustomSubNameDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class CustomSubNameQuery
-    implements QueryReference<CustomSubNameQuerySnapshot> {
+    implements QueryReference<CustomSubName, CustomSubNameQuerySnapshot> {
   @override
   CustomSubNameQuery limit(int limit);
 
@@ -6537,7 +6562,8 @@ abstract class CustomSubNameQuery
   });
 }
 
-class _$CustomSubNameQuery extends QueryReference<CustomSubNameQuerySnapshot>
+class _$CustomSubNameQuery
+    extends QueryReference<CustomSubName, CustomSubNameQuerySnapshot>
     implements CustomSubNameQuery {
   _$CustomSubNameQuery(
     this.reference,
@@ -6826,8 +6852,8 @@ class _$CustomSubNameQuery extends QueryReference<CustomSubNameQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-class CustomSubNameQuerySnapshot
-    extends FirestoreQuerySnapshot<CustomSubNameQueryDocumentSnapshot> {
+class CustomSubNameQuerySnapshot extends FirestoreQuerySnapshot<CustomSubName,
+    CustomSubNameQueryDocumentSnapshot> {
   CustomSubNameQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -6843,7 +6869,8 @@ class CustomSubNameQuerySnapshot
   final List<FirestoreDocumentChange<CustomSubNameDocumentSnapshot>> docChanges;
 }
 
-class CustomSubNameQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class CustomSubNameQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<CustomSubName>
     implements CustomSubNameDocumentSnapshot {
   CustomSubNameQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -6865,7 +6892,7 @@ class CustomSubNameQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 abstract class ExplicitPathCollectionReference
     implements
         ExplicitPathQuery,
-        FirestoreCollectionReference<ExplicitPathQuerySnapshot> {
+        FirestoreCollectionReference<ExplicitPath, ExplicitPathQuerySnapshot> {
   factory ExplicitPathCollectionReference([
     FirebaseFirestore? firestore,
   ]) = _$ExplicitPathCollectionReference;
@@ -6947,8 +6974,8 @@ class _$ExplicitPathCollectionReference extends _$ExplicitPathQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-abstract class ExplicitPathDocumentReference
-    extends FirestoreDocumentReference<ExplicitPathDocumentSnapshot> {
+abstract class ExplicitPathDocumentReference extends FirestoreDocumentReference<
+    ExplicitPath, ExplicitPathDocumentSnapshot> {
   factory ExplicitPathDocumentReference(
           DocumentReference<ExplicitPath> reference) =
       _$ExplicitPathDocumentReference;
@@ -6981,9 +7008,9 @@ abstract class ExplicitPathDocumentReference
   Future<void> set(ExplicitPath value);
 }
 
-class _$ExplicitPathDocumentReference
-    extends FirestoreDocumentReference<ExplicitPathDocumentSnapshot>
-    implements ExplicitPathDocumentReference {
+class _$ExplicitPathDocumentReference extends FirestoreDocumentReference<
+    ExplicitPath,
+    ExplicitPathDocumentSnapshot> implements ExplicitPathDocumentReference {
   _$ExplicitPathDocumentReference(this.reference);
 
   @override
@@ -7050,7 +7077,8 @@ class _$ExplicitPathDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class ExplicitPathDocumentSnapshot extends FirestoreDocumentSnapshot {
+class ExplicitPathDocumentSnapshot
+    extends FirestoreDocumentSnapshot<ExplicitPath> {
   ExplicitPathDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -7071,7 +7099,7 @@ class ExplicitPathDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class ExplicitPathQuery
-    implements QueryReference<ExplicitPathQuerySnapshot> {
+    implements QueryReference<ExplicitPath, ExplicitPathQuerySnapshot> {
   @override
   ExplicitPathQuery limit(int limit);
 
@@ -7191,7 +7219,8 @@ abstract class ExplicitPathQuery
   });
 }
 
-class _$ExplicitPathQuery extends QueryReference<ExplicitPathQuerySnapshot>
+class _$ExplicitPathQuery
+    extends QueryReference<ExplicitPath, ExplicitPathQuerySnapshot>
     implements ExplicitPathQuery {
   _$ExplicitPathQuery(
     this.reference,
@@ -7480,8 +7509,8 @@ class _$ExplicitPathQuery extends QueryReference<ExplicitPathQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-class ExplicitPathQuerySnapshot
-    extends FirestoreQuerySnapshot<ExplicitPathQueryDocumentSnapshot> {
+class ExplicitPathQuerySnapshot extends FirestoreQuerySnapshot<ExplicitPath,
+    ExplicitPathQueryDocumentSnapshot> {
   ExplicitPathQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -7497,7 +7526,8 @@ class ExplicitPathQuerySnapshot
   final List<FirestoreDocumentChange<ExplicitPathDocumentSnapshot>> docChanges;
 }
 
-class ExplicitPathQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
+class ExplicitPathQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<ExplicitPath>
     implements ExplicitPathDocumentSnapshot {
   ExplicitPathQueryDocumentSnapshot._(this.snapshot, this.data);
 
@@ -7519,7 +7549,8 @@ class ExplicitPathQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot
 abstract class ExplicitSubPathCollectionReference
     implements
         ExplicitSubPathQuery,
-        FirestoreCollectionReference<ExplicitSubPathQuerySnapshot> {
+        FirestoreCollectionReference<ExplicitSubPath,
+            ExplicitSubPathQuerySnapshot> {
   factory ExplicitSubPathCollectionReference(
     DocumentReference<ExplicitPath> parent,
   ) = _$ExplicitSubPathCollectionReference;
@@ -7610,7 +7641,8 @@ class _$ExplicitSubPathCollectionReference extends _$ExplicitSubPathQuery
 }
 
 abstract class ExplicitSubPathDocumentReference
-    extends FirestoreDocumentReference<ExplicitSubPathDocumentSnapshot> {
+    extends FirestoreDocumentReference<ExplicitSubPath,
+        ExplicitSubPathDocumentSnapshot> {
   factory ExplicitSubPathDocumentReference(
           DocumentReference<ExplicitSubPath> reference) =
       _$ExplicitSubPathDocumentReference;
@@ -7643,8 +7675,8 @@ abstract class ExplicitSubPathDocumentReference
   Future<void> set(ExplicitSubPath value);
 }
 
-class _$ExplicitSubPathDocumentReference
-    extends FirestoreDocumentReference<ExplicitSubPathDocumentSnapshot>
+class _$ExplicitSubPathDocumentReference extends FirestoreDocumentReference<
+        ExplicitSubPath, ExplicitSubPathDocumentSnapshot>
     implements ExplicitSubPathDocumentReference {
   _$ExplicitSubPathDocumentReference(this.reference);
 
@@ -7712,7 +7744,8 @@ class _$ExplicitSubPathDocumentReference
   int get hashCode => Object.hash(runtimeType, parent, id);
 }
 
-class ExplicitSubPathDocumentSnapshot extends FirestoreDocumentSnapshot {
+class ExplicitSubPathDocumentSnapshot
+    extends FirestoreDocumentSnapshot<ExplicitSubPath> {
   ExplicitSubPathDocumentSnapshot._(
     this.snapshot,
     this.data,
@@ -7733,7 +7766,7 @@ class ExplicitSubPathDocumentSnapshot extends FirestoreDocumentSnapshot {
 }
 
 abstract class ExplicitSubPathQuery
-    implements QueryReference<ExplicitSubPathQuerySnapshot> {
+    implements QueryReference<ExplicitSubPath, ExplicitSubPathQuerySnapshot> {
   @override
   ExplicitSubPathQuery limit(int limit);
 
@@ -7854,7 +7887,7 @@ abstract class ExplicitSubPathQuery
 }
 
 class _$ExplicitSubPathQuery
-    extends QueryReference<ExplicitSubPathQuerySnapshot>
+    extends QueryReference<ExplicitSubPath, ExplicitSubPathQuerySnapshot>
     implements ExplicitSubPathQuery {
   _$ExplicitSubPathQuery(
     this.reference,
@@ -8143,8 +8176,8 @@ class _$ExplicitSubPathQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
-class ExplicitSubPathQuerySnapshot
-    extends FirestoreQuerySnapshot<ExplicitSubPathQueryDocumentSnapshot> {
+class ExplicitSubPathQuerySnapshot extends FirestoreQuerySnapshot<
+    ExplicitSubPath, ExplicitSubPathQueryDocumentSnapshot> {
   ExplicitSubPathQuerySnapshot._(
     this.snapshot,
     this.docs,
@@ -8162,7 +8195,7 @@ class ExplicitSubPathQuerySnapshot
 }
 
 class ExplicitSubPathQueryDocumentSnapshot
-    extends FirestoreQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<ExplicitSubPath>
     implements ExplicitSubPathDocumentSnapshot {
   ExplicitSubPathQueryDocumentSnapshot._(this.snapshot, this.data);
 

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/collection_reference.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/collection_reference.dart
@@ -11,7 +11,7 @@ class CollectionReferenceTemplate extends Template<CollectionData> {
 abstract class ${data.collectionReferenceInterfaceName}
       implements
         ${data.queryReferenceInterfaceName},
-        FirestoreCollectionReference<${data.querySnapshotName}> {
+        FirestoreCollectionReference<${data.type}, ${data.querySnapshotName}> {
   ${data.parent != null ? _subCollectionConstructors(data, asbtract: true) : _rootCollectionConstructors(data, abstract: true)}
 
   static ${data.type} fromFirestore(

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/document_reference.dart
@@ -5,7 +5,7 @@ class DocumentReferenceTemplate extends Template<CollectionData> {
   @override
   String generate(CollectionData data) {
     return '''
-abstract class ${data.documentReferenceName} extends FirestoreDocumentReference<${data.documentSnapshotName}> {
+abstract class ${data.documentReferenceName} extends FirestoreDocumentReference<${data.type}, ${data.documentSnapshotName}> {
   factory ${data.documentReferenceName}(DocumentReference<${data.type}> reference) = _\$${data.documentReferenceName};
 
   DocumentReference<${data.type}> get reference;
@@ -29,7 +29,7 @@ abstract class ${data.documentReferenceName} extends FirestoreDocumentReference<
 }
 
 class _\$${data.documentReferenceName}
-      extends FirestoreDocumentReference<${data.documentSnapshotName}>
+      extends FirestoreDocumentReference<${data.type}, ${data.documentSnapshotName}>
       implements ${data.documentReferenceName} {
   _\$${data.documentReferenceName}(this.reference);
 

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/document_snapshot.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/document_snapshot.dart
@@ -5,7 +5,7 @@ class DocumentSnapshotTemplate extends Template<CollectionData> {
   @override
   String generate(CollectionData data) {
     return '''
-class ${data.documentSnapshotName} extends FirestoreDocumentSnapshot {
+class ${data.documentSnapshotName} extends FirestoreDocumentSnapshot<${data.type}> {
   ${data.documentSnapshotName}._(
     this.snapshot,
     this.data,

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/query_document_snapshot.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/query_document_snapshot.dart
@@ -5,7 +5,7 @@ class QueryDocumentSnapshotTemplate extends Template<CollectionData> {
   @override
   String generate(CollectionData data) {
     return '''
-class ${data.queryDocumentSnapshotName} extends FirestoreQueryDocumentSnapshot implements ${data.documentSnapshotName} {
+class ${data.queryDocumentSnapshotName} extends FirestoreQueryDocumentSnapshot<${data.type}> implements ${data.documentSnapshotName} {
   ${data.queryDocumentSnapshotName}._(this.snapshot, this.data);
 
   @override

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/query_reference.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/query_reference.dart
@@ -7,7 +7,7 @@ class QueryTemplate extends Template<CollectionData> {
   @override
   String generate(CollectionData data) {
     return '''
-abstract class ${data.queryReferenceInterfaceName} implements QueryReference<${data.querySnapshotName}> {
+abstract class ${data.queryReferenceInterfaceName} implements QueryReference<${data.type}, ${data.querySnapshotName}> {
   @override
   ${data.queryReferenceInterfaceName} limit(int limit);
 
@@ -84,7 +84,7 @@ abstract class ${data.queryReferenceInterfaceName} implements QueryReference<${d
 }
 
 class ${data.queryReferenceImplName}
-    extends QueryReference<${data.querySnapshotName}>
+    extends QueryReference<${data.type}, ${data.querySnapshotName}>
     implements ${data.queryReferenceInterfaceName} {
   ${data.queryReferenceImplName}(
     this.reference,

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/query_snapshot.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/query_snapshot.dart
@@ -5,7 +5,7 @@ class QuerySnapshotTemplate extends Template<CollectionData> {
   @override
   String generate(CollectionData data) {
     return '''
-class ${data.querySnapshotName} extends FirestoreQuerySnapshot<${data.queryDocumentSnapshotName}> {
+class ${data.querySnapshotName} extends FirestoreQuerySnapshot<${data.type}, ${data.queryDocumentSnapshotName}> {
   ${data.querySnapshotName}._(
     this.snapshot,
     this.docs,


### PR DESCRIPTION
This change is breaking, as classes such as FirestoreDcoumentReference
now take two generic arguments instead of one.

## Description



## Related Issues



## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
