### PR TITLE
fix(cloud_firestore, web): stop `FirebaseError` appearing in console on hot restart & hot refresh

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -114,7 +114,8 @@ class FirebaseFirestore extends FirebasePluginPlatform {
         final String message = (e as dynamic).message;
         // this catches FirebaseError from web that occurs after hot reloading & hot restarting
         if (!message.contains(
-            'Firestore has already been started and its settings can no longer be changed')) {
+          'Firestore has already been started and its settings can no longer be changed',
+        )) {
           rethrow;
         }
       }

--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -111,11 +111,9 @@ class FirebaseFirestore extends FirebasePluginPlatform {
       try {
         _delegate.useEmulator(host, port);
       } catch (e) {
-        final String message = (e as dynamic).message;
+        final String code = (e as dynamic).code;
         // this catches FirebaseError from web that occurs after hot reloading & hot restarting
-        if (!message.contains(
-          'Firestore has already been started and its settings can no longer be changed',
-        )) {
+        if (code != 'failed-precondition') {
           rethrow;
         }
       }

--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -108,7 +108,16 @@ class FirebaseFirestore extends FirebasePluginPlatform {
   void useFirestoreEmulator(String host, int port, {bool sslEnabled = false}) {
     if (kIsWeb) {
       // use useEmulator() API for web as settings are set immediately unlike native platforms
-      _delegate.useEmulator(host, port);
+      try {
+        _delegate.useEmulator(host, port);
+      } catch (e) {
+        final String message = (e as dynamic).message;
+        // this catches FirebaseError from web that occurs after hot reloading & hot restarting
+        if (!message.contains(
+            'Firestore has already been started and its settings can no longer be changed')) {
+          rethrow;
+        }
+      }
     } else {
       String mappedHost = host;
       // Android considers localhost as 10.0.2.2 - automatically handle this for users.


### PR DESCRIPTION
## Description

see title.
## Related Issues

fixes https://github.com/firebase/flutterfire/issues/6216

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
