### PR TITLE
fix(database, web): change the interop to fix an issue with startAt/endAt/limitTo when compilating with dart2js in release mode

### DIFF
--- a/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
@@ -461,8 +461,6 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
       throw ArgumentError('Please provide "args" parameter.');
     }
     var params = args.map(jsify).toList();
-    print(method);
-    print(params);
     return callMethod(method, 'apply', [null, jsify(params)]);
   }
 }

--- a/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
@@ -7,13 +7,14 @@
 
 import 'dart:async';
 import 'dart:js';
+
 import 'package:firebase_core_web/firebase_core_web_interop.dart'
     as core_interop;
+import 'package:firebase_core_web/firebase_core_web_interop.dart'
+    hide jsify, dartify, callMethod;
 import 'package:firebase_database_platform_interface/firebase_database_platform_interface.dart';
 import 'package:firebase_database_web/firebase_database_web.dart'
     show convertFirebaseDatabaseException;
-import 'package:firebase_core_web/firebase_core_web_interop.dart'
-    hide jsify, dartify, callMethod;
 import 'package:flutter/widgets.dart';
 import 'package:js/js_util.dart';
 
@@ -455,12 +456,14 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
   dynamic toJson() => dartify(jsObject.toJSON());
 
   S? _createQueryConstraint<S>(
-      Function method, List<dynamic>? /*list of primitive value */ args) {
+      Object method, List<dynamic>? /*list of primitive value */ args) {
     if (args == null) {
       throw ArgumentError('Please provide "args" parameter.');
     }
     var params = args.map(jsify).toList();
-    return callMethod(method, 'apply', jsify([null, params]));
+    print(method);
+    print(params);
+    return callMethod(method, 'apply', [null, jsify(params)]);
   }
 }
 

--- a/packages/firebase_database/firebase_database_web/lib/src/interop/database_interop.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/interop/database_interop.dart
@@ -10,13 +10,10 @@ library firebase.database_interop;
 
 import 'package:firebase_core_web/firebase_core_web_interop.dart'
     show PromiseJsImpl, Func1, AppJsImpl;
-
 import 'package:js/js.dart';
 
 part 'data_snapshot_interop.dart';
-
 part 'query_interop.dart';
-
 part 'reference_interop.dart';
 
 @JS()
@@ -29,34 +26,6 @@ external void connectDatabaseEmulator(
 @JS()
 external void enableLogging(
     [/* Func message || bool enabled */ loggerOrEnabled, bool persistent]);
-
-@JS()
-external QueryConstraintJsImpl endAt(
-    dynamic /* number | string | boolean | null */ value,
-    [String key]);
-
-@JS()
-external QueryConstraintJsImpl endBefore(
-    dynamic /* number | string | boolean | null */ value,
-    [String key]);
-
-@JS()
-external QueryConstraintJsImpl equalTo(
-  dynamic /* number | string | boolean | null */ value,
-  String key,
-);
-
-@JS()
-external QueryConstraintJsImpl startAfter(
-  dynamic /* number | string | boolean | null */ value,
-  String key,
-);
-
-@JS()
-external QueryConstraintJsImpl startAt(
-  dynamic /* number | string | boolean | null */ value,
-  String key,
-);
 
 @JS()
 external PromiseJsImpl<void> update(
@@ -85,12 +54,6 @@ external void goOnline(DatabaseJsImpl database);
 
 @JS()
 external dynamic increment(int delta);
-
-@JS()
-external QueryConstraintJsImpl limitToFirst(int limit);
-
-@JS()
-external QueryConstraintJsImpl limitToLast(int limit);
 
 @JS()
 external void off([
@@ -286,3 +249,27 @@ abstract class FirebaseError {
   /// Not part of the core JS API, but occasionally exposed in error objects.
   external Object get serverResponse;
 }
+
+// We type those 7 functions as Object to avoid an issue with dart2js compilation
+// in release mode
+// Discussed internally with dart2js team
+@JS()
+external Object get endAt;
+
+@JS()
+external Object get endBefore;
+
+@JS()
+external Object get equalTo;
+
+@JS()
+external Object get startAfter;
+
+@JS()
+external Object get startAt;
+
+@JS()
+external Object get limitToFirst;
+
+@JS()
+external Object get limitToLast;


### PR DESCRIPTION
## Description

As discussed internally, there is an issue with dart2js compilation in release mode.
One of the workaround is to type those functions as Object.


## Related Issues

Fixes #9091

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
