### PR TITLE
fix(firestore): fix stream order when a transaction is running

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTLoadBundleStreamHandler.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTLoadBundleStreamHandler.m
@@ -50,11 +50,9 @@
       }];
   // use addObserver to update user with snapshot progress
   [self.task addObserver:^(FIRLoadBundleTaskProgress *_Nullable progress) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      if (progress.state != FIRLoadBundleTaskStateError) {
-        events(progress);
-      }
-    });
+    if (progress.state != FIRLoadBundleTaskStateError) {
+      events(progress);
+    }
   }];
 
   return nil;


### PR DESCRIPTION
## Description

Remove the queue to emit the event directly without waiting for other events (transaction event queued) that could interfere.
It matches how Android is handling the events (queue only for Transaction, not for snapshots stream)

## Related Issues

closes #10153 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
