### PR TITLE
fix(ui): Enable row selection on FirestoreDataTable

### DIFF
--- a/packages/firebase_ui_firestore/lib/src/table_builder.dart
+++ b/packages/firebase_ui_firestore/lib/src/table_builder.dart
@@ -221,7 +221,8 @@ class _FirestoreTableState extends State<FirestoreDataTable> {
     onSelectedRows: widget.onSelectedRows,
   );
 
-  bool get selectionEnabled => widget.canDeleteItems;
+  bool get selectionEnabled =>
+      widget.canDeleteItems || (widget.onSelectedRows != null);
 
   @override
   void initState() {


### PR DESCRIPTION
## Description

When using `FirestoreDataTable` row selection is available only if `canDeleteItems = true`, but that's not always desired. For example, if you want to execute another actions when clicking a given data row (*e.g.* navigate to another view).

This PR enables selection when `canDeleteItems` is true or if `onSelectedRows` is given.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
