### PR TITLE
fix(firebase_auth): use correct UTC time from server for `currentUser?.metadata.creationTime` & `currentUser?.metadata.lastSignInTime`

### DIFF
--- a/packages/firebase_auth/firebase_auth/test/user_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/user_test.dart
@@ -333,8 +333,8 @@ void main() {
           'uid: 12345)';
 
       final userMetadata = 'UserMetadata('
-          'creationTime: ${DateTime.fromMillisecondsSinceEpoch(kMockCreationTimestamp)}, '
-          'lastSignInTime: ${DateTime.fromMillisecondsSinceEpoch(kMockLastSignInTimestamp)})';
+          'creationTime: ${DateTime.fromMillisecondsSinceEpoch(kMockCreationTimestamp, isUtc: true)}, '
+          'lastSignInTime: ${DateTime.fromMillisecondsSinceEpoch(kMockLastSignInTimestamp, isUtc: true)})';
 
       expect(
         auth!.currentUser.toString(),

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/user_metadata.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/user_metadata.dart
@@ -17,7 +17,7 @@ class UserMetadata {
   /// When this account was created as dictated by the server clock.
   DateTime? get creationTime => _creationTimestamp == null
       ? null
-      : DateTime.fromMillisecondsSinceEpoch(_creationTimestamp!);
+      : DateTime.fromMillisecondsSinceEpoch(_creationTimestamp!, isUtc: true);
 
   /// When the user last signed in as dictated by the server clock.
   ///

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/user_metadata.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/user_metadata.dart
@@ -25,7 +25,7 @@ class UserMetadata {
   /// sign-in attempts.
   DateTime? get lastSignInTime => _lastSignInTime == null
       ? null
-      : DateTime.fromMillisecondsSinceEpoch(_lastSignInTime!);
+      : DateTime.fromMillisecondsSinceEpoch(_lastSignInTime!, isUtc: true);
 
   @override
   String toString() {


### PR DESCRIPTION
## Description

```js
// On firebase-admin (server)
console.log(user.metadata.creationTime); // Mon, 18 Jul 2022 10:17:31 GMT
```
```dart
// As currently implemented
print('${DateTime.fromMillisecondsSinceEpoch(_creationTimestamp!)}'); // 2022-07-18 11:17:31.699

// Fix
print('${DateTime.fromMillisecondsSinceEpoch(_creationTimestamp!, isUtc: true)}'); // 2022-07-18 10:17:31.699Z


```
## Related Issues

fixes https://github.com/firebase/flutterfire/issues/9162

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
