### PR TITLE
fix(crashlytics): parameter `information` accepts `Iterable<Object>` for further diagnostic logging information

### DIFF
--- a/docs/crashlytics/_customize-crash-reports.md
+++ b/docs/crashlytics/_customize-crash-reports.md
@@ -97,7 +97,7 @@ event is reported or when the app restarts.
 Note: {{crashlytics}} only stores the most recent eight recorded non-fatal
 exceptions. If your app throws more than eight, older exceptions are lost. This
 count is reset each time a fatal exception is thrown, since this causes a report
-to be sent to {{crashlytics}}. 
+to be sent to {{crashlytics}}.
 
 Use the `recordError` method to record non-fatal exceptions in your app's catch
 blocks. For example:
@@ -107,6 +107,18 @@ await FirebaseCrashlytics.instance.recordError(
   error,
   stackTrace,
   reason: 'a non-fatal error'
+);
+```
+
+You may also wish to log further information about the error which is possible
+using the `information` property:
+
+```dart
+await FirebaseCrashlytics.instance.recordError(
+  error,
+  stackTrace,
+  reason: 'a non-fatal error',
+  information: ['further diagnostic information about the error', 'version 2.0'],
 );
 ```
 

--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/firebase_crashlytics.dart
@@ -6,7 +6,7 @@
 library firebase_crashlytics;
 
 import 'package:flutter/foundation.dart'
-    show kDebugMode, FlutterErrorDetails, FlutterError, DiagnosticsNode;
+    show kDebugMode, FlutterErrorDetails, FlutterError;
 
 import 'package:firebase_crashlytics_platform_interface/firebase_crashlytics_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';

--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -79,7 +79,7 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
   /// Submits a Crashlytics report of a caught error.
   Future<void> recordError(dynamic exception, StackTrace? stack,
       {dynamic reason,
-      Iterable<DiagnosticsNode> information = const [],
+      Iterable<Object> information = const [],
       bool? printDetails,
       bool fatal = false}) async {
     // Use the debug flag if printDetails is not provided
@@ -139,13 +139,13 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
       {bool fatal = false}) {
     FlutterError.presentError(flutterErrorDetails);
 
+    final information = flutterErrorDetails.informationCollector?.call() ?? [];
+
     return recordError(
       flutterErrorDetails.exceptionAsString(),
       flutterErrorDetails.stack,
       reason: flutterErrorDetails.context,
-      information: flutterErrorDetails.informationCollector == null
-          ? []
-          : flutterErrorDetails.informationCollector!(),
+      information: information,
       printDetails: false,
       fatal: fatal,
     );


### PR DESCRIPTION
## Description

Updated `recordError` so it now allows `Iterable<Object` in the `information` parameter. This makes it backwards compatible, but also allows users to pass in whatever object they wish (e.g. ['something', 'version']) and it will write it to a `String` for logging in the Crashlytics dashboard in release mode.

I've tested in release mode using this input:
```dart
final err = Exception('AAAAAAAA');
Iterable<Object> properties = ['in release mode'];
FirebaseCrashlytics.instance.recordError(err, StackTrace.current,
    information: properties, fatal: true);
```

It shows on the dashboard correctly:
<img width="1297" alt="Screenshot 2022-10-05 at 10 45 12" src="https://user-images.githubusercontent.com/16018629/194034087-629c9183-addd-428d-958c-1ca8e1fbb24d.png">


## Related Issues

fixes https://github.com/firebase/flutterfire/issues/7912

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
