### PR TITLE
chore(firebase_in_app_messaging, android): update deprecated `Task.call()` to `TaskCompletionSource` API

### DIFF
--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/android/src/main/java/io/flutter/plugins/firebase/inappmessaging/FirebaseInAppMessagingPlugin.java
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/android/src/main/java/io/flutter/plugins/firebase/inappmessaging/FirebaseInAppMessagingPlugin.java
@@ -17,6 +17,7 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugins.firebase.core.FlutterFirebasePlugin;
 import java.util.Map;
+import java.util.Objects;
 
 /** FirebaseInAppMessagingPlugin */
 public class FirebaseInAppMessagingPlugin
@@ -43,16 +44,14 @@ public class FirebaseInAppMessagingPlugin
     switch (call.method) {
       case "FirebaseInAppMessaging#triggerEvent":
         {
-          String eventName = call.argument("eventName");
-          assert eventName != null;
+          String eventName = Objects.requireNonNull(call.argument("eventName"));
           FirebaseInAppMessaging.getInstance().triggerEvent(eventName);
           result.success(null);
           break;
         }
       case "FirebaseInAppMessaging#setMessagesSuppressed":
         {
-          Boolean suppress = (Boolean) call.argument("suppress");
-          assert suppress != null;
+          Boolean suppress = Objects.requireNonNull(call.argument("suppress"));
           FirebaseInAppMessaging.getInstance().setMessagesSuppressed(suppress);
           result.success(null);
           break;

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/android/src/main/java/io/flutter/plugins/firebase/inappmessaging/FirebaseInAppMessagingPlugin.java
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/android/src/main/java/io/flutter/plugins/firebase/inappmessaging/FirebaseInAppMessagingPlugin.java
@@ -4,8 +4,9 @@
 
 package io.flutter.plugins.firebase.inappmessaging;
 
+import androidx.annotation.NonNull;
 import com.google.android.gms.tasks.Task;
-import com.google.android.gms.tasks.Tasks;
+import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.inappmessaging.FirebaseInAppMessaging;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
@@ -30,7 +31,7 @@ public class FirebaseInAppMessagingPlugin
   }
 
   @Override
-  public void onDetachedFromEngine(FlutterPluginBinding binding) {
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
     if (channel != null) {
       channel.setMethodCallHandler(null);
       channel = null;
@@ -38,11 +39,12 @@ public class FirebaseInAppMessagingPlugin
   }
 
   @Override
-  public void onMethodCall(MethodCall call, Result result) {
+  public void onMethodCall(MethodCall call, @NonNull Result result) {
     switch (call.method) {
       case "FirebaseInAppMessaging#triggerEvent":
         {
           String eventName = call.argument("eventName");
+          assert eventName != null;
           FirebaseInAppMessaging.getInstance().triggerEvent(eventName);
           result.success(null);
           break;
@@ -50,6 +52,7 @@ public class FirebaseInAppMessagingPlugin
       case "FirebaseInAppMessaging#setMessagesSuppressed":
         {
           Boolean suppress = (Boolean) call.argument("suppress");
+          assert suppress != null;
           FirebaseInAppMessaging.getInstance().setMessagesSuppressed(suppress);
           result.success(null);
           break;
@@ -71,11 +74,33 @@ public class FirebaseInAppMessagingPlugin
 
   @Override
   public Task<Map<String, Object>> getPluginConstantsForFirebaseApp(FirebaseApp firebaseApp) {
-    return Tasks.call(() -> null);
+    TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
+        () -> {
+          try {
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
+
+    return taskCompletionSource.getTask();
   }
 
   @Override
   public Task<Void> didReinitializeFirebaseCore() {
-    return Tasks.call(() -> null);
+    TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
+        () -> {
+          try {
+            taskCompletionSource.setResult(null);
+          } catch (Exception e) {
+            taskCompletionSource.setException(e);
+          }
+        });
+
+    return taskCompletionSource.getTask();
   }
 }


### PR DESCRIPTION
## Description

See title.

## Related Issues

As part of https://github.com/firebase/flutterfire/issues/8073

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
