### PR TITLE
docs(crashlytics, android): update obfuscated crash reports documentation

### DIFF
--- a/docs/crashlytics/_deobfuscated.md
+++ b/docs/crashlytics/_deobfuscated.md
@@ -143,5 +143,20 @@ and in the app-level `build.gradle`:
   <strong>apply plugin: 'com.google.firebase.crashlytics'</strong>
   </pre>
 
+*1.  If your Flutter project uses the
+    [`--split-debug-info` flag](https://docs.flutter.dev/perf/app-size#reducing-app-size){: .external}
+    (and the
+    [`--obfuscate` flag](https://docs.flutter.dev/deployment/obfuscate){: .external}),
+    you need to use the [{{firebase_cli}}](/docs/cli) (v.11.9.0+) to upload
+    Android symbols.
+
+    You need to upload the debug symbols before reporting a crash from an obfuscated code build (i.e using the above noted flags
+    `--split-debug-info` & `--obfuscate`). From the root directory of your Flutter project, run the following command:
+
+    <pre class="devsite-terminal" data-terminal-prefix="your-flutter-proj$ ">firebase crashlytics:symbols:upload --app=<var class="readonly">APP_ID</var> <var class="readonly">PATH/TO</var>/symbols</pre>
+
+    The <code><var>PATH/TO</var>/symbols</code> directory is the same directory
+    that you pass to the `--split-debug-info` flag when building the application.
+
 If problems persist, refer to the
 [Android-specific guide for troubleshooting obfuscated reports](/docs/crashlytics/get-deobfuscated-reports?platform=android).

--- a/docs/crashlytics/_get-started.md
+++ b/docs/crashlytics/_get-started.md
@@ -53,27 +53,6 @@ first crash report to Firebase.
     flutter run
     ```
 
-1.  _(Optional)_ If your Flutter project uses the
-   [`--split-debug-info` flag](https://docs.flutter.dev/perf/app-size#reducing-app-size){: .external}
-   (and, optionally, the
-   [`--obfuscate` flag](https://docs.flutter.dev/deployment/obfuscate){: .external}),
-   you need to use the [{{firebase_cli}}](/docs/cli) (v.11.9.0+) to upload
-   Android symbols.
-
-   From the root directory of your Flutter project, run the following command:
-
-   <pre class="devsite-terminal" data-terminal-prefix="your-flutter-proj$ ">firebase crashlytics:symbols:upload --app=<var class="readonly">APP_ID</var> <var class="readonly">PATH/TO</var>/symbols</pre>
-
-   The <code><var>PATH/TO</var>/symbols</code> directory is the same directory
-   that you pass to the `--split-debug-info` flag when building the application.
-
-   Note: Support for `--split-debug-info` is currently only available on
-   Android.<br>For Apple platforms, support for this feature will be
-   available in an upcoming release, but you can access it now by using the
-   [master channel](https://docs.flutter.dev/development/tools/sdk/releases){: .external}
-   of the Flutter SDK.
-
-
 ## **Step 2**: Configure crash handlers {: #configure-crash-handlers}
 
 You can automatically catch all errors that are thrown within the Flutter


### PR DESCRIPTION
## Description

See title.

## Related Issues

part of: https://github.com/firebase/flutterfire/issues/8934#issuecomment-1410781888

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
