### PR TITLE
Revert "docs(cloud_firestore): "snapshot_metadata.dart" had misspelling of `isFromCache` "

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/snapshot_metadata.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/snapshot_metadata.dart
@@ -24,7 +24,7 @@ class SnapshotMetadata {
   ///
   /// If you called [DocumentReference.snapshots] or [Query.snapshots] with
   /// `includeMetadataChanges` parameter set to `true` you will receive another
-  /// snapshot with `isFromCache` equal to `false` once the client has received
+  /// snapshot with `isFomCache` equal to `false` once the client has received
   /// up-to-date data from the backend.
   bool get isFromCache => _delegate.isFromCache;
 }


### PR DESCRIPTION
Reverts firebase/flutterfire#9880