### PR TITLE
fix(messaging, android): fix an issue where the notification wasn't restored when going into terminated state

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -279,6 +279,7 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
     cachedThreadPool.execute(
         () -> {
           try {
+            Log.w("COUCOU", "Step 1");
             if (initialMessage != null) {
               Map<String, Object> remoteMessageMap =
                   FlutterFirebaseMessagingUtils.remoteMessageToMap(initialMessage);
@@ -287,10 +288,16 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
               return;
             }
 
+            Log.w("COUCOU", "Step 2");
+
+
             if (mainActivity == null) {
               taskCompletionSource.setResult(null);
               return;
             }
+
+            Log.w("COUCOU", "Step 3");
+
 
             Intent intent = mainActivity.getIntent();
 
@@ -316,7 +323,7 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
             if (remoteMessage == null) {
               remoteMessage =
                   FlutterFirebaseMessagingStore.getInstance().getFirebaseMessage(messageId);
-              Log.d(
+              Log.w(
                   "COUCOU",
                   "getInitialMessage: "
                       + (remoteMessage == null
@@ -336,6 +343,7 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
                 FlutterFirebaseMessagingUtils.remoteMessageToMap(remoteMessage));
 
           } catch (Exception e) {
+            Log.w("COUCOU", "EXCEPTION: ", e);
             taskCompletionSource.setException(e);
           }
         });

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -14,7 +14,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.os.Build;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -26,8 +25,6 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.RemoteMessage;
-
-import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
@@ -55,10 +52,10 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
   private MethodChannel channel;
   private Activity mainActivity;
 
-  // We store the initial notification in a separate
+  private RemoteMessage initialMessage;
+  // We store the initial notification in a separate variable
   // because we cannot set the notification key in
   // the initialMessage Java Builder
-  private RemoteMessage initialMessage;
   private Map<String, Object> initialMessageNotification;
 
   FlutterFirebasePermissionManager permissionManager;
@@ -289,23 +286,18 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
               Map<String, Object> remoteMessageMap =
                   FlutterFirebaseMessagingUtils.remoteMessageToMap(initialMessage);
               if (initialMessageNotification != null) {
-                remoteMessageMap.put(
-                    "notification", initialMessageNotification);
+                remoteMessageMap.put("notification", initialMessageNotification);
               }
-              initialMessage = null;
               taskCompletionSource.setResult(remoteMessageMap);
+              initialMessage = null;
               initialMessageNotification = null;
               return;
             }
-
-
 
             if (mainActivity == null) {
               taskCompletionSource.setResult(null);
               return;
             }
-
-
 
             Intent intent = mainActivity.getIntent();
 
@@ -333,11 +325,12 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
               Map<String, Object> messageMap =
                   FlutterFirebaseMessagingStore.getInstance().getFirebaseMessageMap(messageId);
               if (messageMap != null) {
-                remoteMessage = FlutterFirebaseMessagingUtils.getRemoteMessageForArguments(messageMap);
+                remoteMessage =
+                    FlutterFirebaseMessagingUtils.getRemoteMessageForArguments(messageMap);
 
                 if (messageMap.get("notification") != null) {
                   // noinspection unchecked
-                    notificationMap = (Map<String, Object>) messageMap.get("notification");
+                  notificationMap = (Map<String, Object>) messageMap.get("notification");
                 }
               }
               FlutterFirebaseMessagingStore.getInstance().removeFirebaseMessage(messageId);
@@ -356,8 +349,7 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
               remoteMessageMap.put("notification", notificationMap);
             }
 
-            taskCompletionSource.setResult(
-              remoteMessageMap);
+            taskCompletionSource.setResult(remoteMessageMap);
 
           } catch (Exception e) {
             taskCompletionSource.setException(e);
@@ -558,17 +550,17 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
       return false;
     }
 
-
     RemoteMessage remoteMessage = FlutterFirebaseMessagingReceiver.notifications.get(messageId);
     Map<String, Object> notificationMap = null;
 
     // If we can't find a copy of the remote message in memory then check from our persisted store.
     if (remoteMessage == null) {
       Map<String, Object> messageMap =
-        FlutterFirebaseMessagingStore.getInstance().getFirebaseMessageMap(messageId);
+          FlutterFirebaseMessagingStore.getInstance().getFirebaseMessageMap(messageId);
       if (messageMap != null) {
         remoteMessage = FlutterFirebaseMessagingUtils.getRemoteMessageForArguments(messageMap);
-        notificationMap = FlutterFirebaseMessagingUtils.getRemoteMessageNotificationForArguments(messageMap);
+        notificationMap =
+            FlutterFirebaseMessagingUtils.getRemoteMessageNotificationForArguments(messageMap);
       }
       // Note we don't remove it here as the user may still call getInitialMessage.
     }
