### PR TITLE
fix: The ODM correctly no-longer generates query utilities for getters.

### DIFF
--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/integration.g.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/integration.g.dart
@@ -904,8 +904,6 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
     FieldValue firstNameFieldValue,
     String? lastName,
     FieldValue lastNameFieldValue,
-    int hashCode,
-    FieldValue hashCodeFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -917,8 +915,6 @@ abstract class AdvancedJsonDocumentReference extends FirestoreDocumentReference<
     FieldValue firstNameFieldValue,
     String? lastName,
     FieldValue lastNameFieldValue,
-    int hashCode,
-    FieldValue hashCodeFieldValue,
   });
 }
 
@@ -955,8 +951,6 @@ class _$AdvancedJsonDocumentReference extends FirestoreDocumentReference<
     FieldValue? firstNameFieldValue,
     Object? lastName = _sentinel,
     FieldValue? lastNameFieldValue,
-    Object? hashCode = _sentinel,
-    FieldValue? hashCodeFieldValue,
   }) async {
     assert(
       firstName == _sentinel || firstNameFieldValue == null,
@@ -966,17 +960,11 @@ class _$AdvancedJsonDocumentReference extends FirestoreDocumentReference<
       lastName == _sentinel || lastNameFieldValue == null,
       "Cannot specify both lastName and lastNameFieldValue",
     );
-    assert(
-      hashCode == _sentinel || hashCodeFieldValue == null,
-      "Cannot specify both hashCode and hashCodeFieldValue",
-    );
     final json = {
       if (firstName != _sentinel) 'firstName': firstName as String?,
       if (firstNameFieldValue != null) 'firstName': firstNameFieldValue,
       if (lastName != _sentinel) 'lastName': lastName as String?,
       if (lastNameFieldValue != null) 'lastName': lastNameFieldValue,
-      if (hashCode != _sentinel) 'hashCode': hashCode as int,
-      if (hashCodeFieldValue != null) 'hashCode': hashCodeFieldValue,
     };
 
     return reference.update(json);
@@ -988,8 +976,6 @@ class _$AdvancedJsonDocumentReference extends FirestoreDocumentReference<
     FieldValue? firstNameFieldValue,
     Object? lastName = _sentinel,
     FieldValue? lastNameFieldValue,
-    Object? hashCode = _sentinel,
-    FieldValue? hashCodeFieldValue,
   }) {
     assert(
       firstName == _sentinel || firstNameFieldValue == null,
@@ -999,17 +985,11 @@ class _$AdvancedJsonDocumentReference extends FirestoreDocumentReference<
       lastName == _sentinel || lastNameFieldValue == null,
       "Cannot specify both lastName and lastNameFieldValue",
     );
-    assert(
-      hashCode == _sentinel || hashCodeFieldValue == null,
-      "Cannot specify both hashCode and hashCodeFieldValue",
-    );
     final json = {
       if (firstName != _sentinel) 'firstName': firstName as String?,
       if (firstNameFieldValue != null) 'firstName': firstNameFieldValue,
       if (lastName != _sentinel) 'lastName': lastName as String?,
       if (lastNameFieldValue != null) 'lastName': lastNameFieldValue,
-      if (hashCode != _sentinel) 'hashCode': hashCode as int,
-      if (hashCodeFieldValue != null) 'hashCode': hashCodeFieldValue,
     };
 
     transaction.update(reference, json);
@@ -1133,17 +1113,6 @@ abstract class AdvancedJsonQuery
     List<String?>? whereIn,
     List<String?>? whereNotIn,
   });
-  AdvancedJsonQuery whereHashCode({
-    int? isEqualTo,
-    int? isNotEqualTo,
-    int? isLessThan,
-    int? isLessThanOrEqualTo,
-    int? isGreaterThan,
-    int? isGreaterThanOrEqualTo,
-    bool? isNull,
-    List<int>? whereIn,
-    List<int>? whereNotIn,
-  });
 
   AdvancedJsonQuery orderByDocumentId({
     bool descending = false,
@@ -1175,18 +1144,6 @@ abstract class AdvancedJsonQuery
     String? startAfter,
     String? endAt,
     String? endBefore,
-    AdvancedJsonDocumentSnapshot? startAtDocument,
-    AdvancedJsonDocumentSnapshot? endAtDocument,
-    AdvancedJsonDocumentSnapshot? endBeforeDocument,
-    AdvancedJsonDocumentSnapshot? startAfterDocument,
-  });
-
-  AdvancedJsonQuery orderByHashCode({
-    bool descending = false,
-    int startAt,
-    int startAfter,
-    int endAt,
-    int endBefore,
     AdvancedJsonDocumentSnapshot? startAtDocument,
     AdvancedJsonDocumentSnapshot? endAtDocument,
     AdvancedJsonDocumentSnapshot? endBeforeDocument,
@@ -1433,35 +1390,6 @@ class _$AdvancedJsonQuery
     );
   }
 
-  AdvancedJsonQuery whereHashCode({
-    int? isEqualTo,
-    int? isNotEqualTo,
-    int? isLessThan,
-    int? isLessThanOrEqualTo,
-    int? isGreaterThan,
-    int? isGreaterThanOrEqualTo,
-    bool? isNull,
-    List<int>? whereIn,
-    List<int>? whereNotIn,
-  }) {
-    return _$AdvancedJsonQuery(
-      _collection,
-      $referenceWithoutCursor: $referenceWithoutCursor.where(
-        _$AdvancedJsonFieldMap['hashCode']!,
-        isEqualTo: isEqualTo,
-        isNotEqualTo: isNotEqualTo,
-        isLessThan: isLessThan,
-        isLessThanOrEqualTo: isLessThanOrEqualTo,
-        isGreaterThan: isGreaterThan,
-        isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
-        isNull: isNull,
-        whereIn: whereIn,
-        whereNotIn: whereNotIn,
-      ),
-      $queryCursor: $queryCursor,
-    );
-  }
-
   AdvancedJsonQuery orderByDocumentId({
     bool descending = false,
     Object? startAt = _sentinel,
@@ -1619,78 +1547,6 @@ class _$AdvancedJsonQuery
   }) {
     final query = $referenceWithoutCursor
         .orderBy(_$AdvancedJsonFieldMap['lastName']!, descending: descending);
-    var queryCursor = $queryCursor;
-
-    if (startAtDocument != null) {
-      queryCursor = queryCursor.copyWith(
-        startAt: const [],
-        startAtDocumentSnapshot: startAtDocument.snapshot,
-      );
-    }
-    if (startAfterDocument != null) {
-      queryCursor = queryCursor.copyWith(
-        startAfter: const [],
-        startAfterDocumentSnapshot: startAfterDocument.snapshot,
-      );
-    }
-    if (endAtDocument != null) {
-      queryCursor = queryCursor.copyWith(
-        endAt: const [],
-        endAtDocumentSnapshot: endAtDocument.snapshot,
-      );
-    }
-    if (endBeforeDocument != null) {
-      queryCursor = queryCursor.copyWith(
-        endBefore: const [],
-        endBeforeDocumentSnapshot: endBeforeDocument.snapshot,
-      );
-    }
-
-    if (startAt != _sentinel) {
-      queryCursor = queryCursor.copyWith(
-        startAt: [...queryCursor.startAt, startAt],
-        startAtDocumentSnapshot: null,
-      );
-    }
-    if (startAfter != _sentinel) {
-      queryCursor = queryCursor.copyWith(
-        startAfter: [...queryCursor.startAfter, startAfter],
-        startAfterDocumentSnapshot: null,
-      );
-    }
-    if (endAt != _sentinel) {
-      queryCursor = queryCursor.copyWith(
-        endAt: [...queryCursor.endAt, endAt],
-        endAtDocumentSnapshot: null,
-      );
-    }
-    if (endBefore != _sentinel) {
-      queryCursor = queryCursor.copyWith(
-        endBefore: [...queryCursor.endBefore, endBefore],
-        endBeforeDocumentSnapshot: null,
-      );
-    }
-
-    return _$AdvancedJsonQuery(
-      _collection,
-      $referenceWithoutCursor: query,
-      $queryCursor: queryCursor,
-    );
-  }
-
-  AdvancedJsonQuery orderByHashCode({
-    bool descending = false,
-    Object? startAt = _sentinel,
-    Object? startAfter = _sentinel,
-    Object? endAt = _sentinel,
-    Object? endBefore = _sentinel,
-    AdvancedJsonDocumentSnapshot? startAtDocument,
-    AdvancedJsonDocumentSnapshot? endAtDocument,
-    AdvancedJsonDocumentSnapshot? endBeforeDocument,
-    AdvancedJsonDocumentSnapshot? startAfterDocument,
-  }) {
-    final query = $referenceWithoutCursor
-        .orderBy(_$AdvancedJsonFieldMap['hashCode']!, descending: descending);
     var queryCursor = $queryCursor;
 
     if (startAtDocument != null) {
@@ -1973,8 +1829,6 @@ abstract class _PrivateAdvancedJsonDocumentReference
     FieldValue firstNameFieldValue,
     String? lastName,
     FieldValue lastNameFieldValue,
-    int hashCode,
-    FieldValue hashCodeFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -1986,8 +1840,6 @@ abstract class _PrivateAdvancedJsonDocumentReference
     FieldValue firstNameFieldValue,
     String? lastName,
     FieldValue lastNameFieldValue,
-    int hashCode,
-    FieldValue hashCodeFieldValue,
   });
 }
 
@@ -2028,8 +1880,6 @@ class _$_PrivateAdvancedJsonDocumentReference
     FieldValue? firstNameFieldValue,
     Object? lastName = _sentinel,
     FieldValue? lastNameFieldValue,
-    Object? hashCode = _sentinel,
-    FieldValue? hashCodeFieldValue,
   }) async {
     assert(
       firstName == _sentinel || firstNameFieldValue == null,
@@ -2039,17 +1889,11 @@ class _$_PrivateAdvancedJsonDocumentReference
       lastName == _sentinel || lastNameFieldValue == null,
       "Cannot specify both lastName and lastNameFieldValue",
     );
-    assert(
-      hashCode == _sentinel || hashCodeFieldValue == null,
-      "Cannot specify both hashCode and hashCodeFieldValue",
-    );
     final json = {
       if (firstName != _sentinel) 'firstName': firstName as String?,
       if (firstNameFieldValue != null) 'firstName': firstNameFieldValue,
       if (lastName != _sentinel) 'lastName': lastName as String?,
       if (lastNameFieldValue != null) 'lastName': lastNameFieldValue,
-      if (hashCode != _sentinel) 'hashCode': hashCode as int,
-      if (hashCodeFieldValue != null) 'hashCode': hashCodeFieldValue,
     };
 
     return reference.update(json);
@@ -2061,8 +1905,6 @@ class _$_PrivateAdvancedJsonDocumentReference
     FieldValue? firstNameFieldValue,
     Object? lastName = _sentinel,
     FieldValue? lastNameFieldValue,
-    Object? hashCode = _sentinel,
-    FieldValue? hashCodeFieldValue,
   }) {
     assert(
       firstName == _sentinel || firstNameFieldValue == null,
@@ -2072,17 +1914,11 @@ class _$_PrivateAdvancedJsonDocumentReference
       lastName == _sentinel || lastNameFieldValue == null,
       "Cannot specify both lastName and lastNameFieldValue",
     );
-    assert(
-      hashCode == _sentinel || hashCodeFieldValue == null,
-      "Cannot specify both hashCode and hashCodeFieldValue",
-    );
     final json = {
       if (firstName != _sentinel) 'firstName': firstName as String?,
       if (firstNameFieldValue != null) 'firstName': firstNameFieldValue,
       if (lastName != _sentinel) 'lastName': lastName as String?,
       if (lastNameFieldValue != null) 'lastName': lastNameFieldValue,
-      if (hashCode != _sentinel) 'hashCode': hashCode as int,
-      if (hashCodeFieldValue != null) 'hashCode': hashCodeFieldValue,
     };
 
     transaction.update(reference, json);
@@ -2208,17 +2044,6 @@ abstract class _PrivateAdvancedJsonQuery
     List<String?>? whereIn,
     List<String?>? whereNotIn,
   });
