### PR TITLE
docs(firebase_ui): Fixed typo in firebase_ui_oauth packages for firebase_ui_auth package.

### DIFF
--- a/packages/firebase_ui_oauth_apple/README.md
+++ b/packages/firebase_ui_oauth_apple/README.md
@@ -2,14 +2,14 @@
 
 [![pub package](https://img.shields.io/pub/v/firebase_ui_oauth_apple.svg)](https://pub.dev/packages/firebase_ui_oauth_apple)
 
-Apple Sign In for [Firebase UI](https://pub.dev/packages/firebase_ui_auth)
+Apple Sign In for [Firebase UI Auth](https://pub.dev/packages/firebase_ui_auth)
 
 ## Installation
 
 Add dependency
 
 ```sh
-flutter pub add firebase_ui
+flutter pub add firebase_ui_auth
 flutter pub add firebase_ui_oauth_apple
 
 flutter pub global activate flutterfire_cli

--- a/packages/firebase_ui_oauth_facebook/README.md
+++ b/packages/firebase_ui_oauth_facebook/README.md
@@ -2,14 +2,14 @@
 
 [![pub package](https://img.shields.io/pub/v/firebase_ui_oauth_facebook.svg)](https://pub.dev/packages/firebase_ui_oauth_facebook)
 
-Facebook Sign In for [Firebase UI](https://pub.dev/packages/firebase_ui)
+Facebook Sign In for [Firebase UI Auth](https://pub.dev/packages/firebase_ui_auth)
 
 ## Installation
 
 Add dependencies
 
 ```sh
-flutter pub add firebase_ui
+flutter pub add firebase_ui_auth
 flutter pub add firebase_ui_oauth_facebook
 
 flutter pub global activate flutterfire_cli

--- a/packages/firebase_ui_oauth_google/README.md
+++ b/packages/firebase_ui_oauth_google/README.md
@@ -2,14 +2,14 @@
 
 [![pub package](https://img.shields.io/pub/v/firebase_ui_oauth_google.svg)](https://pub.dev/packages/firebase_ui_oauth_google)
 
-Google Sign In for [Firebase UI](https://pub.dev/packages/firebase_ui)
+Google Sign In for [Firebase UI Auth](https://pub.dev/packages/firebase_ui_auth)
 
 ## Installation
 
 Add dependencies
 
 ```sh
-flutter pub add firebase_ui
+flutter pub add firebase_ui_auth
 flutter pub add firebase_ui_oauth_google
 
 flutter pub global activate flutterfire_cli

--- a/packages/firebase_ui_oauth_twitter/README.md
+++ b/packages/firebase_ui_oauth_twitter/README.md
@@ -2,14 +2,14 @@
 
 [![pub package](https://img.shields.io/pub/v/firebase_ui_oauth_twitter.svg)](https://pub.dev/packages/firebase_ui_oauth_twitter)
 
-Twitter Sign In for [Firebase UI](https://pub.dev/packages/firebase_ui)
+Twitter Sign In for [Firebase UI Auth](https://pub.dev/packages/firebase_ui_auth)
 
 ## Installation
 
 Add dependencies
 
 ```sh
-flutter pub add firebase_ui
+flutter pub add firebase_ui_auth
 flutter pub add firebase_ui_oauth_twitter
 
 flutter pub global activate flutterfire_cli


### PR DESCRIPTION
## Description

I fixed the documentation for `firebase_ui_oauth_google`, `firebase_ui_oauth_apple`, `firebase_ui_oauth_facebook` and `firebase_ui_oauth_twitter` packages, all of these packages has the wrong name and link for `firebase_ui_auth` package.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
