### PR TITLE
fix(ui, android): fix an issue with Google Sign In where the clientId was passed on Android

### DIFF
--- a/packages/firebase_ui_oauth_google/lib/src/provider.dart
+++ b/packages/firebase_ui_oauth_google/lib/src/provider.dart
@@ -7,14 +7,15 @@ import 'package:google_sign_in/google_sign_in.dart';
 class GoogleProvider extends OAuthProvider {
   @override
   final providerId = 'google.com';
+
+  /// The Google client ID.
+  /// Will be ignored on Android since it's not needed.
   final String clientId;
+
   final String? redirectUri;
   final List<String>? scopes;
 
-  late GoogleSignIn provider = GoogleSignIn(
-    scopes: scopes ?? [],
-    clientId: clientId,
-  );
+  late GoogleSignIn provider;
 
   @override
   final GoogleAuthProvider firebaseAuthProvider = GoogleAuthProvider();
@@ -36,6 +37,19 @@ class GoogleProvider extends OAuthProvider {
     firebaseAuthProvider.setCustomParameters(const {
       'prompt': 'select_account',
     });
+
+    // `clientId` is not supported on Android and is misinterpreted as a
+    // `serverClientId`. This is a workaround to avoid the error.
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      provider = GoogleSignIn(
+        scopes: scopes ?? [],
+      );
+    } else {
+      provider = GoogleSignIn(
+        scopes: scopes ?? [],
+        clientId: clientId,
+      );
+    }
   }
 
   @override


### PR DESCRIPTION

## Description

As described in the google_sign_in documentation, we shouldn't pass the `clientId` on Android: https://pub.dev/packages/google_sign_in#android-integration
 
## Related Issues

#10005 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
