### PR TITLE
fix(cloud_firestore): startAfterDocument with where a DocumentReference throws

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
@@ -1873,5 +1873,29 @@ void runQueryTests() {
         },
       );
     });
+
+    group('startAfterDocument', () {
+      test('startAfterDocument() accept DocumentReference in query parameters',
+          () async {
+        final collection = await initializeTest('start-after-document');
+
+        final doc1 = collection.doc('1');
+        final doc2 = collection.doc('2');
+        final doc3 = collection.doc('3');
+        final doc4 = collection.doc('4');
+        await doc1.set({'ref': doc1});
+        await doc2.set({'ref': doc2});
+        await doc3.set({'ref': doc3});
+        await doc4.set({'ref': null});
+
+        final q = collection
+            .where('ref', isNull: false)
+            .orderBy('ref')
+            .startAfterDocument(await doc1.get());
+
+        final res = await q.get();
+        expect(res.docs.map((e) => e.reference), [doc2, doc3]);
+      });
+    });
   });
 }

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -262,7 +262,9 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
       // All order by fields must exist within the snapshot
       if (field != FieldPath.documentId) {
         try {
-          values.add(documentSnapshot.get(field));
+          final codecValue =
+              _CodecUtility.valueEncode(documentSnapshot.get(field));
+          values.add(codecValue);
         } on StateError {
           throw "You are trying to start or end a query using a document for which the field '$field' (used as the orderBy) does not exist.";
         }

--- a/packages/cloud_firestore/cloud_firestore/test/query_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/query_test.dart
@@ -3,42 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
-import 'package:cloud_firestore_platform_interface/src/method_channel/method_channel_firestore.dart';
-import 'package:cloud_firestore_platform_interface/src/method_channel/method_channel_document_reference.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import './mock.dart';
-import 'test_firestore_message_codec.dart';
 
 void main() {
   setupCloudFirestoreMocks();
   late FirebaseFirestore firestore;
   Query? query;
-
-  MethodChannelFirebaseFirestore.channel = const MethodChannel(
-    'plugins.flutter.io/firebase_firestore',
-    StandardMethodCodec(TestFirestoreMessageCodec()),
-  );
-
-  MethodChannelFirebaseFirestore.channel.setMockMethodCallHandler((call) async {
-    if (call.method == 'DocumentReference#get') {
-      DocumentReferencePlatform ref = call.arguments['reference'];
-      if (ref.path == 'movies/exists') {
-        return {
-          'data': {
-            'reference': ref,
-          },
-          'metadata': {
-            'hasPendingWrites': false,
-            'isFromCache': false,
-          }
-        };
-      }
-    }
-  });
 
   group('$Query', () {
     setUpAll(() async {
@@ -335,20 +308,6 @@ void main() {
         q = q.endAt(['456']);
         expect(q.parameters['endBefore'], isNull);
         expect(q.parameters['endAt'], equals(['456']));
-      });
-
-      test('startAfterDocument() encode DocumentReference to Platform class',
-          () async {
-        DocumentSnapshot doc =
-            await firestore.collection('/movies').doc('exists').get();
-        Query q = query!.orderBy('reference').startAfterDocument(doc);
-        expect(
-          q.parameters['startAfter'].first,
-          allOf([
-            isA<MethodChannelDocumentReference>(),
-            isA<DocumentReferencePlatform>(),
-          ]),
-        );
       });
     });
 


### PR DESCRIPTION
## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

closes #10338

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/



The command `melos run analyze` fails in packages not related to my PR, see bellow.
```
$ melos exec
  └> dart analyze . --fatal-infos
     └> FAILED (in 4 packages)
        └> cloud_firestore_odm (with exit code 1)
        └> cloud_firestore_odm_example (with exit code 1)
        └> cloud_firestore_odm_generator (with exit code 1)
        └> cloud_firestore_odm_generator_integration_test (with exit code 1)

```
