### PR TITLE
fix(auth, web): restore default persistence to IndexedDB that was incorrectly set to localStorage

### DIFF
--- a/docs/auth/start.md
+++ b/docs/auth/start.md
@@ -208,7 +208,9 @@ restarts. The user can clear the apps cached data using the device settings,
 which will wipe any existing state being stored.
 
 On web platforms, the user's authentication state is stored in
-[local storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).
+[IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API).
+You can change the persistence to store data in the [local storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
+using `Persistence.LOCAL`.
 If required, you can change this default behavior to only persist
 authentication state for the current session, or not at all. To configure these
 settings, call the following method `FirebaseAuth.instanceFor(app: Firebase.app(), persistence: Persistence.LOCAL);`.

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/types.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/types.dart
@@ -31,9 +31,13 @@ typedef PhoneCodeAutoRetrievalTimeout = void Function(String verificationId);
 ///
 /// Setting a persistence type is only available on web based platforms.
 enum Persistence {
-  /// Indicates that the state will be persisted even when the browser window is
+  /// Indicates that the state will be persisted in Local Storage even when the browser window is
   /// closed.
   LOCAL,
+
+  /// Indicates that the state will be persisted in IndexedDB even when the browser window is
+  /// closed.
+  INDEXED_DB,
 
   /// Indicates that the state will only be stored in memory and will be
   /// cleared when the window or activity is refreshed.

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -27,6 +27,9 @@ Auth getAuthInstance(App app, {Persistence? persistence}) {
       case Persistence.LOCAL:
         setPersistence = auth_interop.browserLocalPersistence;
         break;
+      case Persistence.INDEXED_DB:
+        setPersistence = auth_interop.indexedDBLocalPersistence;
+        break;
       case Persistence.SESSION:
         setPersistence = auth_interop.browserSessionPersistence;
         break;
@@ -42,12 +45,17 @@ Auth getAuthInstance(App app, {Persistence? persistence}) {
           'popupRedirectResolver': auth_interop.browserPopupRedirectResolver
         })));
   }
-  // `browserLocalPersistence` is the default persistence setting.
   return Auth.getInstance(auth_interop.initializeAuth(
       app.jsObject,
       jsify({
         'errorMap': auth_interop.debugErrorMap,
-        'persistence': auth_interop.browserLocalPersistence,
+        // Default persistence can be seen here
+        // https://github.com/firebase/firebase-js-sdk/blob/master/packages/auth/src/platform_browser/index.ts#L47
+        'persistence': [
+          auth_interop.indexedDBLocalPersistence,
+          auth_interop.browserLocalPersistence,
+          auth_interop.browserSessionPersistence
+        ],
         'popupRedirectResolver': auth_interop.browserPopupRedirectResolver
       })));
 }
@@ -542,6 +550,9 @@ class Auth extends JsObjectWrapper<auth_interop.AuthJsImpl> {
     switch (persistence) {
       case Persistence.LOCAL:
         instance = auth_interop.browserLocalPersistence;
+        break;
+      case Persistence.INDEXED_DB:
+        instance = auth_interop.indexedDBLocalPersistence;
         break;
       case Persistence.SESSION:
         instance = auth_interop.browserSessionPersistence;

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
@@ -31,6 +31,8 @@ external Persistence inMemoryPersistence;
 external Persistence browserSessionPersistence;
 @JS()
 external Persistence browserLocalPersistence;
+@JS()
+external Persistence indexedDBLocalPersistence;
 
 @JS()
 external PromiseJsImpl<ActionCodeInfo> checkActionCode(


### PR DESCRIPTION
## Description

It restores the previous (and correct) persistence location, so it shouldn't be considered as breaking.

See correct order here: https://github.com/firebase/firebase-js-sdk/blob/master/packages/auth/src/platform_browser/index.ts#L47
 
## Related Issues

https://github.com/firebase/flutterfire/issues/9243

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
