### PR TITLE
fix(core): Omit unnecessary libraries for web

### DIFF
--- a/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
@@ -6,9 +6,9 @@ import 'dart:async';
 
 import 'package:firebase_app_check_platform_interface/firebase_app_check_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_web/firebase_core_web.dart';
 import 'package:firebase_core_web/firebase_core_web_interop.dart'
     as core_interop;
-import 'package:firebase_core_web/firebase_core_web.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
 import 'src/internals.dart';
@@ -28,7 +28,10 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
 
   /// Called by PluginRegistry to register this plugin for Flutter Web
   static void registerWith(Registrar registrar) {
-    FirebaseCoreWeb.registerService('app-check');
+    FirebaseCoreWeb.registerService(
+      'app-check',
+      productNameOverride: 'app_check',
+    );
     FirebaseAppCheckPlatform.instance = FirebaseAppCheckWeb.instance;
   }
 

--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -91,35 +91,38 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
 
   /// Called by PluginRegistry to register this plugin for Flutter Web
   static void registerWith(Registrar registrar) {
-    FirebaseCoreWeb.registerService('auth', (firebaseApp) async {
-      final authDelegate = auth_interop.getAuthInstance(firebaseApp);
-      // if localhost, and emulator was previously set in localStorage, use it
-      if (window.location.hostname == 'localhost' && kDebugMode) {
-        final String? emulatorOrigin =
-            window.sessionStorage[getOriginName(firebaseApp.name)];
+    FirebaseCoreWeb.registerService(
+      'auth',
+      ensurePluginInitialized: (firebaseApp) async {
+        final authDelegate = auth_interop.getAuthInstance(firebaseApp);
+        // if localhost, and emulator was previously set in localStorage, use it
+        if (window.location.hostname == 'localhost' && kDebugMode) {
+          final String? emulatorOrigin =
+              window.sessionStorage[getOriginName(firebaseApp.name)];
 
-        if (emulatorOrigin != null) {
-          try {
-            authDelegate.useAuthEmulator(emulatorOrigin);
-            // ignore: avoid_print
-            print(
-              'Using previously configured Auth emulator at $emulatorOrigin for ${firebaseApp.name} \nTo switch back to production, restart your app with the emulator turned off.',
-            );
-          } catch (e) {
-            if (e.toString().contains('sooner')) {
-              // Happens during hot reload when the emulator is already configured
+          if (emulatorOrigin != null) {
+            try {
+              authDelegate.useAuthEmulator(emulatorOrigin);
               // ignore: avoid_print
               print(
-                'Auth emulator is already configured at $emulatorOrigin for ${firebaseApp.name} and kept across hot reload.\nTo switch back to production, restart your app with the emulator turned off.',
+                'Using previously configured Auth emulator at $emulatorOrigin for ${firebaseApp.name} \nTo switch back to production, restart your app with the emulator turned off.',
               );
-            } else {
-              rethrow;
+            } catch (e) {
+              if (e.toString().contains('sooner')) {
+                // Happens during hot reload when the emulator is already configured
+                // ignore: avoid_print
+                print(
+                  'Auth emulator is already configured at $emulatorOrigin for ${firebaseApp.name} and kept across hot reload.\nTo switch back to production, restart your app with the emulator turned off.',
+                );
+              } else {
+                rethrow;
+              }
             }
           }
         }
-      }
-      await authDelegate.onWaitInitState();
-    });
+        await authDelegate.onWaitInitState();
+      },
+    );
     FirebaseAuthPlatform.instance = FirebaseAuthWeb.instance;
     PhoneMultiFactorGeneratorPlatform.instance = PhoneMultiFactorGeneratorWeb();
     RecaptchaVerifierFactoryPlatform.instance =

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -37,9 +37,6 @@ typedef EnsurePluginInitialized = Future<void> Function(
 class FirebaseCoreWeb extends FirebasePlatform {
   static Map<String, FirebaseWebService> _services = {
     'core': FirebaseWebService._('app', override: 'core'),
-    'app-check': FirebaseWebService._('app-check', override: 'app_check'),
-    'remote-config':
-        FirebaseWebService._('remote-config', override: 'remote_config'),
   };
 
   /// Internally registers a Firebase Service to be initialized.

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -14,7 +14,7 @@ class FirebaseWebService {
   /// property allows overriding of web naming to Flutterfire plugin naming.
   String? override;
 
-  /// Function to call to ensure the Firebase Service is initalized.
+  /// Function to call to ensure the Firebase Service is initialized.
   /// Usually used to ensure that the Web SDK match the behavior
   /// of native SDKs.
   EnsurePluginInitialized ensurePluginInitialized;
@@ -41,13 +41,15 @@ class FirebaseCoreWeb extends FirebasePlatform {
 
   /// Internally registers a Firebase Service to be initialized.
   static void registerService(
-    String service, [
+    String service, {
+    String? productNameOverride,
     EnsurePluginInitialized? ensurePluginInitialized,
-  ]) {
+  }) {
     _services.putIfAbsent(
       service,
       () => FirebaseWebService._(
         service,
+        override: productNameOverride,
         ensurePluginInitialized: ensurePluginInitialized,
       ),
     );
@@ -70,7 +72,7 @@ class FirebaseCoreWeb extends FirebasePlatform {
   }
 
   /// Returns a list of services which won't be automatically injected on
-  /// initilization. This is useful incases where you wish to manually include
+  /// initialization. This is useful incases where you wish to manually include
   /// the scripts (e.g. in countries where you must request the users permission
   /// to include Analytics).
   ///

--- a/packages/firebase_remote_config/firebase_remote_config_web/lib/firebase_remote_config_web.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_web/lib/firebase_remote_config_web.dart
@@ -34,7 +34,10 @@ class FirebaseRemoteConfigWeb extends FirebaseRemoteConfigPlatform {
 
   /// Create the default instance of the [FirebaseRemoteConfigPlatform] as a [FirebaseRemoteConfigWeb]
   static void registerWith(Registrar registrar) {
-    FirebaseCoreWeb.registerService('remote-config');
+    FirebaseCoreWeb.registerService(
+      'remote-config',
+      productNameOverride: 'remote_config',
+    );
     FirebaseRemoteConfigPlatform.instance = FirebaseRemoteConfigWeb.instance;
   }
 


### PR DESCRIPTION
## Description

Currently it seems that unnecessary web libraries are loaded on start of a Flutter Web application. 

In our case, we only want to use Firebase Analytics to send tracking data. For this we need to install the firebase_core and firebase_analytics package as dependencies in our project. But when we launch the bundled app in the browser, there are additional JS libraries loaded to the expected `firebase-app.js` and `firebase-analytics.js` files. At launch of our app, these JS libraries are loaded.

- firebase-app.js
- firebase-analytics.js
- firebase-app-check.js
- firebase-remote-config.js
- firebase-firestore.js

The `firebase-firestore.js`dependency comes from the firebase_core and firebase_analytics using shared functionality from _flutterfire_internals, which has the `cloud_firestore_platform_interface` and `cloud_firestore_web` packages in its dependencies. But there does not seem to be any code used from these dependencies, so it seems that they could be removed.

The `firebase-app-check.js` and `firebase-remote-config.js` libraries are loaded because the app-check and remote-config JS libraries are installed as default web services in FirebaseCoreWeb platform interface. I have not found any explanation in the code, why this is necessary, because both web plugins register their web service on plugin registration, when they are added as discrete dependency to a project.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
