### PR TITLE
feat(cloud_firestore): Move firestore types to their own package

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/example/pubspec.yaml
@@ -19,6 +19,8 @@ dependency_overrides:
     path: ../../../_flutterfire_internals
   cloud_firestore_platform_interface:
     path: ../../cloud_firestore_platform_interface
+  cloud_firestore_types:
+    path: ../../cloud_firestore_types
   cloud_firestore_web:
     path: ../../cloud_firestore_web
   firebase_core:

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/cloud_firestore_platform_interface.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/cloud_firestore_platform_interface.dart
@@ -7,12 +7,11 @@ library cloud_firestore_platform_interface;
 
 import 'src/internal/pointer.dart';
 
+export 'package:cloud_firestore_types/cloud_firestore_types.dart';
 export 'package:collection/collection.dart' show ListEquality;
 
 export 'src/aggregate_source.dart';
-export 'src/blob.dart';
 export 'src/field_path.dart';
-export 'src/geo_point.dart';
 export 'src/get_options.dart';
 export 'src/load_bundle_task_state.dart';
 export 'src/load_bundle_task_state.dart';
@@ -41,7 +40,6 @@ export 'src/set_options.dart';
 export 'src/settings.dart';
 export 'src/snapshot_metadata.dart';
 export 'src/source.dart';
-export 'src/timestamp.dart';
 
 /// Helper method exposed to determine whether a given [collectionPath] points to
 /// a valid Firestore collection.

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
@@ -10,13 +10,13 @@ environment:
 
 dependencies:
   _flutterfire_internals: ^1.0.12
+  cloud_firestore_types: ^1.0.0
   collection: ^1.15.0
   firebase_core: ^2.4.1
   flutter:
     sdk: flutter
   meta: ^1.3.0
   plugin_platform_interface: ^2.1.3
-
 
 dev_dependencies:
   firebase_core_platform_interface: ^4.5.2

--- a/packages/cloud_firestore/cloud_firestore_types/.gitignore
+++ b/packages/cloud_firestore/cloud_firestore_types/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/cloud_firestore/cloud_firestore_types/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_types/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/packages/cloud_firestore/cloud_firestore_types/README.md
+++ b/packages/cloud_firestore/cloud_firestore_types/README.md
@@ -1,0 +1,3 @@
+# cloud_firestore_types
+
+Common types for the [`cloud_firestore`](../cloud_firestore) plugin.

--- a/packages/cloud_firestore/cloud_firestore_types/lib/cloud_firestore_types.dart
+++ b/packages/cloud_firestore/cloud_firestore_types/lib/cloud_firestore_types.dart
@@ -1,0 +1,3 @@
+export 'src/blob.dart';
+export 'src/geo_point.dart';
+export 'src/timestamp.dart';

--- a/packages/cloud_firestore/cloud_firestore_types/lib/cloud_firestore_types.dart
+++ b/packages/cloud_firestore/cloud_firestore_types/lib/cloud_firestore_types.dart
@@ -1,3 +1,7 @@
+// Copyright 2022, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 export 'src/blob.dart';
 export 'src/geo_point.dart';
 export 'src/timestamp.dart';

--- a/packages/cloud_firestore/cloud_firestore_types/lib/src/blob.dart
+++ b/packages/cloud_firestore/cloud_firestore_types/lib/src/blob.dart
@@ -6,7 +6,7 @@
 import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart' show immutable;
+import 'package:meta/meta.dart';
 
 /// Represents binary data stored in [Uint8List].
 @immutable

--- a/packages/cloud_firestore/cloud_firestore_types/lib/src/geo_point.dart
+++ b/packages/cloud_firestore/cloud_firestore_types/lib/src/geo_point.dart
@@ -3,7 +3,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 /// Represents a geographical point by its longitude and latitude
 @immutable

--- a/packages/cloud_firestore/cloud_firestore_types/lib/src/timestamp.dart
+++ b/packages/cloud_firestore/cloud_firestore_types/lib/src/timestamp.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 const int _kThousand = 1000;
 const int _kMillion = 1000000;

--- a/packages/cloud_firestore/cloud_firestore_types/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_types/pubspec.yaml
@@ -1,0 +1,15 @@
+name: cloud_firestore_types
+description: Common types for the cloud_firestore plugin.
+version: 1.0.0
+homepage: https://github.com/firebase/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_types
+repository: https://github.com/firebase/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_types
+
+environment:
+  sdk: ">=2.18.0 <3.0.0"
+
+dependencies:
+  collection: ^1.16.0
+  meta: ^1.8.0
+
+dev_dependencies:
+  test: ^1.22.2

--- a/packages/cloud_firestore/cloud_firestore_types/test/geo_point_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_types/test/geo_point_test.dart
@@ -3,8 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore_types/cloud_firestore_types.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('$GeoPoint', () {
@@ -15,10 +15,10 @@ void main() {
     });
 
     test('throws if invalid values', () {
-      expect(() => GeoPoint(-100, 0), throwsAssertionError);
-      expect(() => GeoPoint(100, 0), throwsAssertionError);
-      expect(() => GeoPoint(0, -190), throwsAssertionError);
-      expect(() => GeoPoint(0, 190), throwsAssertionError);
+      expect(() => GeoPoint(-100, 0), throwsA(isA<AssertionError>()));
+      expect(() => GeoPoint(100, 0), throwsA(isA<AssertionError>()));
+      expect(() => GeoPoint(0, -190), throwsA(isA<AssertionError>()));
+      expect(() => GeoPoint(0, 190), throwsA(isA<AssertionError>()));
     });
   });
 }

--- a/packages/cloud_firestore/cloud_firestore_types/test/timestamp_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_types/test/timestamp_test.dart
@@ -3,8 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore_types/cloud_firestore_types.dart';
+import 'package:test/test.dart';
 
 const int _kBillion = 1000000000;
 const int _kStartOfTime = -62135596800;


### PR DESCRIPTION
## Description

Moves firestore types to their own package.

I am working on a build_runner generator that needs access to these types, but generators are not allowed to depend on flutter.

## Related Issues

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
