### PR TITLE
chore(firebase_crashlytics, android): Revert PR to send Flutter Build Id to Crashlytics to get --split-debug-info working

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/FlutterFirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/FlutterFirebaseCrashlyticsPlugin.java
@@ -140,11 +140,6 @@ public class FlutterFirebaseCrashlyticsPlugin
             final String information =
                 (String) Objects.requireNonNull(arguments.get(Constants.INFORMATION));
             final boolean fatal = (boolean) Objects.requireNonNull(arguments.get(Constants.FATAL));
-            final String buildId = (String) Objects.requireNonNull(arguments.get("buildId"));
-
-            if (buildId.length() > 0) {
-              crashlytics.setCustomKey("com.crashlytics.flutter.build-id.0", buildId);
-            }
 
             Exception exception;
             if (reason != null) {

--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -119,14 +119,12 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
     // Report error.
     final List<Map<String, String>> stackTraceElements =
         getStackTraceElements(stackTrace);
-    final String? buildId = getBuildId(stackTrace);
 
     return _delegate.recordError(
       exception: exception.toString(),
       reason: reason.toString(),
       information: _information,
       stackTraceElements: stackTraceElements,
-      buildId: buildId,
       fatal: fatal,
     );
   }

--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/utils.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/utils.dart
@@ -52,19 +52,3 @@ List<Map<String, String>> getStackTraceElements(StackTrace stackTrace) {
 
   return elements;
 }
-
-String? getBuildId(StackTrace stackTrace) {
-  final Trace trace = Trace.parseVM(stackTrace.toString()).terse;
-
-  for (final Frame frame in trace.frames) {
-    if (frame is UnparsedFrame) {
-      if (frame.member.startsWith("build_id: '") &&
-          frame.member.endsWith("'")) {
-        // format is: "build_id: '8deece9b0e5bf1aa541b5a91e171282e'"
-        return frame.member.substring(11, frame.member.length - 1);
-      }
-    }
-  }
-
-  return null;
-}

--- a/packages/firebase_crashlytics/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -3,13 +3,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_crashlytics/firebase_crashlytics.dart';
-import 'package:firebase_crashlytics/src/utils.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:firebase_crashlytics/src/utils.dart';
 import './mock.dart';
 
 void main() {
@@ -77,8 +76,7 @@ void main() {
             'reason': exceptionReason,
             'information': '',
             'fatal': false,
-            'stackTraceElements': getStackTraceElements(stack),
-            'buildId': '',
+            'stackTraceElements': getStackTraceElements(stack)
           })
         ]);
         // Confirm that the stack trace contains current stack.
@@ -139,8 +137,7 @@ void main() {
             'reason': exceptionReason,
             'fatal': false,
             'information': '$exceptionFirstMessage\n$exceptionSecondMessage',
-            'stackTraceElements': getStackTraceElements(stack),
-            'buildId': '',
+            'stackTraceElements': getStackTraceElements(stack)
           })
         ]);
       } finally {

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/method_channel/method_channel_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/method_channel/method_channel_crashlytics.dart
@@ -94,7 +94,6 @@ class MethodChannelFirebaseCrashlytics extends FirebaseCrashlyticsPlatform {
     required String information,
     required String reason,
     bool fatal = false,
-    String? buildId,
     List<Map<String, String>>? stackTraceElements,
   }) async {
     try {
@@ -104,7 +103,6 @@ class MethodChannelFirebaseCrashlytics extends FirebaseCrashlyticsPlatform {
         'information': information,
         'reason': reason,
         'fatal': fatal,
-        'buildId': buildId ?? '',
         'stackTraceElements': stackTraceElements ?? [],
       });
     } on PlatformException catch (e, s) {

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/platform_interface/platform_interface_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/platform_interface/platform_interface_crashlytics.dart
@@ -112,7 +112,6 @@ abstract class FirebaseCrashlyticsPlatform extends PlatformInterface {
     required String information,
     required String reason,
     bool fatal = false,
-    String? buildId,
     List<Map<String, String>>? stackTraceElements,
   }) {
     throw UnimplementedError('recordError() is not implemented');

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/test/method_channel_tests/method_channel_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/test/method_channel_tests/method_channel_crashlytics_test.dart
@@ -29,7 +29,6 @@ void main() {
     'reason': 'MethodChannelTest',
     'fatal': false,
     'information': 'This is a test exception',
-    'buildId': '',
     'stackTraceElements': <Map<String, String>>[
       <String, String>{
         'declaringClass': 'MethodChannelCrashlyticsTest',
@@ -218,7 +217,6 @@ void main() {
               'fatal': kMockError['fatal'],
               'information': kMockError['information'],
               'stackTraceElements': kMockError['stackTraceElements'],
-              'buildId': '',
             },
           ),
         ]);


### PR DESCRIPTION
As requested, this PR reverts firebase/flutterfire#9365