### PR TITLE
fix(analytics, web): `setCurrentScreen()` API is now obsolete, using `logEvent()` instead

### DIFF
--- a/packages/firebase_analytics/firebase_analytics_web/lib/interop/analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/interop/analytics.dart
@@ -60,9 +60,10 @@ class Analytics extends JsObjectWrapper<analytics_interop.AnalyticsJsImpl> {
     String? screenName,
     AnalyticsCallOptions? callOptions,
   }) {
-    return analytics_interop.setCurrentScreen(
+    return analytics_interop.logEvent(
       jsObject,
-      screenName,
+      'screen_view',
+      jsify({'firebase_screen': screenName}),
       callOptions,
     );
   }


### PR DESCRIPTION
## Description

[setCurrentScreen()](https://firebase.google.com/docs/reference/js/analytics#setcurrentscreen) is now obsolete. Using `logEvent()` as documentation recommends. 

Using `firebase_screen` parameter as mentioned in [docs](https://firebase.google.com/docs/reference/js/analytics.eventparams.md#eventparamsfirebase_screen).


## Related Issues

fixes https://github.com/firebase/flutterfire/issues/8403

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
