### PR TITLE
docs(cloud_firestore_odm): details supported data types

### DIFF
--- a/packages/cloud_firestore_odm/doc/defining-models.md
+++ b/packages/cloud_firestore_odm/doc/defining-models.md
@@ -1,15 +1,17 @@
-- [Defining Models](#defining-models)
-  - [Creating references](#creating-references)
-  - [Injecting the document ID in the model](#injecting-the-document-id-in-the-model)
-  - [Model validation](#model-validation)
-    - [Available validators](#available-validators)
-      - [`int`](#int)
-    - [Custom validators](#custom-validators)
-  - [Next Steps](#next-steps)
-
-# Defining Models
+# Defining models
 
 > The Cloud Firestore ODM is currently in **alpha**. Expect breaking changes, API changes and more. The documentation is still a work in progress. See the [discussion](https://github.com/firebase/flutterfire/discussions/7475) for more details.
+
+- [Creating models](#creating-models)
+- [Creating references](#creating-references)
+- [Injecting the document ID in the model](#injecting-the-document-id-in-the-model)
+- [Model validation](#model-validation)
+  - [Available validators](#available-validators)
+    - [`int`](#int)
+  - [Custom validators](#custom-validators)
+- [Next steps](#next-steps)
+
+## Creating models
 
 A model represents exactly what data we expect to both receive and mutate on Firestore. The ODM
 ensures that all data is validated against a model, and if the model is not valid an error will be
@@ -21,6 +23,7 @@ define a model for this data, create a class:
 
 ```dart
 import 'package:json_annotation/json_annotation.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_firestore_odm/cloud_firestore_odm.dart';
 
 // This doesn't exist yet...! See "Next Steps"
@@ -51,6 +54,14 @@ class User {
 ```
 
 The `User` model defines that a user must have a name and email as a `String` and age as an `int`.
+
+Supported data types are those of Firestore (string, boolean, number, geo point, timestamp, list), 
+plus `DateTime` and `DocumentReference<Map<String, dynamic>>`. Nested object and custom types are 
+supported with `@JsonKey` (see [json_serializable](https://pub.dev/packages/json_serializable)). 
+In addition to `toJson` and `fromJson`, `@JsonKey` also offer `ignore` and `name` parameters.
+
+A current limitation, typesafe query method and update parameters are not generated for nested object 
+and custom types like enum.
 
 :::caution
 If your model class is defined in a separate file than the Firestore reference,
@@ -104,7 +115,7 @@ By default, the document ID is not present in the firestore object once decoded.
 
 While you can acccess it using the `DocumentSnapshot`, it isn't always convenient.
 A solution to that is to use the `@Id` annotation, to tell Firestore that a
-a given property in a class would be the document ID:
+given property in a class would be the document ID:
 
 ```dart
 @Collection<Person>('users')
@@ -222,7 +233,7 @@ class User {
 }
 ```
 
-## Next Steps
+## Next steps
 
 Some of the code on this page is created via code generation
 (e.g. `_$assertUser`, `UserCollectionReference`) - you can learn more about


### PR DESCRIPTION
Also include various small improvements to defining-models.md.

## Description

While useful information can be found in the discussion linked in doc, I added the bits I would have loved to find directly in the doc when I take interest in Cloud Firestore ODM. Especially data type support. 

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
