### PR TITLE
fix(ui_auth): emit UserCreated state when signed in user is new

### DIFF
--- a/packages/firebase_ui_auth/lib/firebase_ui_auth.dart
+++ b/packages/firebase_ui_auth/lib/firebase_ui_auth.dart
@@ -18,6 +18,7 @@ export 'src/auth_state.dart'
         CredentialReceived,
         SignedIn,
         SigningIn,
+        UserCreated,
         AuthFailed,
         DifferentSignInMethodsFound,
         MFARequired;

--- a/packages/firebase_ui_auth/lib/src/auth_flow.dart
+++ b/packages/firebase_ui_auth/lib/src/auth_flow.dart
@@ -144,7 +144,11 @@ class AuthFlow<T extends AuthProvider> extends ValueNotifier<AuthState>
 
   @override
   void onSignedIn(UserCredential credential) {
-    value = SignedIn(credential.user);
+    if (credential.additionalUserInfo?.isNewUser ?? false) {
+      value = UserCreated(credential);
+    } else {
+      value = SignedIn(credential.user);
+    }
   }
 
   @override

--- a/packages/firebase_ui_auth/lib/src/auth_state.dart
+++ b/packages/firebase_ui_auth/lib/src/auth_state.dart
@@ -5,7 +5,7 @@
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/widgets.dart';
 import 'package:firebase_auth/firebase_auth.dart'
-    show AuthCredential, MultiFactorResolver, User;
+    show AuthCredential, MultiFactorResolver, User, UserCredential;
 
 /// An abstract class for all auth states.
 /// [AuthState] transitions could be captured with an [AuthStateChangeAction]:
@@ -144,6 +144,14 @@ class SignedIn extends AuthState {
 
   /// {@macro ui.auth.auth_state.signed_in}
   SignedIn(this.user);
+}
+
+/// A state that indicates that a new user account was created.
+class UserCreated extends AuthState {
+  /// A [UserCredential] that was obtained during authentication process.
+  final UserCredential credential;
+
+  UserCreated(this.credential);
 }
 
 /// {@template ui.auth.auth_state.different_sign_in_methods_found}

--- a/packages/firebase_ui_auth/lib/src/flows/email_flow.dart
+++ b/packages/firebase_ui_auth/lib/src/flows/email_flow.dart
@@ -10,14 +10,6 @@ import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 /// [AwaitingEmailAndPassword].
 class AwaitingEmailAndPassword extends AuthState {}
 
-/// A state that indicates that a new user account was created.
-class UserCreated extends AuthState {
-  /// A [fba.UserCredential] that was obtained during authentication process.
-  final fba.UserCredential credential;
-
-  UserCreated(this.credential);
-}
-
 /// A state that indicates that user registration is in progress.
 /// UIs often reflect this state with a loading indicator.
 class SigningUp extends AuthState {}


### PR DESCRIPTION
## Description

Check for additional user info and emit `UserCreated` when `credential.additionalUserInfo?.isNewUser` is true

## Related Issues

Closes #10124

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
