### PR TITLE
fix(firestore, web): change the interop to fix an issue with `startAt()` & `endAt()` when compiling with dart2js in release mode

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -467,7 +467,7 @@ class Query<T extends firestore_interop.QueryJsImpl>
   /// We need to call this method in all paginating methods to fix that Dart
   /// doesn't support varargs - we need to use [List] to call js function.
   S? _createQueryConstraint<S>(
-      Function method, DocumentSnapshot? snapshot, List<dynamic>? fieldValues) {
+      Object method, DocumentSnapshot? snapshot, List<dynamic>? fieldValues) {
     if (snapshot == null && fieldValues == null) {
       throw ArgumentError(
           'Please provide either snapshot or fieldValues parameter.');
@@ -477,7 +477,7 @@ class Query<T extends firestore_interop.QueryJsImpl>
         ? [snapshot.jsObject]
         : fieldValues!.map(jsify).toList();
 
-    return callMethod(method, 'apply', jsify([null, args]));
+    return callMethod(method, 'apply', [null, jsify(args)]);
   }
 }
 

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore_interop.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore_interop.dart
@@ -93,15 +93,6 @@ external PromiseJsImpl<void> enableMultiTabIndexedDbPersistence(
 external PromiseJsImpl<void> enableNetwork(FirestoreJsImpl firestore);
 
 @JS()
-external QueryConstraintJsImpl endBefore(
-  dynamic /* DocumentSnapshot | ...fieldValues */ fieldValues,
-);
-
-@JS()
-external QueryConstraintJsImpl endAt(
-  dynamic /* DocumentSnapshot | ...fieldValues */ fieldValues,
-);
-@JS()
 external PromiseJsImpl<DocumentSnapshotJsImpl> getDoc(
   DocumentReferenceJsImpl reference,
 );
@@ -218,16 +209,6 @@ external void setLogLevel(String logLevel);
 external bool snapshotEqual(
   dynamic /* DocumentSnapshot | QuerySnapshot */ left,
   dynamic /* DocumentSnapshot | QuerySnapshot */ right,
-);
-
-@JS()
-external QueryConstraintJsImpl startAfter(
-  dynamic /* DocumentSnapshot | ...fieldValues */ fieldValues,
-);
-
-@JS()
-external QueryConstraintJsImpl startAt(
-  dynamic /* DocumentSnapshot | ...fieldValues */ fieldValues,
 );
 
 @JS()
@@ -655,3 +636,18 @@ abstract class SnapshotOptions {
 
   external factory SnapshotOptions({String? serverTimestamps});
 }
+
+// We type those 4 functions as Object to avoid an issue with dart2js compilation
+// in release mode
+// Discussed internally with dart2js team
+@JS()
+external Object get startAfter;
+
+@JS()
+external Object get startAt;
+
+@JS()
+external Object get endBefore;
+
+@JS()
+external Object get endAt;


### PR DESCRIPTION
## Description

As discussed internally, there is an issue with dart2js compilation in release mode. 
One of the workaround is to type those functions as Object.

The tests for Cloud Firestore are currently skipped, we'll bring back those tests in another PR.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/9106

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
