### PR TITLE
fix(auth, iOS): fix an error where MultifactorInfo factorId could be null on iOS

### DIFF
--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/GeneratedAndroidFirebaseAuth.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/GeneratedAndroidFirebaseAuth.java
@@ -166,16 +166,13 @@ public class GeneratedAndroidFirebaseAuth {
       this.enrollmentTimestamp = setterArg;
     }
 
-    private @NonNull String factorId;
+    private @Nullable String factorId;
 
-    public @NonNull String getFactorId() {
+    public @Nullable String getFactorId() {
       return factorId;
     }
 
-    public void setFactorId(@NonNull String setterArg) {
-      if (setterArg == null) {
-        throw new IllegalStateException("Nonnull field \"factorId\" is null.");
-      }
+    public void setFactorId(@Nullable String setterArg) {
       this.factorId = setterArg;
     }
 
@@ -222,7 +219,7 @@ public class GeneratedAndroidFirebaseAuth {
 
       private @Nullable String factorId;
 
-      public @NonNull Builder setFactorId(@NonNull String setterArg) {
+      public @NonNull Builder setFactorId(@Nullable String setterArg) {
         this.factorId = setterArg;
         return this;
       }

--- a/packages/firebase_auth/firebase_auth/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/firebase_auth/firebase_auth/example/ios/Runner.xcodeproj/project.pbxproj
@@ -275,6 +275,7 @@
 				"${BUILT_PRODUCTS_DIR}/FirebaseAuth/FirebaseAuth.framework",
 				"${BUILT_PRODUCTS_DIR}/FirebaseCore/FirebaseCore.framework",
 				"${BUILT_PRODUCTS_DIR}/FirebaseCoreDiagnostics/FirebaseCoreDiagnostics.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseCoreInternal/FirebaseCoreInternal.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMAppAuth/GTMAppAuth.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleDataTransport/GoogleDataTransport.framework",
@@ -292,6 +293,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseAuth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCoreDiagnostics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCoreInternal.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMAppAuth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleDataTransport.framework",
@@ -409,7 +411,10 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -542,7 +547,10 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -570,7 +578,10 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",

--- a/packages/firebase_auth/firebase_auth/example/lib/profile.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/profile.dart
@@ -176,6 +176,14 @@ class _ProfilePageState extends State<ProfilePage> {
                       child: const Text('Verify Email'),
                     ),
                     const SizedBox(height: 20),
+                    TextButton(
+                      onPressed: () async {
+                        final a = await user.multiFactor.getEnrolledFactors();
+                        print(a);
+                      },
+                      child: const Text('Get enrolled factors'),
+                    ),
+                    const SizedBox(height: 20),
                     TextFormField(
                       controller: phoneController,
                       decoration: const InputDecoration(

--- a/packages/firebase_auth/firebase_auth/ios/Classes/messages.g.h
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/messages.g.h
@@ -33,12 +33,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)makeWithDisplayName:(nullable NSString *)displayName
                 enrollmentTimestamp:(NSNumber *)enrollmentTimestamp
-                           factorId:(NSString *)factorId
+                           factorId:(nullable NSString *)factorId
                                 uid:(NSString *)uid
                         phoneNumber:(nullable NSString *)phoneNumber;
 @property(nonatomic, copy, nullable) NSString *displayName;
 @property(nonatomic, strong) NSNumber *enrollmentTimestamp;
-@property(nonatomic, copy) NSString *factorId;
+@property(nonatomic, copy, nullable) NSString *factorId;
 @property(nonatomic, copy) NSString *uid;
 @property(nonatomic, copy, nullable) NSString *phoneNumber;
 @end

--- a/packages/firebase_auth/firebase_auth/ios/Classes/messages.g.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/messages.g.m
@@ -102,7 +102,7 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 @implementation PigeonMultiFactorInfo
 + (instancetype)makeWithDisplayName:(nullable NSString *)displayName
                 enrollmentTimestamp:(NSNumber *)enrollmentTimestamp
-                           factorId:(NSString *)factorId
+                           factorId:(nullable NSString *)factorId
                                 uid:(NSString *)uid
                         phoneNumber:(nullable NSString *)phoneNumber {
   PigeonMultiFactorInfo *pigeonResult = [[PigeonMultiFactorInfo alloc] init];
@@ -119,7 +119,6 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
   pigeonResult.enrollmentTimestamp = GetNullableObject(dict, @"enrollmentTimestamp");
   NSAssert(pigeonResult.enrollmentTimestamp != nil, @"");
   pigeonResult.factorId = GetNullableObject(dict, @"factorId");
-  NSAssert(pigeonResult.factorId != nil, @"");
   pigeonResult.uid = GetNullableObject(dict, @"uid");
   NSAssert(pigeonResult.uid != nil, @"");
   pigeonResult.phoneNumber = GetNullableObject(dict, @"phoneNumber");

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/utils/pigeon_helper.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/utils/pigeon_helper.dart
@@ -10,7 +10,9 @@ List<MultiFactorInfo> multiFactorInfoPigeonToObject(
       return PhoneMultiFactorInfo(
         displayName: e.displayName,
         enrollmentTimestamp: e.enrollmentTimestamp,
-        factorId: e.factorId,
+        // Sometimes can be null on iOS when it shouldn't be.
+        // Adding default value to prevent null exception.
+        factorId: e.factorId ?? 'phone',
         uid: e.uid,
         phoneNumber: e.phoneNumber!,
       );
@@ -18,7 +20,7 @@ List<MultiFactorInfo> multiFactorInfoPigeonToObject(
     return MultiFactorInfo(
       displayName: e.displayName,
       enrollmentTimestamp: e.enrollmentTimestamp,
-      factorId: e.factorId,
+      factorId: e.factorId ?? '',
       uid: e.uid,
     );
   }).toList();

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/pigeon/messages.pigeon.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/pigeon/messages.pigeon.dart
@@ -57,14 +57,14 @@ class PigeonMultiFactorInfo {
   PigeonMultiFactorInfo({
     this.displayName,
     required this.enrollmentTimestamp,
-    required this.factorId,
+    this.factorId,
     required this.uid,
     this.phoneNumber,
   });
 
   String? displayName;
   double enrollmentTimestamp;
-  String factorId;
+  String? factorId;
   String uid;
   String? phoneNumber;
 
@@ -83,7 +83,7 @@ class PigeonMultiFactorInfo {
     return PigeonMultiFactorInfo(
       displayName: pigeonMap['displayName'] as String?,
       enrollmentTimestamp: pigeonMap['enrollmentTimestamp']! as double,
-      factorId: pigeonMap['factorId']! as String,
+      factorId: pigeonMap['factorId'] as String?,
       uid: pigeonMap['uid']! as String,
       phoneNumber: pigeonMap['phoneNumber'] as String?,
     );

--- a/packages/firebase_auth/firebase_auth_platform_interface/pigeons/messages.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pigeons/messages.dart
@@ -39,14 +39,14 @@ class PigeonMultiFactorInfo {
   const PigeonMultiFactorInfo({
     this.displayName,
     required this.enrollmentTimestamp,
-    required this.factorId,
+    this.factorId,
     required this.uid,
     required this.phoneNumber,
   });
 
   final String? displayName;
   final double enrollmentTimestamp;
-  final String factorId;
+  final String? factorId;
   final String uid;
   final String? phoneNumber;
 }


### PR DESCRIPTION
## Description

Even tho it doesn't happen in e2e tests, factorId can be null on iOS, causing a null exception.
I've changed the pigeon interface to be nullable on factorId, and added a default value.

## Related Issues

https://github.com/firebase/flutterfire/issues/9363

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
