### PR TITLE
fix(firebase_messaging, iOS): ensure initial notification was tapped to open app. fixes `getInitialMessage()` & `onMessageOpenedApp()` .

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
@@ -120,17 +120,6 @@ class _Application extends State<Application> {
   @override
   void initState() {
     super.initState();
-    FirebaseMessaging.instance
-        .getInitialMessage()
-        .then((RemoteMessage? message) {
-      if (message != null) {
-        Navigator.pushNamed(
-          context,
-          '/message',
-          arguments: MessageArguments(message, true),
-        );
-      }
-    });
 
     FirebaseMessaging.onMessage.listen((RemoteMessage message) {
       RemoteNotification? notification = message.notification;
@@ -274,6 +263,21 @@ class _Application extends State<Application> {
                     : Text(token, style: const TextStyle(fontSize: 12));
               }),
             ),
+            ElevatedButton(
+                onPressed: () {
+                  FirebaseMessaging.instance
+                      .getInitialMessage()
+                      .then((RemoteMessage? message) {
+                    if (message != null) {
+                      Navigator.pushNamed(
+                        context,
+                        '/message',
+                        arguments: MessageArguments(message, true),
+                      );
+                    }
+                  });
+                },
+                child: const Text('getInitialMessage()')),
             MetaCard('Message Stream', MessageList()),
           ],
         ),

--- a/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
@@ -264,20 +264,21 @@ class _Application extends State<Application> {
               }),
             ),
             ElevatedButton(
-                onPressed: () {
-                  FirebaseMessaging.instance
-                      .getInitialMessage()
-                      .then((RemoteMessage? message) {
-                    if (message != null) {
-                      Navigator.pushNamed(
-                        context,
-                        '/message',
-                        arguments: MessageArguments(message, true),
-                      );
-                    }
-                  });
-                },
-                child: const Text('getInitialMessage()')),
+              onPressed: () {
+                FirebaseMessaging.instance
+                    .getInitialMessage()
+                    .then((RemoteMessage? message) {
+                  if (message != null) {
+                    Navigator.pushNamed(
+                      context,
+                      '/message',
+                      arguments: MessageArguments(message, true),
+                    );
+                  }
+                });
+              },
+              child: const Text('getInitialMessage()'),
+            ),
             MetaCard('Message Stream', MessageList()),
           ],
         ),

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -22,6 +22,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   NSObject<FlutterPluginRegistrar> *_registrar;
   NSData *_apnsToken;
   NSDictionary *_initialNotification;
+  bool _notificationOpenedApp;
 
 #ifdef __FF_NOTIFICATIONS_SUPPORTED_PLATFORM
   API_AVAILABLE(ios(10), macosx(10.14))
@@ -43,7 +44,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   if (self) {
     _channel = channel;
     _registrar = registrar;
-
+    _notificationOpenedApp = false;
     // Application
     // Dart -> `getInitialNotification`
     // ObjC -> Initialize other delegates & observers
@@ -333,6 +334,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler
     API_AVAILABLE(macos(10.14), ios(10.0)) {
+  _notificationOpenedApp = true;
   NSDictionary *remoteNotification = response.notification.request.content.userInfo;
   // We only want to handle FCM notifications.
   if (remoteNotification[@"gcm.message_id"]) {
@@ -995,7 +997,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 
 - (nullable NSDictionary *)copyInitialNotification {
   @synchronized(self) {
-    if (_initialNotification != nil) {
+    if (_initialNotification != nil && _notificationOpenedApp == true) {
       NSDictionary *initialNotificationCopy = [_initialNotification copy];
       _initialNotification = nil;
       return initialNotificationCopy;

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -340,7 +340,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   // We only want to handle FCM notifications and stop firing `onMessageOpenedApp()` when app is
   // coming from a terminated state.
   if (remoteNotification[@"gcm.message_id"] &&
-      ![_initialNoticationID isEqualToString:remoteNotification[@"gcm.message_id"]]) {
+      ![_initialNoticationID isEqualToString:_notificationOpenedAppID]) {
     NSDictionary *notificationDict =
         [FLTFirebaseMessagingPlugin remoteMessageUserInfoToDict:remoteNotification];
     [_channel invokeMethod:@"Messaging#onMessageOpenedApp" arguments:notificationDict];
@@ -1000,7 +1000,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 
 - (nullable NSDictionary *)copyInitialNotification {
   @synchronized(self) {
-    // Only return if initial notification was pushed when app is terminated. Also ensure that
+    // Only return if initial notification was sent when app is terminated. Also ensure that
     // it was the initial notification that was tapped to open the app.
     if (_initialNotification != nil &&
         [_initialNoticationID isEqualToString:_notificationOpenedAppID]) {

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -338,7 +338,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   NSDictionary *remoteNotification = response.notification.request.content.userInfo;
   _notificationOpenedAppID = remoteNotification[@"gcm.message_id"];
   // We only want to handle FCM notifications and stop firing `onMessageOpenedApp()` when app is
-  // coming from terminated state.
+  // coming from a terminated state.
   if (remoteNotification[@"gcm.message_id"] &&
       ![_initialNoticationID isEqualToString:remoteNotification[@"gcm.message_id"]]) {
     NSDictionary *notificationDict =

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -339,7 +339,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   _notificationOpenedAppID = remoteNotification[@"gcm.message_id"];
   // We only want to handle FCM notifications and stop firing `onMessageOpenedApp()` when app is
   // coming from a terminated state.
-  if (remoteNotification[@"gcm.message_id"] &&
+  if (_notificationOpenedAppID != nil &&
       ![_initialNoticationID isEqualToString:_notificationOpenedAppID]) {
     NSDictionary *notificationDict =
         [FLTFirebaseMessagingPlugin remoteMessageUserInfoToDict:remoteNotification];


### PR DESCRIPTION
## Description

This fixes the scenario where a push notification is sent but the user presses the app icon to open app. This PR ensures that the notification that was tapped to open the app is the RemoteMessage from `getInitialMessage()`.

This also fixes `onMessageOpenedApp` which was opening the app when tapping a notification from a terminated state.

I've also discovered that when the app is in a terminated state and a push notification is sent, the `initState()` and `build()` functions within the Flutter application are called before the app has been opened. Therefore, the `getInitialMessage()` cannot be put into`initState()`. Otherwise, the `RemoteMessage` returned from `getInitialMessage()` will be `null` as it is not known whether the app was opened via notification yet.

This bug is being tracked here: https://github.com/firebase/flutterfire/issues/6517

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/4188
fixes https://github.com/firebase/flutterfire/issues/8979

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
