### PR TITLE
fix: Exceptions inside Query.snapshots() and more now have a stack trace that correctly points to the invocation of the throwing method

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_document_reference.dart
@@ -104,12 +104,12 @@ class MethodChannelDocumentReference extends DocumentReferencePlatform {
     late StreamController<DocumentSnapshotPlatform>
         controller; // ignore: close_sinks
 
-    StreamSubscription<dynamic>? snapshotStream;
+    StreamSubscription<dynamic>? snapshotStreamSubscription;
     controller = StreamController<DocumentSnapshotPlatform>.broadcast(
       onListen: () async {
         final observerId = await MethodChannelFirebaseFirestore.channel
             .invokeMethod<String>('DocumentReference#snapshots');
-        snapshotStream =
+        snapshotStreamSubscription =
             MethodChannelFirebaseFirestore.documentSnapshotChannel(observerId!)
                 .receiveGuardedBroadcastStream(
           arguments: <String, dynamic>{
@@ -134,7 +134,7 @@ class MethodChannelDocumentReference extends DocumentReferencePlatform {
         );
       },
       onCancel: () {
-        snapshotStream?.cancel();
+        snapshotStreamSubscription?.cancel();
       },
     );
 

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_load_bundle_task.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_load_bundle_task.dart
@@ -37,6 +37,8 @@ class MethodChannelLoadBundleTask extends LoadBundleTaskPlatform {
           }
         }
       } catch (exception) {
+        // TODO this should be refactored to use `convertPlatformException`,
+        // then change receiveBroadcastStream -> receiveGuardedBroadedStream
         if (exception is! Exception || exception is! PlatformException) {
           rethrow;
         }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query.dart
@@ -135,16 +135,15 @@ class MethodChannelQuery extends QueryPlatform {
     // subscribers have cancelled; this analyzer warning is safe to ignore.
     late StreamController<QuerySnapshotPlatform>
         controller; // ignore: close_sinks
-    StreamSubscription<dynamic>? snapshotStream;
 
-    final incomingStackTrace = StackTrace.current;
+    StreamSubscription<dynamic>? snapshotStreamSubscription;
 
     controller = StreamController<QuerySnapshotPlatform>.broadcast(
       onListen: () async {
         final observerId = await MethodChannelFirebaseFirestore.channel
             .invokeMethod<String>('Query#snapshots');
 
-        snapshotStream =
+        snapshotStreamSubscription =
             MethodChannelFirebaseFirestore.querySnapshotChannel(observerId!)
                 .receiveGuardedBroadcastStream(
           arguments: <String, dynamic>{
@@ -160,7 +159,7 @@ class MethodChannelQuery extends QueryPlatform {
         );
       },
       onCancel: () {
-        snapshotStream?.cancel();
+        snapshotStreamSubscription?.cancel();
       },
     );
 

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:_flutterfire_internals/_flutterfire_internals.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -22,7 +23,9 @@ class MethodChannelFirebaseAppCheck extends FirebaseAppCheckPlatform {
       'appName': app.name,
     }).then((channelName) {
       final events = EventChannel(channelName!, channel.codec);
-      events.receiveBroadcastStream().listen(
+      events
+          .receiveGuardedBroadcastStream(onError: convertPlatformException)
+          .listen(
         (arguments) {
           // ignore: close_sinks
           StreamController<String?> controller =

--- a/packages/firebase_app_installations/firebase_app_installations_platform_interface/lib/src/method_channel/method_channel_firebase_app_installations.dart
+++ b/packages/firebase_app_installations/firebase_app_installations_platform_interface/lib/src/method_channel/method_channel_firebase_app_installations.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:_flutterfire_internals/_flutterfire_internals.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_app_installations_platform_interface/firebase_app_installations_platform_interface.dart';
 import 'package:flutter/services.dart';
@@ -37,9 +38,9 @@ class MethodChannelFirebaseAppInstallations
       'appName': app.name,
     }).then((channelName) {
       final events = EventChannel(channelName!, channel.codec);
+
       events
-          .receiveBroadcastStream()
-          .handleError(convertPlatformException)
+          .receiveGuardedBroadcastStream(onError: convertPlatformException)
           .listen(
             (Object? arguments) => controller.add((arguments as Map)['token']),
             onError: controller.addError,

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_firebase_auth.dart
@@ -6,6 +6,7 @@
 import 'dart:async';
 import 'dart:io' show Platform;
 
+import 'package:_flutterfire_internals/_flutterfire_internals.dart';
 import 'package:firebase_auth_platform_interface/src/method_channel/method_channel_multi_factor.dart';
 import 'package:firebase_auth_platform_interface/src/method_channel/utils/convert_auth_provider.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -67,7 +68,9 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
       'appName': app.name,
     }).then((channelName) {
       final events = EventChannel(channelName!, channel.codec);
-      events.receiveBroadcastStream().listen(
+      events
+          .receiveGuardedBroadcastStream(onError: convertPlatformException)
+          .listen(
         (arguments) {
           _handleIdTokenChangesListener(app.name, arguments);
         },
@@ -78,7 +81,9 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
       'appName': app.name,
     }).then((channelName) {
       final events = EventChannel(channelName!, channel.codec);
-      events.receiveBroadcastStream().listen(
+      events
+          .receiveGuardedBroadcastStream(onError: convertPlatformException)
+          .listen(
         (arguments) {
           _handleAuthStateChangesListener(app.name, arguments);
         },
@@ -636,7 +641,7 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
           }));
 
       EventChannel(eventChannelName!)
-          .receiveBroadcastStream()
+          .receiveGuardedBroadcastStream(onError: convertPlatformException)
           .listen((arguments) {
         final name = arguments['name'];
         if (name == 'Auth#phoneVerificationCompleted') {

--- a/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
   flutter: '>=1.9.1+hotfix.5'
 
 dependencies:
+  _flutterfire_internals: ^1.0.0
   collection: ^1.16.0
   firebase_core: ^1.10.0
   flutter:

--- a/packages/firebase_database/firebase_database_platform_interface/lib/src/method_channel/method_channel_query.dart
+++ b/packages/firebase_database/firebase_database_platform_interface/lib/src/method_channel/method_channel_query.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:_flutterfire_internals/_flutterfire_internals.dart';
 import 'package:firebase_database_platform_interface/firebase_database_platform_interface.dart';
 import 'package:flutter/services.dart';
 
@@ -53,18 +54,13 @@ class MethodChannelQuery extends QueryPlatform {
       }),
     );
 
-    yield* EventChannel(channelName!)
-        .receiveBroadcastStream(<String, Object?>{
-          'eventType': eventTypeToString(eventType),
-        })
-        .map(
-          (event) =>
-              MethodChannelDatabaseEvent(ref, Map<String, dynamic>.from(event)),
-        )
-        .handleError(
-          convertPlatformException,
-          test: (err) => err is PlatformException,
-        );
+    yield* EventChannel(channelName!).receiveGuardedBroadcastStream(
+      arguments: <String, Object?>{'eventType': eventTypeToString(eventType)},
+      onError: convertPlatformException,
+    ).map(
+      (event) =>
+          MethodChannelDatabaseEvent(ref, Map<String, dynamic>.from(event)),
+    );
   }
 
   /// Gets the most up-to-date result for this query.


### PR DESCRIPTION

## Description

Due to `StreamController.onListen` shenanigans, exceptions within its callback have an incorrect stacktrace.
To fix this, we can keep a reference on the caller stacktrace, and on error, report the error with that stacktrace instead.

While we're at this, this PR also changes a few `EventChanne.receiveBroadcastStream` that did not implement a "handleError", so platform exceptions were not converted to FirebaseExceptions.

## Related Issues
fixes #6743

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
