### PR TITLE
feat(auth): add `linkWithProvider` to support for linking auth providers

### DIFF
--- a/docs/auth/federated-auth.md
+++ b/docs/auth/federated-auth.md
@@ -359,7 +359,7 @@ final appleProvider = AppleAuthProvider();
 if (kIsWeb) {
   await FirebaseAuth.instance.currentUser?.linkWithPopup(appleProvider);
 } else {
-  await FirebaseAuth.instance.currentUser?.linkWithAuthProvider(appleProvider);
+  await FirebaseAuth.instance.currentUser?.linkWithProvider(appleProvider);
 }
 
 // You're anonymous user is now upgraded to be able to connect with Sign In With Apple

--- a/docs/auth/federated-auth.md
+++ b/docs/auth/federated-auth.md
@@ -349,6 +349,7 @@ Future<UserCredential> signInWithYahoo() async {
 
 
 # Linking an Authentication Provider
+
 If you want to link a provider to a current user, you can use the following method:
 ```dart
 await FirebaseAuth.instance.signInAnonymously();

--- a/docs/auth/federated-auth.md
+++ b/docs/auth/federated-auth.md
@@ -346,3 +346,20 @@ Future<UserCredential> signInWithYahoo() async {
   }
 }
 ```
+
+
+# Linking an Authentication Provider
+If you want to link a provider to a current user, you can use the following method:
+```dart
+await FirebaseAuth.instance.signInAnonymously();
+
+final appleProvider = AppleAuthProvider();
+
+if (kIsWeb) {
+  await FirebaseAuth.instance.currentUser?.linkWithPopup(appleProvider);
+} else {
+  await FirebaseAuth.instance.currentUser?.linkWithAuthProvider(appleProvider);
+}
+
+// You're anonymous user is now upgraded to be able to connect with Sign In With Apple
+```

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -1494,8 +1494,8 @@ public class FlutterFirebaseAuthPlugin
       case "Auth#signInWithAuthProvider":
         methodCallTask = signInWithAuthProvider(call.arguments());
         break;
-      case "User#linkWithAuthProvider":
-        methodCallTask = startActivityForlinkWithAuthProvider(call.arguments());
+      case "User#linkWithProvider":
+        methodCallTask = startActivityForLinkWithProvider(call.arguments());
         break;
       case "User#delete":
         methodCallTask = deleteUser(call.arguments());
@@ -1552,7 +1552,7 @@ public class FlutterFirebaseAuthPlugin
         });
   }
 
-  private Task<Map<String, Object>> startActivityForlinkWithAuthProvider(
+  private Task<Map<String, Object>> startActivityForLinkWithProvider(
       Map<String, Object> arguments) {
     TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
 

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -1494,6 +1494,9 @@ public class FlutterFirebaseAuthPlugin
       case "Auth#signInWithAuthProvider":
         methodCallTask = signInWithAuthProvider(call.arguments());
         break;
+      case "User#linkWithAuthProvider":
+        methodCallTask = startActivityForlinkWithAuthProvider(call.arguments());
+        break;
       case "User#delete":
         methodCallTask = deleteUser(call.arguments());
         break;
@@ -1547,6 +1550,48 @@ public class FlutterFirebaseAuthPlugin
                 getExceptionDetails(exception));
           }
         });
