### PR TITLE
refactor(auth): deprecate `signInWithAuthProvider` in favor of `signInWithProvider`

### DIFF
--- a/docs/auth/federated-auth.md
+++ b/docs/auth/federated-auth.md
@@ -196,7 +196,7 @@ Future<UserCredential> signInWithApple() async {
   if (kIsWeb) {
     await FirebaseAuth.instance.signInWithPopup(appleProvider);
   } else {
-    await FirebaseAuth.instance.signInWithAuthProvider(appleProvider);
+    await FirebaseAuth.instance.signInWithProvider(appleProvider);
   }
 }
 ```
@@ -225,7 +225,7 @@ Future<UserCredential> signInWithMicrosoft() async {
   if (kIsWeb) {
     await FirebaseAuth.instance.signInWithPopup(microsoftProvider);
   } else {
-    await FirebaseAuth.instance.signInWithAuthProvider(microsoftProvider);
+    await FirebaseAuth.instance.signInWithProvider(microsoftProvider);
   }
 }
 ```
@@ -260,7 +260,7 @@ Future<void> _signInWithTwitter() async {
   if (kIsWeb) {
     await FirebaseAuth.instance.signInWithPopup(twitterProvider);
   } else {
-    await FirebaseAuth.instance.signInWithAuthProvider(twitterProvider);
+    await FirebaseAuth.instance.signInWithProvider(twitterProvider);
   }
 }
 ```
@@ -283,7 +283,7 @@ with the Client ID and Secret are set, with the callback URL set in the GitHub a
     // Create a new provider
     GithubAuthProvider githubProvider = GithubAuthProvider();
 
-    return await FirebaseAuth.instance.signInWithAuthProvider(githubProvider);
+    return await FirebaseAuth.instance.signInWithProvider(githubProvider);
   }
   ```
 
