### PR TITLE
fix: a false positive by checking that there are no prefix duplicates.

### DIFF
--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/movie.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/movie.dart
@@ -4,8 +4,6 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'movie.g.dart';
 
-int a = 1;
-
 @JsonSerializable()
 class Movie {
   Movie({

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/movie.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/movie.dart
@@ -4,6 +4,8 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'movie.g.dart';
 
+int a = 1;
+
 @JsonSerializable()
 class Movie {
   Movie({


### PR DESCRIPTION
fixes #9551

No clue on how to write tests for this, as this is related to watch mode.


## Description

The code generator was stateful, so some state was preserved between builds, triggering an unwanted exception.

This PR refactors the generator to make it stateless, preventing the issue.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
