### PR TITLE
fix(firebase_core): provide better errors for accessing an uninitialized app.

### DIFF
--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_core_exceptions.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_core_exceptions.dart
@@ -7,12 +7,30 @@ part of firebase_core_platform_interface;
 
 /// Throws a consistent cross-platform error message when usage of an app occurs but
 /// no app has been created.
-FirebaseException noAppExists(String appName) {
-  return FirebaseException(
-      plugin: 'core',
-      code: 'no-app',
-      message:
-          "No Firebase App '$appName' has been created - call Firebase.initializeApp()");
+FirebaseException noAppExists(String appName, Set<String> availableApps) {
+  if (availableApps.isEmpty) {
+    return FirebaseException(
+        plugin: 'core',
+        code: 'no-app',
+        message:
+            "No Firebase App '$appName' has been created - call Firebase.initializeApp()");
+  } else if (appName == defaultFirebaseAppName) {
+    return FirebaseException(
+        plugin: 'core',
+        code: 'no-app',
+        message:
+            'The default Firebase App has not been created. Either initialize a'
+            ' default app by calling Firebase.initializeApp() with no `name`'
+            ' parameter, or look up the app by name. Available apps:'
+            ' ${availableApps}');
+  } else {
+    return FirebaseException(
+        plugin: 'core',
+        code: 'no-app',
+        message:
+            "No Firebase App '$appName' has been created. Available apps:"
+            ' ${availableApps}');
+  }
 }
 
 /// Throws a consistent cross-platform error message when an app is being created

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -265,8 +265,16 @@ class FirebaseCoreWeb extends FirebasePlatform {
     try {
       app = guardNotInitialized(() => firebase.app(name));
     } catch (e) {
+      final Set<String> availableApps = {};
+      try {
+        availableApps.addAll(apps.map((app) => app.name));
+      } catch (_) {
+        // If we fail to get apps here, that's OK. Continue with an
+        // empty set of apps.
+      }
+
       if (_getJSErrorCode(e) == 'app/no-app') {
-        throw noAppExists(name);
+        throw noAppExists(name, availableApps);
       }
 
       throw _catchJSError(e);


### PR DESCRIPTION
Also provide a warning for native apps that are loaded from android
resources, as these may give users a false impression that their flutter
firebase config will work cross platform.

I did have issues using melos:

```bash
Michaels-MBP:flutterfire mike$ melos bootstrap
melos bootstrap
  └> /Users/mike/projects/flutterfire

Running "flutter pub get" in workspace packages...
Note: this may take a while in large workspaces such as this one.
  ✓ cloud_firestore
    └> packages/cloud_firestore/cloud_firestore
  ✓ cloud_firestore_example
    └> packages/cloud_firestore/cloud_firestore/example
  ✓ cloud_firestore_odm
    └> packages/cloud_firestore_odm/cloud_firestore_odm
  ✓ cloud_firestore_odm_example
    └> packages/cloud_firestore_odm/cloud_firestore_odm/example
  - cloud_firestore_odm_generator
    └> packages/cloud_firestore_odm/cloud_firestore_odm_generator
       └> Failed to install.

Resolving dependencies...
Because every version of firebase_core_web from path depends on flutter_web_plugins from sdk which is forbidden, firebase_core_web from path is forbidden.
So, because cloud_firestore_odm_generator depends on firebase_core_web from path, version solving failed.
Flutter users should run `flutter pub get` instead of `dart pub get`.
BootstrapException: Failed to install.: cloud_firestore_odm_generator at /Users/mike/projects/flutterfire/packages/cloud_firestore_odm/cloud_firestore_odm_generator.
````

## Description

This new error messaging and warnings is intended to make it easier to diagnose what was happening to me in #9400. It is possible this has happened to others as well, though how often is unknown.

## Related Issues

#9400 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
