### PR TITLE
Fix IOS build error with firestore-ios-sdk-frameworks

### DIFF
--- a/packages/cloud_functions/cloud_functions/ios/cloud_functions.podspec
+++ b/packages/cloud_functions/cloud_functions/ios/cloud_functions.podspec
@@ -34,6 +34,9 @@ Pod::Spec.new do |s|
   # Firebase dependencies
   s.dependency 'firebase_core'
   s.dependency 'Firebase/Functions', firebase_sdk_version
+  # required until firestore-ios-sdk-frameworks is updated, otherwise users of that distribution will have compile failures
+  # see https://github.com/invertase/firestore-ios-sdk-frameworks/issues/59
+  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
 
   s.static_framework = true
   s.pod_target_xcconfig = {


### PR DESCRIPTION
## Description

Potential fix for https://github.com/firebase/flutterfire/issues/9761
The IOS build is failing with `cloud_functions: 4.0.1` and pre-compiled ios SDK together.

This might be a missing change of https://github.com/firebase/flutterfire/pull/9708

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
