### PR TITLE
chore: fix CI analyze issue and temporary fix for formatting CI issue

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -184,7 +184,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   if ([[GULAppDelegateSwizzler sharedApplication].delegate
           respondsToSelector:messaging_didReceiveRegistrationTokenSelector]) {
     void (*usersDidReceiveRegistrationTokenIMP)(id, SEL, FIRMessaging *, NSString *) =
-        (typeof(usersDidReceiveRegistrationTokenIMP))&objc_msgSend;
+        (typeof(usersDidReceiveRegistrationTokenIMP)) & objc_msgSend;
     usersDidReceiveRegistrationTokenIMP([GULAppDelegateSwizzler sharedApplication].delegate,
                                         messaging_didReceiveRegistrationTokenSelector, messaging,
                                         fcmToken);

--- a/packages/firebase_ui_localizations/example/pubspec.yaml
+++ b/packages/firebase_ui_localizations/example/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.16.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/packages/firebase_ui_localizations/example/pubspec.yaml
+++ b/packages/firebase_ui_localizations/example/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.18.2 <3.0.0'
+  sdk: '>=2.16.0 <3.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/packages/firebase_ui_localizations/pubspec.yaml
+++ b/packages/firebase_ui_localizations/pubspec.yaml
@@ -7,7 +7,7 @@ false_secrets:
   - example/**
 
 environment:
-  sdk: '>=2.16.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
   flutter: '>=1.17.0'
 
 dependencies:

--- a/packages/firebase_ui_localizations/pubspec.yaml
+++ b/packages/firebase_ui_localizations/pubspec.yaml
@@ -3,8 +3,11 @@ description: Localization package for firebase_ui_auth, firebase_ui_firestore an
 version: 1.0.0-dev.0
 homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_ui_localizations
 
+false_secrets:
+  - example/**
+
 environment:
-  sdk: '>=2.17.6 <3.0.0'
+  sdk: '>=2.16.0 <3.0.0'
   flutter: '>=1.17.0'
 
 dependencies:


### PR DESCRIPTION
## Description

1. CI failing because `firebase_ui_localizations` package doesn't have false secrets set:https://github.com/firebase/flutterfire/actions/runs/3248718911/jobs/5331015686
2. Loosened version constraints for dart SDK. (Just encountered issue when running `melos bootstrap`).
3. speculative fix for formatting CI bug. 

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
