### PR TITLE
fix: in app messages were suppressed on iOS

### DIFF
--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/Classes/FirebaseInAppMessagingPlugin.m
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/Classes/FirebaseInAppMessagingPlugin.m
@@ -27,9 +27,9 @@ NSString *const kFLTFirebaseInAppMessagingChannelName =
     [fiam triggerEvent:eventName];
     result(nil);
   } else if ([@"FirebaseInAppMessaging#setMessagesSuppressed" isEqualToString:call.method]) {
-    NSNumber *suppress = [NSNumber numberWithBool:(NSNumber *)call.arguments[@"suppress"]];
+    BOOL suppress = [[call.arguments objectForKey:@"suppress"] boolValue];
     FIRInAppMessaging *fiam = [FIRInAppMessaging inAppMessaging];
-    fiam.messageDisplaySuppressed = [suppress boolValue];
+    fiam.messageDisplaySuppressed = suppress;
     result(nil);
   } else if ([@"FirebaseInAppMessaging#setAutomaticDataCollectionEnabled"
                  isEqualToString:call.method]) {


### PR DESCRIPTION
## Description

Prevent suppress variable from being converted to `true` or `YES`.

This change grabs the object key for "suppress" and assigns it to the boolean value that is was passed in as.

## Related Issues

In App Messages on iOS were continually being suppressed even after turning off suppression `await firebaseIam.setMessagesSuppressed(true);`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
