### PR TITLE
chore(firebase_app_check, android): update deprecated `Tasks.call()`  to `TaskCompletionSource` API

### DIFF
--- a/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppCheckPlugin.java
+++ b/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppCheckPlugin.java
@@ -9,6 +9,7 @@ import static io.flutter.plugins.firebase.core.FlutterFirebasePluginRegistry.reg
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.appcheck.AppCheckTokenResult;
@@ -71,53 +72,85 @@ public class FlutterFirebaseAppCheckPlugin
   }
 
   private Task<Void> activate(Map<String, Object> arguments) {
-    return Tasks.call(
-        cachedThreadPool,
+    TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
         () -> {
-          FirebaseAppCheck firebaseAppCheck = getAppCheck(arguments);
-          firebaseAppCheck.installAppCheckProviderFactory(
-              SafetyNetAppCheckProviderFactory.getInstance());
-          return null;
+          try {
+            FirebaseAppCheck firebaseAppCheck = getAppCheck(arguments);
+            firebaseAppCheck.installAppCheckProviderFactory(
+                SafetyNetAppCheckProviderFactory.getInstance());
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
         });
+
+    return taskCompletionSource.getTask();
   }
 
   private Task<Map<String, Object>> getToken(Map<String, Object> arguments) {
-    return Tasks.call(
-        cachedThreadPool,
+    TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
         () -> {
-          FirebaseAppCheck firebaseAppCheck = getAppCheck(arguments);
-          Boolean forceRefresh = (Boolean) Objects.requireNonNull(arguments.get("forceRefresh"));
-          AppCheckTokenResult tokenResult = Tasks.await(firebaseAppCheck.getToken(forceRefresh));
-          return tokenResultToMap(tokenResult);
+          try {
+            FirebaseAppCheck firebaseAppCheck = getAppCheck(arguments);
+            Boolean forceRefresh = (Boolean) Objects.requireNonNull(arguments.get("forceRefresh"));
+            AppCheckTokenResult tokenResult = Tasks.await(firebaseAppCheck.getToken(forceRefresh));
+
+            taskCompletionSource.setResult(tokenResultToMap(tokenResult));
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
         });
+
+    return taskCompletionSource.getTask();
   }
 
   private Task<Void> setTokenAutoRefreshEnabled(Map<String, Object> arguments) {
-    return Tasks.call(
-        cachedThreadPool,
+    TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
         () -> {
-          FirebaseAppCheck firebaseAppCheck = getAppCheck(arguments);
-          Boolean isTokenAutoRefreshEnabled =
-              (Boolean) Objects.requireNonNull(arguments.get("isTokenAutoRefreshEnabled"));
-          firebaseAppCheck.setTokenAutoRefreshEnabled(isTokenAutoRefreshEnabled);
-          return null;
+          try {
+            FirebaseAppCheck firebaseAppCheck = getAppCheck(arguments);
+            Boolean isTokenAutoRefreshEnabled =
+                (Boolean) Objects.requireNonNull(arguments.get("isTokenAutoRefreshEnabled"));
+            firebaseAppCheck.setTokenAutoRefreshEnabled(isTokenAutoRefreshEnabled);
+
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
         });
+
+    return taskCompletionSource.getTask();
   }
 
   private Task<String> registerTokenListener(Map<String, Object> arguments) {
-    return Tasks.call(
-        cachedThreadPool,
-        () -> {
-          String appName = (String) Objects.requireNonNull(arguments.get("appName"));
-          FirebaseAppCheck firebaseAppCheck = getAppCheck(arguments);
+    TaskCompletionSource<String> taskCompletionSource = new TaskCompletionSource<>();
 
-          final TokenChannelStreamHandler handler = new TokenChannelStreamHandler(firebaseAppCheck);
-          final String name = METHOD_CHANNEL_NAME + "/token/" + appName;
-          final EventChannel channel = new EventChannel(messenger, name);
-          channel.setStreamHandler(handler);
-          streamHandlers.put(channel, handler);
-          return name;
+    cachedThreadPool.execute(
+        () -> {
+          try {
+            String appName = (String) Objects.requireNonNull(arguments.get("appName"));
+            FirebaseAppCheck firebaseAppCheck = getAppCheck(arguments);
+
+            final TokenChannelStreamHandler handler =
+                new TokenChannelStreamHandler(firebaseAppCheck);
+            final String name = METHOD_CHANNEL_NAME + "/token/" + appName;
+            final EventChannel channel = new EventChannel(messenger, name);
+            channel.setStreamHandler(handler);
+            streamHandlers.put(channel, handler);
+
+            taskCompletionSource.setResult(name);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
         });
+
+    return taskCompletionSource.getTask();
   }
 
   @Override
@@ -169,12 +202,34 @@ public class FlutterFirebaseAppCheckPlugin
 
   @Override
   public Task<Map<String, Object>> getPluginConstantsForFirebaseApp(FirebaseApp firebaseApp) {
-    return Tasks.call(() -> null);
+    TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
+        () -> {
+          try {
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
+
+    return taskCompletionSource.getTask();
   }
 
   @Override
   public Task<Void> didReinitializeFirebaseCore() {
-    return Tasks.call(() -> null);
+    TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
+        () -> {
+          try {
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
+
+    return taskCompletionSource.getTask();
   }
 
   private void removeEventListeners() {


### PR DESCRIPTION
## Description

See title.

## Related Issues

As part of https://github.com/firebase/flutterfire/issues/8073

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