-  _PrivateAdvancedJsonQuery whereHashCode({
-    int? isEqualTo,
-    int? isNotEqualTo,
-    int? isLessThan,
-    int? isLessThanOrEqualTo,
-    int? isGreaterThan,
-    int? isGreaterThanOrEqualTo,
-    bool? isNull,
-    List<int>? whereIn,
-    List<int>? whereNotIn,
-  });
 
   _PrivateAdvancedJsonQuery orderByDocumentId({
     bool descending = false,
@@ -2250,18 +2075,6 @@ abstract class _PrivateAdvancedJsonQuery
     String? startAfter,
     String? endAt,
     String? endBefore,
-    _PrivateAdvancedJsonDocumentSnapshot? startAtDocument,
-    _PrivateAdvancedJsonDocumentSnapshot? endAtDocument,
-    _PrivateAdvancedJsonDocumentSnapshot? endBeforeDocument,
-    _PrivateAdvancedJsonDocumentSnapshot? startAfterDocument,
-  });
-
-  _PrivateAdvancedJsonQuery orderByHashCode({
-    bool descending = false,
-    int startAt,
-    int startAfter,
-    int endAt,
-    int endBefore,
     _PrivateAdvancedJsonDocumentSnapshot? startAtDocument,
     _PrivateAdvancedJsonDocumentSnapshot? endAtDocument,
     _PrivateAdvancedJsonDocumentSnapshot? endBeforeDocument,
@@ -2508,35 +2321,6 @@ class _$_PrivateAdvancedJsonQuery extends QueryReference<_PrivateAdvancedJson,
     );
   }
 
