### PR TITLE
fix(messaging, ios): prevent getInitialMessage from being null at the start of the app

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
@@ -9,14 +9,14 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:http/http.dart' as http;
 
+import 'firebase_options.dart';
 import 'message.dart';
 import 'message_list.dart';
 import 'permissions.dart';
 import 'token_monitor.dart';
-import 'firebase_options.dart';
 
 /// Working example of FirebaseMessaging.
 /// Please use this in order to verify messages are working in foreground, background & terminated state.
@@ -171,10 +171,19 @@ class Application extends StatefulWidget {
 
 class _Application extends State<Application> {
   String? _token;
+  String? initialMessage;
 
   @override
   void initState() {
     super.initState();
+
+    FirebaseMessaging.instance.getInitialMessage().then(
+          (value) => setState(
+            () {
+              initialMessage = value?.data.toString();
+            },
+          ),
+        );
 
     FirebaseMessaging.onMessage.listen(showFlutterNotification);
 
@@ -289,13 +298,17 @@ class _Application extends State<Application> {
         child: Column(
           children: [
             MetaCard('Permissions', Permissions()),
+            MetaCard('Initial Message', Text(initialMessage ?? 'None')),
             MetaCard(
               'FCM Token',
               TokenMonitor((token) {
                 _token = token;
                 return token == null
                     ? const CircularProgressIndicator()
-                    : Text(token, style: const TextStyle(fontSize: 12));
+                    : SelectableText(
+                        token,
+                        style: const TextStyle(fontSize: 12),
+                      );
               }),
             ),
             ElevatedButton(

--- a/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
@@ -172,6 +172,7 @@ class Application extends StatefulWidget {
 class _Application extends State<Application> {
   String? _token;
   String? initialMessage;
+  bool _resolved = false;
 
   @override
   void initState() {
@@ -180,6 +181,7 @@ class _Application extends State<Application> {
     FirebaseMessaging.instance.getInitialMessage().then(
           (value) => setState(
             () {
+              _resolved = true;
               initialMessage = value?.data.toString();
             },
           ),
@@ -298,7 +300,15 @@ class _Application extends State<Application> {
         child: Column(
           children: [
             MetaCard('Permissions', Permissions()),
-            MetaCard('Initial Message', Text(initialMessage ?? 'None')),
+            MetaCard(
+              'Initial Message',
+              Column(
+                children: [
+                  Text(_resolved ? 'Resolved' : 'Resolving'),
+                  Text(initialMessage ?? 'None'),
+                ],
+              ),
+            ),
             MetaCard(
               'FCM Token',
               TokenMonitor((token) {

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -116,9 +116,9 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   [self ensureAPNSTokenSetting];
 
   if ([@"Messaging#getInitialMessage" isEqualToString:call.method]) {
-      _initialNotificationResult = methodCallResult;
-      [self initialNotificationCallback];
-    
+    _initialNotificationResult = methodCallResult;
+    [self initialNotificationCallback];
+
   } else if ([@"Messaging#deleteToken" isEqualToString:call.method]) {
     [self messagingDeleteToken:call.arguments withMethodCallResult:methodCallResult];
   } else if ([@"Messaging#getAPNSToken" isEqualToString:call.method]) {
@@ -215,7 +215,6 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     _initialNotification =
         [FLTFirebaseMessagingPlugin remoteMessageUserInfoToDict:remoteNotification];
     _initialNoticationID = remoteNotification[@"gcm.message_id"];
-            
   }
   _initialNotificationGathered = YES;
   [self initialNotificationCallback];
@@ -1014,7 +1013,8 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   @synchronized(self) {
     // Only return if initial notification was sent when app is terminated. Also ensure that
     // it was the initial notification that was tapped to open the app.
-    if (_initialNotification != nil) {
+    if (_initialNotification != nil &&
+        [_initialNoticationID isEqualToString:_notificationOpenedAppID]) {
       NSDictionary *initialNotificationCopy = [_initialNotification copy];
       _initialNotification = nil;
       return initialNotificationCopy;
@@ -1025,8 +1025,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 }
 
 - (void)initialNotificationCallback {
-  if (_initialNotificationGathered &&
-      _initialNotificationResult != nil) {
+  if (_initialNotificationGathered && _initialNotificationResult != nil) {
     _initialNotificationResult.success([self copyInitialNotification]);
     _initialNotificationResult = nil;
   }

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -26,7 +26,6 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   // Used to track if everything as been initialized before answering
   // to the initialNotification request
   BOOL _initialNotificationGathered;
-  BOOL _initialNotificationIdGathered;
   FLTFirebaseMethodCallResult *_initialNotificationResult;
 
   NSString *_initialNoticationID;
@@ -51,7 +50,6 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   self = [super init];
   if (self) {
     _initialNotificationGathered = NO;
-    _initialNotificationIdGathered = NO;
     _channel = channel;
     _registrar = registrar;
     // Application
@@ -118,11 +116,9 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   [self ensureAPNSTokenSetting];
 
   if ([@"Messaging#getInitialMessage" isEqualToString:call.method]) {
-    if (_initialNotificationGathered && _initialNotificationIdGathered) {
-      methodCallResult.success([self copyInitialNotification]);
-    } else {
       _initialNotificationResult = methodCallResult;
-    }
+      [self initialNotificationCallback];
+    
   } else if ([@"Messaging#deleteToken" isEqualToString:call.method]) {
     [self messagingDeleteToken:call.arguments withMethodCallResult:methodCallResult];
   } else if ([@"Messaging#getAPNSToken" isEqualToString:call.method]) {
@@ -219,12 +215,10 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     _initialNotification =
         [FLTFirebaseMessagingPlugin remoteMessageUserInfoToDict:remoteNotification];
     _initialNoticationID = remoteNotification[@"gcm.message_id"];
+            
   }
   _initialNotificationGathered = YES;
-  if (_initialNotificationResult != nil && _initialNotificationIdGathered) {
-    _initialNotificationResult.success([self copyInitialNotification]);
-    _initialNotificationResult = nil;
-  }
+  [self initialNotificationCallback];
 
 #if TARGET_OS_OSX
   // For macOS we use swizzling to intercept as addApplicationDelegate does not exist on the macOS
@@ -348,7 +342,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   }
 }
 
-// Called when a use interacts with a notification.
+// Called when a user interacts with a notification.
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
     didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler
@@ -362,12 +356,6 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     NSDictionary *notificationDict =
         [FLTFirebaseMessagingPlugin remoteMessageUserInfoToDict:remoteNotification];
     [_channel invokeMethod:@"Messaging#onMessageOpenedApp" arguments:notificationDict];
-  }
-
-  _initialNotificationIdGathered = YES;
-  if (_initialNotificationResult != nil && _initialNotificationGathered) {
-    _initialNotificationResult.success([self copyInitialNotification]);
-    _initialNotificationResult = nil;
   }
 
   // Forward on to any other delegates.
@@ -1026,8 +1014,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   @synchronized(self) {
     // Only return if initial notification was sent when app is terminated. Also ensure that
     // it was the initial notification that was tapped to open the app.
-    if (_initialNotification != nil &&
-        [_initialNoticationID isEqualToString:_notificationOpenedAppID]) {
+    if (_initialNotification != nil) {
       NSDictionary *initialNotificationCopy = [_initialNotification copy];
       _initialNotification = nil;
       return initialNotificationCopy;
@@ -1035,6 +1022,14 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   }
 
   return nil;
+}
+
+- (void)initialNotificationCallback {
+  if (_initialNotificationGathered &&
+      _initialNotificationResult != nil) {
+    _initialNotificationResult.success([self copyInitialNotification]);
+    _initialNotificationResult = nil;
+  }
 }
 
 - (NSDictionary *)NSDictionaryForNSError:(NSError *)error {


### PR DESCRIPTION
## Description

Tested the different behavior:
- Receiving multiples notification and check the good one is in the initialMessage
- Receiving multiple notifications but opening the app with the icon
- Opening the app in background state from a notification and check that the initialMessage is null
- Opening the app in terminated state from a notification and check that the initialMessage is correct

## Related Issues

#9906 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
