### PR TITLE
fix(firebase_core): broken homepage link in pubspec.yaml

### DIFF
--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_core
 description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
-homepage: https://firebase.flutter.dev/docs/core/usage
+homepage: https://firebase.flutter.dev/docs/core/usage/
 repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_core/firebase_core
 version: 1.20.0
 


### PR DESCRIPTION
## Description

Adds `/` in homepage url in `pubspec.yaml` to get response status `200`

<details>
<summary>Screenshots</summary>

Without `/`

![image](https://user-images.githubusercontent.com/74326345/183353807-80378631-5afc-4099-bb05-4473e4b2be89.png)

<br />

With `/`

![image](https://user-images.githubusercontent.com/74326345/183353897-1db6b8ac-b053-482a-a96e-3699e4e0d5ee.png)

</details>

## Related Issues

Fixes #9313 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
