### PR TITLE
chore: Replace `FallThroughError` with `UnsupportedError`

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/utils/load_bundle_task_state.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/utils/load_bundle_task_state.dart
@@ -14,6 +14,6 @@ LoadBundleTaskState convertToTaskState(String state) {
     case 'error':
       return LoadBundleTaskState.error;
     default:
-      throw FallThroughError();
+      throw UnsupportedError('Unknown LoadBundleTaskState value: $state.');
   }
 }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/web_utils.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/web_utils.dart
@@ -68,7 +68,7 @@ DocumentChangeType convertWebDocumentChangeType(String changeType) {
     case _kChangeTypeRemoved:
       return DocumentChangeType.removed;
     default:
-      throw FallThroughError();
+      throw UnsupportedError('Unknown DocumentChangeType: $changeType.');
   }
 }
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/action_code_info.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/action_code_info.dart
@@ -62,7 +62,7 @@ class ActionCodeInfo {
       case 6:
         return ActionCodeInfoOperation.revertSecondFactorAddition;
       default:
-        throw FallThroughError();
+        throw UnsupportedError('Unknown ActionCodeInfoOperation: $_operation.');
     }
   }
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/action_code_info_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/action_code_info_test.dart
@@ -111,13 +111,13 @@ void main() {
       });
 
       test(
-          'throws a [FallThroughError] when operation does not match a known type',
+          'throws a [UnsupportedError] when operation does not match a known type',
           () {
         ActionCodeInfo testActionCodeInfo =
             ActionCodeInfo(operation: -1, data: kMockData);
 
         expect(() => testActionCodeInfo.operation,
-            throwsA(isA<FallThroughError>()));
+            throwsA(isA<UnsupportedError>()));
       });
     });
   });

--- a/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
@@ -265,7 +265,7 @@ auth_interop.AuthProvider convertPlatformAuthProvider(
     return auth_interop.SAMLAuthProvider(authProvider.providerId);
   }
 
-  throw FallThroughError();
+  throw UnsupportedError('Unknown AuthProvider: $authProvider.');
 }
 
 /// Converts a [auth_interop.AuthCredential] into a [AuthCredential].


### PR DESCRIPTION
## Description

`FallThroughError` is deprecated and will be removed with Dart 3.0. Since this rolls into g3, it's blocking us [landing the removal](https://dart-review.googlesource.com/c/sdk/+/259041).

This PR migrates the errors to `UnsupportedError`s.

## Related Issues

* https://github.com/dart-lang/sdk/issues/49529
* https://github.com/firebase/flutterfire/issues/10079

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

Users should _not_ catch `Error`s, only `Exceptions`. As such this is not a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
