### PR TITLE
fix(performance, ios): fix a crash that would occur when creating a trace with performance collection disabled

### DIFF
--- a/packages/firebase_performance/firebase_performance/example/integration_test/firebase_performance_e2e_test.dart
+++ b/packages/firebase_performance/firebase_performance/example/integration_test/firebase_performance_e2e_test.dart
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:firebase_core/firebase_core.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_performance/firebase_performance.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'firebase_options.dart';
@@ -46,14 +46,20 @@ void main() {
 
     setUpAll(() async {
       performance = FirebasePerformance.instance;
-      await performance.setPerformanceCollectionEnabled(true);
     });
 
     setUp(() async {
+      await performance.setPerformanceCollectionEnabled(true);
       testTrace = performance.newTrace('test-trace');
     });
 
     test('start & stop trace', () async {
+      await testTrace.start();
+      await testTrace.stop();
+    });
+
+    test('starting trace with performance collection disabled', () async {
+      await performance.setPerformanceCollectionEnabled(false);
       await testTrace.start();
       await testTrace.stop();
     });

--- a/packages/firebase_performance/firebase_performance/ios/Classes/FLTFirebasePerformancePlugin.m
+++ b/packages/firebase_performance/firebase_performance/ios/Classes/FLTFirebasePerformancePlugin.m
@@ -130,6 +130,11 @@ NSString *const kFLTFirebasePerformanceChannelName = @"plugins.flutter.io/fireba
   NSString *name = arguments[@"name"];
 
   FIRTrace *trace = [FIRPerformance startTraceWithName:name];
+  if (trace == nil) {
+    // Performance collection is disabled
+    result.success(nil);
+    return;
+  }
   _traceHandle = [NSNumber numberWithInt:[_traceHandle intValue] + 1];
   [_traces setObject:trace forKey:_traceHandle];
 


### PR DESCRIPTION
## Description

By returning nil, we have the same behavior as Android :) 

## Related Issues

closes #10240 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
