### PR TITLE
fix(auth, web): `currentUser` is now populated right at the start of the application without needing to wait for `authStateChange``

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -89,7 +89,13 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
 
   /// Called by PluginRegistry to register this plugin for Flutter Web
   static void registerWith(Registrar registrar) {
-    FirebaseCoreWeb.registerService('auth');
+    FirebaseCoreWeb.registerService('auth', () async {
+      print('coucou');
+      FirebaseAuthWeb.instance.authStateChanges().listen((event) {
+        print('authStateChanges: $event');
+      });
+      print('coucou 2');
+    });
     FirebaseAuthPlatform.instance = FirebaseAuthWeb.instance;
     PhoneMultiFactorGeneratorPlatform.instance = PhoneMultiFactorGeneratorWeb();
     RecaptchaVerifierFactoryPlatform.instance =

--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -90,7 +90,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   /// Called by PluginRegistry to register this plugin for Flutter Web
   static void registerWith(Registrar registrar) {
     FirebaseCoreWeb.registerService('auth', () async {
-      // await FirebaseAuthWeb.instance.delegate.onAuthStateChanged.first;
+      await FirebaseAuthWeb.instance.delegate.onWaitInitState();
     });
     FirebaseAuthPlatform.instance = FirebaseAuthWeb.instance;
     PhoneMultiFactorGeneratorPlatform.instance = PhoneMultiFactorGeneratorWeb();

--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -90,7 +90,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   /// Called by PluginRegistry to register this plugin for Flutter Web
   static void registerWith(Registrar registrar) {
     FirebaseCoreWeb.registerService('auth', () async {
-      await FirebaseAuthWeb.instance.delegate.onAuthStateChanged.first;
+      // await FirebaseAuthWeb.instance.delegate.onAuthStateChanged.first;
     });
     FirebaseAuthPlatform.instance = FirebaseAuthWeb.instance;
     PhoneMultiFactorGeneratorPlatform.instance = PhoneMultiFactorGeneratorWeb();

--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -90,11 +90,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   /// Called by PluginRegistry to register this plugin for Flutter Web
   static void registerWith(Registrar registrar) {
     FirebaseCoreWeb.registerService('auth', () async {
-      print('coucou');
-      FirebaseAuthWeb.instance.authStateChanges().listen((event) {
-        print('authStateChanges: $event');
-      });
-      print('coucou 2');
+      await FirebaseAuthWeb.instance.delegate.onAuthStateChanged.first;
     });
     FirebaseAuthPlatform.instance = FirebaseAuthWeb.instance;
     PhoneMultiFactorGeneratorPlatform.instance = PhoneMultiFactorGeneratorWeb();

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -20,8 +20,11 @@ class FirebaseWebService {
   EnsureInitializedFunction ensureInitializedFunction;
 
   /// Creates a new [FirebaseWebService].
-  FirebaseWebService._(this.name,
-      {this.override, this.ensureInitializedFunction});
+  FirebaseWebService._(
+    this.name, {
+    this.override,
+    this.ensureInitializedFunction,
+  });
 }
 
 typedef EnsureInitializedFunction = Future<void> Function()?;

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -17,17 +17,17 @@ class FirebaseWebService {
   /// Function to call to ensure the Firebase Service is initalized.
   /// Usually used to ensure that the Web SDK match the behavior
   /// of native SDKs.
-  EnsureInitializedFunction ensureInitializedFunction;
+  EnsurePluginInitialized ensurePluginInitialized;
 
   /// Creates a new [FirebaseWebService].
   FirebaseWebService._(
     this.name, {
     this.override,
-    this.ensureInitializedFunction,
+    this.ensurePluginInitialized,
   });
 }
 
-typedef EnsureInitializedFunction = Future<void> Function()?;
+typedef EnsurePluginInitialized = Future<void> Function()?;
 
 /// The entry point for accessing Firebase.
 ///
@@ -43,13 +43,13 @@ class FirebaseCoreWeb extends FirebasePlatform {
   /// Internally registers a Firebase Service to be initialized.
   static void registerService(
     String service, [
-    EnsureInitializedFunction? ensureInitializedFunction,
+    EnsurePluginInitialized? ensurePluginInitialized,
   ]) {
     _services.putIfAbsent(
       service,
       () => FirebaseWebService._(
         service,
-        ensureInitializedFunction: ensureInitializedFunction,
+        ensurePluginInitialized: ensurePluginInitialized,
       ),
     );
   }
@@ -274,7 +274,7 @@ class FirebaseCoreWeb extends FirebasePlatform {
 
     await Future.wait(
       _services.values.map((service) {
-        final ensureInitializedFunction = service.ensureInitializedFunction;
+        final ensureInitializedFunction = service.ensurePluginInitialized;
 
         if (ensureInitializedFunction == null) {
           return Future.value();

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -116,6 +116,7 @@ class FirebaseCoreWeb extends FirebasePlatform {
 
     await Future.wait(
       _services.values.map((service) {
+        print(service);
         if (ignored.contains(service.override ?? service.name)) {
           return Future.value();
         }

--- a/packages/firebase_ui_auth/example/lib/main.dart
+++ b/packages/firebase_ui_auth/example/lib/main.dart
@@ -1,19 +1,18 @@
 import 'package:firebase_auth/firebase_auth.dart'
     hide PhoneAuthProvider, EmailAuthProvider;
 import 'package:firebase_core/firebase_core.dart';
-import 'package:flutter/material.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:firebase_ui_oauth_apple/firebase_ui_oauth_apple.dart';
 import 'package:firebase_ui_oauth_facebook/firebase_ui_oauth_facebook.dart';
 import 'package:firebase_ui_oauth_google/firebase_ui_oauth_google.dart';
 import 'package:firebase_ui_oauth_twitter/firebase_ui_oauth_twitter.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-
-import 'firebase_options.dart';
 
 import 'config.dart';
 import 'decorations.dart';
+import 'firebase_options.dart';
 
 final actionCodeSettings = ActionCodeSettings(
   url: 'https://flutterfire-e2e-tests.firebaseapp.com',


### PR DESCRIPTION
## Description



## Related Issues

fix https://github.com/firebase/flutterfire/issues/10008

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