-  _PrivateAdvancedJsonQuery whereHashCode({
-    int? isEqualTo,
-    int? isNotEqualTo,
-    int? isLessThan,
-    int? isLessThanOrEqualTo,
-    int? isGreaterThan,
-    int? isGreaterThanOrEqualTo,
-    bool? isNull,
-    List<int>? whereIn,
-    List<int>? whereNotIn,
-  }) {
-    return _$_PrivateAdvancedJsonQuery(
-      _collection,
-      $referenceWithoutCursor: $referenceWithoutCursor.where(
-        _$PrivateAdvancedJsonFieldMap['hashCode']!,
-        isEqualTo: isEqualTo,
-        isNotEqualTo: isNotEqualTo,
-        isLessThan: isLessThan,
-        isLessThanOrEqualTo: isLessThanOrEqualTo,
-        isGreaterThan: isGreaterThan,
-        isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
-        isNull: isNull,
-        whereIn: whereIn,
-        whereNotIn: whereNotIn,
-      ),
-      $queryCursor: $queryCursor,
-    );
-  }
-
   _PrivateAdvancedJsonQuery orderByDocumentId({
     bool descending = false,
     Object? startAt = _sentinel,
@@ -2695,79 +2479,6 @@ class _$_PrivateAdvancedJsonQuery extends QueryReference<_PrivateAdvancedJson,
   }) {
     final query = $referenceWithoutCursor.orderBy(
         _$PrivateAdvancedJsonFieldMap['lastName']!,
-        descending: descending);
-    var queryCursor = $queryCursor;
-
-    if (startAtDocument != null) {
-      queryCursor = queryCursor.copyWith(
-        startAt: const [],
-        startAtDocumentSnapshot: startAtDocument.snapshot,
-      );
-    }
-    if (startAfterDocument != null) {
-      queryCursor = queryCursor.copyWith(
-        startAfter: const [],
-        startAfterDocumentSnapshot: startAfterDocument.snapshot,
-      );
-    }
-    if (endAtDocument != null) {
-      queryCursor = queryCursor.copyWith(
-        endAt: const [],
-        endAtDocumentSnapshot: endAtDocument.snapshot,
-      );
-    }
-    if (endBeforeDocument != null) {
-      queryCursor = queryCursor.copyWith(
-        endBefore: const [],
-        endBeforeDocumentSnapshot: endBeforeDocument.snapshot,
-      );
-    }
-
-    if (startAt != _sentinel) {
-      queryCursor = queryCursor.copyWith(
-        startAt: [...queryCursor.startAt, startAt],
-        startAtDocumentSnapshot: null,
-      );
-    }
-    if (startAfter != _sentinel) {
-      queryCursor = queryCursor.copyWith(
-        startAfter: [...queryCursor.startAfter, startAfter],
-        startAfterDocumentSnapshot: null,
-      );
-    }
-    if (endAt != _sentinel) {
-      queryCursor = queryCursor.copyWith(
-        endAt: [...queryCursor.endAt, endAt],
-        endAtDocumentSnapshot: null,
-      );
-    }
-    if (endBefore != _sentinel) {
-      queryCursor = queryCursor.copyWith(
-        endBefore: [...queryCursor.endBefore, endBefore],
-        endBeforeDocumentSnapshot: null,
-      );
-    }
-
-    return _$_PrivateAdvancedJsonQuery(
-      _collection,
-      $referenceWithoutCursor: query,
-      $queryCursor: queryCursor,
-    );
-  }
-
-  _PrivateAdvancedJsonQuery orderByHashCode({
-    bool descending = false,
-    Object? startAt = _sentinel,
-    Object? startAfter = _sentinel,
-    Object? endAt = _sentinel,
-    Object? endBefore = _sentinel,
-    _PrivateAdvancedJsonDocumentSnapshot? startAtDocument,
-    _PrivateAdvancedJsonDocumentSnapshot? endAtDocument,
-    _PrivateAdvancedJsonDocumentSnapshot? endBeforeDocument,
-    _PrivateAdvancedJsonDocumentSnapshot? startAfterDocument,
-  }) {
-    final query = $referenceWithoutCursor.orderBy(
-        _$PrivateAdvancedJsonFieldMap['hashCode']!,
         descending: descending);
     var queryCursor = $queryCursor;
 

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/freezed.g.dart
@@ -160,32 +160,17 @@ class _$PersonDocumentReference
 
   @override
   Stream<PersonDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return PersonDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(PersonDocumentSnapshot._);
   }
 
   @override
   Future<PersonDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return PersonDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(PersonDocumentSnapshot._);
   }
 
   @override
   Future<PersonDocumentSnapshot> transactionGet(Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return PersonDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction.get(reference).then(PersonDocumentSnapshot._);
   }
 
   Future<void> update({
@@ -247,26 +232,6 @@ class _$PersonDocumentReference
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class PersonDocumentSnapshot extends FirestoreDocumentSnapshot<Person> {
-  PersonDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<Person> snapshot;
-
-  @override
-  PersonDocumentReference get reference {
-    return PersonDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final Person? data;
 }
 
 abstract class PersonQuery
@@ -426,37 +391,14 @@ class _$PersonQuery extends QueryReference<Person, PersonQuerySnapshot>
 
   final CollectionReference<Object?> _collection;
 
-  PersonQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<Person> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return PersonQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<PersonDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: PersonDocumentSnapshot._(change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return PersonQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<PersonQuerySnapshot> snapshots([SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference.snapshots().map(PersonQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<PersonQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference.get(options).then(PersonQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -897,6 +839,23 @@ class _$PersonQuery extends QueryReference<Person, PersonQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class PersonDocumentSnapshot extends FirestoreDocumentSnapshot<Person> {
+  PersonDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<Person> snapshot;
+
+  @override
+  PersonDocumentReference get reference {
+    return PersonDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final Person? data;
+}
+
 class PersonQuerySnapshot
     extends FirestoreQuerySnapshot<Person, PersonQueryDocumentSnapshot> {
   PersonQuerySnapshot._(
@@ -904,6 +863,38 @@ class PersonQuerySnapshot
     this.docs,
     this.docChanges,
   );
+
+  factory PersonQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<Person> snapshot,
+  ) {
+    final docs = snapshot.docs.map(PersonQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        PersonDocumentSnapshot._,
+      );
+    }).toList();
+
+    return PersonQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<PersonDocumentSnapshot>
+      _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    PersonDocumentSnapshot Function(DocumentSnapshot<T> doc) decodeDoc,
+  ) {
+    return FirestoreDocumentChange<PersonDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<Person> snapshot;
 
@@ -916,18 +907,18 @@ class PersonQuerySnapshot
 
 class PersonQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot<Person>
     implements PersonDocumentSnapshot {
-  PersonQueryDocumentSnapshot._(this.snapshot, this.data);
+  PersonQueryDocumentSnapshot._(this.snapshot) : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<Person> snapshot;
 
   @override
+  final Person data;
+
+  @override
   PersonDocumentReference get reference {
     return PersonDocumentReference(snapshot.reference);
   }
-
-  @override
-  final Person data;
 }
 
 /// A collection reference object can be used for adding documents,
@@ -1077,33 +1068,18 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
 
   @override
   Stream<PublicRedirectedDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return PublicRedirectedDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(PublicRedirectedDocumentSnapshot._);
   }
 
   @override
   Future<PublicRedirectedDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return PublicRedirectedDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(PublicRedirectedDocumentSnapshot._);
   }
 
   @override
   Future<PublicRedirectedDocumentSnapshot> transactionGet(
       Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return PublicRedirectedDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction.get(reference).then(PublicRedirectedDocumentSnapshot._);
   }
 
   Future<void> update({
@@ -1149,27 +1125,6 @@ class _$PublicRedirectedDocumentReference extends FirestoreDocumentReference<
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class PublicRedirectedDocumentSnapshot
-    extends FirestoreDocumentSnapshot<PublicRedirected> {
-  PublicRedirectedDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<PublicRedirected> snapshot;
-
-  @override
-  PublicRedirectedDocumentReference get reference {
-    return PublicRedirectedDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final PublicRedirected? data;
 }
 
 abstract class PublicRedirectedQuery
@@ -1307,37 +1262,18 @@ class _$PublicRedirectedQuery
 
   final CollectionReference<Object?> _collection;
 
-  PublicRedirectedQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<PublicRedirected> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return PublicRedirectedQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<PublicRedirectedDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: PublicRedirectedDocumentSnapshot._(change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return PublicRedirectedQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<PublicRedirectedQuerySnapshot> snapshots([SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference
+        .snapshots()
+        .map(PublicRedirectedQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<PublicRedirectedQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference
+        .get(options)
+        .then(PublicRedirectedQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -1678,6 +1614,24 @@ class _$PublicRedirectedQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class PublicRedirectedDocumentSnapshot
+    extends FirestoreDocumentSnapshot<PublicRedirected> {
+  PublicRedirectedDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<PublicRedirected> snapshot;
+
+  @override
+  PublicRedirectedDocumentReference get reference {
+    return PublicRedirectedDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final PublicRedirected? data;
+}
+
 class PublicRedirectedQuerySnapshot extends FirestoreQuerySnapshot<
     PublicRedirected, PublicRedirectedQueryDocumentSnapshot> {
   PublicRedirectedQuerySnapshot._(
@@ -1685,6 +1639,40 @@ class PublicRedirectedQuerySnapshot extends FirestoreQuerySnapshot<
     this.docs,
     this.docChanges,
   );
+
+  factory PublicRedirectedQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<PublicRedirected> snapshot,
+  ) {
+    final docs =
+        snapshot.docs.map(PublicRedirectedQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        PublicRedirectedDocumentSnapshot._,
+      );
+    }).toList();
+
+    return PublicRedirectedQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<PublicRedirectedDocumentSnapshot>
+      _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    PublicRedirectedDocumentSnapshot Function(DocumentSnapshot<T> doc)
+        decodeDoc,
+  ) {
+    return FirestoreDocumentChange<PublicRedirectedDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<PublicRedirected> snapshot;
 
@@ -1699,18 +1687,19 @@ class PublicRedirectedQuerySnapshot extends FirestoreQuerySnapshot<
 class PublicRedirectedQueryDocumentSnapshot
     extends FirestoreQueryDocumentSnapshot<PublicRedirected>
     implements PublicRedirectedDocumentSnapshot {
-  PublicRedirectedQueryDocumentSnapshot._(this.snapshot, this.data);
+  PublicRedirectedQueryDocumentSnapshot._(this.snapshot)
+      : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<PublicRedirected> snapshot;
 
   @override
+  final PublicRedirected data;
+
+  @override
   PublicRedirectedDocumentReference get reference {
     return PublicRedirectedDocumentReference(snapshot.reference);
   }
-
-  @override
-  final PublicRedirected data;
 }
 
 // **************************************************************************

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.dart
@@ -5,6 +5,24 @@ import 'model.dart';
 
 part 'simple.g.dart';
 
+final ignoredGetterRef = IgnoredGetterCollectionReference();
+
+@Collection<IgnoredGetter>('firestore-example-app/test/getter')
+@JsonSerializable()
+class IgnoredGetter {
+  IgnoredGetter(this.value);
+
+  final int value;
+
+  int get count => 42;
+
+  @JsonKey(ignore: true)
+  int get count2 => 42;
+
+  @JsonKey(ignore: false)
+  int get count3 => 42;
+}
+
 @Collection<Model>('root')
 @JsonSerializable()
 class Model {

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
@@ -18,6 +18,782 @@ const _sentinel = _Sentinel();
 /// A collection reference object can be used for adding documents,
 /// getting document references, and querying for documents
 /// (using the methods inherited from Query).
+abstract class IgnoredGetterCollectionReference
+    implements
+        IgnoredGetterQuery,
+        FirestoreCollectionReference<IgnoredGetter,
+            IgnoredGetterQuerySnapshot> {
+  factory IgnoredGetterCollectionReference([
+    FirebaseFirestore? firestore,
+  ]) = _$IgnoredGetterCollectionReference;
+
+  static IgnoredGetter fromFirestore(
+    DocumentSnapshot<Map<String, Object?>> snapshot,
+    SnapshotOptions? options,
+  ) {
+    return _$IgnoredGetterFromJson(snapshot.data()!);
+  }
+
+  static Map<String, Object?> toFirestore(
+    IgnoredGetter value,
+    SetOptions? options,
+  ) {
+    return _$IgnoredGetterToJson(value);
+  }
+
+  @override
+  CollectionReference<IgnoredGetter> get reference;
+
+  @override
+  IgnoredGetterDocumentReference doc([String? id]);
+
+  /// Add a new document to this collection with the specified data,
+  /// assigning it a document ID automatically.
+  Future<IgnoredGetterDocumentReference> add(IgnoredGetter value);
+}
+
+class _$IgnoredGetterCollectionReference extends _$IgnoredGetterQuery
+    implements IgnoredGetterCollectionReference {
+  factory _$IgnoredGetterCollectionReference([FirebaseFirestore? firestore]) {
+    firestore ??= FirebaseFirestore.instance;
+
+    return _$IgnoredGetterCollectionReference._(
+      firestore.collection('firestore-example-app/test/getter').withConverter(
+            fromFirestore: IgnoredGetterCollectionReference.fromFirestore,
+            toFirestore: IgnoredGetterCollectionReference.toFirestore,
+          ),
+    );
+  }
+
+  _$IgnoredGetterCollectionReference._(
+    CollectionReference<IgnoredGetter> reference,
+  ) : super(reference, $referenceWithoutCursor: reference);
+
+  String get path => reference.path;
+
+  @override
+  CollectionReference<IgnoredGetter> get reference =>
+      super.reference as CollectionReference<IgnoredGetter>;
+
+  @override
+  IgnoredGetterDocumentReference doc([String? id]) {
+    assert(
+      id == null || id.split('/').length == 1,
+      'The document ID cannot be from a different collection',
+    );
+    return IgnoredGetterDocumentReference(
+      reference.doc(id),
+    );
+  }
+
+  @override
+  Future<IgnoredGetterDocumentReference> add(IgnoredGetter value) {
+    return reference
+        .add(value)
+        .then((ref) => IgnoredGetterDocumentReference(ref));
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is _$IgnoredGetterCollectionReference &&
+        other.runtimeType == runtimeType &&
+        other.reference == reference;
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, reference);
+}
+
+abstract class IgnoredGetterDocumentReference
+    extends FirestoreDocumentReference<IgnoredGetter,
+        IgnoredGetterDocumentSnapshot> {
+  factory IgnoredGetterDocumentReference(
+          DocumentReference<IgnoredGetter> reference) =
+      _$IgnoredGetterDocumentReference;
+
+  DocumentReference<IgnoredGetter> get reference;
+
+  /// A reference to the [IgnoredGetterCollectionReference] containing this document.
+  IgnoredGetterCollectionReference get parent {
+    return _$IgnoredGetterCollectionReference(reference.firestore);
+  }
+
+  @override
+  Stream<IgnoredGetterDocumentSnapshot> snapshots();
+
+  @override
+  Future<IgnoredGetterDocumentSnapshot> get([GetOptions? options]);
+
+  @override
+  Future<void> delete();
+
+  /// Updates data on the document. Data will be merged with any existing
+  /// document data.
+  ///
+  /// If no document exists yet, the update will fail.
+  Future<void> update({
+    int value,
+    FieldValue valueFieldValue,
+  });
+
+  /// Updates fields in the current document using the transaction API.
+  ///
+  /// The update will fail if applied to a document that does not exist.
+  void transactionUpdate(
+    Transaction transaction, {
+    int value,
+    FieldValue valueFieldValue,
+  });
+}
+
+class _$IgnoredGetterDocumentReference extends FirestoreDocumentReference<
+    IgnoredGetter,
+    IgnoredGetterDocumentSnapshot> implements IgnoredGetterDocumentReference {
+  _$IgnoredGetterDocumentReference(this.reference);
+
+  @override
+  final DocumentReference<IgnoredGetter> reference;
+
+  /// A reference to the [IgnoredGetterCollectionReference] containing this document.
+  IgnoredGetterCollectionReference get parent {
+    return _$IgnoredGetterCollectionReference(reference.firestore);
+  }
+
+  @override
+  Stream<IgnoredGetterDocumentSnapshot> snapshots() {
+    return reference.snapshots().map(IgnoredGetterDocumentSnapshot._);
+  }
+
+  @override
+  Future<IgnoredGetterDocumentSnapshot> get([GetOptions? options]) {
+    return reference.get(options).then(IgnoredGetterDocumentSnapshot._);
+  }
+
+  @override
+  Future<IgnoredGetterDocumentSnapshot> transactionGet(
+      Transaction transaction) {
+    return transaction.get(reference).then(IgnoredGetterDocumentSnapshot._);
+  }
+
+  Future<void> update({
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
+  }) async {
+    assert(
+      value == _sentinel || valueFieldValue == null,
+      "Cannot specify both value and valueFieldValue",
+    );
+    final json = {
+      if (value != _sentinel) 'value': value as int,
+      if (valueFieldValue != null) 'value': valueFieldValue,
+    };
+
+    return reference.update(json);
+  }
+
+  void transactionUpdate(
+    Transaction transaction, {
+    Object? value = _sentinel,
+    FieldValue? valueFieldValue,
+  }) {
+    assert(
+      value == _sentinel || valueFieldValue == null,
+      "Cannot specify both value and valueFieldValue",
+    );
+    final json = {
+      if (value != _sentinel) 'value': value as int,
+      if (valueFieldValue != null) 'value': valueFieldValue,
+    };
+
+    transaction.update(reference, json);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is IgnoredGetterDocumentReference &&
+        other.runtimeType == runtimeType &&
+        other.parent == parent &&
+        other.id == id;
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, parent, id);
+}
+
+abstract class IgnoredGetterQuery
+    implements QueryReference<IgnoredGetter, IgnoredGetterQuerySnapshot> {
+  @override
+  IgnoredGetterQuery limit(int limit);
+
+  @override
+  IgnoredGetterQuery limitToLast(int limit);
+
+  /// Perform an order query based on a [FieldPath].
+  ///
+  /// This method is considered unsafe as it does check that the field path
+  /// maps to a valid property or that parameters such as [isEqualTo] receive
+  /// a value of the correct type.
+  ///
+  /// If possible, instead use the more explicit variant of order queries:
+  ///
+  /// **AVOID**:
+  /// ```dart
+  /// collection.orderByFieldPath(
+  ///   FieldPath.fromString('title'),
+  ///   startAt: 'title',
+  /// );
+  /// ```
+  ///
+  /// **PREFER**:
+  /// ```dart
+  /// collection.orderByTitle(startAt: 'title');
+  /// ```
+  IgnoredGetterQuery orderByFieldPath(
+    FieldPath fieldPath, {
+    bool descending = false,
+    Object? startAt,
+    Object? startAfter,
+    Object? endAt,
+    Object? endBefore,
+    IgnoredGetterDocumentSnapshot? startAtDocument,
+    IgnoredGetterDocumentSnapshot? endAtDocument,
+    IgnoredGetterDocumentSnapshot? endBeforeDocument,
+    IgnoredGetterDocumentSnapshot? startAfterDocument,
+  });
+
+  /// Perform a where query based on a [FieldPath].
+  ///
+  /// This method is considered unsafe as it does check that the field path
+  /// maps to a valid property or that parameters such as [isEqualTo] receive
+  /// a value of the correct type.
+  ///
+  /// If possible, instead use the more explicit variant of where queries:
+  ///
+  /// **AVOID**:
+  /// ```dart
+  /// collection.whereFieldPath(FieldPath.fromString('title'), isEqualTo: 'title');
+  /// ```
+  ///
+  /// **PREFER**:
+  /// ```dart
+  /// collection.whereTitle(isEqualTo: 'title');
+  /// ```
+  IgnoredGetterQuery whereFieldPath(
+    FieldPath fieldPath, {
+    Object? isEqualTo,
+    Object? isNotEqualTo,
+    Object? isLessThan,
+    Object? isLessThanOrEqualTo,
+    Object? isGreaterThan,
+    Object? isGreaterThanOrEqualTo,
+    Object? arrayContains,
+    List<Object?>? arrayContainsAny,
+    List<Object?>? whereIn,
+    List<Object?>? whereNotIn,
+    bool? isNull,
+  });
+
+  IgnoredGetterQuery whereDocumentId({
+    String? isEqualTo,
+    String? isNotEqualTo,
+    String? isLessThan,
+    String? isLessThanOrEqualTo,
+    String? isGreaterThan,
+    String? isGreaterThanOrEqualTo,
+    bool? isNull,
+    List<String>? whereIn,
+    List<String>? whereNotIn,
+  });
+  IgnoredGetterQuery whereValue({
+    int? isEqualTo,
+    int? isNotEqualTo,
+    int? isLessThan,
+    int? isLessThanOrEqualTo,
+    int? isGreaterThan,
+    int? isGreaterThanOrEqualTo,
+    bool? isNull,
+    List<int>? whereIn,
+    List<int>? whereNotIn,
+  });
+
+  IgnoredGetterQuery orderByDocumentId({
+    bool descending = false,
+    String startAt,
+    String startAfter,
+    String endAt,
+    String endBefore,
+    IgnoredGetterDocumentSnapshot? startAtDocument,
+    IgnoredGetterDocumentSnapshot? endAtDocument,
+    IgnoredGetterDocumentSnapshot? endBeforeDocument,
+    IgnoredGetterDocumentSnapshot? startAfterDocument,
+  });
+
+  IgnoredGetterQuery orderByValue({
+    bool descending = false,
+    int startAt,
+    int startAfter,
+    int endAt,
+    int endBefore,
+    IgnoredGetterDocumentSnapshot? startAtDocument,
+    IgnoredGetterDocumentSnapshot? endAtDocument,
+    IgnoredGetterDocumentSnapshot? endBeforeDocument,
+    IgnoredGetterDocumentSnapshot? startAfterDocument,
+  });
+}
+
+class _$IgnoredGetterQuery
+    extends QueryReference<IgnoredGetter, IgnoredGetterQuerySnapshot>
+    implements IgnoredGetterQuery {
+  _$IgnoredGetterQuery(
+    this._collection, {
+    required Query<IgnoredGetter> $referenceWithoutCursor,
+    $QueryCursor $queryCursor = const $QueryCursor(),
+  }) : super(
+          $referenceWithoutCursor: $referenceWithoutCursor,
+          $queryCursor: $queryCursor,
+        );
+
+  final CollectionReference<Object?> _collection;
+
+  @override
+  Stream<IgnoredGetterQuerySnapshot> snapshots([SnapshotOptions? options]) {
+    return reference
+        .snapshots()
+        .map(IgnoredGetterQuerySnapshot._fromQuerySnapshot);
+  }
+
+  @override
+  Future<IgnoredGetterQuerySnapshot> get([GetOptions? options]) {
+    return reference
+        .get(options)
+        .then(IgnoredGetterQuerySnapshot._fromQuerySnapshot);
+  }
+
+  @override
+  IgnoredGetterQuery limit(int limit) {
+    return _$IgnoredGetterQuery(
+      _collection,
+      $referenceWithoutCursor: $referenceWithoutCursor.limit(limit),
+      $queryCursor: $queryCursor,
+    );
+  }
+
+  @override
+  IgnoredGetterQuery limitToLast(int limit) {
+    return _$IgnoredGetterQuery(
+      _collection,
+      $referenceWithoutCursor: $referenceWithoutCursor.limitToLast(limit),
+      $queryCursor: $queryCursor,
+    );
+  }
+
+  IgnoredGetterQuery orderByFieldPath(
+    FieldPath fieldPath, {
+    bool descending = false,
+    Object? startAt = _sentinel,
+    Object? startAfter = _sentinel,
+    Object? endAt = _sentinel,
+    Object? endBefore = _sentinel,
+    IgnoredGetterDocumentSnapshot? startAtDocument,
+    IgnoredGetterDocumentSnapshot? endAtDocument,
+    IgnoredGetterDocumentSnapshot? endBeforeDocument,
+    IgnoredGetterDocumentSnapshot? startAfterDocument,
+  }) {
+    final query =
+        $referenceWithoutCursor.orderBy(fieldPath, descending: descending);
+    var queryCursor = $queryCursor;
+
+    if (startAtDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        startAt: const [],
+        startAtDocumentSnapshot: startAtDocument.snapshot,
+      );
+    }
+    if (startAfterDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        startAfter: const [],
+        startAfterDocumentSnapshot: startAfterDocument.snapshot,
+      );
+    }
+    if (endAtDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        endAt: const [],
+        endAtDocumentSnapshot: endAtDocument.snapshot,
+      );
+    }
+    if (endBeforeDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        endBefore: const [],
+        endBeforeDocumentSnapshot: endBeforeDocument.snapshot,
+      );
+    }
+
+    if (startAt != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        startAt: [...queryCursor.startAt, startAt],
+        startAtDocumentSnapshot: null,
+      );
+    }
+    if (startAfter != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        startAfter: [...queryCursor.startAfter, startAfter],
+        startAfterDocumentSnapshot: null,
+      );
+    }
+    if (endAt != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        endAt: [...queryCursor.endAt, endAt],
+        endAtDocumentSnapshot: null,
+      );
+    }
+    if (endBefore != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        endBefore: [...queryCursor.endBefore, endBefore],
+        endBeforeDocumentSnapshot: null,
+      );
+    }
+    return _$IgnoredGetterQuery(
+      _collection,
+      $referenceWithoutCursor: query,
+      $queryCursor: queryCursor,
+    );
+  }
+
+  IgnoredGetterQuery whereFieldPath(
+    FieldPath fieldPath, {
+    Object? isEqualTo,
+    Object? isNotEqualTo,
+    Object? isLessThan,
+    Object? isLessThanOrEqualTo,
+    Object? isGreaterThan,
+    Object? isGreaterThanOrEqualTo,
+    Object? arrayContains,
+    List<Object?>? arrayContainsAny,
+    List<Object?>? whereIn,
+    List<Object?>? whereNotIn,
+    bool? isNull,
+  }) {
+    return _$IgnoredGetterQuery(
+      _collection,
+      $referenceWithoutCursor: $referenceWithoutCursor.where(
+        fieldPath,
+        isEqualTo: isEqualTo,
+        isNotEqualTo: isNotEqualTo,
+        isLessThan: isLessThan,
+        isLessThanOrEqualTo: isLessThanOrEqualTo,
+        isGreaterThan: isGreaterThan,
+        isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
+        arrayContains: arrayContains,
+        arrayContainsAny: arrayContainsAny,
+        whereIn: whereIn,
+        whereNotIn: whereNotIn,
+        isNull: isNull,
+      ),
+      $queryCursor: $queryCursor,
+    );
+  }
+
+  IgnoredGetterQuery whereDocumentId({
+    String? isEqualTo,
+    String? isNotEqualTo,
+    String? isLessThan,
+    String? isLessThanOrEqualTo,
+    String? isGreaterThan,
+    String? isGreaterThanOrEqualTo,
+    bool? isNull,
+    List<String>? whereIn,
+    List<String>? whereNotIn,
+  }) {
+    return _$IgnoredGetterQuery(
+      _collection,
+      $referenceWithoutCursor: $referenceWithoutCursor.where(
+        FieldPath.documentId,
+        isEqualTo: isEqualTo,
+        isNotEqualTo: isNotEqualTo,
+        isLessThan: isLessThan,
+        isLessThanOrEqualTo: isLessThanOrEqualTo,
+        isGreaterThan: isGreaterThan,
+        isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
+        isNull: isNull,
+        whereIn: whereIn,
+        whereNotIn: whereNotIn,
+      ),
+      $queryCursor: $queryCursor,
+    );
+  }
+
+  IgnoredGetterQuery whereValue({
+    int? isEqualTo,
+    int? isNotEqualTo,
+    int? isLessThan,
+    int? isLessThanOrEqualTo,
+    int? isGreaterThan,
+    int? isGreaterThanOrEqualTo,
+    bool? isNull,
+    List<int>? whereIn,
+    List<int>? whereNotIn,
+  }) {
+    return _$IgnoredGetterQuery(
+      _collection,
+      $referenceWithoutCursor: $referenceWithoutCursor.where(
+        _$IgnoredGetterFieldMap['value']!,
+        isEqualTo: isEqualTo,
+        isNotEqualTo: isNotEqualTo,
+        isLessThan: isLessThan,
+        isLessThanOrEqualTo: isLessThanOrEqualTo,
+        isGreaterThan: isGreaterThan,
+        isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
+        isNull: isNull,
+        whereIn: whereIn,
+        whereNotIn: whereNotIn,
+      ),
+      $queryCursor: $queryCursor,
+    );
+  }
+
+  IgnoredGetterQuery orderByDocumentId({
+    bool descending = false,
+    Object? startAt = _sentinel,
+    Object? startAfter = _sentinel,
+    Object? endAt = _sentinel,
+    Object? endBefore = _sentinel,
+    IgnoredGetterDocumentSnapshot? startAtDocument,
+    IgnoredGetterDocumentSnapshot? endAtDocument,
+    IgnoredGetterDocumentSnapshot? endBeforeDocument,
+    IgnoredGetterDocumentSnapshot? startAfterDocument,
+  }) {
+    final query = $referenceWithoutCursor.orderBy(FieldPath.documentId,
+        descending: descending);
+    var queryCursor = $queryCursor;
+
+    if (startAtDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        startAt: const [],
+        startAtDocumentSnapshot: startAtDocument.snapshot,
+      );
+    }
+    if (startAfterDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        startAfter: const [],
+        startAfterDocumentSnapshot: startAfterDocument.snapshot,
+      );
+    }
+    if (endAtDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        endAt: const [],
+        endAtDocumentSnapshot: endAtDocument.snapshot,
+      );
+    }
+    if (endBeforeDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        endBefore: const [],
+        endBeforeDocumentSnapshot: endBeforeDocument.snapshot,
+      );
+    }
+
+    if (startAt != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        startAt: [...queryCursor.startAt, startAt],
+        startAtDocumentSnapshot: null,
+      );
+    }
+    if (startAfter != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        startAfter: [...queryCursor.startAfter, startAfter],
+        startAfterDocumentSnapshot: null,
+      );
+    }
+    if (endAt != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        endAt: [...queryCursor.endAt, endAt],
+        endAtDocumentSnapshot: null,
+      );
+    }
+    if (endBefore != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        endBefore: [...queryCursor.endBefore, endBefore],
+        endBeforeDocumentSnapshot: null,
+      );
+    }
+
+    return _$IgnoredGetterQuery(
+      _collection,
+      $referenceWithoutCursor: query,
+      $queryCursor: queryCursor,
+    );
+  }
+
+  IgnoredGetterQuery orderByValue({
+    bool descending = false,
+    Object? startAt = _sentinel,
+    Object? startAfter = _sentinel,
+    Object? endAt = _sentinel,
+    Object? endBefore = _sentinel,
+    IgnoredGetterDocumentSnapshot? startAtDocument,
+    IgnoredGetterDocumentSnapshot? endAtDocument,
+    IgnoredGetterDocumentSnapshot? endBeforeDocument,
+    IgnoredGetterDocumentSnapshot? startAfterDocument,
+  }) {
+    final query = $referenceWithoutCursor
+        .orderBy(_$IgnoredGetterFieldMap['value']!, descending: descending);
+    var queryCursor = $queryCursor;
+
+    if (startAtDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        startAt: const [],
+        startAtDocumentSnapshot: startAtDocument.snapshot,
+      );
+    }
+    if (startAfterDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        startAfter: const [],
+        startAfterDocumentSnapshot: startAfterDocument.snapshot,
+      );
+    }
+    if (endAtDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        endAt: const [],
+        endAtDocumentSnapshot: endAtDocument.snapshot,
+      );
+    }
+    if (endBeforeDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        endBefore: const [],
+        endBeforeDocumentSnapshot: endBeforeDocument.snapshot,
+      );
+    }
+
+    if (startAt != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        startAt: [...queryCursor.startAt, startAt],
+        startAtDocumentSnapshot: null,
+      );
+    }
+    if (startAfter != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        startAfter: [...queryCursor.startAfter, startAfter],
+        startAfterDocumentSnapshot: null,
+      );
+    }
+    if (endAt != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        endAt: [...queryCursor.endAt, endAt],
+        endAtDocumentSnapshot: null,
+      );
+    }
+    if (endBefore != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        endBefore: [...queryCursor.endBefore, endBefore],
+        endBeforeDocumentSnapshot: null,
+      );
+    }
+
+    return _$IgnoredGetterQuery(
+      _collection,
+      $referenceWithoutCursor: query,
+      $queryCursor: queryCursor,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is _$IgnoredGetterQuery &&
+        other.runtimeType == runtimeType &&
+        other.reference == reference;
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, reference);
+}
+
+class IgnoredGetterDocumentSnapshot
+    extends FirestoreDocumentSnapshot<IgnoredGetter> {
+  IgnoredGetterDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<IgnoredGetter> snapshot;
+
+  @override
+  IgnoredGetterDocumentReference get reference {
+    return IgnoredGetterDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final IgnoredGetter? data;
+}
+
+class IgnoredGetterQuerySnapshot extends FirestoreQuerySnapshot<IgnoredGetter,
+    IgnoredGetterQueryDocumentSnapshot> {
+  IgnoredGetterQuerySnapshot._(
+    this.snapshot,
+    this.docs,
+    this.docChanges,
+  );
+
+  factory IgnoredGetterQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<IgnoredGetter> snapshot,
+  ) {
+    final docs =
+        snapshot.docs.map(IgnoredGetterQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        IgnoredGetterDocumentSnapshot._,
+      );
+    }).toList();
+
+    return IgnoredGetterQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<IgnoredGetterDocumentSnapshot>
+      _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    IgnoredGetterDocumentSnapshot Function(DocumentSnapshot<T> doc) decodeDoc,
+  ) {
+    return FirestoreDocumentChange<IgnoredGetterDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
+
+  final QuerySnapshot<IgnoredGetter> snapshot;
+
+  @override
+  final List<IgnoredGetterQueryDocumentSnapshot> docs;
+
+  @override
+  final List<FirestoreDocumentChange<IgnoredGetterDocumentSnapshot>> docChanges;
+}
+
+class IgnoredGetterQueryDocumentSnapshot
+    extends FirestoreQueryDocumentSnapshot<IgnoredGetter>
+    implements IgnoredGetterDocumentSnapshot {
+  IgnoredGetterQueryDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final QueryDocumentSnapshot<IgnoredGetter> snapshot;
+
+  @override
+  final IgnoredGetter data;
+
+  @override
+  IgnoredGetterDocumentReference get reference {
+    return IgnoredGetterDocumentReference(snapshot.reference);
+  }
+}
+
+/// A collection reference object can be used for adding documents,
+/// getting document references, and querying for documents
+/// (using the methods inherited from Query).
 abstract class ModelCollectionReference
     implements
         ModelQuery,