+  }
+
+  private Task<Map<String, Object>> startActivityForlinkWithAuthProvider(
+      Map<String, Object> arguments) {
+    TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
+
+    cachedThreadPool.execute(
+        () -> {
+          try {
+            FirebaseUser firebaseUser = getCurrentUser(arguments);
+
+            String providerId =
+                (String) Objects.requireNonNull(arguments.get(Constants.SIGN_IN_PROVIDER));
+            @SuppressWarnings("unchecked")
+            List<String> scopes = (List<String>) arguments.get(Constants.SIGN_IN_PROVIDER_SCOPE);
+            @SuppressWarnings("unchecked")
+            Map<String, String> customParameters =
+                (Map<String, String>) arguments.get(Constants.SIGN_IN_PROVIDER_CUSTOM_PARAMETERS);
+
+            OAuthProvider.Builder provider = OAuthProvider.newBuilder(providerId);
+            if (scopes != null) {
+              provider.setScopes(scopes);
+            }
+            if (customParameters != null) {
+              provider.addCustomParameters(customParameters);
+            }
+
+            AuthResult authResult =
+                Tasks.await(
+                    firebaseUser.startActivityForLinkWithProvider(
+                        /* activity= */ activity, provider.build()));
+            taskCompletionSource.setResult(parseAuthResult(authResult));
+          } catch (Exception e) {
+            if (e.getCause() instanceof FirebaseAuthMultiFactorException) {
+              handleMultiFactorException(arguments, taskCompletionSource, e);
+            } else {
+              taskCompletionSource.setException(e);
+            }
+          }
+        });
+
+    return taskCompletionSource.getTask();
   }
 
   private Task<Map<String, Object>> signInWithAuthProvider(Map<String, Object> arguments) {

--- a/packages/firebase_auth/firebase_auth/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/firebase_auth/firebase_auth/example/macos/Runner.xcodeproj/project.pbxproj
@@ -332,7 +332,6 @@
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
 				"${BUILT_PRODUCTS_DIR}/PromisesObjC/FBLPromises.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
-				"${BUILT_PRODUCTS_DIR}/url_launcher_macos/url_launcher_macos.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -345,7 +344,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBLPromises.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher_macos.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -621,7 +621,7 @@ static void handleSignInWithApple(FLTFirebaseAuthPlugin *object, FIRAuthDataResu
     return;
   }
 #if TARGET_OS_OSX
