### PR TITLE
fix(ui_oauth_apple): set default scope to 'email' and add a way to provide custom scopes

### DIFF
--- a/packages/firebase_ui_auth/example/macos/Podfile
+++ b/packages/firebase_ui_auth/example/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.12'
+platform :osx, '10.13'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/firebase_ui_auth/example/test_driver/apple_sign_in_test.dart
+++ b/packages/firebase_ui_auth/example/test_driver/apple_sign_in_test.dart
@@ -109,6 +109,18 @@ void main() async {
     },
     skip: !provider.supportsPlatform(defaultTargetPlatform),
   );
+
+  group('AppleProvider', () {
+    test('has default scopes', () {
+      final provider = AppleProvider();
+      expect(provider.firebaseAuthProvider.scopes, ['email']);
+    });
+
+    test('provides a way to pass custom scopes', () {
+      final provider = AppleProvider(scopes: {'email', 'name'});
+      expect(provider.firebaseAuthProvider.scopes, ['email', 'name']);
+    });
+  });
 }
 
 class MockListener<T> extends Mock {
@@ -144,14 +156,16 @@ class MockApp extends Mock implements FirebaseApp {}
 
 class MockAuth extends Mock implements FirebaseAuth {
   @override
-  Future<UserCredential> signInWithAuthProvider(Object provider) async {
+  Future<UserCredential> signInWithProvider(Object provider) async {
     return super.noSuchMethod(
       Invocation.method(#signInWithAuthProvider, [provider]),
-      returnValue: Future.delayed(const Duration(milliseconds: 50))
-          .then((_) => MockCredential()),
+      returnValue: Future.delayed(const Duration(milliseconds: 10)).then(
+        (_) => MockCredential(),
+      ),
       returnValueForMissingStub:
-          Future.delayed(const Duration(milliseconds: 50))
-              .then((_) => MockCredential()),
+          Future.delayed(const Duration(milliseconds: 10)).then(
+        (_) => MockCredential(),
+      ),
     );
   }
 }

--- a/packages/firebase_ui_auth/example/test_driver/firebase_ui_auth_e2e.dart
+++ b/packages/firebase_ui_auth/example/test_driver/firebase_ui_auth_e2e.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -36,8 +37,10 @@ Future<void> main() async {
     phone_verification.main();
     google_sign_in.main();
     twitter_sign_in.main();
-    apple_sign_in.main();
     facebook_sign_in.main();
+    apple_sign_in.main();
+  } else if (defaultTargetPlatform == TargetPlatform.macOS) {
+    apple_sign_in.main();
   }
 
   layout.main();

--- a/packages/firebase_ui_oauth_apple/lib/src/provider.dart
+++ b/packages/firebase_ui_oauth_apple/lib/src/provider.dart
@@ -11,8 +11,20 @@ class AppleProvider extends OAuthProvider {
   @override
   final style = const AppleProviderButtonStyle();
 
+  /// {@template ui.auth.oauth.apple_provider.scopes}
+  /// The scopes that will be passed down to the [fba.AppleAuthProvider].
+  /// {@endtemplate}
+  final Set<String> scopes;
+
   @override
   fba.AppleAuthProvider firebaseAuthProvider = fba.AppleAuthProvider();
+
+  AppleProvider({
+    /// {@macro ui.auth.oauth.apple_provider.scopes}
+    this.scopes = const <String>{'email'},
+  }) {
+    scopes.forEach(firebaseAuthProvider.addScope);
+  }
 
   @override
   void mobileSignIn(AuthAction action) {


### PR DESCRIPTION
## Description

See title.

## Related Issues

fixes #9778 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
