### PR TITLE
feat(auth): add Sign in with Apple directly in Firebase Auth for Android, iOS 13+ and Web

### DIFF
--- a/docs/auth/federated-auth.md
+++ b/docs/auth/federated-auth.md
@@ -171,7 +171,7 @@ For further information, see this [issue](https://github.com/firebase/flutterfir
 
 ## Apple
 
-* {iOS and macOS}
+* {iOS+}
 
   Before you begin [configure Sign In with Apple](/docs/auth/ios/apple#configure-sign-in-with-apple)
   and [enable Apple as a sign-in provider](/docs/auth/ios/apple#enable-apple-as-a-sign-in-provider).

--- a/docs/auth/federated-auth.md
+++ b/docs/auth/federated-auth.md
@@ -171,12 +171,16 @@ For further information, see this [issue](https://github.com/firebase/flutterfir
 
 ## Apple
 
-* {iOS+ and Android}
+* {iOS and macOS}
 
-  Before you begin [configure Sign In with Apple for iOS](/docs/auth/ios/apple#configure-sign-in-with-apple) and [Android](/docs/auth/ios/android#configure-sign-in-with-apple).
-  Then [enable Apple as a sign-in provider](/docs/auth/ios/apple#enable-apple-as-a-sign-in-provider).
+  Before you begin [configure Sign In with Apple](/docs/auth/ios/apple#configure-sign-in-with-apple)
+  and [enable Apple as a sign-in provider](/docs/auth/ios/apple#enable-apple-as-a-sign-in-provider).
 
-  Next, make sure that your iOS `Runner` apps have the "Sign in with Apple" capability.
+  Next, make sure that your `Runner` apps have the "Sign in with Apple" capability.
+
+* {Android}
+  Before you begin [configure Sign In with Apple](/docs/auth/android/apple#configure-sign-in-with-apple)
+  and [enable Apple as a sign-in provider](/docs/auth/android/apple#enable-apple-as-a-sign-in-provider).
 
 * {Web}
 
@@ -188,31 +192,12 @@ For further information, see this [issue](https://github.com/firebase/flutterfir
 import 'package:firebase_auth/firebase_auth.dart';
 
 Future<UserCredential> signInWithApple() async {
-  // To prevent replay attacks with the credential returned from Apple, we
-  // include a nonce in the credential request. When signing in with
-  // Firebase, the nonce in the id token returned by Apple, is expected to
-  // match the sha256 hash of `rawNonce`.
-  final rawNonce = generateNonce();
-  final nonce = sha256ofString(rawNonce);
-
-  // Request credential for the currently signed in Apple account.
-  final appleCredential = await SignInWithApple.getAppleIDCredential(
-    scopes: [
-      AppleIDAuthorizationScopes.email,
-      AppleIDAuthorizationScopes.fullName,
-    ],
-    nonce: nonce,
-  );
-
-  // Create an `OAuthCredential` from the credential returned by Apple.
-  final oauthCredential = OAuthProvider("apple.com").credential(
-    idToken: appleCredential.identityToken,
-    rawNonce: rawNonce,
-  );
-
-  // Sign in the user with Firebase. If the nonce we generated earlier does
-  // not match the nonce in `appleCredential.identityToken`, sign in will fail.
-  return await FirebaseAuth.instance.signInWithCredential(oauthCredential);
+  final appleProvider = AppleAuthProvider();
+  if (kIsWeb) {
+    await _auth.signInWithPopup(appleProvider);
+  } else {
+    await _auth.signInWithAuthProvider(appleProvider);
+  }
 }
 ```
 
@@ -293,20 +278,20 @@ with the Client ID and Secret are set, with the callback URL set in the GitHub a
 
 * {iOS+ and Android}
 
-For native platforms, you need to add the `google-services.json` and `GoogleService-Info.plist`.
+  For native platforms, you need to add the `google-services.json` and `GoogleService-Info.plist`.
 
-For iOS, add the custom URL scheme as [described on the iOS guide](https://firebase.google.com/docs/auth/ios/github-auth#handle_the_sign-in_flow_with_the_firebase_sdk) step 1.
+  For iOS, add the custom URL scheme as [described on the iOS guide](https://firebase.google.com/docs/auth/ios/github-auth#handle_the_sign-in_flow_with_the_firebase_sdk) step 1.
 
-```dart
-import 'package:github_sign_in/github_sign_in.dart';
+  ```dart
+  import 'package:github_sign_in/github_sign_in.dart';
 
-Future<UserCredential> signInWithGitHub() async {
-  // Create a new provider
-  GithubAuthProvider githubProvider = GithubAuthProvider();
+  Future<UserCredential> signInWithGitHub() async {
+    // Create a new provider
+    GithubAuthProvider githubProvider = GithubAuthProvider();
 
-  return await _auth.signInWithAuthProvider(githubProvider);
-}
-```
+    return await _auth.signInWithAuthProvider(githubProvider);
+  }
+  ```
 
 * {Web}
 

--- a/docs/auth/federated-auth.md
+++ b/docs/auth/federated-auth.md
@@ -173,96 +173,48 @@ For further information, see this [issue](https://github.com/firebase/flutterfir
 
 * {iOS+ and Android}
 
-  Before you begin [configure Sign In with Apple](/docs/auth/ios/apple#configure-sign-in-with-apple)
-  and [enable Apple as a sign-in provider](/docs/auth/ios/apple#enable-apple-as-a-sign-in-provider).
+  Before you begin [configure Sign In with Apple for iOS](/docs/auth/ios/apple#configure-sign-in-with-apple) and [Android](/docs/auth/ios/android#configure-sign-in-with-apple).
+  Then [enable Apple as a sign-in provider](/docs/auth/ios/apple#enable-apple-as-a-sign-in-provider).
 
-  Next, make sure that your `Runner` apps have the "Sign in with Apple" capability.
-
-  Install the [`sign_in_with_apple`](https://pub.dev/packages/sign_in_with_apple) plugin, as well as the
-  [`crypto`](https://pub.dev/packages/crypto) package:
-
-  ```yaml title="pubspec.yaml"
-  dependencies:
-    sign_in_with_apple: ^3.0.0
-    crypto: ^3.0.1
-  ```
-
-  ```dart
-  import 'dart:convert';
-  import 'dart:math';
-
-  import 'package:crypto/crypto.dart';
-  import 'package:firebase_auth/firebase_auth.dart';
-  import 'package:sign_in_with_apple/sign_in_with_apple.dart';
-
-  /// Generates a cryptographically secure random nonce, to be included in a
-  /// credential request.
-  String generateNonce([int length = 32]) {
-    const charset =
-        '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._';
-    final random = Random.secure();
-    return List.generate(length, (_) => charset[random.nextInt(charset.length)])
-        .join();
-  }
-
-  /// Returns the sha256 hash of [input] in hex notation.
-  String sha256ofString(String input) {
-    final bytes = utf8.encode(input);
-    final digest = sha256.convert(bytes);
-    return digest.toString();
-  }
-
-  Future<UserCredential> signInWithApple() async {
-    // To prevent replay attacks with the credential returned from Apple, we
-    // include a nonce in the credential request. When signing in with
-    // Firebase, the nonce in the id token returned by Apple, is expected to
-    // match the sha256 hash of `rawNonce`.
-    final rawNonce = generateNonce();
-    final nonce = sha256ofString(rawNonce);
-
-    // Request credential for the currently signed in Apple account.
-    final appleCredential = await SignInWithApple.getAppleIDCredential(
-      scopes: [
-        AppleIDAuthorizationScopes.email,
-        AppleIDAuthorizationScopes.fullName,
-      ],
-      nonce: nonce,
-    );
-
-    // Create an `OAuthCredential` from the credential returned by Apple.
-    final oauthCredential = OAuthProvider("apple.com").credential(
-      idToken: appleCredential.identityToken,
-      rawNonce: rawNonce,
-    );
-
-    // Sign in the user with Firebase. If the nonce we generated earlier does
-    // not match the nonce in `appleCredential.identityToken`, sign in will fail.
-    return await FirebaseAuth.instance.signInWithCredential(oauthCredential);
-  }
-  ```
+  Next, make sure that your iOS `Runner` apps have the "Sign in with Apple" capability.
 
 * {Web}
 
   Before you begin [configure Sign In with Apple](/docs/auth/web/apple#configure-sign-in-with-apple)
   and [enable Apple as a sign-in provider](/docs/auth/web/apple#enable-apple-as-a-sign-in-provider).
 
-  ```dart
-  import 'package:firebase_auth/firebase_auth.dart';
 
-  Future<UserCredential> signInWithApple() async {
-    // Create and configure an OAuthProvider for Sign In with Apple.
-    final provider = OAuthProvider("apple.com")
-      ..addScope('email')
-      ..addScope('name');
+```dart
+import 'package:firebase_auth/firebase_auth.dart';
 
-    // Sign in the user with Firebase.
-    return await FirebaseAuth.instance.signInWithPopup(provider);
-  }
-  ```
+Future<UserCredential> signInWithApple() async {
+  // To prevent replay attacks with the credential returned from Apple, we
+  // include a nonce in the credential request. When signing in with
+  // Firebase, the nonce in the id token returned by Apple, is expected to
+  // match the sha256 hash of `rawNonce`.
+  final rawNonce = generateNonce();
+  final nonce = sha256ofString(rawNonce);
 
-  An alternative is to use `signInWithRedirect`. In that case the browser will navigate away from your app
-  and you have to use `getRedirectResult` to check for authentication results during app startup.
+  // Request credential for the currently signed in Apple account.
+  final appleCredential = await SignInWithApple.getAppleIDCredential(
+    scopes: [
+      AppleIDAuthorizationScopes.email,
+      AppleIDAuthorizationScopes.fullName,
+    ],
+    nonce: nonce,
+  );
 
+  // Create an `OAuthCredential` from the credential returned by Apple.
+  final oauthCredential = OAuthProvider("apple.com").credential(
+    idToken: appleCredential.identityToken,
+    rawNonce: rawNonce,
+  );
+
+  // Sign in the user with Firebase. If the nonce we generated earlier does
+  // not match the nonce in `appleCredential.identityToken`, sign in will fail.
+  return await FirebaseAuth.instance.signInWithCredential(oauthCredential);
+}
+```
 
 ## Twitter
 

--- a/packages/firebase_auth/firebase_auth/example/ios/Podfile
+++ b/packages/firebase_auth/firebase_auth/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '10.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/firebase_auth/firebase_auth/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/firebase_auth/firebase_auth/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -176,6 +176,7 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
+						DevelopmentTeam = YYX2P3XVJ7;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -404,17 +405,15 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YYX2P3XVJ7;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -540,17 +539,15 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YYX2P3XVJ7;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -571,17 +568,15 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YYX2P3XVJ7;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",

--- a/packages/firebase_auth/firebase_auth/example/ios/Runner/Runner.entitlements
+++ b/packages/firebase_auth/firebase_auth/example/ios/Runner/Runner.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
 </plist>

--- a/packages/firebase_auth/firebase_auth/example/lib/auth.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/auth.dart
@@ -83,17 +83,26 @@ class _AuthGateState extends State<AuthGate> {
   @override
   void initState() {
     super.initState();
-    if (kIsWeb) {
+    if (!kIsWeb && Platform.isMacOS) {
       authButtons = {
-        Buttons.Google: _signInWithGoogle,
-        Buttons.GitHub: _signInWithGitHub,
-        Buttons.Twitter: _signInWithTwitter,
+        Buttons.Apple: () => _handleMultiFactorException(
+              _signInWithApple,
+            ),
       };
     } else {
       authButtons = {
-        if (!Platform.isMacOS) Buttons.Google: _signInWithGoogle,
-        if (!Platform.isMacOS) Buttons.GitHub: _signInWithGitHub,
-        if (!Platform.isMacOS) Buttons.Twitter: _signInWithTwitter,
+        Buttons.Apple: () => _handleMultiFactorException(
+              _signInWithApple,
+            ),
+        Buttons.Google: () => _handleMultiFactorException(
+              _signInWithGoogle,
+            ),
+        Buttons.GitHub: () => _handleMultiFactorException(
+              _signInWithGitHub,
+            ),
+        Buttons.Twitter: () => _handleMultiFactorException(
+              _signInWithTwitter,
+            ),
       };
     }
   }
@@ -188,7 +197,11 @@ class _AuthGateState extends State<AuthGate> {
                             width: double.infinity,
                             height: 50,
                             child: ElevatedButton(
-                              onPressed: isLoading ? null : _emailAndPassword,
+                              onPressed: isLoading
+                                  ? null
+                                  : () => _handleMultiFactorException(
+                                        _emailAndPassword,
+                                      ),
                               child: isLoading
                                   ? const CircularProgressIndicator.adaptive()
                                   : Text(mode.label),
@@ -364,38 +377,104 @@ class _AuthGateState extends State<AuthGate> {
     }
   }
 
+  Future<void> _handleMultiFactorException(
+    Future<void> Function() authFunction,
+  ) async {
+    setIsLoading();
+    try {
+      await authFunction();
+    } on FirebaseAuthMultiFactorException catch (e) {
+      setState(() {
+        error = '${e.message}';
+      });
+      final firstHint = e.resolver.hints.first;
+      if (firstHint is! PhoneMultiFactorInfo) {
+        return;
+      }
+      final auth = FirebaseAuth.instance;
+      await auth.verifyPhoneNumber(
+        multiFactorSession: e.resolver.session,
+        multiFactorInfo: firstHint,
+        verificationCompleted: (_) {},
+        verificationFailed: print,
+        codeSent: (String verificationId, int? resendToken) async {
+          final smsCode = await getSmsCodeFromUser(context);
+
+          if (smsCode != null) {
+            // Create a PhoneAuthCredential with the code
+            final credential = PhoneAuthProvider.credential(
+              verificationId: verificationId,
+              smsCode: smsCode,
+            );
+
+            try {
+              await e.resolver.resolveSignIn(
+                PhoneMultiFactorGenerator.getAssertion(
+                  credential,
+                ),
+              );
+            } on FirebaseAuthException catch (e) {
+              print(e.message);
+            }
+          }
+        },
+        codeAutoRetrievalTimeout: print,
+      );
+    } on FirebaseAuthException catch (e) {
+      setState(() {
+        error = '${e.message}';
+      });
+    } catch (e) {
+      setState(() {
+        error = '$e';
+      });
+    } finally {
+      setIsLoading();
+    }
+  }
+
   Future<void> _emailAndPassword() async {
     if (formKey.currentState?.validate() ?? false) {
       setIsLoading();
+      if (mode == AuthMode.login) {
+        await _auth.signInWithEmailAndPassword(
+          email: emailController.text,
+          password: passwordController.text,
+        );
+      } else if (mode == AuthMode.register) {
+        await _auth.createUserWithEmailAndPassword(
+          email: emailController.text,
+          password: passwordController.text,
+        );
+      } else {
+        await _phoneAuth();
+      }
+    }
+  }
 
-      try {
-        if (mode == AuthMode.login) {
-          await _auth.signInWithEmailAndPassword(
-            email: emailController.text,
-            password: passwordController.text,
-          );
-        } else if (mode == AuthMode.register) {
-          await _auth.createUserWithEmailAndPassword(
-            email: emailController.text,
-            password: passwordController.text,
-          );
-        } else {
-          await _phoneAuth();
+  Future<void> _phoneAuth() async {
+    if (mode != AuthMode.phone) {
+      setState(() {
+        mode = AuthMode.phone;
+      });
+    } else {
+      if (kIsWeb) {
+        final confirmationResult =
+            await _auth.signInWithPhoneNumber(phoneController.text);
+        final smsCode = await getSmsCodeFromUser(context);
+
+        if (smsCode != null) {
+          await confirmationResult.confirm(smsCode);
         }
-      } on FirebaseAuthMultiFactorException catch (e) {
-        setState(() {
-          error = '${e.message}';
-        });
-        final firstHint = e.resolver.hints.first;
-        if (firstHint is! PhoneMultiFactorInfo) {
-          return;
-        }
-        final auth = FirebaseAuth.instance;
-        await auth.verifyPhoneNumber(
-          multiFactorSession: e.resolver.session,
-          multiFactorInfo: firstHint,
+      } else {
+        await _auth.verifyPhoneNumber(
+          phoneNumber: phoneController.text,
           verificationCompleted: (_) {},
-          verificationFailed: print,
+          verificationFailed: (e) {
+            setState(() {
+              error = '${e.message}';
+            });
+          },
           codeSent: (String verificationId, int? resendToken) async {
             final smsCode = await getSmsCodeFromUser(context);
 
@@ -407,183 +486,100 @@ class _AuthGateState extends State<AuthGate> {
               );
 
               try {
-                await e.resolver.resolveSignIn(
-                  PhoneMultiFactorGenerator.getAssertion(
-                    credential,
-                  ),
-                );
+                // Sign the user in (or link) with the credential
+                await _auth.signInWithCredential(credential);
               } on FirebaseAuthException catch (e) {
-                print(e.message);
+                setState(() {
+                  error = e.message ?? '';
+                });
               }
             }
           },
-          codeAutoRetrievalTimeout: print,
+          codeAutoRetrievalTimeout: (e) {
+            setState(() {
+              error = e;
+            });
+          },
         );
-      } on FirebaseAuthException catch (e) {
-        setState(() {
-          error = '${e.message}';
-        });
-      } catch (e) {
-        setState(() {
-          error = '$e';
-        });
-      } finally {
-        setIsLoading();
-      }
-    }
-  }
-
-  Future<void> _phoneAuth() async {
-    if (mode != AuthMode.phone) {
-      setState(() {
-        mode = AuthMode.phone;
-      });
-    } else {
-      try {
-        if (kIsWeb) {
-          final confirmationResult =
-              await _auth.signInWithPhoneNumber(phoneController.text);
-          final smsCode = await getSmsCodeFromUser(context);
-
-          if (smsCode != null) {
-            await confirmationResult.confirm(smsCode);
-          }
-        } else {
-          await _auth.verifyPhoneNumber(
-            phoneNumber: phoneController.text,
-            verificationCompleted: (_) {},
-            verificationFailed: (e) {
-              setState(() {
-                error = '${e.message}';
-              });
-            },
-            codeSent: (String verificationId, int? resendToken) async {
-              final smsCode = await getSmsCodeFromUser(context);
-
-              if (smsCode != null) {
-                // Create a PhoneAuthCredential with the code
-                final credential = PhoneAuthProvider.credential(
-                  verificationId: verificationId,
-                  smsCode: smsCode,
-                );
-
-                try {
-                  // Sign the user in (or link) with the credential
-                  await _auth.signInWithCredential(credential);
-                } on FirebaseAuthException catch (e) {
-                  setState(() {
-                    error = e.message ?? '';
-                  });
-                }
-              }
-            },
-            codeAutoRetrievalTimeout: (e) {
-              setState(() {
-                error = e;
-              });
-            },
-          );
-        }
-      } catch (e) {
-        setState(() {
-          error = '$e';
-        });
-      } finally {
-        setIsLoading();
       }
     }
   }
 
   Future<void> _signInWithGoogle() async {
-    setIsLoading();
-    try {
-      // Trigger the authentication flow
-      final googleUser = await GoogleSignIn().signIn();
+    // Trigger the authentication flow
+    final googleUser = await GoogleSignIn().signIn();
 
-      // Obtain the auth details from the request
-      final googleAuth = await googleUser?.authentication;
+    // Obtain the auth details from the request
+    final googleAuth = await googleUser?.authentication;
 
-      if (googleAuth != null) {
-        // Create a new credential
-        final credential = GoogleAuthProvider.credential(
-          accessToken: googleAuth.accessToken,
-          idToken: googleAuth.idToken,
-        );
+    if (googleAuth != null) {
+      // Create a new credential
+      final credential = GoogleAuthProvider.credential(
+        accessToken: googleAuth.accessToken,
+        idToken: googleAuth.idToken,
+      );
 
-        // Once signed in, return the UserCredential
-        await _auth.signInWithCredential(credential);
-      }
-    } on FirebaseAuthException catch (e) {
-      setState(() {
-        error = '${e.message}';
-      });
-    } finally {
-      setIsLoading();
+      // Once signed in, return the UserCredential
+      await _auth.signInWithCredential(credential);
     }
   }
 
   Future<void> _signInWithTwitter() async {
-    setIsLoading();
-    try {
-      if (kIsWeb) {
-        // Create a new provider
-        TwitterAuthProvider twitterProvider = TwitterAuthProvider();
+    if (kIsWeb) {
+      // Create a new provider
+      TwitterAuthProvider twitterProvider = TwitterAuthProvider();
 
-        // Once signed in, return the UserCredential
-        await FirebaseAuth.instance.signInWithPopup(twitterProvider);
-      } else {
-        // Create a TwitterLogin instance
-        final twitterLogin = TwitterLogin(
-          apiKey: TwitterConfig['API_KEY']!,
-          apiSecretKey: TwitterConfig['API_SECRET_KEY']!,
-          redirectURI: TwitterConfig['REDIRECT_URL']!,
+      // Once signed in, return the UserCredential
+      await FirebaseAuth.instance.signInWithPopup(twitterProvider);
+    } else {
+      // Create a TwitterLogin instance
+      final twitterLogin = TwitterLogin(
+        apiKey: TwitterConfig['API_KEY']!,
+        apiSecretKey: TwitterConfig['API_SECRET_KEY']!,
+        redirectURI: TwitterConfig['REDIRECT_URL']!,
+      );
+
+      // Trigger the sign-in flow
+      final authResult = await twitterLogin.login();
+
+      if (authResult.status == TwitterLoginStatus.loggedIn) {
+        // Create a credential from the access token
+        final twitterAuthCredential = TwitterAuthProvider.credential(
+          accessToken: authResult.authToken!,
+          secret: authResult.authTokenSecret!,
         );
 
-        // Trigger the sign-in flow
-        final authResult = await twitterLogin.login();
-
-        if (authResult.status == TwitterLoginStatus.loggedIn) {
-          // Create a credential from the access token
-          final twitterAuthCredential = TwitterAuthProvider.credential(
-            accessToken: authResult.authToken!,
-            secret: authResult.authTokenSecret!,
-          );
-
-          // Once signed in, return the UserCredential
-          await _auth.signInWithCredential(twitterAuthCredential);
-        }
+        // Once signed in, return the UserCredential
+        await _auth.signInWithCredential(twitterAuthCredential);
       }
-    } on FirebaseAuthException catch (e) {
-      setState(() {
-        error = '${e.message}';
-      });
-    } finally {
-      setIsLoading();
+    }
+  }
+
+  Future<void> _signInWithApple() async {
+    if (kIsWeb) {
+      final appleProvider = AppleAuthProvider();
+
+      // Once signed in, return the UserCredential
+      await _auth.signInWithPopup(appleProvider);
+    } else {
+      final appleProvider = AppleAuthProvider();
+
+      await _auth.signInWithAuthProvider(appleProvider);
     }
   }
 
   Future<void> _signInWithGitHub() async {
-    setIsLoading();
+    if (kIsWeb) {
+      // Create a new provider
+      final githubProvider = GithubAuthProvider();
 
-    try {
-      if (kIsWeb) {
-        // Create a new provider
-        GithubAuthProvider githubProvider = GithubAuthProvider();
+      // Once signed in, return the UserCredential
+      await _auth.signInWithPopup(githubProvider);
+    } else {
+      // Create a new provider
+      final githubProvider = GithubAuthProvider();
 
-        // Once signed in, return the UserCredential
-        await _auth.signInWithPopup(githubProvider);
-      } else {
-        // Create a new provider
-        GithubAuthProvider githubProvider = GithubAuthProvider();
-
-        await _auth.signInWithAuthProvider(githubProvider);
-      }
-    } on FirebaseAuthException catch (e) {
-      setState(() {
-        error = '${e.message}';
-      });
-    } finally {
-      setIsLoading();
+      await _auth.signInWithAuthProvider(githubProvider);
     }
   }
 }

--- a/packages/firebase_auth/firebase_auth/example/macos/Podfile
+++ b/packages/firebase_auth/firebase_auth/example/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.12'
+platform :osx, '10.15'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/firebase_auth/firebase_auth/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/firebase_auth/firebase_auth/example/macos/Runner.xcodeproj/project.pbxproj
@@ -326,6 +326,7 @@
 				"${BUILT_PRODUCTS_DIR}/FirebaseAuth/FirebaseAuth.framework",
 				"${BUILT_PRODUCTS_DIR}/FirebaseCore/FirebaseCore.framework",
 				"${BUILT_PRODUCTS_DIR}/FirebaseCoreDiagnostics/FirebaseCoreDiagnostics.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseCoreInternal/FirebaseCoreInternal.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleDataTransport/GoogleDataTransport.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
@@ -338,6 +339,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseAuth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCoreDiagnostics.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCoreInternal.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleDataTransport.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
@@ -442,7 +444,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 7K2HVKAM5V;
+				DEVELOPMENT_TEAM = YYX2P3XVJ7;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter/ephemeral",
@@ -575,7 +577,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 7K2HVKAM5V;
+				DEVELOPMENT_TEAM = YYX2P3XVJ7;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter/ephemeral",
@@ -602,7 +604,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 7K2HVKAM5V;
+				DEVELOPMENT_TEAM = YYX2P3XVJ7;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter/ephemeral",

--- a/packages/firebase_auth/firebase_auth/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/firebase_auth/firebase_auth/example/macos/Runner/DebugProfile.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>

--- a/packages/firebase_auth/firebase_auth/example/macos/Runner/Release.entitlements
+++ b/packages/firebase_auth/firebase_auth/example/macos/Runner/Release.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -12,6 +12,8 @@
 
 #import "Private/CustomPigeonHeader.h"
 #import "Public/FLTFirebaseAuthPlugin.h"
+@import CommonCrypto;
+#import <AuthenticationServices/AuthenticationServices.h>
 
 NSString *const kFLTFirebaseAuthChannelName = @"plugins.flutter.io/firebase_auth";
 
@@ -25,6 +27,7 @@ NSString *const kSignInMethodFacebook = @"facebook.com";
 NSString *const kSignInMethodGoogle = @"google.com";
 NSString *const kSignInMethodTwitter = @"twitter.com";
 NSString *const kSignInMethodGithub = @"github.com";
+NSString *const kSignInMethodApple = @"apple.com";
 NSString *const kSignInMethodPhone = @"phone";
 NSString *const kSignInMethodOAuth = @"oauth";
 
@@ -62,6 +65,10 @@ NSString *const kErrMsgInvalidCredential =
 @interface FLTFirebaseAuthPlugin ()
 @property(nonatomic, retain) NSObject<FlutterBinaryMessenger> *messenger;
 @property(strong, nonatomic) FIROAuthProvider *authProvider;
+@property(strong, nonatomic) NSString *currentNonce;
+@property(strong, nonatomic) FLTFirebaseMethodCallResult *appleResult;
+@property(strong, nonatomic) id appleArguments;
+
 @end
 
 @implementation FLTFirebaseAuthPlugin {
@@ -487,8 +494,130 @@ NSString *const kErrMsgInvalidCredential =
                   }];
 }
 
+// Adapted from https://auth0.com/docs/api-auth/tutorials/nonce#generate-a-cryptographically-random-nonce
+// Used for Apple Sign In
+- (NSString *)randomNonce:(NSInteger)length {
+  NSAssert(length > 0, @"Expected nonce to have positive length");
+  NSString *characterSet = @"0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._";
+  NSMutableString *result = [NSMutableString string];
+  NSInteger remainingLength = length;
+
+  while (remainingLength > 0) {
+    NSMutableArray *randoms = [NSMutableArray arrayWithCapacity:16];
+    for (NSInteger i = 0; i < 16; i++) {
+      uint8_t random = 0;
+      int errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random);
+      NSAssert(errorCode == errSecSuccess, @"Unable to generate nonce: OSStatus %i", errorCode);
+
+      [randoms addObject:@(random)];
+    }
+
+    for (NSNumber *random in randoms) {
+      if (remainingLength == 0) {
+        break;
+      }
+
+      if (random.unsignedIntValue < characterSet.length) {
+        unichar character = [characterSet characterAtIndex:random.unsignedIntValue];
+        [result appendFormat:@"%C", character];
+        remainingLength--;
+      }
+    }
+  }
+
+  return [result copy];
+}
+
+
+- (NSString *)stringBySha256HashingString:(NSString *)input {
+  const char *string = [input UTF8String];
+  unsigned char result[CC_SHA256_DIGEST_LENGTH];
+  CC_SHA256(string, (CC_LONG)strlen(string), result);
+
+  NSMutableString *hashed = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+  for (NSInteger i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
+    [hashed appendFormat:@"%02x", result[i]];
+  }
+  return hashed;
+}
+
+
+
+- (void)authorizationController:(ASAuthorizationController *)controller
+   didCompleteWithAuthorization:(ASAuthorization *)authorization API_AVAILABLE(macos(10.15), ios(13.0)) {
+  if ([authorization.credential isKindOfClass:[ASAuthorizationAppleIDCredential class]]) {
+    ASAuthorizationAppleIDCredential *appleIDCredential = authorization.credential;
+    NSString *rawNonce = self.currentNonce;
+    NSAssert(rawNonce != nil, @"Invalid state: A login callback was received, but no login request was sent.");
+
+    if (appleIDCredential.identityToken == nil) {
+      NSLog(@"Unable to fetch identity token.");
+      return;
+    }
+
+    NSString *idToken = [[NSString alloc] initWithData:appleIDCredential.identityToken
+                                              encoding:NSUTF8StringEncoding];
+    if (idToken == nil) {
+      NSLog(@"Unable to serialize id token from data: %@", appleIDCredential.identityToken);
+    }
+
+    // Initialize a Firebase credential.
+    FIROAuthCredential *credential = [FIROAuthProvider credentialWithProviderID:@"apple.com"
+                                                                        IDToken:idToken
+                                                                       rawNonce:rawNonce];
+
+    // Sign in with Firebase.
+    [[FIRAuth auth] signInWithCredential:credential
+                              completion:^(FIRAuthDataResult * _Nullable authResult,
+                                           NSError * _Nullable error) {
+      if (error != nil) {
+          if (error.code == FIRAuthErrorCodeSecondFactorRequired) {
+            [self handleMultiFactorError:self.appleArguments
+                              withResult:self.appleResult
+                               withError:error];
+          } else {
+              self.appleResult.error(nil, nil, nil, error);
+          }
+          return;
+      }
+      self.appleResult.success(authResult);
+    }];
+  }
+}
+
+- (void)authorizationController:(ASAuthorizationController *)controller
+           didCompleteWithError:(NSError *)error API_AVAILABLE(macos(10.15), ios(13.0)) {
+  NSLog(@"Sign in with Apple errored: %@", error);
+  self.appleResult.error(nil, nil, nil, error);
+}
+
+
+
 - (void)signInWithAuthProvider:(id)arguments
           withMethodCallResult:(FLTFirebaseMethodCallResult *)result {
+    if ([arguments[@"signInProvider"] isEqualToString:kSignInMethodApple]) {
+        if (@available(iOS 13.0, macOS 10.15, *)) {
+            NSString *nonce = [self randomNonce:32];
+            self.currentNonce = nonce;
+            self.appleResult = result;
+            self.appleArguments = arguments;
+
+            ASAuthorizationAppleIDProvider *appleIDProvider = [[ASAuthorizationAppleIDProvider alloc] init];
+            
+            ASAuthorizationAppleIDRequest *request = [appleIDProvider createRequest];
+            request.requestedScopes = @[ASAuthorizationScopeFullName, ASAuthorizationScopeEmail];
+            request.nonce = [self stringBySha256HashingString:nonce];
+
+            ASAuthorizationController *authorizationController =
+                [[ASAuthorizationController alloc] initWithAuthorizationRequests:@[request]];
+            authorizationController.delegate = self;
+            authorizationController.presentationContextProvider = self;
+            [authorizationController performRequests];
+        } else {
+            NSLog(@"Sign in with Apple was introduced in iOS 13, update your Podfile with platform :ios, '13.0'");
+        }
+        return;
+    }
 #if TARGET_OS_OSX
   NSLog(@"The Firebase Phone Authentication provider is not supported on the "
         @"MacOS platform.");
@@ -1618,5 +1747,13 @@ NSString *const kErrMsgInvalidCredential =
 }
 
 #endif
+
+- (nonnull ASPresentationAnchor)presentationAnchorForAuthorizationController:(nonnull ASAuthorizationController *)controller  API_AVAILABLE(macos(10.15), ios(13.0)){
+#if TARGET_OS_OSX
+    return [[NSApplication sharedApplication] keyWindow];
+#else
+    return [[UIApplication sharedApplication] keyWindow];
+#endif
+}
 
 @end

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -494,8 +494,9 @@ NSString *const kErrMsgInvalidCredential =
                   }];
 }
 
-// Adapted from https://auth0.com/docs/api-auth/tutorials/nonce#generate-a-cryptographically-random-nonce
-// Used for Apple Sign In
+// Adapted from
+// https://auth0.com/docs/api-auth/tutorials/nonce#generate-a-cryptographically-random-nonce Used
+// for Apple Sign In
 - (NSString *)randomNonce:(NSInteger)length {
   NSAssert(length > 0, @"Expected nonce to have positive length");
   NSString *characterSet = @"0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._";
@@ -528,7 +529,6 @@ NSString *const kErrMsgInvalidCredential =
   return [result copy];
 }
 
-
 - (NSString *)stringBySha256HashingString:(NSString *)input {
   const char *string = [input UTF8String];
   unsigned char result[CC_SHA256_DIGEST_LENGTH];
@@ -541,14 +541,14 @@ NSString *const kErrMsgInvalidCredential =
   return hashed;
 }
 
-
-
 - (void)authorizationController:(ASAuthorizationController *)controller
-   didCompleteWithAuthorization:(ASAuthorization *)authorization API_AVAILABLE(macos(10.15), ios(13.0)) {
+    didCompleteWithAuthorization:(ASAuthorization *)authorization
+    API_AVAILABLE(macos(10.15), ios(13.0)) {
   if ([authorization.credential isKindOfClass:[ASAuthorizationAppleIDCredential class]]) {
     ASAuthorizationAppleIDCredential *appleIDCredential = authorization.credential;
     NSString *rawNonce = self.currentNonce;
-    NSAssert(rawNonce != nil, @"Invalid state: A login callback was received, but no login request was sent.");
+    NSAssert(rawNonce != nil,
+             @"Invalid state: A login callback was received, but no login request was sent.");
 
     if (appleIDCredential.identityToken == nil) {
       NSLog(@"Unable to fetch identity token.");
@@ -567,21 +567,21 @@ NSString *const kErrMsgInvalidCredential =
                                                                        rawNonce:rawNonce];
 
     // Sign in with Firebase.
-    [[FIRAuth auth] signInWithCredential:credential
-                              completion:^(FIRAuthDataResult * _Nullable authResult,
-                                           NSError * _Nullable error) {
-      if (error != nil) {
-          if (error.code == FIRAuthErrorCodeSecondFactorRequired) {
-            [self handleMultiFactorError:self.appleArguments
-                              withResult:self.appleResult
-                               withError:error];
-          } else {
-              self.appleResult.error(nil, nil, nil, error);
-          }
-          return;
-      }
-      self.appleResult.success(authResult);
-    }];
+    [[FIRAuth auth]
+        signInWithCredential:credential
+                  completion:^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error) {
+                    if (error != nil) {
+                      if (error.code == FIRAuthErrorCodeSecondFactorRequired) {
+                        [self handleMultiFactorError:self.appleArguments
+                                          withResult:self.appleResult
+                                           withError:error];
+                      } else {
+                        self.appleResult.error(nil, nil, nil, error);
+                      }
+                      return;
+                    }
+                    self.appleResult.success(authResult);
+                  }];
   }
 }
 
@@ -591,33 +591,33 @@ NSString *const kErrMsgInvalidCredential =
   self.appleResult.error(nil, nil, nil, error);
 }
 
-
-
 - (void)signInWithAuthProvider:(id)arguments
           withMethodCallResult:(FLTFirebaseMethodCallResult *)result {
-    if ([arguments[@"signInProvider"] isEqualToString:kSignInMethodApple]) {
-        if (@available(iOS 13.0, macOS 10.15, *)) {
-            NSString *nonce = [self randomNonce:32];
-            self.currentNonce = nonce;
-            self.appleResult = result;
-            self.appleArguments = arguments;
+  if ([arguments[@"signInProvider"] isEqualToString:kSignInMethodApple]) {
+    if (@available(iOS 13.0, macOS 10.15, *)) {
+      NSString *nonce = [self randomNonce:32];
+      self.currentNonce = nonce;
+      self.appleResult = result;
+      self.appleArguments = arguments;
 
-            ASAuthorizationAppleIDProvider *appleIDProvider = [[ASAuthorizationAppleIDProvider alloc] init];
-            
-            ASAuthorizationAppleIDRequest *request = [appleIDProvider createRequest];
-            request.requestedScopes = @[ASAuthorizationScopeFullName, ASAuthorizationScopeEmail];
-            request.nonce = [self stringBySha256HashingString:nonce];
+      ASAuthorizationAppleIDProvider *appleIDProvider =
+          [[ASAuthorizationAppleIDProvider alloc] init];
 
-            ASAuthorizationController *authorizationController =
-                [[ASAuthorizationController alloc] initWithAuthorizationRequests:@[request]];
-            authorizationController.delegate = self;
-            authorizationController.presentationContextProvider = self;
-            [authorizationController performRequests];
-        } else {
-            NSLog(@"Sign in with Apple was introduced in iOS 13, update your Podfile with platform :ios, '13.0'");
-        }
-        return;
+      ASAuthorizationAppleIDRequest *request = [appleIDProvider createRequest];
+      request.requestedScopes = @[ ASAuthorizationScopeFullName, ASAuthorizationScopeEmail ];
+      request.nonce = [self stringBySha256HashingString:nonce];
+
+      ASAuthorizationController *authorizationController =
+          [[ASAuthorizationController alloc] initWithAuthorizationRequests:@[ request ]];
+      authorizationController.delegate = self;
+      authorizationController.presentationContextProvider = self;
+      [authorizationController performRequests];
+    } else {
+      NSLog(@"Sign in with Apple was introduced in iOS 13, update your Podfile with platform :ios, "
+            @"'13.0'");
     }
+    return;
+  }
 #if TARGET_OS_OSX
   NSLog(@"The Firebase Phone Authentication provider is not supported on the "
         @"MacOS platform.");
@@ -1748,11 +1748,12 @@ NSString *const kErrMsgInvalidCredential =
 
 #endif
 
-- (nonnull ASPresentationAnchor)presentationAnchorForAuthorizationController:(nonnull ASAuthorizationController *)controller  API_AVAILABLE(macos(10.15), ios(13.0)){
+- (nonnull ASPresentationAnchor)presentationAnchorForAuthorizationController:
+    (nonnull ASAuthorizationController *)controller API_AVAILABLE(macos(10.15), ios(13.0)) {
 #if TARGET_OS_OSX
-    return [[NSApplication sharedApplication] keyWindow];
+  return [[NSApplication sharedApplication] keyWindow];
 #else
-    return [[UIApplication sharedApplication] keyWindow];
+  return [[UIApplication sharedApplication] keyWindow];
 #endif
 }
 

--- a/packages/firebase_auth/firebase_auth/ios/Classes/Public/FLTFirebaseAuthPlugin.h
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/Public/FLTFirebaseAuthPlugin.h
@@ -14,9 +14,10 @@
 #import <Foundation/Foundation.h>
 #import <firebase_core/FLTFirebasePlugin.h>
 #import "messages.g.h"
+#import <AuthenticationServices/AuthenticationServices.h>
 
 @interface FLTFirebaseAuthPlugin
-    : FLTFirebasePlugin <FlutterPlugin, MultiFactorUserHostApi, MultiFactoResolverHostApi>
+    : FLTFirebasePlugin <FlutterPlugin, MultiFactorUserHostApi, MultiFactoResolverHostApi, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding>
 
 + (id)getNSDictionaryFromAuthCredential:(FIRAuthCredential *)authCredential;
 + (NSDictionary *)getNSDictionaryFromUserInfo:(id<FIRUserInfo>)userInfo;

--- a/packages/firebase_auth/firebase_auth/ios/Classes/Public/FLTFirebaseAuthPlugin.h
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/Public/FLTFirebaseAuthPlugin.h
@@ -11,13 +11,17 @@
 #import <Flutter/Flutter.h>
 #endif
 
+#import <AuthenticationServices/AuthenticationServices.h>
 #import <Foundation/Foundation.h>
 #import <firebase_core/FLTFirebasePlugin.h>
 #import "messages.g.h"
-#import <AuthenticationServices/AuthenticationServices.h>
 
 @interface FLTFirebaseAuthPlugin
-    : FLTFirebasePlugin <FlutterPlugin, MultiFactorUserHostApi, MultiFactoResolverHostApi, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding>
+    : FLTFirebasePlugin <FlutterPlugin,
+                         MultiFactorUserHostApi,
+                         MultiFactoResolverHostApi,
+                         ASAuthorizationControllerDelegate,
+                         ASAuthorizationControllerPresentationContextProviding>
 
 + (id)getNSDictionaryFromAuthCredential:(FIRAuthCredential *)authCredential;
 + (NSDictionary *)getNSDictionaryFromUserInfo:(id<FIRUserInfo>)userInfo;

--- a/packages/firebase_auth/firebase_auth/lib/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/firebase_auth.dart
@@ -30,6 +30,7 @@ export 'package:firebase_auth_platform_interface/firebase_auth_platform_interfac
         PhoneCodeSent,
         PhoneCodeAutoRetrievalTimeout,
         AuthCredential,
+        AppleAuthProvider,
         EmailAuthProvider,
         EmailAuthCredential,
         FacebookAuthProvider,

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/firebase_auth_platform_interface.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/firebase_auth_platform_interface.dart
@@ -19,6 +19,7 @@ export 'src/platform_interface/platform_interface_multi_factor.dart';
 export 'src/platform_interface/platform_interface_recaptcha_verifier_factory.dart';
 export 'src/platform_interface/platform_interface_user.dart';
 export 'src/platform_interface/platform_interface_user_credential.dart';
+export 'src/providers/apple_auth.dart';
 export 'src/providers/email_auth.dart';
 export 'src/providers/facebook_auth.dart';
 export 'src/providers/github_auth.dart';

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/apple_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/apple_auth.dart
@@ -1,0 +1,101 @@
+// ignore_for_file: require_trailing_commas
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart';
+
+const _kProviderId = 'apple.com';
+
+/// This class should be used to either create a new Apple credential with an
+/// access code, or use the provider to trigger user authentication flows.
+///
+/// For example, on web based platforms pass the provider to a Firebase method
+/// (such as [signInWithPopup]):
+///
+/// ```dart
+/// var appleProvider = AppleAuthProvider();
+/// appleProvider.addScope('email');
+/// appleProvider.setCustomParameters({
+///   'locale': 'fr',
+/// });
+///
+/// FirebaseAuth.instance.signInWithPopup(appleProvider)
+///   .then(...);
+/// ```
+///
+/// If authenticating with Apple via a 3rd party, use the returned
+/// `accessToken` to sign-in or link the user with the created credential, for
+/// example:
+///
+/// ```dart
+/// String accessToken = '...'; // From 3rd party provider
+/// var appleAuthCredential = AppleAuthProvider.credential(accessToken);
+///
+/// FirebaseAuth.instance.signInWithCredential(appleAuthCredential)
+///   .then(...);
+/// ```
+class AppleAuthProvider extends AuthProvider {
+  /// Creates a new instance.
+  AppleAuthProvider() : super(_kProviderId);
+
+  /// Create a new [AppleAuthCredential] from a provided [accessToken];
+  static OAuthCredential credential(String accessToken) {
+    return AppleAuthCredential._credential(
+      accessToken,
+    );
+  }
+
+  /// This corresponds to the sign-in method identifier.
+  static String get APPLE_SIGN_IN_METHOD {
+    return _kProviderId;
+  }
+
+  // ignore: public_member_api_docs
+  static String get PROVIDER_ID {
+    return _kProviderId;
+  }
+
+  List<String> _scopes = [];
+  Map<dynamic, dynamic> _parameters = {};
+
+  /// Returns the currently assigned scopes to this provider instance.
+  List<String> get scopes {
+    return _scopes;
+  }
+
+  /// Returns the parameters for this provider instance.
+  Map<dynamic, dynamic> get parameters {
+    return _parameters;
+  }
+
+  /// Adds Apple OAuth scope.
+  AppleAuthProvider addScope(String scope) {
+    _scopes.add(scope);
+    return this;
+  }
+
+  /// Sets the OAuth custom parameters to pass in a Apple OAuth
+  /// request for popup and redirect sign-in operations.
+  AppleAuthProvider setCustomParameters(
+    Map<dynamic, dynamic> customOAuthParameters,
+  ) {
+    _parameters = customOAuthParameters;
+    return this;
+  }
+}
+
+/// The auth credential returned from calling
+/// [AppleAuthProvider.credential].
+class AppleAuthCredential extends OAuthCredential {
+  AppleAuthCredential._({
+    required String accessToken,
+  }) : super(
+            providerId: _kProviderId,
+            signInMethod: _kProviderId,
+            accessToken: accessToken);
+
+  factory AppleAuthCredential._credential(String accessToken) {
+    return AppleAuthCredential._(accessToken: accessToken);
+  }
+}

--- a/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
@@ -194,6 +194,15 @@ auth_interop.AuthProvider convertPlatformAuthProvider(
     return facebookAuthProvider;
   }
 
+  if (authProvider is AppleAuthProvider) {
+    auth_interop.OAuthProvider oAuthProvider =
+        auth_interop.OAuthProvider(authProvider.providerId);
+
+    authProvider.scopes.forEach(oAuthProvider.addScope);
+    oAuthProvider.setCustomParameters(authProvider.parameters);
+    return oAuthProvider;
+  }
+
   if (authProvider is GithubAuthProvider) {
     auth_interop.GithubAuthProvider githubAuthProvider =
         auth_interop.GithubAuthProvider();


### PR DESCRIPTION

## Description

We currently rely on [sign_in_with_apple](https://pub.dev/packages/sign_in_with_apple) for Sign In With Apple. We now recommend directly using directly Firebase to connect with Apple.

## Related Issues

Closes https://github.com/firebase/flutterfire/discussions/5560

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
