### PR TITLE
fix(dynamic-links): check if `MethodChannel` is `null` which was causing `NullPointerException`

### DIFF
--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -41,8 +41,9 @@ public class FlutterFirebaseDynamicLinksPlugin
         NewIntentListener {
   private final AtomicReference<Activity> activity = new AtomicReference<>(null);
 
+  private static final String TAG = "FLTFirebaseDynamicLinks";
+
   private MethodChannel channel;
-  @Nullable private BinaryMessenger messenger;
 
   private static final String METHOD_CHANNEL_NAME = "plugins.flutter.io/firebase_dynamic_links";
 
@@ -50,8 +51,6 @@ public class FlutterFirebaseDynamicLinksPlugin
     channel = new MethodChannel(messenger, METHOD_CHANNEL_NAME);
     channel.setMethodCallHandler(this);
     FlutterFirebasePluginRegistry.registerPlugin(METHOD_CHANNEL_NAME, this);
-
-    this.messenger = messenger;
   }
 
   @Override
@@ -62,8 +61,6 @@ public class FlutterFirebaseDynamicLinksPlugin
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
     channel.setMethodCallHandler(null);
-    channel = null;
-    messenger = null;
   }
 
   @Override
@@ -94,7 +91,7 @@ public class FlutterFirebaseDynamicLinksPlugin
 
   static FirebaseDynamicLinks getDynamicLinkInstance(@Nullable Map<String, Object> arguments) {
     if (arguments != null) {
-      String appName = (String) arguments.get(Constants.APP_NAME);
+      String appName = (String) arguments.get(io.flutter.plugins.firebase.dynamiclinks.Constants.APP_NAME);
       if (appName != null) {
         FirebaseApp app = FirebaseApp.getInstance(appName);
         return FirebaseDynamicLinks.getInstance(app);
@@ -105,13 +102,13 @@ public class FlutterFirebaseDynamicLinksPlugin
   }
 
   @Override
-  public boolean onNewIntent(Intent intent) {
+  public boolean onNewIntent(@NonNull Intent intent) {
     getDynamicLinkInstance(null)
         .getDynamicLink(intent)
         .addOnSuccessListener(
             pendingDynamicLinkData -> {
               Map<String, Object> dynamicLink =
-                  Utils.getMapFromPendingDynamicLinkData(pendingDynamicLinkData);
+                  io.flutter.plugins.firebase.dynamiclinks.Utils.getMapFromPendingDynamicLinkData(pendingDynamicLinkData);
               if (dynamicLink != null) {
                 channel.invokeMethod("FirebaseDynamicLink#onLinkSuccess", dynamicLink);
               }
@@ -119,7 +116,7 @@ public class FlutterFirebaseDynamicLinksPlugin
         .addOnFailureListener(
             exception ->
                 channel.invokeMethod(
-                    "FirebaseDynamicLink#onLinkError", Utils.getExceptionDetails(exception)));
+                    "FirebaseDynamicLink#onLinkError", io.flutter.plugins.firebase.dynamiclinks.Utils.getExceptionDetails(exception)));
     return false;
   }
 
@@ -152,7 +149,7 @@ public class FlutterFirebaseDynamicLinksPlugin
           } else {
             Exception exception = task.getException();
             result.error(
-                Constants.DEFAULT_ERROR_CODE,
+                io.flutter.plugins.firebase.dynamiclinks.Constants.DEFAULT_ERROR_CODE,
                 exception != null ? exception.getMessage() : null,
                 io.flutter.plugins.firebase.dynamiclinks.Utils.getExceptionDetails(exception));
           }
@@ -243,7 +240,7 @@ public class FlutterFirebaseDynamicLinksPlugin
             }
 
             taskCompletionSource.setResult(
-                Utils.getMapFromPendingDynamicLinkData(pendingDynamicLink));
+                io.flutter.plugins.firebase.dynamiclinks.Utils.getMapFromPendingDynamicLinkData(pendingDynamicLink));
           } catch (Exception e) {
             taskCompletionSource.setException(e);
           }

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -130,7 +130,7 @@ public class FlutterFirebaseDynamicLinksPlugin
              Map<String, Object> dynamicLinkException = Utils.getExceptionDetails(exception);
               if (channel != null) {
                 channel.invokeMethod(
-                    "FirebaseDynamicLink#onLinkError", Utils.getExceptionDetails(exception));
+                    "FirebaseDynamicLink#onLinkError", dynamicLinkException);
               } else {
                 cachedDynamicLinkException = dynamicLinkException;
               }

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -91,7 +91,7 @@ public class FlutterFirebaseDynamicLinksPlugin
 
   static FirebaseDynamicLinks getDynamicLinkInstance(@Nullable Map<String, Object> arguments) {
     if (arguments != null) {
-      String appName = (String) arguments.get(io.flutter.plugins.firebase.dynamiclinks.Constants.APP_NAME);
+      String appName = (String) arguments.get(Constants.APP_NAME);
       if (appName != null) {
         FirebaseApp app = FirebaseApp.getInstance(appName);
         return FirebaseDynamicLinks.getInstance(app);
@@ -149,7 +149,7 @@ public class FlutterFirebaseDynamicLinksPlugin
           } else {
             Exception exception = task.getException();
             result.error(
-                io.flutter.plugins.firebase.dynamiclinks.Constants.DEFAULT_ERROR_CODE,
+                Constants.DEFAULT_ERROR_CODE,
                 exception != null ? exception.getMessage() : null,
                 Utils.getExceptionDetails(exception));
           }

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -108,7 +108,7 @@ public class FlutterFirebaseDynamicLinksPlugin
         .addOnSuccessListener(
             pendingDynamicLinkData -> {
               Map<String, Object> dynamicLink =
-                  io.flutter.plugins.firebase.dynamiclinks.Utils.getMapFromPendingDynamicLinkData(pendingDynamicLinkData);
+                  Utils.getMapFromPendingDynamicLinkData(pendingDynamicLinkData);
               if (dynamicLink != null) {
                 channel.invokeMethod("FirebaseDynamicLink#onLinkSuccess", dynamicLink);
               }
@@ -116,7 +116,7 @@ public class FlutterFirebaseDynamicLinksPlugin
         .addOnFailureListener(
             exception ->
                 channel.invokeMethod(
-                    "FirebaseDynamicLink#onLinkError", io.flutter.plugins.firebase.dynamiclinks.Utils.getExceptionDetails(exception)));
+                    "FirebaseDynamicLink#onLinkError", Utils.getExceptionDetails(exception)));
     return false;
   }
 
@@ -151,7 +151,7 @@ public class FlutterFirebaseDynamicLinksPlugin
             result.error(
                 io.flutter.plugins.firebase.dynamiclinks.Constants.DEFAULT_ERROR_CODE,
                 exception != null ? exception.getMessage() : null,
-                io.flutter.plugins.firebase.dynamiclinks.Utils.getExceptionDetails(exception));
+                Utils.getExceptionDetails(exception));
           }
         });
   }
