### PR TITLE
test: Remove useless `StreamSubscription` from e2e tests

### DIFF
--- a/packages/firebase_auth/firebase_auth_platform_interface/test/method_channel_tests/method_channel_firebase_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/method_channel_tests/method_channel_firebase_auth_test.dart
@@ -1006,12 +1006,6 @@ void main() {
     });
 
     group('authStateChanges()', () {
-      StreamSubscription<UserPlatform?>? subscription;
-
-      tearDown(() {
-        subscription?.cancel();
-      });
-
       test('returns [Stream<UserPlatform>]', () async {
         // Checks that `authStateChanges` does not throw UnimplementedError
         expect(auth.authStateChanges(), isNotNull);
@@ -1051,12 +1045,6 @@ void main() {
     });
 
     group('idTokenChanges()', () {
-      StreamSubscription<UserPlatform?>? subscription;
-
-      tearDown(() {
-        subscription?.cancel();
-      });
-
       test('returns [Stream<UserPlatform>]', () async {
         // Checks that `idTokenChanges` does not throw UnimplementedError
         expect(auth.idTokenChanges(), isNotNull);
@@ -1097,12 +1085,6 @@ void main() {
     });
 
     group('userChanges()', () {
-      StreamSubscription<UserPlatform?>? subscription;
-
-      tearDown(() {
-        subscription?.cancel();
-      });
-
       test('returns [Stream<UserPlatform>]', () async {
         // Checks that `userChanges` does not throw UnimplementedError
         expect(auth.userChanges(), isNotNull);

--- a/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface/test/method_channel_tests/method_channel_firebase_dynamic_links_test.dart
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface/test/method_channel_tests/method_channel_firebase_dynamic_links_test.dart
@@ -2,8 +2,6 @@
 // Copyright 2021, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-import 'dart:async';
-
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_dynamic_links_platform_interface/firebase_dynamic_links_platform_interface.dart';
 import 'package:firebase_dynamic_links_platform_interface/src/method_channel/method_channel_firebase_dynamic_links.dart';
@@ -293,12 +291,6 @@ void main() {
     });
 
     group('onLink()', () {
-      StreamSubscription<PendingDynamicLinkData?>? subscription;
-
-      tearDown(() {
-        subscription?.cancel();
-      });
-
       test('returns [Stream<PendingDynamicLinkData>]', () async {
         // Checks that `onLink` does not throw UnimplementedError
         expect(dynamicLinks.onLink, isNotNull);


### PR DESCRIPTION
## Description

*I removed the `StreamSubscription` which was useless in the tests.*

## Related Issues

*No related issues*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
