### PR TITLE
fix: Add speculative fix for null object reference crash

### DIFF
--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -236,7 +236,7 @@ public class FlutterFirebaseDynamicLinksPlugin
                 taskCompletionSource.setResult(null);
                 return;
               }
-              
+
               activity.get().getIntent().putExtra("flutterfire-used-link", true);
               pendingDynamicLink =
                   Tasks.await(dynamicLinks.getDynamicLink(activity.get().getIntent()));

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -239,7 +239,10 @@ public class FlutterFirebaseDynamicLinksPlugin
               pendingDynamicLink =
                   Tasks.await(dynamicLinks.getDynamicLink(activity.get().getIntent()));
 
-              activity.get().getIntent().putExtra("flutterfire-used-link", true);
+              // Only save that the link was used if the activity is not detached already.
+              if (activity.get() == null || activity.get().getIntent() == null) {
+                activity.get().getIntent().putExtra("flutterfire-used-link", true);
+              }
             }
 
             taskCompletionSource.setResult(

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -240,7 +240,7 @@ public class FlutterFirebaseDynamicLinksPlugin
                   Tasks.await(dynamicLinks.getDynamicLink(activity.get().getIntent()));
 
               // Only save that the link was used if the activity is not detached already.
-              if (activity.get() == null || activity.get().getIntent() == null) {
+              if (activity.get() != null || activity.get().getIntent() != null) {
                 activity.get().getIntent().putExtra("flutterfire-used-link", true);
               }
             }

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -236,13 +236,10 @@ public class FlutterFirebaseDynamicLinksPlugin
                 taskCompletionSource.setResult(null);
                 return;
               }
+              
+              activity.get().getIntent().putExtra("flutterfire-used-link", true);
               pendingDynamicLink =
                   Tasks.await(dynamicLinks.getDynamicLink(activity.get().getIntent()));
-
-              // Only save that the link was used if the activity is not detached already.
-              if (activity.get() != null || activity.get().getIntent() != null) {
-                activity.get().getIntent().putExtra("flutterfire-used-link", true);
-              }
             }
 
             taskCompletionSource.setResult(


### PR DESCRIPTION
## Description

The activity is accessed potentially unsafely, and we are seeing some null reference crashes from this file.
## Related Issues

https://github.com/firebase/flutterfire/issues/9544

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [-] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