@@ -588,10 +580,7 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
       message.put("notification", initialMessageNotification);
     }
 
-    channel.invokeMethod(
-        "Messaging#onMessageOpenedApp",
-      message
-        );
+    channel.invokeMethod("Messaging#onMessageOpenedApp", message);
     mainActivity.setIntent(intent);
     return true;
   }

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -345,7 +345,9 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
 
             Map<String, Object> remoteMessageMap =
                 FlutterFirebaseMessagingUtils.remoteMessageToMap(remoteMessage);
-            if (notificationMap != null) {
+
+            // If no notification map is available in the remote message we override with the one we got
+            if (remoteMessage.getNotification() == null && notificationMap != null) {
               remoteMessageMap.put("notification", notificationMap);
             }
 
@@ -576,7 +578,7 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
     FlutterFirebaseMessagingReceiver.notifications.remove(messageId);
     Map<String, Object> message = FlutterFirebaseMessagingUtils.remoteMessageToMap(remoteMessage);
 
-    if (initialMessageNotification != null) {
+    if (remoteMessage.getNotification() == null && initialMessageNotification != null) {
       message.put("notification", initialMessageNotification);
     }
 

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -14,6 +14,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.os.Build;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -25,6 +26,8 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.RemoteMessage;
+
+import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
@@ -313,7 +316,13 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
             if (remoteMessage == null) {
               remoteMessage =
                   FlutterFirebaseMessagingStore.getInstance().getFirebaseMessage(messageId);
-              FlutterFirebaseMessagingStore.getInstance().removeFirebaseMessage(messageId);
+              Log.d(
+                  "COUCOU",
+                  "getInitialMessage: "
+                      + (remoteMessage == null
+                          ? "No remote message found in store"
+                          : "Found remote message in store"));
+              // FlutterFirebaseMessagingStore.getInstance().removeFirebaseMessage(messageId);
             }
 
             if (remoteMessage == null) {
@@ -515,6 +524,7 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
   @Override
   public boolean onNewIntent(Intent intent) {
     if (intent == null || intent.getExtras() == null) {
+      Log.w("COUCOU", "onNewIntent: intent or extras are null");
       return false;
     }
 
@@ -525,7 +535,10 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
       return false;
     }
 
+    Log.w("COUCOU", "messageId: " + messageId);
+
     RemoteMessage remoteMessage = FlutterFirebaseMessagingReceiver.notifications.get(messageId);
+    Log.w("COUCOU", "onNewIntent: remoteMessage: " + FlutterFirebaseMessagingReceiver.notifications.toString());
 
     // If we can't find a copy of the remote message in memory then check from our persisted store.
     if (remoteMessage == null) {
@@ -534,6 +547,7 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
     }
 
     if (remoteMessage == null) {
+      Log.w("COUCOU", "onNewIntent: intent or extras are null");
       return false;
     }
 

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -285,11 +285,9 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
     cachedThreadPool.execute(
         () -> {
           try {
-            Log.w("COUCOU", "Step 1");
             if (initialMessage != null) {
               Map<String, Object> remoteMessageMap =
                   FlutterFirebaseMessagingUtils.remoteMessageToMap(initialMessage);
-              Log.w("COUCOU", "Step 1_" + initialMessageNotification);
               if (initialMessageNotification != null) {
                 remoteMessageMap.put(
                     "notification", initialMessageNotification);
@@ -300,7 +298,6 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
               return;
             }
 
-            Log.w("COUCOU", "Step 2");
 
 
             if (mainActivity == null) {
@@ -308,7 +305,6 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
               return;
             }
 
-            Log.w("COUCOU", "Step 3");
 
 
             Intent intent = mainActivity.getIntent();
@@ -552,7 +548,6 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
   @Override
   public boolean onNewIntent(Intent intent) {
     if (intent == null || intent.getExtras() == null) {
-      Log.w("COUCOU", "onNewIntent: intent or extras are null");
       return false;
     }
 
@@ -563,7 +558,6 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
       return false;
     }
 
-    Log.w("COUCOU", "messageId: " + messageId);
 
     RemoteMessage remoteMessage = FlutterFirebaseMessagingReceiver.notifications.get(messageId);
     Map<String, Object> notificationMap = null;
@@ -580,7 +574,6 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
     }
 
     if (remoteMessage == null) {
-      Log.w("COUCOU", "onNewIntent: intent or extras are null");
       return false;
     }
 

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingStore.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingStore.java
@@ -115,6 +115,7 @@ public class FlutterFirebaseMessagingStore {
       }
       map.put(key, value);
     }
+    Log.w("COUCOU", "jsonObjectToMap: " + map);
     return map;
   }
 

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingStore.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingStore.java
@@ -6,6 +6,8 @@ package io.flutter.plugins.firebase.messaging;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.util.Log;
+
 import com.google.firebase.messaging.RemoteMessage;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -74,6 +76,7 @@ public class FlutterFirebaseMessagingStore {
 
   public RemoteMessage getFirebaseMessage(String remoteMessageId) {
     String remoteMessageString = getPreferencesStringValue(remoteMessageId, null);
+    Log.w("COUCOU", "getFirebaseMessage: " + remoteMessageString);
     if (remoteMessageString != null) {
       try {
         Map<String, Object> argumentsMap = new HashMap<>(1);
@@ -83,6 +86,7 @@ public class FlutterFirebaseMessagingStore {
         argumentsMap.put("message", messageOutMap);
         return FlutterFirebaseMessagingUtils.getRemoteMessageForArguments(argumentsMap);
       } catch (JSONException e) {
+        Log.e("COUCOU", "Error parsing remote message", e);
         e.printStackTrace();
       }
     }

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingStore.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingStore.java
@@ -6,8 +6,6 @@ package io.flutter.plugins.firebase.messaging;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.util.Log;
-
 import com.google.firebase.messaging.RemoteMessage;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingStore.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingStore.java
@@ -76,7 +76,6 @@ public class FlutterFirebaseMessagingStore {
 
   public Map<String, Object> getFirebaseMessageMap(String remoteMessageId) {
     String remoteMessageString = getPreferencesStringValue(remoteMessageId, null);
-    Log.w("COUCOU", "getFirebaseMessage: " + remoteMessageString);
     if (remoteMessageString != null) {
       try {
         Map<String, Object> argumentsMap = new HashMap<>(1);
@@ -84,10 +83,8 @@ public class FlutterFirebaseMessagingStore {
         // Add a fake 'to' - as it's required to construct a RemoteMessage instance.
         messageOutMap.put("to", remoteMessageId);
         argumentsMap.put("message", messageOutMap);
-        Log.w("COUCOU", "getFirebaseMessage result: " + argumentsMap);
         return argumentsMap;
       } catch (JSONException e) {
-        Log.e("COUCOU", "Error parsing remote message", e);
         e.printStackTrace();
       }
     }
@@ -116,7 +113,6 @@ public class FlutterFirebaseMessagingStore {
       }
       map.put(key, value);
     }
-    Log.w("COUCOU", "jsonObjectToMap: " + map);
     return map;
   }
 

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingStore.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingStore.java
@@ -74,7 +74,7 @@ public class FlutterFirebaseMessagingStore {
     setPreferencesStringValue(KEY_NOTIFICATION_IDS, notifications);
   }
 
-  public RemoteMessage getFirebaseMessage(String remoteMessageId) {
+  public Map<String, Object> getFirebaseMessageMap(String remoteMessageId) {
     String remoteMessageString = getPreferencesStringValue(remoteMessageId, null);
     Log.w("COUCOU", "getFirebaseMessage: " + remoteMessageString);
     if (remoteMessageString != null) {
@@ -84,7 +84,8 @@ public class FlutterFirebaseMessagingStore {
         // Add a fake 'to' - as it's required to construct a RemoteMessage instance.
         messageOutMap.put("to", remoteMessageId);
         argumentsMap.put("message", messageOutMap);
-        return FlutterFirebaseMessagingUtils.getRemoteMessageForArguments(argumentsMap);
+        Log.w("COUCOU", "getFirebaseMessage result: " + argumentsMap);
+        return argumentsMap;
       } catch (JSONException e) {
         Log.e("COUCOU", "Error parsing remote message", e);
         e.printStackTrace();

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
@@ -76,6 +76,8 @@ class FlutterFirebaseMessagingUtils {
     messageMap.put(KEY_TTL, remoteMessage.getTtl());
     messageMap.put(KEY_SENT_TIME, remoteMessage.getSentTime());
 
+
+
     Log.w("COUCOU", "Parsing notification: " + remoteMessage.getNotification());
     if (remoteMessage.getNotification() != null) {
       messageMap.put(
@@ -250,6 +252,29 @@ class FlutterFirebaseMessagingUtils {
       builder.setData(data);
     }
 
+
     return builder.build();
   }
+
+  /**
+   * Returns the notification associated to a RemoteMessage map.
+   *
+   * @param arguments Method channel call arguments.
+   * @return RemoteMessage
+   */
+  static Map<String, Object> getRemoteMessageNotificationForArguments(Map<String, Object> arguments) {
+    @SuppressWarnings("unchecked")
+    Map<String, Object> messageMap =
+      (Map<String, Object>) Objects.requireNonNull(arguments.get("message"));
+
+    if (messageMap.get("notification") == null) {
+      return null;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> notification = (Map<String, Object>) messageMap.get("notification");
+
+return notification;  }
+
 }

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
@@ -7,6 +7,7 @@ package io.flutter.plugins.firebase.messaging;
 import android.app.ActivityManager;
 import android.app.KeyguardManager;
 import android.content.Context;
+
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.RemoteMessage;
 import java.util.Arrays;
@@ -15,6 +16,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
+import io.flutter.Log;
 
 @FunctionalInterface
 interface ErrorCallback {
@@ -73,6 +76,7 @@ class FlutterFirebaseMessagingUtils {
     messageMap.put(KEY_TTL, remoteMessage.getTtl());
     messageMap.put(KEY_SENT_TIME, remoteMessage.getSentTime());
 
+    Log.w("COUCOU", "Remote message notification" +( remoteMessage.getNotification() != null ? " not null" : " null"));
     if (remoteMessage.getNotification() != null) {
       messageMap.put(
           "notification", remoteMessageNotificationToMap(remoteMessage.getNotification()));

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
@@ -76,7 +76,7 @@ class FlutterFirebaseMessagingUtils {
     messageMap.put(KEY_TTL, remoteMessage.getTtl());
     messageMap.put(KEY_SENT_TIME, remoteMessage.getSentTime());
 
-    Log.w("COUCOU", "Remote message notification" +( remoteMessage.getNotification() != null ? " not null" : " null"));
+    Log.w("COUCOU", "Parsing notification: " + remoteMessage.getNotification());
     if (remoteMessage.getNotification() != null) {
       messageMap.put(
           "notification", remoteMessageNotificationToMap(remoteMessage.getNotification()));

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-
 @FunctionalInterface
 interface ErrorCallback {
   void onError(String errorDescription);

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
@@ -7,7 +7,6 @@ package io.flutter.plugins.firebase.messaging;
 import android.app.ActivityManager;
 import android.app.KeyguardManager;
 import android.content.Context;
-
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.RemoteMessage;
 import java.util.Arrays;
@@ -17,7 +16,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import io.flutter.Log;
 
 @FunctionalInterface
 interface ErrorCallback {
@@ -75,8 +73,6 @@ class FlutterFirebaseMessagingUtils {
     messageMap.put(KEY_DATA, dataMap);
     messageMap.put(KEY_TTL, remoteMessage.getTtl());
     messageMap.put(KEY_SENT_TIME, remoteMessage.getSentTime());
-
-
 
     if (remoteMessage.getNotification() != null) {
       messageMap.put(
@@ -251,7 +247,6 @@ class FlutterFirebaseMessagingUtils {
       builder.setData(data);
     }
 
-
     return builder.build();
   }
 
@@ -261,19 +256,19 @@ class FlutterFirebaseMessagingUtils {
    * @param arguments Method channel call arguments.
    * @return RemoteMessage
    */
-  static Map<String, Object> getRemoteMessageNotificationForArguments(Map<String, Object> arguments) {
+  static Map<String, Object> getRemoteMessageNotificationForArguments(
+      Map<String, Object> arguments) {
     @SuppressWarnings("unchecked")
     Map<String, Object> messageMap =
-      (Map<String, Object>) Objects.requireNonNull(arguments.get("message"));
+        (Map<String, Object>) Objects.requireNonNull(arguments.get("message"));
 
     if (messageMap.get("notification") == null) {
       return null;
     }
 
-
     @SuppressWarnings("unchecked")
     Map<String, Object> notification = (Map<String, Object>) messageMap.get("notification");
 
-return notification;  }
-
+    return notification;
+  }
 }

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
@@ -78,7 +78,6 @@ class FlutterFirebaseMessagingUtils {
 
 
 
-    Log.w("COUCOU", "Parsing notification: " + remoteMessage.getNotification());
     if (remoteMessage.getNotification() != null) {
       messageMap.put(
           "notification", remoteMessageNotificationToMap(remoteMessage.getNotification()));


### PR DESCRIPTION

## Description

Since we don't have access to the `notification` field in the RemoteMessage Builder, we are forced to add a second field to hold the value of the notification and restore it from the SharedPreferences

## Related Issues

closes #9813

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