@@ -156,32 +932,17 @@ class _$ModelDocumentReference
 
   @override
   Stream<ModelDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return ModelDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(ModelDocumentSnapshot._);
   }
 
   @override
   Future<ModelDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return ModelDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(ModelDocumentSnapshot._);
   }
 
   @override
   Future<ModelDocumentSnapshot> transactionGet(Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return ModelDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction.get(reference).then(ModelDocumentSnapshot._);
   }
 
   Future<void> update({
@@ -227,26 +988,6 @@ class _$ModelDocumentReference
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class ModelDocumentSnapshot extends FirestoreDocumentSnapshot<Model> {
-  ModelDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<Model> snapshot;
-
-  @override
-  ModelDocumentReference get reference {
-    return ModelDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final Model? data;
 }
 
 abstract class ModelQuery implements QueryReference<Model, ModelQuerySnapshot> {
@@ -382,37 +1123,14 @@ class _$ModelQuery extends QueryReference<Model, ModelQuerySnapshot>
 
   final CollectionReference<Object?> _collection;
 
-  ModelQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<Model> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return ModelQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<ModelDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: ModelDocumentSnapshot._(change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return ModelQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<ModelQuerySnapshot> snapshots([SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference.snapshots().map(ModelQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<ModelQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference.get(options).then(ModelQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -752,6 +1470,23 @@ class _$ModelQuery extends QueryReference<Model, ModelQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class ModelDocumentSnapshot extends FirestoreDocumentSnapshot<Model> {
+  ModelDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<Model> snapshot;
+
+  @override
+  ModelDocumentReference get reference {
+    return ModelDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final Model? data;
+}
+
 class ModelQuerySnapshot
     extends FirestoreQuerySnapshot<Model, ModelQueryDocumentSnapshot> {
   ModelQuerySnapshot._(
@@ -759,6 +1494,38 @@ class ModelQuerySnapshot
     this.docs,
     this.docChanges,
   );
+
+  factory ModelQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<Model> snapshot,
+  ) {
+    final docs = snapshot.docs.map(ModelQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        ModelDocumentSnapshot._,
+      );
+    }).toList();
+
+    return ModelQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<ModelDocumentSnapshot>
+      _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    ModelDocumentSnapshot Function(DocumentSnapshot<T> doc) decodeDoc,
+  ) {
+    return FirestoreDocumentChange<ModelDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<Model> snapshot;
 
@@ -771,18 +1538,18 @@ class ModelQuerySnapshot
 
 class ModelQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot<Model>
     implements ModelDocumentSnapshot {
-  ModelQueryDocumentSnapshot._(this.snapshot, this.data);
+  ModelQueryDocumentSnapshot._(this.snapshot) : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<Model> snapshot;
 
   @override
+  final Model data;
+
+  @override
   ModelDocumentReference get reference {
     return ModelDocumentReference(snapshot.reference);
   }
-
-  @override
-  final Model data;
 }
 
 /// A collection reference object can be used for adding documents,
@@ -946,32 +1713,17 @@ class _$NestedDocumentReference
 
   @override
   Stream<NestedDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return NestedDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(NestedDocumentSnapshot._);
   }
 
   @override
   Future<NestedDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return NestedDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(NestedDocumentSnapshot._);
   }
 
   @override
   Future<NestedDocumentSnapshot> transactionGet(Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return NestedDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction.get(reference).then(NestedDocumentSnapshot._);
   }
 
   Future<void> update({
@@ -1099,26 +1851,6 @@ class _$NestedDocumentReference
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class NestedDocumentSnapshot extends FirestoreDocumentSnapshot<Nested> {
-  NestedDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<Nested> snapshot;
-
-  @override
-  NestedDocumentReference get reference {
-    return NestedDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final Nested? data;
 }
 
 abstract class NestedQuery
@@ -1370,37 +2102,14 @@ class _$NestedQuery extends QueryReference<Nested, NestedQuerySnapshot>
 
   final CollectionReference<Object?> _collection;
 
-  NestedQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<Nested> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return NestedQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<NestedDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: NestedDocumentSnapshot._(change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return NestedQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<NestedQuerySnapshot> snapshots([SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference.snapshots().map(NestedQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<NestedQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference.get(options).then(NestedQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -2245,6 +2954,23 @@ class _$NestedQuery extends QueryReference<Nested, NestedQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class NestedDocumentSnapshot extends FirestoreDocumentSnapshot<Nested> {
+  NestedDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<Nested> snapshot;
+
+  @override
+  NestedDocumentReference get reference {
+    return NestedDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final Nested? data;
+}
+
 class NestedQuerySnapshot
     extends FirestoreQuerySnapshot<Nested, NestedQueryDocumentSnapshot> {
   NestedQuerySnapshot._(
@@ -2252,6 +2978,38 @@ class NestedQuerySnapshot
     this.docs,
     this.docChanges,
   );
+
+  factory NestedQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<Nested> snapshot,
+  ) {
+    final docs = snapshot.docs.map(NestedQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        NestedDocumentSnapshot._,
+      );
+    }).toList();
+
+    return NestedQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<NestedDocumentSnapshot>
+      _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    NestedDocumentSnapshot Function(DocumentSnapshot<T> doc) decodeDoc,
+  ) {
+    return FirestoreDocumentChange<NestedDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<Nested> snapshot;
 
@@ -2264,18 +3022,18 @@ class NestedQuerySnapshot
 
 class NestedQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot<Nested>
     implements NestedDocumentSnapshot {
-  NestedQueryDocumentSnapshot._(this.snapshot, this.data);
+  NestedQueryDocumentSnapshot._(this.snapshot) : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<Nested> snapshot;
 
   @override
+  final Nested data;
+
+  @override
   NestedDocumentReference get reference {
     return NestedDocumentReference(snapshot.reference);
   }
-
-  @override
-  final Nested data;
 }
 
 /// A collection reference object can be used for adding documents,
@@ -2406,33 +3164,18 @@ class _$SplitFileModelDocumentReference extends FirestoreDocumentReference<
 
   @override
   Stream<SplitFileModelDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return SplitFileModelDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(SplitFileModelDocumentSnapshot._);
   }
 
   @override
   Future<SplitFileModelDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return SplitFileModelDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(SplitFileModelDocumentSnapshot._);
   }
 
   @override
   Future<SplitFileModelDocumentSnapshot> transactionGet(
       Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return SplitFileModelDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction.get(reference).then(SplitFileModelDocumentSnapshot._);
   }
 
   @override
@@ -2445,27 +3188,6 @@ class _$SplitFileModelDocumentReference extends FirestoreDocumentReference<
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class SplitFileModelDocumentSnapshot
-    extends FirestoreDocumentSnapshot<SplitFileModel> {
-  SplitFileModelDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<SplitFileModel> snapshot;
-
-  @override
-  SplitFileModelDocumentReference get reference {
-    return SplitFileModelDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final SplitFileModel? data;
 }
 
 abstract class SplitFileModelQuery
@@ -2580,37 +3302,18 @@ class _$SplitFileModelQuery
 
   final CollectionReference<Object?> _collection;
 
-  SplitFileModelQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<SplitFileModel> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return SplitFileModelQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<SplitFileModelDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: SplitFileModelDocumentSnapshot._(change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return SplitFileModelQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<SplitFileModelQuerySnapshot> snapshots([SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference
+        .snapshots()
+        .map(SplitFileModelQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<SplitFileModelQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference
+        .get(options)
+        .then(SplitFileModelQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -2849,6 +3552,24 @@ class _$SplitFileModelQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class SplitFileModelDocumentSnapshot
+    extends FirestoreDocumentSnapshot<SplitFileModel> {
+  SplitFileModelDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<SplitFileModel> snapshot;
+
+  @override
+  SplitFileModelDocumentReference get reference {
+    return SplitFileModelDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final SplitFileModel? data;
+}
+
 class SplitFileModelQuerySnapshot extends FirestoreQuerySnapshot<SplitFileModel,
     SplitFileModelQueryDocumentSnapshot> {
   SplitFileModelQuerySnapshot._(
@@ -2856,6 +3577,39 @@ class SplitFileModelQuerySnapshot extends FirestoreQuerySnapshot<SplitFileModel,
     this.docs,
     this.docChanges,
   );
+
+  factory SplitFileModelQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<SplitFileModel> snapshot,
+  ) {
+    final docs =
+        snapshot.docs.map(SplitFileModelQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        SplitFileModelDocumentSnapshot._,
+      );
+    }).toList();
+
+    return SplitFileModelQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<SplitFileModelDocumentSnapshot>
+      _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    SplitFileModelDocumentSnapshot Function(DocumentSnapshot<T> doc) decodeDoc,
+  ) {
+    return FirestoreDocumentChange<SplitFileModelDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<SplitFileModel> snapshot;
 
@@ -2870,18 +3624,18 @@ class SplitFileModelQuerySnapshot extends FirestoreQuerySnapshot<SplitFileModel,
 class SplitFileModelQueryDocumentSnapshot
     extends FirestoreQueryDocumentSnapshot<SplitFileModel>
     implements SplitFileModelDocumentSnapshot {
-  SplitFileModelQueryDocumentSnapshot._(this.snapshot, this.data);
+  SplitFileModelQueryDocumentSnapshot._(this.snapshot) : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<SplitFileModel> snapshot;
 
   @override
+  final SplitFileModel data;
+
+  @override
   SplitFileModelDocumentReference get reference {
     return SplitFileModelDocumentReference(snapshot.reference);
   }
-
-  @override
-  final SplitFileModel data;
 }
 
 /// A collection reference object can be used for adding documents,
@@ -3007,32 +3761,17 @@ class _$EmptyModelDocumentReference
 
   @override
   Stream<EmptyModelDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return EmptyModelDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(EmptyModelDocumentSnapshot._);
   }
 
   @override
   Future<EmptyModelDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return EmptyModelDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(EmptyModelDocumentSnapshot._);
   }
 
   @override
   Future<EmptyModelDocumentSnapshot> transactionGet(Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return EmptyModelDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction.get(reference).then(EmptyModelDocumentSnapshot._);
   }
 
   @override
@@ -3045,26 +3784,6 @@ class _$EmptyModelDocumentReference
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class EmptyModelDocumentSnapshot extends FirestoreDocumentSnapshot<EmptyModel> {
-  EmptyModelDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<EmptyModel> snapshot;
-
-  @override
-  EmptyModelDocumentReference get reference {
-    return EmptyModelDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final EmptyModel? data;
 }
 
 abstract class EmptyModelQuery
@@ -3179,37 +3898,18 @@ class _$EmptyModelQuery
 
   final CollectionReference<Object?> _collection;
 
-  EmptyModelQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<EmptyModel> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return EmptyModelQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<EmptyModelDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: EmptyModelDocumentSnapshot._(change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return EmptyModelQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<EmptyModelQuerySnapshot> snapshots([SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference
+        .snapshots()
+        .map(EmptyModelQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<EmptyModelQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference
+        .get(options)
+        .then(EmptyModelQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -3448,6 +4148,23 @@ class _$EmptyModelQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class EmptyModelDocumentSnapshot extends FirestoreDocumentSnapshot<EmptyModel> {
+  EmptyModelDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<EmptyModel> snapshot;
+
+  @override
+  EmptyModelDocumentReference get reference {
+    return EmptyModelDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final EmptyModel? data;
+}
+
 class EmptyModelQuerySnapshot extends FirestoreQuerySnapshot<EmptyModel,
     EmptyModelQueryDocumentSnapshot> {
   EmptyModelQuerySnapshot._(
@@ -3455,6 +4172,38 @@ class EmptyModelQuerySnapshot extends FirestoreQuerySnapshot<EmptyModel,
     this.docs,
     this.docChanges,
   );
+
+  factory EmptyModelQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<EmptyModel> snapshot,
+  ) {
+    final docs = snapshot.docs.map(EmptyModelQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        EmptyModelDocumentSnapshot._,
+      );
+    }).toList();
+
+    return EmptyModelQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<EmptyModelDocumentSnapshot>
+      _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    EmptyModelDocumentSnapshot Function(DocumentSnapshot<T> doc) decodeDoc,
+  ) {
+    return FirestoreDocumentChange<EmptyModelDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<EmptyModel> snapshot;
 
@@ -3468,18 +4217,18 @@ class EmptyModelQuerySnapshot extends FirestoreQuerySnapshot<EmptyModel,
 class EmptyModelQueryDocumentSnapshot
     extends FirestoreQueryDocumentSnapshot<EmptyModel>
     implements EmptyModelDocumentSnapshot {
-  EmptyModelQueryDocumentSnapshot._(this.snapshot, this.data);
+  EmptyModelQueryDocumentSnapshot._(this.snapshot) : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<EmptyModel> snapshot;
 
   @override
+  final EmptyModel data;
+
+  @override
   EmptyModelDocumentReference get reference {
     return EmptyModelDocumentReference(snapshot.reference);
   }
-
-  @override
-  final EmptyModel data;
 }
 
 /// A collection reference object can be used for adding documents,
@@ -3626,32 +4375,17 @@ class _$OptionalJsonDocumentReference extends FirestoreDocumentReference<
 
   @override
   Stream<OptionalJsonDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return OptionalJsonDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(OptionalJsonDocumentSnapshot._);
   }
 
   @override
   Future<OptionalJsonDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return OptionalJsonDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(OptionalJsonDocumentSnapshot._);
   }
 
   @override
   Future<OptionalJsonDocumentSnapshot> transactionGet(Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return OptionalJsonDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction.get(reference).then(OptionalJsonDocumentSnapshot._);
   }
 
   Future<void> update({
@@ -3697,27 +4431,6 @@ class _$OptionalJsonDocumentReference extends FirestoreDocumentReference<
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class OptionalJsonDocumentSnapshot
-    extends FirestoreDocumentSnapshot<OptionalJson> {
-  OptionalJsonDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<OptionalJson> snapshot;
-
-  @override
-  OptionalJsonDocumentReference get reference {
-    return OptionalJsonDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final OptionalJson? data;
 }
 
 abstract class OptionalJsonQuery
@@ -3855,37 +4568,18 @@ class _$OptionalJsonQuery
 
   final CollectionReference<Object?> _collection;
 
-  OptionalJsonQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<OptionalJson> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return OptionalJsonQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<OptionalJsonDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: OptionalJsonDocumentSnapshot._(change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return OptionalJsonQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<OptionalJsonQuerySnapshot> snapshots([SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference
+        .snapshots()
+        .map(OptionalJsonQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<OptionalJsonQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference
+        .get(options)
+        .then(OptionalJsonQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -4225,6 +4919,24 @@ class _$OptionalJsonQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class OptionalJsonDocumentSnapshot
+    extends FirestoreDocumentSnapshot<OptionalJson> {
+  OptionalJsonDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<OptionalJson> snapshot;
+
+  @override
+  OptionalJsonDocumentReference get reference {
+    return OptionalJsonDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final OptionalJson? data;
+}
+
 class OptionalJsonQuerySnapshot extends FirestoreQuerySnapshot<OptionalJson,
     OptionalJsonQueryDocumentSnapshot> {
   OptionalJsonQuerySnapshot._(
@@ -4232,6 +4944,39 @@ class OptionalJsonQuerySnapshot extends FirestoreQuerySnapshot<OptionalJson,
     this.docs,
     this.docChanges,
   );
+
+  factory OptionalJsonQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<OptionalJson> snapshot,
+  ) {
+    final docs =
+        snapshot.docs.map(OptionalJsonQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        OptionalJsonDocumentSnapshot._,
+      );
+    }).toList();
+
+    return OptionalJsonQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<OptionalJsonDocumentSnapshot>
+      _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    OptionalJsonDocumentSnapshot Function(DocumentSnapshot<T> doc) decodeDoc,
+  ) {
+    return FirestoreDocumentChange<OptionalJsonDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<OptionalJson> snapshot;
 
@@ -4245,18 +4990,18 @@ class OptionalJsonQuerySnapshot extends FirestoreQuerySnapshot<OptionalJson,
 class OptionalJsonQueryDocumentSnapshot
     extends FirestoreQueryDocumentSnapshot<OptionalJson>
     implements OptionalJsonDocumentSnapshot {
-  OptionalJsonQueryDocumentSnapshot._(this.snapshot, this.data);
+  OptionalJsonQueryDocumentSnapshot._(this.snapshot) : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<OptionalJson> snapshot;
 
   @override
+  final OptionalJson data;
+
+  @override
   OptionalJsonDocumentReference get reference {
     return OptionalJsonDocumentReference(snapshot.reference);
   }
-
-  @override
-  final OptionalJson data;
 }
 
 /// A collection reference object can be used for adding documents,
@@ -4400,32 +5145,17 @@ class _$MixedJsonDocumentReference
 
   @override
   Stream<MixedJsonDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return MixedJsonDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(MixedJsonDocumentSnapshot._);
   }
 
   @override
   Future<MixedJsonDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return MixedJsonDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(MixedJsonDocumentSnapshot._);
   }
 
   @override
   Future<MixedJsonDocumentSnapshot> transactionGet(Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return MixedJsonDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction.get(reference).then(MixedJsonDocumentSnapshot._);
   }
 
   Future<void> update({
@@ -4471,26 +5201,6 @@ class _$MixedJsonDocumentReference
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class MixedJsonDocumentSnapshot extends FirestoreDocumentSnapshot<MixedJson> {
-  MixedJsonDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<MixedJson> snapshot;
-
-  @override
-  MixedJsonDocumentReference get reference {
-    return MixedJsonDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final MixedJson? data;
 }
 
 abstract class MixedJsonQuery
@@ -4627,37 +5337,16 @@ class _$MixedJsonQuery extends QueryReference<MixedJson, MixedJsonQuerySnapshot>
 
   final CollectionReference<Object?> _collection;
 
-  MixedJsonQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<MixedJson> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return MixedJsonQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<MixedJsonDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: MixedJsonDocumentSnapshot._(change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return MixedJsonQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<MixedJsonQuerySnapshot> snapshots([SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference.snapshots().map(MixedJsonQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<MixedJsonQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference
+        .get(options)
+        .then(MixedJsonQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -4997,6 +5686,23 @@ class _$MixedJsonQuery extends QueryReference<MixedJson, MixedJsonQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class MixedJsonDocumentSnapshot extends FirestoreDocumentSnapshot<MixedJson> {
+  MixedJsonDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<MixedJson> snapshot;
+
+  @override
+  MixedJsonDocumentReference get reference {
+    return MixedJsonDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final MixedJson? data;
+}
+
 class MixedJsonQuerySnapshot
     extends FirestoreQuerySnapshot<MixedJson, MixedJsonQueryDocumentSnapshot> {
   MixedJsonQuerySnapshot._(
@@ -5004,6 +5710,38 @@ class MixedJsonQuerySnapshot
     this.docs,
     this.docChanges,
   );
+
+  factory MixedJsonQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<MixedJson> snapshot,
+  ) {
+    final docs = snapshot.docs.map(MixedJsonQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        MixedJsonDocumentSnapshot._,
+      );
+    }).toList();
+
+    return MixedJsonQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<MixedJsonDocumentSnapshot>
+      _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    MixedJsonDocumentSnapshot Function(DocumentSnapshot<T> doc) decodeDoc,
+  ) {
+    return FirestoreDocumentChange<MixedJsonDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<MixedJson> snapshot;
 
@@ -5017,18 +5755,18 @@ class MixedJsonQuerySnapshot
 class MixedJsonQueryDocumentSnapshot
     extends FirestoreQueryDocumentSnapshot<MixedJson>
     implements MixedJsonDocumentSnapshot {
-  MixedJsonQueryDocumentSnapshot._(this.snapshot, this.data);
+  MixedJsonQueryDocumentSnapshot._(this.snapshot) : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<MixedJson> snapshot;
 
   @override
+  final MixedJson data;
+
+  @override
   MixedJsonDocumentReference get reference {
     return MixedJsonDocumentReference(snapshot.reference);
   }
-
-  @override
-  final MixedJson data;
 }
 
 /// A collection reference object can be used for adding documents,
@@ -5214,32 +5952,17 @@ class _$RootDocumentReference
 
   @override
   Stream<RootDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return RootDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(RootDocumentSnapshot._);
   }
 
   @override
   Future<RootDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return RootDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(RootDocumentSnapshot._);
   }
 
   @override
   Future<RootDocumentSnapshot> transactionGet(Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return RootDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction.get(reference).then(RootDocumentSnapshot._);
   }
 
   Future<void> update({
@@ -5301,26 +6024,6 @@ class _$RootDocumentReference
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class RootDocumentSnapshot extends FirestoreDocumentSnapshot<Root> {
-  RootDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<Root> snapshot;
-
-  @override
-  RootDocumentReference get reference {
-    return RootDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final Root? data;
 }
 
 abstract class RootQuery implements QueryReference<Root, RootQuerySnapshot> {
@@ -5479,37 +6182,14 @@ class _$RootQuery extends QueryReference<Root, RootQuerySnapshot>
 
   final CollectionReference<Object?> _collection;
 
-  RootQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<Root> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return RootQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<RootDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: RootDocumentSnapshot._(change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return RootQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<RootQuerySnapshot> snapshots([SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference.snapshots().map(RootQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<RootQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference.get(options).then(RootQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -5950,6 +6630,23 @@ class _$RootQuery extends QueryReference<Root, RootQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class RootDocumentSnapshot extends FirestoreDocumentSnapshot<Root> {
+  RootDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<Root> snapshot;
+
+  @override
+  RootDocumentReference get reference {
+    return RootDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final Root? data;
+}
+
 class RootQuerySnapshot
     extends FirestoreQuerySnapshot<Root, RootQueryDocumentSnapshot> {
   RootQuerySnapshot._(
@@ -5957,6 +6654,37 @@ class RootQuerySnapshot
     this.docs,
     this.docChanges,
   );
+
+  factory RootQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<Root> snapshot,
+  ) {
+    final docs = snapshot.docs.map(RootQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        RootDocumentSnapshot._,
+      );
+    }).toList();
+
+    return RootQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<RootDocumentSnapshot> _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    RootDocumentSnapshot Function(DocumentSnapshot<T> doc) decodeDoc,
+  ) {
+    return FirestoreDocumentChange<RootDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<Root> snapshot;
 
@@ -5969,18 +6697,18 @@ class RootQuerySnapshot
 
 class RootQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot<Root>
     implements RootDocumentSnapshot {
-  RootQueryDocumentSnapshot._(this.snapshot, this.data);
+  RootQueryDocumentSnapshot._(this.snapshot) : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<Root> snapshot;
 
   @override
+  final Root data;
+
+  @override
   RootDocumentReference get reference {
     return RootDocumentReference(snapshot.reference);
   }
-
-  @override
-  final Root data;
 }
 
 /// A collection reference object can be used for adding documents,
@@ -6144,32 +6872,17 @@ class _$SubDocumentReference
 
   @override
   Stream<SubDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return SubDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(SubDocumentSnapshot._);
   }
 
   @override
   Future<SubDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return SubDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(SubDocumentSnapshot._);
   }
 
   @override
   Future<SubDocumentSnapshot> transactionGet(Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return SubDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction.get(reference).then(SubDocumentSnapshot._);
   }
 
   Future<void> update({
@@ -6231,26 +6944,6 @@ class _$SubDocumentReference
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class SubDocumentSnapshot extends FirestoreDocumentSnapshot<Sub> {
-  SubDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<Sub> snapshot;
-
-  @override
-  SubDocumentReference get reference {
-    return SubDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final Sub? data;
 }
 
 abstract class SubQuery implements QueryReference<Sub, SubQuerySnapshot> {
@@ -6409,37 +7102,14 @@ class _$SubQuery extends QueryReference<Sub, SubQuerySnapshot>
 
   final CollectionReference<Object?> _collection;
 
-  SubQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<Sub> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return SubQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<SubDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: SubDocumentSnapshot._(change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return SubQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<SubQuerySnapshot> snapshots([SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference.snapshots().map(SubQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<SubQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference.get(options).then(SubQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -6880,6 +7550,23 @@ class _$SubQuery extends QueryReference<Sub, SubQuerySnapshot>
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class SubDocumentSnapshot extends FirestoreDocumentSnapshot<Sub> {
+  SubDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<Sub> snapshot;
+
+  @override
+  SubDocumentReference get reference {
+    return SubDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final Sub? data;
+}
+
 class SubQuerySnapshot
     extends FirestoreQuerySnapshot<Sub, SubQueryDocumentSnapshot> {
   SubQuerySnapshot._(
@@ -6887,6 +7574,37 @@ class SubQuerySnapshot
     this.docs,
     this.docChanges,
   );
+
+  factory SubQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<Sub> snapshot,
+  ) {
+    final docs = snapshot.docs.map(SubQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        SubDocumentSnapshot._,
+      );
+    }).toList();
+
+    return SubQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<SubDocumentSnapshot> _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    SubDocumentSnapshot Function(DocumentSnapshot<T> doc) decodeDoc,
+  ) {
+    return FirestoreDocumentChange<SubDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<Sub> snapshot;
 
@@ -6899,18 +7617,18 @@ class SubQuerySnapshot
 
 class SubQueryDocumentSnapshot extends FirestoreQueryDocumentSnapshot<Sub>
     implements SubDocumentSnapshot {
-  SubQueryDocumentSnapshot._(this.snapshot, this.data);
+  SubQueryDocumentSnapshot._(this.snapshot) : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<Sub> snapshot;
 
   @override
+  final Sub data;
+
+  @override
   SubDocumentReference get reference {
     return SubDocumentReference(snapshot.reference);
   }
-
-  @override
-  final Sub data;
 }
 
 /// A collection reference object can be used for adding documents,
@@ -7075,32 +7793,17 @@ class _$AsCamelCaseDocumentReference
 
   @override
   Stream<AsCamelCaseDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return AsCamelCaseDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(AsCamelCaseDocumentSnapshot._);
   }
 
   @override
   Future<AsCamelCaseDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return AsCamelCaseDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(AsCamelCaseDocumentSnapshot._);
   }
 
   @override
   Future<AsCamelCaseDocumentSnapshot> transactionGet(Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return AsCamelCaseDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction.get(reference).then(AsCamelCaseDocumentSnapshot._);
   }
 
   Future<void> update({
@@ -7146,27 +7849,6 @@ class _$AsCamelCaseDocumentReference
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class AsCamelCaseDocumentSnapshot
-    extends FirestoreDocumentSnapshot<AsCamelCase> {
-  AsCamelCaseDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<AsCamelCase> snapshot;
-
-  @override
-  AsCamelCaseDocumentReference get reference {
-    return AsCamelCaseDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final AsCamelCase? data;
 }
 
 abstract class AsCamelCaseQuery
@@ -7304,37 +7986,18 @@ class _$AsCamelCaseQuery
 
   final CollectionReference<Object?> _collection;
 
-  AsCamelCaseQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<AsCamelCase> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return AsCamelCaseQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<AsCamelCaseDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: AsCamelCaseDocumentSnapshot._(change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return AsCamelCaseQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<AsCamelCaseQuerySnapshot> snapshots([SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference
+        .snapshots()
+        .map(AsCamelCaseQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<AsCamelCaseQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference
+        .get(options)
+        .then(AsCamelCaseQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -7674,6 +8337,24 @@ class _$AsCamelCaseQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class AsCamelCaseDocumentSnapshot
+    extends FirestoreDocumentSnapshot<AsCamelCase> {
+  AsCamelCaseDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<AsCamelCase> snapshot;
+
+  @override
+  AsCamelCaseDocumentReference get reference {
+    return AsCamelCaseDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final AsCamelCase? data;
+}
+
 class AsCamelCaseQuerySnapshot extends FirestoreQuerySnapshot<AsCamelCase,
     AsCamelCaseQueryDocumentSnapshot> {
   AsCamelCaseQuerySnapshot._(
@@ -7681,6 +8362,38 @@ class AsCamelCaseQuerySnapshot extends FirestoreQuerySnapshot<AsCamelCase,
     this.docs,
     this.docChanges,
   );
+
+  factory AsCamelCaseQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<AsCamelCase> snapshot,
+  ) {
+    final docs = snapshot.docs.map(AsCamelCaseQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        AsCamelCaseDocumentSnapshot._,
+      );
+    }).toList();
+
+    return AsCamelCaseQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<AsCamelCaseDocumentSnapshot>
+      _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    AsCamelCaseDocumentSnapshot Function(DocumentSnapshot<T> doc) decodeDoc,
+  ) {
+    return FirestoreDocumentChange<AsCamelCaseDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<AsCamelCase> snapshot;
 
@@ -7694,18 +8407,18 @@ class AsCamelCaseQuerySnapshot extends FirestoreQuerySnapshot<AsCamelCase,
 class AsCamelCaseQueryDocumentSnapshot
     extends FirestoreQueryDocumentSnapshot<AsCamelCase>
     implements AsCamelCaseDocumentSnapshot {
-  AsCamelCaseQueryDocumentSnapshot._(this.snapshot, this.data);
+  AsCamelCaseQueryDocumentSnapshot._(this.snapshot) : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<AsCamelCase> snapshot;
 
   @override
+  final AsCamelCase data;
+
+  @override
   AsCamelCaseDocumentReference get reference {
     return AsCamelCaseDocumentReference(snapshot.reference);
   }
-
-  @override
-  final AsCamelCase data;
 }
 
 /// A collection reference object can be used for adding documents,
@@ -7872,33 +8585,18 @@ class _$CustomSubNameDocumentReference extends FirestoreDocumentReference<
 
   @override
   Stream<CustomSubNameDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return CustomSubNameDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(CustomSubNameDocumentSnapshot._);
   }
 
   @override
   Future<CustomSubNameDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return CustomSubNameDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(CustomSubNameDocumentSnapshot._);
   }
 
   @override
   Future<CustomSubNameDocumentSnapshot> transactionGet(
       Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return CustomSubNameDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction.get(reference).then(CustomSubNameDocumentSnapshot._);
   }
 
   Future<void> update({
@@ -7944,27 +8642,6 @@ class _$CustomSubNameDocumentReference extends FirestoreDocumentReference<
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class CustomSubNameDocumentSnapshot
-    extends FirestoreDocumentSnapshot<CustomSubName> {
-  CustomSubNameDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<CustomSubName> snapshot;
-
-  @override
-  CustomSubNameDocumentReference get reference {
-    return CustomSubNameDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final CustomSubName? data;
 }
 
 abstract class CustomSubNameQuery
@@ -8102,37 +8779,18 @@ class _$CustomSubNameQuery
 
   final CollectionReference<Object?> _collection;
 
-  CustomSubNameQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<CustomSubName> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return CustomSubNameQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<CustomSubNameDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: CustomSubNameDocumentSnapshot._(change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return CustomSubNameQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<CustomSubNameQuerySnapshot> snapshots([SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference
+        .snapshots()
+        .map(CustomSubNameQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<CustomSubNameQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference
+        .get(options)
+        .then(CustomSubNameQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -8472,6 +9130,24 @@ class _$CustomSubNameQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class CustomSubNameDocumentSnapshot
+    extends FirestoreDocumentSnapshot<CustomSubName> {
+  CustomSubNameDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<CustomSubName> snapshot;
+
+  @override
+  CustomSubNameDocumentReference get reference {
+    return CustomSubNameDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final CustomSubName? data;
+}
+
 class CustomSubNameQuerySnapshot extends FirestoreQuerySnapshot<CustomSubName,
     CustomSubNameQueryDocumentSnapshot> {
   CustomSubNameQuerySnapshot._(
@@ -8479,6 +9155,39 @@ class CustomSubNameQuerySnapshot extends FirestoreQuerySnapshot<CustomSubName,
     this.docs,
     this.docChanges,
   );
+
+  factory CustomSubNameQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<CustomSubName> snapshot,
+  ) {
+    final docs =
+        snapshot.docs.map(CustomSubNameQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        CustomSubNameDocumentSnapshot._,
+      );
+    }).toList();
+
+    return CustomSubNameQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<CustomSubNameDocumentSnapshot>
+      _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    CustomSubNameDocumentSnapshot Function(DocumentSnapshot<T> doc) decodeDoc,
+  ) {
+    return FirestoreDocumentChange<CustomSubNameDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<CustomSubName> snapshot;
 
@@ -8492,18 +9201,18 @@ class CustomSubNameQuerySnapshot extends FirestoreQuerySnapshot<CustomSubName,
 class CustomSubNameQueryDocumentSnapshot
     extends FirestoreQueryDocumentSnapshot<CustomSubName>
     implements CustomSubNameDocumentSnapshot {
-  CustomSubNameQueryDocumentSnapshot._(this.snapshot, this.data);
+  CustomSubNameQueryDocumentSnapshot._(this.snapshot) : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<CustomSubName> snapshot;
 
   @override
+  final CustomSubName data;
+
+  @override
   CustomSubNameDocumentReference get reference {
     return CustomSubNameDocumentReference(snapshot.reference);
   }
-
-  @override
-  final CustomSubName data;
 }
 
 /// A collection reference object can be used for adding documents,
@@ -8671,33 +9380,20 @@ class _$ThisIsACustomPrefixDocumentReference extends FirestoreDocumentReference<
 
   @override
   Stream<ThisIsACustomPrefixDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return ThisIsACustomPrefixDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(ThisIsACustomPrefixDocumentSnapshot._);
   }
 
   @override
   Future<ThisIsACustomPrefixDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return ThisIsACustomPrefixDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(ThisIsACustomPrefixDocumentSnapshot._);
   }
 
   @override
   Future<ThisIsACustomPrefixDocumentSnapshot> transactionGet(
       Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return ThisIsACustomPrefixDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction
+        .get(reference)
+        .then(ThisIsACustomPrefixDocumentSnapshot._);
   }
 
   Future<void> update({
@@ -8743,27 +9439,6 @@ class _$ThisIsACustomPrefixDocumentReference extends FirestoreDocumentReference<
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class ThisIsACustomPrefixDocumentSnapshot
-    extends FirestoreDocumentSnapshot<CustomClassPrefix> {
-  ThisIsACustomPrefixDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<CustomClassPrefix> snapshot;
-
-  @override
-  ThisIsACustomPrefixDocumentReference get reference {
-    return ThisIsACustomPrefixDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final CustomClassPrefix? data;
 }
 
 abstract class ThisIsACustomPrefixQuery
@@ -8902,39 +9577,19 @@ class _$ThisIsACustomPrefixQuery
 
   final CollectionReference<Object?> _collection;
 
-  ThisIsACustomPrefixQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<CustomClassPrefix> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return ThisIsACustomPrefixQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<ThisIsACustomPrefixDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: ThisIsACustomPrefixDocumentSnapshot._(
-            change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return ThisIsACustomPrefixQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<ThisIsACustomPrefixQuerySnapshot> snapshots(
       [SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference
+        .snapshots()
+        .map(ThisIsACustomPrefixQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<ThisIsACustomPrefixQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference
+        .get(options)
+        .then(ThisIsACustomPrefixQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -9274,6 +9929,24 @@ class _$ThisIsACustomPrefixQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class ThisIsACustomPrefixDocumentSnapshot
+    extends FirestoreDocumentSnapshot<CustomClassPrefix> {
+  ThisIsACustomPrefixDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<CustomClassPrefix> snapshot;
+
+  @override
+  ThisIsACustomPrefixDocumentReference get reference {
+    return ThisIsACustomPrefixDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final CustomClassPrefix? data;
+}
+
 class ThisIsACustomPrefixQuerySnapshot extends FirestoreQuerySnapshot<
     CustomClassPrefix, ThisIsACustomPrefixQueryDocumentSnapshot> {
   ThisIsACustomPrefixQuerySnapshot._(
@@ -9281,6 +9954,40 @@ class ThisIsACustomPrefixQuerySnapshot extends FirestoreQuerySnapshot<
     this.docs,
     this.docChanges,
   );
+
+  factory ThisIsACustomPrefixQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<CustomClassPrefix> snapshot,
+  ) {
+    final docs =
+        snapshot.docs.map(ThisIsACustomPrefixQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        ThisIsACustomPrefixDocumentSnapshot._,
+      );
+    }).toList();
+
+    return ThisIsACustomPrefixQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<ThisIsACustomPrefixDocumentSnapshot>
+      _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    ThisIsACustomPrefixDocumentSnapshot Function(DocumentSnapshot<T> doc)
+        decodeDoc,
+  ) {
+    return FirestoreDocumentChange<ThisIsACustomPrefixDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<CustomClassPrefix> snapshot;
 
@@ -9295,18 +10002,19 @@ class ThisIsACustomPrefixQuerySnapshot extends FirestoreQuerySnapshot<
 class ThisIsACustomPrefixQueryDocumentSnapshot
     extends FirestoreQueryDocumentSnapshot<CustomClassPrefix>
     implements ThisIsACustomPrefixDocumentSnapshot {
-  ThisIsACustomPrefixQueryDocumentSnapshot._(this.snapshot, this.data);
+  ThisIsACustomPrefixQueryDocumentSnapshot._(this.snapshot)
+      : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<CustomClassPrefix> snapshot;
 
   @override
+  final CustomClassPrefix data;
+
+  @override
   ThisIsACustomPrefixDocumentReference get reference {
     return ThisIsACustomPrefixDocumentReference(snapshot.reference);
   }
-
-  @override
-  final CustomClassPrefix data;
 }
 
 /// A collection reference object can be used for adding documents,
@@ -9463,32 +10171,17 @@ class _$ExplicitPathDocumentReference extends FirestoreDocumentReference<
 
   @override
   Stream<ExplicitPathDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return ExplicitPathDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(ExplicitPathDocumentSnapshot._);
   }
 
   @override
   Future<ExplicitPathDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return ExplicitPathDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(ExplicitPathDocumentSnapshot._);
   }
 
   @override
   Future<ExplicitPathDocumentSnapshot> transactionGet(Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return ExplicitPathDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction.get(reference).then(ExplicitPathDocumentSnapshot._);
   }
 
   Future<void> update({
@@ -9534,27 +10227,6 @@ class _$ExplicitPathDocumentReference extends FirestoreDocumentReference<
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class ExplicitPathDocumentSnapshot
-    extends FirestoreDocumentSnapshot<ExplicitPath> {
-  ExplicitPathDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<ExplicitPath> snapshot;
-
-  @override
-  ExplicitPathDocumentReference get reference {
-    return ExplicitPathDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final ExplicitPath? data;
 }
 
 abstract class ExplicitPathQuery
@@ -9692,37 +10364,18 @@ class _$ExplicitPathQuery
 
   final CollectionReference<Object?> _collection;
 
-  ExplicitPathQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<ExplicitPath> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return ExplicitPathQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<ExplicitPathDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: ExplicitPathDocumentSnapshot._(change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return ExplicitPathQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<ExplicitPathQuerySnapshot> snapshots([SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference
+        .snapshots()
+        .map(ExplicitPathQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<ExplicitPathQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference
+        .get(options)
+        .then(ExplicitPathQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -10062,6 +10715,24 @@ class _$ExplicitPathQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class ExplicitPathDocumentSnapshot
+    extends FirestoreDocumentSnapshot<ExplicitPath> {
+  ExplicitPathDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<ExplicitPath> snapshot;
+
+  @override
+  ExplicitPathDocumentReference get reference {
+    return ExplicitPathDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final ExplicitPath? data;
+}
+
 class ExplicitPathQuerySnapshot extends FirestoreQuerySnapshot<ExplicitPath,
     ExplicitPathQueryDocumentSnapshot> {
   ExplicitPathQuerySnapshot._(
@@ -10069,6 +10740,39 @@ class ExplicitPathQuerySnapshot extends FirestoreQuerySnapshot<ExplicitPath,
     this.docs,
     this.docChanges,
   );
+
+  factory ExplicitPathQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<ExplicitPath> snapshot,
+  ) {
+    final docs =
+        snapshot.docs.map(ExplicitPathQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        ExplicitPathDocumentSnapshot._,
+      );
+    }).toList();
+
+    return ExplicitPathQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<ExplicitPathDocumentSnapshot>
+      _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    ExplicitPathDocumentSnapshot Function(DocumentSnapshot<T> doc) decodeDoc,
+  ) {
+    return FirestoreDocumentChange<ExplicitPathDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<ExplicitPath> snapshot;
 
@@ -10082,18 +10786,18 @@ class ExplicitPathQuerySnapshot extends FirestoreQuerySnapshot<ExplicitPath,
 class ExplicitPathQueryDocumentSnapshot
     extends FirestoreQueryDocumentSnapshot<ExplicitPath>
     implements ExplicitPathDocumentSnapshot {
-  ExplicitPathQueryDocumentSnapshot._(this.snapshot, this.data);
+  ExplicitPathQueryDocumentSnapshot._(this.snapshot) : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<ExplicitPath> snapshot;
 
   @override
+  final ExplicitPath data;
+
+  @override
   ExplicitPathDocumentReference get reference {
     return ExplicitPathDocumentReference(snapshot.reference);
   }
-
-  @override
-  final ExplicitPath data;
 }
 
 /// A collection reference object can be used for adding documents,
@@ -10260,33 +10964,18 @@ class _$ExplicitSubPathDocumentReference extends FirestoreDocumentReference<
 
   @override
   Stream<ExplicitSubPathDocumentSnapshot> snapshots() {
-    return reference.snapshots().map((snapshot) {
-      return ExplicitSubPathDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.snapshots().map(ExplicitSubPathDocumentSnapshot._);
   }
 
   @override
   Future<ExplicitSubPathDocumentSnapshot> get([GetOptions? options]) {
-    return reference.get(options).then((snapshot) {
-      return ExplicitSubPathDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return reference.get(options).then(ExplicitSubPathDocumentSnapshot._);
   }
 
   @override
   Future<ExplicitSubPathDocumentSnapshot> transactionGet(
       Transaction transaction) {
-    return transaction.get(reference).then((snapshot) {
-      return ExplicitSubPathDocumentSnapshot._(
-        snapshot,
-        snapshot.data(),
-      );
-    });
+    return transaction.get(reference).then(ExplicitSubPathDocumentSnapshot._);
   }
 
   Future<void> update({
@@ -10332,27 +11021,6 @@ class _$ExplicitSubPathDocumentReference extends FirestoreDocumentReference<
 
   @override
   int get hashCode => Object.hash(runtimeType, parent, id);
-}
-
-class ExplicitSubPathDocumentSnapshot
-    extends FirestoreDocumentSnapshot<ExplicitSubPath> {
-  ExplicitSubPathDocumentSnapshot._(
-    this.snapshot,
-    this.data,
-  );
-
-  @override
-  final DocumentSnapshot<ExplicitSubPath> snapshot;
-
-  @override
-  ExplicitSubPathDocumentReference get reference {
-    return ExplicitSubPathDocumentReference(
-      snapshot.reference,
-    );
-  }
-
-  @override
-  final ExplicitSubPath? data;
 }
 
 abstract class ExplicitSubPathQuery
@@ -10490,37 +11158,18 @@ class _$ExplicitSubPathQuery
 
   final CollectionReference<Object?> _collection;
 
-  ExplicitSubPathQuerySnapshot _decodeSnapshot(
-    QuerySnapshot<ExplicitSubPath> snapshot,
-  ) {
-    final docs = snapshot.docs.map((e) {
-      return ExplicitSubPathQueryDocumentSnapshot._(e, e.data());
-    }).toList();
-
-    final docChanges = snapshot.docChanges.map((change) {
-      return FirestoreDocumentChange<ExplicitSubPathDocumentSnapshot>(
-        type: change.type,
-        oldIndex: change.oldIndex,
-        newIndex: change.newIndex,
-        doc: ExplicitSubPathDocumentSnapshot._(change.doc, change.doc.data()),
-      );
-    }).toList();
-
-    return ExplicitSubPathQuerySnapshot._(
-      snapshot,
-      docs,
-      docChanges,
-    );
-  }
-
   @override
   Stream<ExplicitSubPathQuerySnapshot> snapshots([SnapshotOptions? options]) {
-    return reference.snapshots().map(_decodeSnapshot);
+    return reference
+        .snapshots()
+        .map(ExplicitSubPathQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
   Future<ExplicitSubPathQuerySnapshot> get([GetOptions? options]) {
-    return reference.get(options).then(_decodeSnapshot);
+    return reference
+        .get(options)
+        .then(ExplicitSubPathQuerySnapshot._fromQuerySnapshot);
   }
 
   @override
@@ -10860,6 +11509,24 @@ class _$ExplicitSubPathQuery
   int get hashCode => Object.hash(runtimeType, reference);
 }
 
+class ExplicitSubPathDocumentSnapshot
+    extends FirestoreDocumentSnapshot<ExplicitSubPath> {
+  ExplicitSubPathDocumentSnapshot._(this.snapshot) : data = snapshot.data();
+
+  @override
+  final DocumentSnapshot<ExplicitSubPath> snapshot;
+
+  @override
+  ExplicitSubPathDocumentReference get reference {
+    return ExplicitSubPathDocumentReference(
+      snapshot.reference,
+    );
+  }
+
+  @override
+  final ExplicitSubPath? data;
+}
+
 class ExplicitSubPathQuerySnapshot extends FirestoreQuerySnapshot<
     ExplicitSubPath, ExplicitSubPathQueryDocumentSnapshot> {
   ExplicitSubPathQuerySnapshot._(
@@ -10867,6 +11534,39 @@ class ExplicitSubPathQuerySnapshot extends FirestoreQuerySnapshot<
     this.docs,
     this.docChanges,
   );
+
+  factory ExplicitSubPathQuerySnapshot._fromQuerySnapshot(
+    QuerySnapshot<ExplicitSubPath> snapshot,
+  ) {
+    final docs =
+        snapshot.docs.map(ExplicitSubPathQueryDocumentSnapshot._).toList();
+
+    final docChanges = snapshot.docChanges.map((change) {
+      return _decodeDocumentChange(
+        change,
+        ExplicitSubPathDocumentSnapshot._,
+      );
+    }).toList();
+
+    return ExplicitSubPathQuerySnapshot._(
+      snapshot,
+      docs,
+      docChanges,
+    );
+  }
+
+  static FirestoreDocumentChange<ExplicitSubPathDocumentSnapshot>
+      _decodeDocumentChange<T>(
+    DocumentChange<T> docChange,
+    ExplicitSubPathDocumentSnapshot Function(DocumentSnapshot<T> doc) decodeDoc,
+  ) {
+    return FirestoreDocumentChange<ExplicitSubPathDocumentSnapshot>(
+      type: docChange.type,
+      oldIndex: docChange.oldIndex,
+      newIndex: docChange.newIndex,
+      doc: decodeDoc(docChange.doc),
+    );
+  }
 
   final QuerySnapshot<ExplicitSubPath> snapshot;
 
@@ -10881,18 +11581,19 @@ class ExplicitSubPathQuerySnapshot extends FirestoreQuerySnapshot<
 class ExplicitSubPathQueryDocumentSnapshot
     extends FirestoreQueryDocumentSnapshot<ExplicitSubPath>
     implements ExplicitSubPathDocumentSnapshot {
-  ExplicitSubPathQueryDocumentSnapshot._(this.snapshot, this.data);
+  ExplicitSubPathQueryDocumentSnapshot._(this.snapshot)
+      : data = snapshot.data();
 
   @override
   final QueryDocumentSnapshot<ExplicitSubPath> snapshot;
 
   @override
+  final ExplicitSubPath data;
+
+  @override
   ExplicitSubPathDocumentReference get reference {
     return ExplicitSubPathDocumentReference(snapshot.reference);
   }
-
-  @override
-  final ExplicitSubPath data;
 }
 
 // **************************************************************************
@@ -10909,6 +11610,20 @@ void _$assertMinValidation(MinValidation instance) {
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
+
+IgnoredGetter _$IgnoredGetterFromJson(Map<String, dynamic> json) =>
+    IgnoredGetter(
+      json['value'] as int,
+    );
+
+const _$IgnoredGetterFieldMap = <String, String>{
+  'value': 'value',
+};
+
+Map<String, dynamic> _$IgnoredGetterToJson(IgnoredGetter instance) =>
+    <String, dynamic>{
+      'value': instance.value,
+    };
 
 Model _$ModelFromJson(Map<String, dynamic> json) => Model(
       json['value'] as String,

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/collection_data.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/collection_data.dart
@@ -385,6 +385,9 @@ extension on ClassElement {
       final uniqueFields = <String, FieldElement>{};
 
       for (final field in fields) {
+        if (field.getter != null && !field.getter!.isSynthetic) {
+          continue;
+        }
         uniqueFields[field.name] ??= field;
       }
 
@@ -392,6 +395,9 @@ extension on ClassElement {
         if (supertype.isDartCoreObject) continue;
 
         for (final field in supertype.element2.fields) {
+          if (field.getter != null && !field.getter!.isSynthetic) {
+            continue;
+          }
           uniqueFields[field.name] ??= field;
         }
       }

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/test/query_reference_test.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/test/query_reference_test.dart
@@ -9,6 +9,29 @@ Future<void> main() async {
   );
 
   group('query', () {
+    test('does not generate utilities for getters', () {
+      expect(
+        library.withCode(
+          '''
+import 'simple.dart';
+
+void main() {
+  ignoredGetterRef.whereValue();
+  // expect-error: UNDEFINED_METHOD
+  ignoredGetterRef.whereCount();
+  // expect-error: UNDEFINED_METHOD
+  ignoredGetterRef.whereCount2();
+  // expect-error: UNDEFINED_METHOD
+  ignoredGetterRef.whereCount3();
+  // expect-error: UNDEFINED_METHOD
+  ignoredGetterRef.whereHashCode();
+}
+''',
+        ),
+        compiles,
+      );
+    });
+
     test('property type offset queries from value', () {
       expect(
         library.withCode(


### PR DESCRIPTION
The ODM used to generate methods such as `whereHashCode`

closes #9419

## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
