### PR TITLE
chore(dynamic-links, android): suppress "unchecked" API & annotate non-nullable API

### DIFF
--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class FlutterFirebaseDynamicLinksPlugin
@@ -148,7 +149,7 @@ public class FlutterFirebaseDynamicLinksPlugin
         result.success(url);
         return;
       case "FirebaseDynamicLinks#buildShortLink":
-        methodCallTask = buildShortLink(call.arguments());
+        methodCallTask = buildShortLink(Objects.requireNonNull(call.arguments()));
         break;
       case "FirebaseDynamicLinks#getDynamicLink":
       case "FirebaseDynamicLinks#getInitialLink":
@@ -190,7 +191,7 @@ public class FlutterFirebaseDynamicLinksPlugin
     return urlBuilder.buildDynamicLink().getUri().toString();
   }
 
-  private Task<Map<String, Object>> buildShortLink(@Nullable Map<String, Object> arguments) {
+  private Task<Map<String, Object>> buildShortLink(@NonNull Map<String, Object> arguments) {
     TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
 
     cachedThreadPool.execute(
@@ -280,12 +281,12 @@ public class FlutterFirebaseDynamicLinksPlugin
   private DynamicLink.Builder setupParameters(Map<String, Object> arguments) {
     DynamicLink.Builder dynamicLinkBuilder = getDynamicLinkInstance(arguments).createDynamicLink();
 
-    String uriPrefix = (String) arguments.get("uriPrefix");
+    String uriPrefix = (String) Objects.requireNonNull(arguments.get("uriPrefix"));
     String link = (String) arguments.get("link");
 
     dynamicLinkBuilder.setDomainUriPrefix(uriPrefix);
     dynamicLinkBuilder.setLink(Uri.parse(link));
-
+    @SuppressWarnings("unchecked")
     Map<String, Object> androidParameters =
         (Map<String, Object>) arguments.get("androidParameters");
     if (androidParameters != null) {
@@ -301,7 +302,7 @@ public class FlutterFirebaseDynamicLinksPlugin
 
       dynamicLinkBuilder.setAndroidParameters(builder.build());
     }
-
+    @SuppressWarnings("unchecked")
     Map<String, Object> googleAnalyticsParameters =
         (Map<String, Object>) arguments.get("googleAnalyticsParameters");
     if (googleAnalyticsParameters != null) {
@@ -322,7 +323,7 @@ public class FlutterFirebaseDynamicLinksPlugin
 
       dynamicLinkBuilder.setGoogleAnalyticsParameters(builder.build());
     }
-
+    @SuppressWarnings("unchecked")
     Map<String, Object> iosParameters = (Map<String, Object>) arguments.get("iosParameters");
     if (iosParameters != null) {
       String bundleId = valueFor("bundleId", iosParameters);
@@ -344,7 +345,7 @@ public class FlutterFirebaseDynamicLinksPlugin
 
       dynamicLinkBuilder.setIosParameters(builder.build());
     }
-
+    @SuppressWarnings("unchecked")
     Map<String, Object> itunesConnectAnalyticsParameters =
         (Map<String, Object>) arguments.get("itunesConnectAnalyticsParameters");
     if (itunesConnectAnalyticsParameters != null) {
@@ -361,7 +362,7 @@ public class FlutterFirebaseDynamicLinksPlugin
 
       dynamicLinkBuilder.setItunesConnectAnalyticsParameters(builder.build());
     }
-
+    @SuppressWarnings("unchecked")
     Map<String, Object> navigationInfoParameters =
         (Map<String, Object>) arguments.get("navigationInfoParameters");
     if (navigationInfoParameters != null) {
@@ -374,7 +375,7 @@ public class FlutterFirebaseDynamicLinksPlugin
 
       dynamicLinkBuilder.setNavigationInfoParameters(builder.build());
     }
-
+    @SuppressWarnings("unchecked")
     Map<String, Object> socialMetaTagParameters =
         (Map<String, Object>) arguments.get("socialMetaTagParameters");
     if (socialMetaTagParameters != null) {

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/example/android/app/build.gradle
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-  compileSdkVersion 31
+  compileSdkVersion 33
 
   lintOptions {
     disable 'InvalidPackage'


### PR DESCRIPTION
## Description

1. `buildShortLink` will always have arguments object so I've made that object non-nullable.
2. `uriPrefix` is a required property. Made this non-nullable.
3. Suppressed warnings for objects that could be `null` but they are checked whether `null` before accessing. We use suppress this warning in other plugins when we know it is checked first.
4. Updated `compileSdkVersion` for example.

## Related Issues

part of https://github.com/firebase/flutterfire/issues/8073

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
