### PR TITLE
[firebase_ui_auth] [firebase_ui_oauth] Allow for custom labels to be used for custom OAuth providers

### DIFF
--- a/packages/firebase_ui_auth/lib/src/widgets/internal/oauth_provider_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/internal/oauth_provider_button.dart
@@ -91,6 +91,7 @@ class OAuthProviderButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final labels = FirebaseUILocalizations.labelsOf(context);
     final brightness = Theme.of(context).brightness;
+    final label = provider.style.label;
 
     return AuthFlowBuilder<OAuthController>(
       provider: provider,
@@ -110,7 +111,8 @@ class OAuthProviderButton extends StatelessWidget {
           ),
           label: variant == OAuthButtonVariant.icon
               ? ''
-              : resolveProviderButtonLabel(provider.providerId, labels),
+              : label ??
+                  resolveProviderButtonLabel(provider.providerId, labels),
           auth: auth,
         );
 

--- a/packages/firebase_ui_auth/lib/src/widgets/internal/oauth_provider_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/internal/oauth_provider_button.dart
@@ -91,7 +91,6 @@ class OAuthProviderButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final labels = FirebaseUILocalizations.labelsOf(context);
     final brightness = Theme.of(context).brightness;
-    final label = provider.style.label;
 
     return AuthFlowBuilder<OAuthController>(
       provider: provider,
@@ -111,7 +110,7 @@ class OAuthProviderButton extends StatelessWidget {
           ),
           label: variant == OAuthButtonVariant.icon
               ? ''
-              : label ??
+              : provider.style.label ??
                   resolveProviderButtonLabel(provider.providerId, labels),
           auth: auth,
         );

--- a/packages/firebase_ui_auth/pubspec.yaml
+++ b/packages/firebase_ui_auth/pubspec.yaml
@@ -28,6 +28,10 @@ dev_dependencies:
   flutter_lints: ^2.0.0
   mockito: ^5.2.0
 
+dependency_overrides:
+  firebase_ui_oauth:
+    path: ../firebase_ui_oauth
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 # The following section is specific to Flutter.

--- a/packages/firebase_ui_oauth/lib/src/oauth_provider_button_style.dart
+++ b/packages/firebase_ui_oauth/lib/src/oauth_provider_button_style.dart
@@ -45,6 +45,10 @@ abstract class ThemedOAuthProviderButtonStyle {
   ThemedColor get borderColor => backgroundColor;
   double get iconPadding => 0;
   String get assetsPackage;
+
+  /// A custom label string.
+  /// 
+  /// Required for custom OAuth providers.
   String? get label => null;
 
   /// {@macro ui.oauth.themed_oauth_provider_button_style}

--- a/packages/firebase_ui_oauth/lib/src/oauth_provider_button_style.dart
+++ b/packages/firebase_ui_oauth/lib/src/oauth_provider_button_style.dart
@@ -45,6 +45,7 @@ abstract class ThemedOAuthProviderButtonStyle {
   ThemedColor get borderColor => backgroundColor;
   double get iconPadding => 0;
   String get assetsPackage;
+  String? get label => null;
 
   /// {@macro ui.oauth.themed_oauth_provider_button_style}
   const ThemedOAuthProviderButtonStyle();


### PR DESCRIPTION
## Description

I made a custom OAuth provider so that I could add it to the sign in page. The issue is that the existing code expects there to only ever be the providers that exist in this repo. This was causing a crash when fetching the OAuth button label text.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
