### PR TITLE
feat: [firebase_ui_firestore] Added empty builder in FirestoreListView

### DIFF
--- a/packages/firebase_ui_firestore/lib/src/query_builder.dart
+++ b/packages/firebase_ui_firestore/lib/src/query_builder.dart
@@ -362,6 +362,9 @@ typedef FirestoreErrorBuilder = Widget Function(
   StackTrace stackTrace,
 );
 
+/// A type representing the function passed to [FirestoreListView] for its `emptyBuilder`.
+typedef FirestoreEmptyBuilder = Widget Function(BuildContext context);
+
 /// {@template firebase_ui.firestorelistview}
 /// A [ListView.builder] that obtains its items from a Firestore query.
 ///
@@ -422,6 +425,7 @@ class FirestoreListView<Document> extends FirestoreQueryBuilder<Document> {
     int pageSize = 10,
     FirestoreLoadingBuilder? loadingBuilder,
     FirestoreErrorBuilder? errorBuilder,
+    FirestoreEmptyBuilder? emptyBuilder,
     Axis scrollDirection = Axis.vertical,
     bool reverse = false,
     ScrollController? controller,
@@ -457,6 +461,10 @@ class FirestoreListView<Document> extends FirestoreQueryBuilder<Document> {
                 snapshot.error!,
                 snapshot.stackTrace!,
               );
+            }
+            
+            if (snapshot.docs.isEmpty && emptyBuilder != null) {
+              return emptyBuilder(context);
             }
 
             return ListView.builder(


### PR DESCRIPTION
## Description

I added a emptyBuilder property in FirestoreListView. It detects if the docs is empty, then show a widget describing why no docs available.

## Related Issues

#8614 fixed

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
