### PR TITLE
fix(crashlytics, android): improve reason field handling in recordError

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/FlutterFirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/FlutterFirebaseCrashlyticsPlugin.java
@@ -148,7 +148,7 @@ public class FlutterFirebaseCrashlyticsPlugin
             }
 
             Exception exception;
-            if (reason != null && !reason.equals("null")) {
+            if (reason != null) {
               // Set a "reason" (to match iOS) to show where the exception was thrown.
               crashlytics.setCustomKey(Constants.FLUTTER_ERROR_REASON, "thrown " + reason);
               exception =

--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -126,7 +126,7 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
 
     return _delegate.recordError(
       exception: exception.toString(),
-      reason: reason.toString(),
+      reason: reason?.toString(),
       information: _information,
       stackTraceElements: stackTraceElements,
       buildId: buildId,

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/method_channel/method_channel_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/method_channel/method_channel_crashlytics.dart
@@ -8,8 +8,8 @@ import 'dart:async';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/services.dart';
 
-import '../platform_interface/platform_interface_crashlytics.dart';
 import './utils/exception.dart';
+import '../platform_interface/platform_interface_crashlytics.dart';
 
 /// The entry point for accessing a method channel based Crashlytics instance.
 ///
@@ -92,7 +92,7 @@ class MethodChannelFirebaseCrashlytics extends FirebaseCrashlyticsPlatform {
   Future<void> recordError({
     required String exception,
     required String information,
-    required String reason,
+    required String? reason,
     bool fatal = false,
     String? buildId,
     List<Map<String, String>>? stackTraceElements,

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/platform_interface/platform_interface_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/platform_interface/platform_interface_crashlytics.dart
@@ -111,7 +111,7 @@ abstract class FirebaseCrashlyticsPlatform extends PlatformInterface {
   Future<void> recordError({
     required String exception,
     required String information,
-    required String reason,
+    required String? reason,
     bool fatal = false,
     String? buildId,
     List<Map<String, String>>? stackTraceElements,


### PR DESCRIPTION
## Description

Revert and fix https://github.com/firebase/flutterfire/pull/10256.
Since reason is typed as dynamic, it would send `"null"` to to native instead of properly sending `null` when there is no reasons.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
