### PR TITLE
fix(ui_auth): unfocus to dismiss keyboard when submitting email form

### DIFF
--- a/packages/firebase_ui_auth/lib/src/widgets/email_form.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/email_form.dart
@@ -184,6 +184,8 @@ class _SignInFormContentState extends State<_SignInFormContent> {
   }
 
   void _submit([String? password]) {
+    FocusManager.instance.primaryFocus?.unfocus();
+
     final ctrl = AuthController.ofType<EmailAuthController>(context);
     final email = (widget.email ?? emailCtrl.text).trim();
 


### PR DESCRIPTION
## Description

Currently, when clicking the Sign In button, the in-screen keyboard is not dismissed. This PR automatically dismisses the keyboard (by unfocusing) when the form is submitted.

## Related Issues

Fixes #10207

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
