### PR TITLE
fix(auth): Pass the clientId into GoogleSignIn

### DIFF
--- a/packages/firebase_ui_oauth_google/lib/src/provider.dart
+++ b/packages/firebase_ui_oauth_google/lib/src/provider.dart
@@ -11,7 +11,10 @@ class GoogleProvider extends OAuthProvider {
   final String? redirectUri;
   final List<String>? scopes;
 
-  late GoogleSignIn provider = GoogleSignIn(scopes: scopes ?? []);
+  late GoogleSignIn provider = GoogleSignIn(
+    scopes: scopes ?? [],
+    clientId: clientId,
+  );
 
   @override
   final GoogleAuthProvider firebaseAuthProvider = GoogleAuthProvider();


### PR DESCRIPTION
## Description

I started noticing flutter/flutter#114304 when migrating to `firebase_ui` from `flutterfire_ui`, and tried to fix it, since I really need to ship an update that depends on not including all the providers. I found that the `clientId` is not passed into `GoogleSignIn`, so I tried adding it, which works. I also checked the previous provider implementation from `flutterfire_ui` which added it too, so I assume this is a mistake that `firebase_ui` doesn't ATM.

Note that I use Dart-only initialization, it may not surface when the Google plist is included in the iOS app.

By the way, the issue prevents users from logging out regardless of the authentication method they used to log in.

Regarding the checklist: I couldn't manage to run the e2e tests with Melos, I had a ton of Xcode compilation errors, so I gave up on that, the changes are fairly small, and the unit tests passed, so I hope this PR is a good starter to have this issue fixed as it is. Also, I'm not sure how to add tests for these changes, if you want them, please advise.

Thank you.

## Related Issues

### Flutterfire repo

- May be related: #9808

### Main flutter repo

- Fixes flutter/flutter#114304

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