@@ -240,7 +240,7 @@ public class FlutterFirebaseDynamicLinksPlugin
             }
 
             taskCompletionSource.setResult(
-                io.flutter.plugins.firebase.dynamiclinks.Utils.getMapFromPendingDynamicLinkData(pendingDynamicLink));
+                Utils.getMapFromPendingDynamicLinkData(pendingDynamicLink));
           } catch (Exception e) {
             taskCompletionSource.setException(e);
           }

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -115,7 +115,7 @@ public class FlutterFirebaseDynamicLinksPlugin
               Map<String, Object> dynamicLink =
                   Utils.getMapFromPendingDynamicLinkData(pendingDynamicLinkData);
               if (dynamicLink != null) {
-                if( channel != null) {
+                if(channel != null) {
                   channel.invokeMethod("FirebaseDynamicLink#onLinkSuccess", dynamicLink);
                 } else {
                   // If channel is `null`, we store the dynamic link in the `cachedDynamicLinkData` to be sent once channel is initialized.

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -115,7 +115,7 @@ public class FlutterFirebaseDynamicLinksPlugin
               Map<String, Object> dynamicLink =
                   Utils.getMapFromPendingDynamicLinkData(pendingDynamicLinkData);
               if (dynamicLink != null) {
-                if(channel != null) {
+                if (channel != null) {
                   channel.invokeMethod("FirebaseDynamicLink#onLinkSuccess", dynamicLink);
                 } else {
                   // If channel is `null`, we store the dynamic link in the `cachedDynamicLinkData` to be sent once channel is initialized.
@@ -127,10 +127,9 @@ public class FlutterFirebaseDynamicLinksPlugin
             })
         .addOnFailureListener(
             exception -> {
-             Map<String, Object> dynamicLinkException = Utils.getExceptionDetails(exception);
+              Map<String, Object> dynamicLinkException = Utils.getExceptionDetails(exception);
               if (channel != null) {
-                channel.invokeMethod(
-                    "FirebaseDynamicLink#onLinkError", dynamicLinkException);
+                channel.invokeMethod("FirebaseDynamicLink#onLinkError", dynamicLinkException);
               } else {
                 cachedDynamicLinkException = dynamicLinkException;
               }
@@ -174,12 +173,12 @@ public class FlutterFirebaseDynamicLinksPlugin
         });
   }
 
-  private void checkForCachedData(){
-    if(cachedDynamicLinkData != null) {
+  private void checkForCachedData() {
+    if (cachedDynamicLinkData != null) {
       channel.invokeMethod("FirebaseDynamicLink#onLinkSuccess", cachedDynamicLinkData);
       cachedDynamicLinkData = null;
     }
-    if(cachedDynamicLinkException != null) {
+    if (cachedDynamicLinkException != null) {
       channel.invokeMethod("FirebaseDynamicLink#onLinkError", cachedDynamicLinkException);
       cachedDynamicLinkException = null;
     }

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/example/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,13 @@
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
+      <intent-filter android:autoVerify="true">
+        <action android:name="android.intent.action.VIEW"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+        <data android:host="flutterfiretests.page.link" android:scheme="http"/>
+        <data android:host="flutterfiretests.page.link" android:scheme="https"/>
+      </intent-filter>
     </activity>
     <!-- Don't delete the meta-data below.
          This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->


### PR DESCRIPTION
## Description

This exception:

```
Attempt to invoke virtual method 'void ce.j.c(java.lang.String, java.lang.Object)'
```

is this [line of code](https://github.com/firebase/flutterfire/blob/ec2ac7cd6cbfb5e4429144fc9c14b78c81e068b9/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java#L113):

```
channel.invokeMethod("FirebaseDynamicLink#onLinkSuccess", dynamicLink);
```

The [important change](https://github.com/firebase/flutterfire/compare/%40russell/dynamic-links-8516?expand=1#diff-279c05314f8201e2db23679d738073b04bef856810b327d22bc260d3be96fbc2L65) here is checking if `channel` is `null`. If it is, it means the FlutterEngine is in a detached state and we shouldn't be calling the method channel.

I've updated code to cache dynamic link and pass via `onLink` when FlutterEngine is attached and the plugin has registered.


## Related Issues

fixes https://github.com/firebase/flutterfire/issues/8516

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
