### PR TITLE
docs(firebase_database): removed duplicated words in dart doc comment

### DIFF
--- a/packages/firebase_database/firebase_database/lib/src/query.dart
+++ b/packages/firebase_database/firebase_database/lib/src/query.dart
@@ -92,7 +92,7 @@ class Query {
   /// If only a value is provided, children with a value greater than
   /// the specified value will be included in the query.
   /// If a key is specified, then children must have a value greater than
-  /// or equal to the specified value and a a key name greater than
+  /// or equal to the specified value and a key name greater than
   /// the specified key.
   Query startAfter(Object? value, {String? key}) {
     return Query._(
@@ -116,7 +116,7 @@ class Query {
   /// The ending point is exclusive. If only a value is provided,
   /// children with a value less than the specified value will be included in
   /// the query. If a key is specified, then children must have a value lesss
-  /// than or equal to the specified value and a a key name less than the
+  /// than or equal to the specified value and a key name less than the
   /// specified key.
   Query endBefore(Object? value, {String? key}) {
     return Query._(


### PR DESCRIPTION
## Description

Removes consecutively duplicated word in dart doc comments.

## Related Issues

Fixes #9619

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