-  NSLog(@"signInWithAuthProvider is not supported on the "
+  NSLog(@"signInWithProvider is not supported on the "
         @"MacOS platform.");
   result.success(nil);
 #else

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -920,8 +920,8 @@ static void launchAppleSignInRequest(FLTFirebaseAuthPlugin *object, id arguments
 }
 
 static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, id arguments, FIRAuth *auth,
-                                    FIRAuthCredential *credentials, NSError *error,
-                                    FLTFirebaseMethodCallResult *result) {
+                                  FIRAuthCredential *credentials, NSError *error,
+                                  FLTFirebaseMethodCallResult *result) {
   if (error) {
     if (error.code == FIRAuthErrorCodeSecondFactorRequired) {
       [object handleMultiFactorError:arguments withResult:result withError:error];

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -621,7 +621,7 @@ static void handleSignInWithApple(FLTFirebaseAuthPlugin *object, FIRAuthDataResu
     return;
   }
 #if TARGET_OS_OSX
-  NSLog(@"The Firebase Phone Authentication provider is not supported on the "
+  NSLog(@"signInWithAuthProvider is not supported on the "
         @"MacOS platform.");
   result.success(nil);
 #else
@@ -976,7 +976,7 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, id arguments, F
     return;
   }
 #if TARGET_OS_OSX
-  NSLog(@"The Firebase Phone Authentication provider is not supported on the "
+  NSLog(@"linkWithAuthProvider is not supported on the "
         @"MacOS platform.");
   result.success(nil);
 #else

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -640,7 +640,7 @@ static void handleSignInWithApple(FLTFirebaseAuthPlugin *object, FIRAuthDataResu
       getCredentialWithUIDelegate:nil
                        completion:^(FIRAuthCredential *_Nullable credential,
                                     NSError *_Nullable error) {
-                         handleAppleSignInResult(self, arguments, auth, credential, error, result);
+                         handleAppleAuthResult(self, arguments, auth, credential, error, result);
                        }];
 #endif
 }
@@ -919,7 +919,7 @@ static void launchAppleSignInRequest(FLTFirebaseAuthPlugin *object, id arguments
   [authorizationController performRequests];
 }
 
-static void handleAppleSignInResult(FLTFirebaseAuthPlugin *object, id arguments, FIRAuth *auth,
+static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, id arguments, FIRAuth *auth,
                                     FIRAuthCredential *credentials, NSError *error,
                                     FLTFirebaseMethodCallResult *result) {
   if (error) {
@@ -994,7 +994,7 @@ static void handleAppleSignInResult(FLTFirebaseAuthPlugin *object, id arguments,
       linkWithProvider:self.authProvider
             UIDelegate:nil
             completion:^(FIRAuthDataResult *authResult, NSError *error) {
-              handleAppleSignInResult(self, arguments, auth, authResult.credential, error, result);
+              handleAppleAuthResult(self, arguments, auth, authResult.credential, error, result);
             }];
 #endif
 }

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -251,7 +251,7 @@ NSString *const kErrMsgInvalidCredential =
     [self userGetIdToken:call.arguments withMethodCallResult:methodCallResult];
   } else if ([@"User#linkWithCredential" isEqualToString:call.method]) {
     [self userLinkWithCredential:call.arguments withMethodCallResult:methodCallResult];
-  } else if ([@"User#linkWithAuthProvider" isEqualToString:call.method]) {
+  } else if ([@"User#linkWithProvider" isEqualToString:call.method]) {
     [self userLinkWithProvider:call.arguments withMethodCallResult:methodCallResult];
   } else if ([@"User#reauthenticateUserWithCredential" isEqualToString:call.method]) {
     [self userReauthenticateUserWithCredential:call.arguments
@@ -976,7 +976,7 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, id arguments, F
     return;
   }
 #if TARGET_OS_OSX
-  NSLog(@"linkWithAuthProvider is not supported on the "
+  NSLog(@"linkWithProvider is not supported on the "
         @"MacOS platform.");
   result.success(nil);
 #else

--- a/packages/firebase_auth/firebase_auth/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/user.dart
@@ -226,13 +226,13 @@ class User {
   ///  - Thrown if you have not enabled the provider in the Firebase Console. Go
   ///    to the Firebase Console for your project, in the Auth section and the
   ///    Sign in Method tab and configure the provider.
-  Future<UserCredential> linkWithAuthProvider(
+  Future<UserCredential> linkWithProvider(
     AuthProvider provider,
   ) async {
     try {
       return UserCredential._(
         _auth,
-        await _delegate.linkWithAuthProvider(provider),
+        await _delegate.linkWithProvider(provider),
       );
     } on FirebaseAuthMultiFactorExceptionPlatform catch (e) {
       throw FirebaseAuthMultiFactorException._(_auth, e);

--- a/packages/firebase_auth/firebase_auth/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/user.dart
@@ -190,6 +190,57 @@ class User {
     );
   }
 
+  /// Links with an AuthProvider using native authentication flow.
+  /// On web, you should use [linkWithPopup] instead.
+  ///
+  /// A [FirebaseAuthException] maybe thrown with the following error code:
+  /// - **provider-already-linked**:
+  ///  - Thrown if the provider has already been linked to the user. This error
+  ///    is thrown even if this is not the same provider's account that is
+  ///    currently linked to the user.
+  /// - **invalid-credential**:
+  ///  - Thrown if the provider's credential is not valid. This can happen if it
+  ///    has already expired when calling link, or if it used invalid token(s).
+  ///    See the Firebase documentation for your provider, and make sure you
+  ///    pass in the correct parameters to the credential method.
+  /// - **credential-already-in-use**:
+  ///  - Thrown if the account corresponding to the credential already exists
+  ///    among your users, or is already linked to a Firebase User. For example,
+  ///    this error could be thrown if you are upgrading an anonymous user to a
+  ///    Google user by linking a Google credential to it and the Google
+  ///    credential used is already associated with an existing Firebase Google
+  ///    user. The fields `email`, `phoneNumber`, and `credential`
+  ///    ([AuthCredential]) may be provided, depending on the type of
+  ///    credential. You can recover from this error by signing in with
+  ///    `credential` directly via [signInWithCredential].
+  /// - **email-already-in-use**:
+  ///  - Thrown if the email corresponding to the credential already exists
+  ///    among your users. When thrown while linking a credential to an existing
+  ///    user, an `email` and `credential` ([AuthCredential]) fields are also
+  ///    provided. You have to link the credential to the existing user with
+  ///    that email if you wish to continue signing in with that credential.
+  ///    To do so, call [fetchSignInMethodsForEmail], sign in to `email` via one
+  ///    of the providers returned and then [User.linkWithCredential] the
+  ///    original credential to that newly signed in user.
+  /// - **operation-not-allowed**:
+  ///  - Thrown if you have not enabled the provider in the Firebase Console. Go
+  ///    to the Firebase Console for your project, in the Auth section and the
+  ///    Sign in Method tab and configure the provider.
+  Future<UserCredential> linkWithAuthProvider(
+    AuthProvider provider,
+  ) async {
+    try {
+      return UserCredential._(
+        _auth,
+        await _delegate.linkWithAuthProvider(provider),
+      );
+    } on FirebaseAuthMultiFactorExceptionPlatform catch (e) {
+      throw FirebaseAuthMultiFactorException._(_auth, e);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
   /// Links the user account with the given provider.
   ///
   /// A [FirebaseAuthException] maybe thrown with the following error code:
@@ -226,10 +277,16 @@ class User {
   ///    to the Firebase Console for your project, in the Auth section and the
   ///    Sign in Method tab and configure the provider.
   Future<UserCredential> linkWithPopup(AuthProvider provider) async {
-    return UserCredential._(
-      _auth,
-      await _delegate.linkWithPopup(provider),
-    );
+    try {
+      return UserCredential._(
+        _auth,
+        await _delegate.linkWithPopup(provider),
+      );
+    } on FirebaseAuthMultiFactorExceptionPlatform catch (e) {
+      throw FirebaseAuthMultiFactorException._(_auth, e);
+    } catch (e) {
+      rethrow;
+    }
   }
 
   /// Links the user account with the given phone number.

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_user.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_user.dart
@@ -101,7 +101,7 @@ class MethodChannelUser extends UserPlatform {
   }
 
   @override
-  Future<UserCredentialPlatform> linkWithAuthProvider(
+  Future<UserCredentialPlatform> linkWithProvider(
     AuthProvider provider,
   ) async {
     try {
@@ -110,7 +110,7 @@ class MethodChannelUser extends UserPlatform {
 
       Map<String, dynamic> data = (await MethodChannelFirebaseAuth.channel
           .invokeMapMethod<String, dynamic>(
-              'User#linkWithAuthProvider',
+              'User#linkWithProvider',
               _withChannelDefaults({
                 'signInProvider': convertedProvider.providerId,
                 if (convertedProvider is OAuthProvider) ...{

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_user.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_user.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart';
 import 'package:firebase_auth_platform_interface/src/method_channel/method_channel_firebase_auth.dart';
 import 'package:firebase_auth_platform_interface/src/method_channel/method_channel_user_credential.dart';
+import 'package:firebase_auth_platform_interface/src/method_channel/utils/convert_auth_provider.dart';
 
 import 'utils/exception.dart';
 
@@ -88,6 +89,35 @@ class MethodChannelUser extends UserPlatform {
                   'credential': credential.asMap(),
                 },
               )))!;
+
+      MethodChannelUserCredential userCredential =
+          MethodChannelUserCredential(auth, data);
+
+      auth.currentUser = userCredential.user;
+      return userCredential;
+    } catch (e, stack) {
+      convertPlatformException(e, stack);
+    }
+  }
+
+  @override
+  Future<UserCredentialPlatform> linkWithAuthProvider(
+    AuthProvider provider,
+  ) async {
+    try {
+      // To extract scopes and custom parameters from the provider
+      final convertedProvider = convertToOAuthProvider(provider);
+
+      Map<String, dynamic> data = (await MethodChannelFirebaseAuth.channel
+          .invokeMapMethod<String, dynamic>(
+              'User#linkWithAuthProvider',
+              _withChannelDefaults({
+                'signInProvider': convertedProvider.providerId,
+                if (convertedProvider is OAuthProvider) ...{
+                  'scopes': convertedProvider.scopes,
+                  'customParameters': convertedProvider.parameters
+                },
+              })))!;
 
       MethodChannelUserCredential userCredential =
           MethodChannelUserCredential(auth, data);

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_user_credential.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_user_credential.dart
@@ -28,6 +28,7 @@ class MethodChannelUserCredential extends UserCredentialPlatform {
               : AuthCredential(
                   providerId: data['authCredential']['providerId'],
                   signInMethod: data['authCredential']['signInMethod'],
+                  token: data['authCredential']['token'],
                 ),
           user: data['user'] == null
               ? null

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_user.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_user.dart
@@ -235,8 +235,8 @@ abstract class UserPlatform extends PlatformInterface {
   /// - **invalid-verification-id**:
   ///  - Thrown if the credential is a [PhoneAuthProvider.credential] and the
   ///    verification ID of the credential is not valid.
-  Future<UserCredentialPlatform> linkWithAuthProvider(AuthProvider provider) {
-    throw UnimplementedError('linkWithAuthProvider() is not implemented');
+  Future<UserCredentialPlatform> linkWithProvider(AuthProvider provider) {
+    throw UnimplementedError('linkWithProvider() is not implemented');
   }
 
   /// Links the user account with the given provider.

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_user.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_user.dart
@@ -193,6 +193,52 @@ abstract class UserPlatform extends PlatformInterface {
     throw UnimplementedError('linkWithCredential() is not implemented');
   }
 
+  /// Signs in with an AuthProvider using native authentication flow.
+  /// On Web you should use [linkWithPopup] instead.
+  ///
+  /// A [FirebaseAuthException] maybe thrown with the following error code:
+  /// - **provider-already-linked**:
+  ///  - Thrown if the provider has already been linked to the user. This error
+  ///    is thrown even if this is not the same provider's account that is
+  ///    currently linked to the user.
+  /// - **invalid-credential**:
+  ///  - Thrown if the provider's credential is not valid. This can happen if it
+  ///    has already expired when calling link, or if it used invalid token(s).
+  ///    See the Firebase documentation for your provider, and make sure you
+  ///    pass in the correct parameters to the credential method.
+  /// - **credential-already-in-use**:
+  ///  - Thrown if the account corresponding to the credential already exists
+  ///    among your users, or is already linked to a Firebase User. For example,
+  ///    this error could be thrown if you are upgrading an anonymous user to a
+  ///    Google user by linking a Google credential to it and the Google
+  ///    credential used is already associated with an existing Firebase Google
+  ///    user. The fields `email`, `phoneNumber`, and `credential`
+  ///    ([AuthCredential]) may be provided, depending on the type of
+  ///    credential. You can recover from this error by signing in with
+  ///    `credential` directly via [signInWithCredential].
+  /// - **email-already-in-use**:
+  ///  - Thrown if the email corresponding to the credential already exists
+  ///    among your users. When thrown while linking a credential to an existing
+  ///    user, an `email` and `credential` ([AuthCredential]) fields are also
+  ///    provided. You have to link the credential to the existing user with
+  ///    that email if you wish to continue signing in with that credential.
+  ///    To do so, call [fetchSignInMethodsForEmail], sign in to `email` via one
+  ///    of the providers returned and then [User.linkWithCredential] the
+  ///    original credential to that newly signed in user.
+  /// - **operation-not-allowed**:
+  ///  - Thrown if you have not enabled the provider in the Firebase Console. Go
+  ///    to the Firebase Console for your project, in the Auth section and the
+  ///    Sign in Method tab and configure the provider.
+  /// - **invalid-verification-code**:
+  ///  - Thrown if the credential is a [PhoneAuthProvider.credential] and the
+  ///    verification code of the credential is not valid.
+  /// - **invalid-verification-id**:
+  ///  - Thrown if the credential is a [PhoneAuthProvider.credential] and the
+  ///    verification ID of the credential is not valid.
+  Future<UserCredentialPlatform> linkWithAuthProvider(AuthProvider provider) {
+    throw UnimplementedError('linkWithAuthProvider() is not implemented');
+  }
+
   /// Links the user account with the given provider.
   ///
   /// A [FirebaseAuthException] maybe thrown with the following error code:


### PR DESCRIPTION
## Description

We were lacking the ability to link AuthProvider with currently connected users.
It's needed to upgrade anonymous users.

## Related Issues

Closes #9442

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
