### PR TITLE
fix(dynamic-link): fix unhandled exception caused by "additionalData" map

### DIFF
--- a/packages/_flutterfire_internals/lib/src/exception.dart
+++ b/packages/_flutterfire_internals/lib/src/exception.dart
@@ -45,9 +45,9 @@ FirebaseException platformExceptionToFirebaseException(
   String? code;
   String message = platformException.message ?? '';
 
-  if (details != null) {
-    code = details['code']! as String ?? code;
-    message = details['message']! as String ?? message;
+  if (details != null) {    
+    code = (details['code'] as String?) ?? code;
+    message = (details['message'] as String?) ?? message;
   }
 
   return FirebaseException(

--- a/packages/_flutterfire_internals/lib/src/exception.dart
+++ b/packages/_flutterfire_internals/lib/src/exception.dart
@@ -38,16 +38,16 @@ FirebaseException platformExceptionToFirebaseException(
   PlatformException platformException, {
   required String plugin,
 }) {
-  Map<String, String>? details = platformException.details != null
-      ? Map<String, String>.from(platformException.details)
+  Map<String, Object>? details = platformException.details != null
+      ? Map<String, Object>.from(platformException.details)
       : null;
 
   String? code;
   String message = platformException.message ?? '';
 
   if (details != null) {
-    code = details['code'] ?? code;
-    message = details['message'] ?? message;
+    code = details['code']! as String ?? code;
+    message = details['message']! as String ?? message;
   }
 
   return FirebaseException(

--- a/packages/_flutterfire_internals/lib/src/exception.dart
+++ b/packages/_flutterfire_internals/lib/src/exception.dart
@@ -45,7 +45,7 @@ FirebaseException platformExceptionToFirebaseException(
   String? code;
   String message = platformException.message ?? '';
 
-  if (details != null) {    
+  if (details != null) {
     code = (details['code'] as String?) ?? code;
     message = (details['message'] as String?) ?? message;
   }


### PR DESCRIPTION
## Description

1. We send `additionalData` property as part of exception [here](https://github.com/firebase/flutterfire/blob/master/packages/firebase_dynamic_links/firebase_dynamic_links/ios/Classes/FLTFirebaseDynamicLinksPlugin.m#L52-L75). This causes an uncaught exception [here](https://github.com/firebase/flutterfire/blob/master/packages/_flutterfire_internals/lib/src/exception.dart#L41-L42) because it is expecting `Map<String, String>` type. I've updated to allow nested maps (i.e. `Map<String, Object>`). 

The other issue I want to highlight is `code` and `message`. They are really unhelpful. On the other hand, `additionalData` has more accurate information. 

As you can see from the below noted, `additionalData` has the `additionalData.message`: "Requested entity was not found" compared to the `message`: "An unknown error has occurred".
<img width="814" alt="Screenshot 2022-11-10 at 12 58 00" src="https://user-images.githubusercontent.com/16018629/201100983-22ada5ad-7168-4367-826b-8861a477b800.png">

We should think about how we can include `additionalData` in the exception, this is not the first time descriptive messages have been obfuscated from the user.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
