### PR TITLE
refactor!: remove FallThroughError before deletion in Dart 3

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/utils/load_bundle_task_state.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/utils/load_bundle_task_state.dart
@@ -14,6 +14,6 @@ LoadBundleTaskState convertToTaskState(String state) {
     case 'error':
       return LoadBundleTaskState.error;
     default:
-      throw FallThroughError();
+      throw Exception('Unknown LoadBundleTaskState: $state');
   }
 }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/web_utils.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/web_utils.dart
@@ -5,8 +5,8 @@
 
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 
-import '../utils/decode_utility.dart';
 import '../interop/firestore.dart' as firestore_interop;
+import '../utils/decode_utility.dart';
 
 const _kChangeTypeAdded = 'added';
 const _kChangeTypeModified = 'modified';
@@ -68,7 +68,9 @@ DocumentChangeType convertWebDocumentChangeType(String changeType) {
     case _kChangeTypeRemoved:
       return DocumentChangeType.removed;
     default:
-      throw FallThroughError();
+      throw Exception(
+        'Unknown DocumentChangeType: ${changeType.toLowerCase()}',
+      );
   }
 }
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/action_code_info.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/action_code_info.dart
@@ -62,7 +62,7 @@ class ActionCodeInfo {
       case 6:
         return ActionCodeInfoOperation.revertSecondFactorAddition;
       default:
-        throw FallThroughError();
+        throw Exception('Unknown ActionCodeInfoOperation: $_operation');
     }
   }
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/action_code_info_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/action_code_info_test.dart
@@ -110,14 +110,12 @@ void main() {
             equals(ActionCodeInfoOperation.verifyEmail));
       });
 
-      test(
-          'throws a [FallThroughError] when operation does not match a known type',
+      test('throws a [Exception] when operation does not match a known type',
           () {
         ActionCodeInfo testActionCodeInfo =
             ActionCodeInfo(operation: -1, data: kMockData);
 
-        expect(() => testActionCodeInfo.operation,
-            throwsA(isA<FallThroughError>()));
+        expect(() => testActionCodeInfo.operation, throwsA(isA<Exception>()));
       });
     });
   });

--- a/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
@@ -265,7 +265,7 @@ auth_interop.AuthProvider convertPlatformAuthProvider(
     return auth_interop.SAMLAuthProvider(authProvider.providerId);
   }
 
-  throw FallThroughError();
+  throw Exception('Unknown AuthProvider: $authProvider');
 }
 
 /// Converts a [auth_interop.AuthCredential] into a [AuthCredential].

--- a/packages/firebase_database/firebase_database/lib/ui/firebase_list.dart
+++ b/packages/firebase_database/firebase_database/lib/ui/firebase_list.dart
@@ -103,7 +103,7 @@ class FirebaseList extends ListBase<DataSnapshot>
       }
     }
 
-    throw FallThroughError();
+    throw Exception('Unknown key: key');
   }
 
   void _onChildAdded(DatabaseEvent event) {


### PR DESCRIPTION
## Description

The API [FallThroughError](https://api.dart.dev/stable/2.17.4/dart-core/FallThroughError-class.html) is deprecated and scheduled for https://github.com/dart-lang/sdk/issues/49529.

Replacing with `Exception`

## Related Issues

closes #10079

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