@@ -342,7 +342,7 @@ Future<UserCredential> signInWithYahoo() async {
   if (kIsWeb) {
     await _auth.signInWithPopup(yahooProvider);
   } else {
-    await _auth.signInWithAuthProvider(yahooProvider);
+    await _auth.signInWithProvider(yahooProvider);
   }
 }
 ```

--- a/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
@@ -9,7 +9,7 @@ class FirebaseAnalytics extends FirebasePluginPlatform {
   FirebaseAnalytics._({required this.app})
       : super(app.name, 'plugins.flutter.io/firebase_analytics');
 
-  /// Namespace for analytics API available on Android only. This is deprecated in favour of calling directly
+  /// Namespace for analytics API available on Android only. This is deprecated in favor of
   /// `FirebaseAnalytics.instance.setSessionTimeoutDuration()`.
   ///
   /// The value of this field is `null` on non-Android platforms. If you are

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -1491,8 +1491,8 @@ public class FlutterFirebaseAuthPlugin
       case "Auth#verifyPhoneNumber":
         methodCallTask = verifyPhoneNumber(call.arguments());
         break;
-      case "Auth#signInWithAuthProvider":
-        methodCallTask = signInWithAuthProvider(call.arguments());
+      case "Auth#signInWithProvider":
+        methodCallTask = signInWithProvider(call.arguments());
         break;
       case "User#linkWithProvider":
         methodCallTask = startActivityForLinkWithProvider(call.arguments());
@@ -1594,7 +1594,7 @@ public class FlutterFirebaseAuthPlugin
     return taskCompletionSource.getTask();
   }
 
-  private Task<Map<String, Object>> signInWithAuthProvider(Map<String, Object> arguments) {
+  private Task<Map<String, Object>> signInWithProvider(Map<String, Object> arguments) {
     TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
 
     cachedThreadPool.execute(

--- a/packages/firebase_auth/firebase_auth/example/lib/auth.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/auth.dart
@@ -534,7 +534,7 @@ class _AuthGateState extends State<AuthGate> {
     if (kIsWeb) {
       await _auth.signInWithPopup(twitterProvider);
     } else {
-      await _auth.signInWithAuthProvider(twitterProvider);
+      await _auth.signInWithProvider(twitterProvider);
     }
   }
 
@@ -546,7 +546,7 @@ class _AuthGateState extends State<AuthGate> {
       // Once signed in, return the UserCredential
       await _auth.signInWithPopup(appleProvider);
     } else {
-      await _auth.signInWithAuthProvider(appleProvider);
+      await _auth.signInWithProvider(appleProvider);
     }
   }
 
@@ -557,7 +557,7 @@ class _AuthGateState extends State<AuthGate> {
       // Once signed in, return the UserCredential
       await _auth.signInWithPopup(yahooProvider);
     } else {
-      await _auth.signInWithAuthProvider(yahooProvider);
+      await _auth.signInWithProvider(yahooProvider);
     }
   }
 
@@ -567,7 +567,7 @@ class _AuthGateState extends State<AuthGate> {
     if (kIsWeb) {
       await _auth.signInWithPopup(githubProvider);
     } else {
-      await _auth.signInWithAuthProvider(githubProvider);
+      await _auth.signInWithProvider(githubProvider);
     }
   }
 
@@ -577,7 +577,7 @@ class _AuthGateState extends State<AuthGate> {
     if (kIsWeb) {
       await _auth.signInWithPopup(microsoftProvider);
     } else {
-      await _auth.signInWithAuthProvider(microsoftProvider);
+      await _auth.signInWithProvider(microsoftProvider);
     }
   }
 }

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -241,8 +241,8 @@ NSString *const kErrMsgInvalidCredential =
     [self useEmulator:call.arguments withMethodCallResult:methodCallResult];
   } else if ([@"Auth#verifyPasswordResetCode" isEqualToString:call.method]) {
     [self verifyPasswordResetCode:call.arguments withMethodCallResult:methodCallResult];
-  } else if ([@"Auth#signInWithAuthProvider" isEqualToString:call.method]) {
-    [self signInWithAuthProvider:call.arguments withMethodCallResult:methodCallResult];
+  } else if ([@"Auth#signInWithProvider" isEqualToString:call.method]) {
+    [self signInWithProvider:call.arguments withMethodCallResult:methodCallResult];
   } else if ([@"Auth#verifyPhoneNumber" isEqualToString:call.method]) {
     [self verifyPhoneNumber:call.arguments withMethodCallResult:methodCallResult];
   } else if ([@"User#delete" isEqualToString:call.method]) {
@@ -609,7 +609,7 @@ static void handleSignInWithApple(FLTFirebaseAuthPlugin *object, FIRAuthDataResu
   self.appleResult.error(nil, nil, nil, error);
 }
 
-- (void)signInWithAuthProvider:(id)arguments
+- (void)signInWithProvider:(id)arguments
           withMethodCallResult:(FLTFirebaseMethodCallResult *)result {
   if ([arguments[@"signInProvider"] isEqualToString:kSignInMethodApple]) {
     if (@available(iOS 13.0, macOS 10.15, *)) {

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -610,7 +610,7 @@ static void handleSignInWithApple(FLTFirebaseAuthPlugin *object, FIRAuthDataResu
 }
 
 - (void)signInWithProvider:(id)arguments
-          withMethodCallResult:(FLTFirebaseMethodCallResult *)result {
+      withMethodCallResult:(FLTFirebaseMethodCallResult *)result {
   if ([arguments[@"signInProvider"] isEqualToString:kSignInMethodApple]) {
     if (@available(iOS 13.0, macOS 10.15, *)) {
       launchAppleSignInRequest(self, arguments, result);

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -610,7 +610,7 @@ class FirebaseAuth extends FirebasePluginPlatform {
   }
 
   /// Signs in with an AuthProvider using native authentication flow. This is
-  /// deprecated in favour of calling directly `signInWithProvider()`.
+  /// deprecated in favor of `signInWithProvider()`.
   ///
   /// A [FirebaseAuthException] maybe thrown with the following error code:
   /// - **user-disabled**:

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -609,18 +609,31 @@ class FirebaseAuth extends FirebasePluginPlatform {
     }
   }
 
+  /// Signs in with an AuthProvider using native authentication flow. This is
+  /// deprecated in favour of calling directly `signInWithProvider()`.
+  ///
+  /// A [FirebaseAuthException] maybe thrown with the following error code:
+  /// - **user-disabled**:
+  ///  - Thrown if the user corresponding to the given email has been disabled.
+  @Deprecated('You should use signInWithProvider instead')
+  Future<UserCredential> signInWithAuthProvider(
+    AuthProvider provider,
+  ) async {
+    return signInWithProvider(provider);
+  }
+
   /// Signs in with an AuthProvider using native authentication flow.
   ///
   /// A [FirebaseAuthException] maybe thrown with the following error code:
   /// - **user-disabled**:
   ///  - Thrown if the user corresponding to the given email has been disabled.
-  Future<UserCredential> signInWithAuthProvider(
+  Future<UserCredential> signInWithProvider(
     AuthProvider provider,
   ) async {
     try {
       return UserCredential._(
         this,
-        await _delegate.signInWithAuthProvider(provider),
+        await _delegate.signInWithProvider(provider),
       );
     } on FirebaseAuthMultiFactorExceptionPlatform catch (e) {
       throw FirebaseAuthMultiFactorException._(this, e);

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_firebase_auth.dart
@@ -574,7 +574,7 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
   }
 
   @override
-  Future<UserCredentialPlatform> signInWithAuthProvider(
+  Future<UserCredentialPlatform> signInWithProvider(
     AuthProvider provider,
   ) async {
     try {
@@ -583,7 +583,7 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
 
       Map<String, dynamic> data =
           (await channel.invokeMapMethod<String, dynamic>(
-              'Auth#signInWithAuthProvider',
+              'Auth#signInWithProvider',
               _withChannelDefaults({
                 'signInProvider': convertedProvider.providerId,
                 if (convertedProvider is OAuthProvider) ...{

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_firebase_auth.dart
@@ -530,10 +530,10 @@ abstract class FirebaseAuthPlatform extends PlatformInterface {
   /// A [FirebaseAuthException] maybe thrown with the following error code:
   /// - **user-disabled**:
   ///  - Thrown if the user corresponding to the given email has been disabled.
-  Future<UserCredentialPlatform> signInWithAuthProvider(
+  Future<UserCredentialPlatform> signInWithProvider(
     AuthProvider provider,
   ) async {
-    throw UnimplementedError('signInWithAuthProvider() is not implemented');
+    throw UnimplementedError('signInWithProvider() is not implemented');
   }
 
   /// Starts a sign-in flow for a phone number.


### PR DESCRIPTION
## Description

See title - this method has been renamed to match naming conventions used in other Firebase SDKs and the old API marked as deprecated (to be removed in a later release).

## Related Issues

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
