### PR TITLE
fix(firebase_auth): missing export for `MultiFactorSession` from universal package

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/firebase_auth.dart
@@ -17,6 +17,7 @@ export 'package:firebase_auth_platform_interface/firebase_auth_platform_interfac
         FirebaseAuthMultiFactorException,
         MultiFactorInfo,
         PhoneMultiFactorInfo,
+        MultiFactorSession,
         IdTokenResult,
         UserMetadata,
         UserInfo,


### PR DESCRIPTION
export multi factor session for Fakes / Mocks

fixes #9190 9190