### PR TITLE
feat(firestore): add support to update using FieldPath

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -43,6 +43,8 @@ import io.flutter.plugins.firebase.firestore.streamhandler.SnapshotsInSyncStream
 import io.flutter.plugins.firebase.firestore.streamhandler.TransactionStreamHandler;
 import io.flutter.plugins.firebase.firestore.utils.ExceptionConverter;
 import io.flutter.plugins.firebase.firestore.utils.ServerTimestampBehaviorConverter;
+
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -420,10 +422,23 @@ public class FlutterFirebaseFirestorePlugin
             DocumentReference documentReference =
                 (DocumentReference) Objects.requireNonNull(arguments.get("reference"));
             @SuppressWarnings("unchecked")
-            Map<String, Object> data =
-                (Map<String, Object>) Objects.requireNonNull(arguments.get("data"));
+            Map<FieldPath, Object> data =
+                (Map<FieldPath, Object>) Objects.requireNonNull(arguments.get("data"));
 
-            taskCompletionSource.setResult(Tasks.await(documentReference.update(data)));
+            // Due to the signature of the function, I extract the first element of the map and
+            // pass the rest of the map as an array of alternating keys and values.
+            FieldPath firstFieldPath = data.keySet().iterator().next();
+            Object firstObject = data.get(firstFieldPath);
+
+            ArrayList<Object> flattenData = new ArrayList<>();
+            for (FieldPath fieldPath : data.keySet()) {
+              if (fieldPath.equals(firstFieldPath)) {
+                continue;
+              }
+              flattenData.add(fieldPath);
+              flattenData.add(data.get(fieldPath));
+            }
+            taskCompletionSource.setResult(Tasks.await(documentReference.update(firstFieldPath, firstObject, flattenData.toArray())));
           } catch (Exception e) {
             taskCompletionSource.setException(e);
           }

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -43,7 +43,6 @@ import io.flutter.plugins.firebase.firestore.streamhandler.SnapshotsInSyncStream
 import io.flutter.plugins.firebase.firestore.streamhandler.TransactionStreamHandler;
 import io.flutter.plugins.firebase.firestore.utils.ExceptionConverter;
 import io.flutter.plugins.firebase.firestore.utils.ServerTimestampBehaviorConverter;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -438,7 +437,9 @@ public class FlutterFirebaseFirestorePlugin
               flattenData.add(fieldPath);
               flattenData.add(data.get(fieldPath));
             }
-            taskCompletionSource.setResult(Tasks.await(documentReference.update(firstFieldPath, firstObject, flattenData.toArray())));
+            taskCompletionSource.setResult(
+                Tasks.await(
+                    documentReference.update(firstFieldPath, firstObject, flattenData.toArray())));
           } catch (Exception e) {
             taskCompletionSource.setException(e);
           }

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/document_reference_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/document_reference_e2e.dart
@@ -4,9 +4,9 @@
 
 import 'dart:async';
 
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 
 void runDocumentReferenceTests() {
   group('$DocumentReference', () {
@@ -401,6 +401,76 @@ void runDocumentReferenceTests() {
         await document.update({'bar': 'baz'});
         DocumentSnapshot<Map<String, dynamic>> snapshot2 = await document.get();
         expect(snapshot2.data(), equals({'foo': 'bar', 'bar': 'baz'}));
+      });
+
+      test('updates nested data using dots', () async {
+        DocumentReference<Map<String, dynamic>> document =
+            await initializeTest('document-update-field-path');
+        await document.set({
+          'foo': {'bar': 'baz'}
+        });
+        DocumentSnapshot<Map<String, dynamic>> snapshot = await document.get();
+        expect(
+          snapshot.data(),
+          equals({
+            'foo': {'bar': 'baz'}
+          }),
+        );
+
+        await document.update({'foo.bar': 'toto'});
+        DocumentSnapshot<Map<String, dynamic>> snapshot2 = await document.get();
+        expect(
+          snapshot2.data(),
+          equals({
+            'foo': {'bar': 'toto'}
+          }),
+        );
+      });
+
+      test('updates nested data using FieldPath', () async {
+        DocumentReference<Map<String, dynamic>> document =
+            await initializeTest('document-update-field-path');
+        await document.set({
+          'foo': {'bar': 'baz'}
+        });
+        DocumentSnapshot<Map<String, dynamic>> snapshot = await document.get();
+        expect(
+          snapshot.data(),
+          equals({
+            'foo': {'bar': 'baz'}
+          }),
+        );
+
+        await document.update({
+          FieldPath(const ['foo', 'bar']): 'toto'
+        });
+        DocumentSnapshot<Map<String, dynamic>> snapshot2 = await document.get();
+        expect(
+          snapshot2.data(),
+          equals({
+            'foo': {'bar': 'toto'}
+          }),
+        );
+      });
+
+      test('updates nested data containing a dot using FieldPath', () async {
+        DocumentReference<Map<String, dynamic>> document =
+            await initializeTest('document-update-field-path');
+        await document.set({'foo.bar': 'baz'});
+        DocumentSnapshot<Map<String, dynamic>> snapshot = await document.get();
+        expect(
+          snapshot.data(),
+          equals({'foo.bar': 'baz'}),
+        );
+
+        await document.update({
+          FieldPath(const ['foo.bar']): 'toto'
+        });
+        DocumentSnapshot<Map<String, dynamic>> snapshot2 = await document.get();
+        expect(
+          snapshot2.data(),
+          equals({'foo.bar': 'toto'}),
+        );
       });
 
       test('throws if document does not exist', () async {

--- a/packages/cloud_firestore/cloud_firestore/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/cloud_firestore/cloud_firestore/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -221,6 +221,7 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -252,6 +253,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/packages/cloud_firestore/cloud_firestore/example/ios/Runner/Info.plist
+++ b/packages/cloud_firestore/cloud_firestore/example/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
@@ -197,12 +197,14 @@ class _FilmListState extends State<FilmList> {
       ),
     );
 
-    WriteBatch batch = FirebaseFirestore.instance.batch();
+    await movies.docs.first.reference.update({'likes': 0});
 
-    for (final movie in movies.docs) {
-      batch.update(movie.reference, {'likes': 0});
-    }
-    await batch.commit();
+    // WriteBatch batch = FirebaseFirestore.instance.batch();
+
+    // for (final movie in movies.docs) {
+    //   batch.update(movie.reference, {'likes': 0});
+    // }
+    // await batch.commit();
   }
 }
 

--- a/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
@@ -197,14 +197,12 @@ class _FilmListState extends State<FilmList> {
       ),
     );
 
-    await movies.docs.first.reference.update({'likes': 0});
+    WriteBatch batch = FirebaseFirestore.instance.batch();
 
-    // WriteBatch batch = FirebaseFirestore.instance.batch();
-
-    // for (final movie in movies.docs) {
-    //   batch.update(movie.reference, {'likes': 0});
-    // }
-    // await batch.commit();
+    for (final movie in movies.docs) {
+      batch.update(movie.reference, {'likes': 0});
+    }
+    await batch.commit();
   }
 }
 

--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
@@ -174,7 +174,7 @@ class _JsonDocumentReference
   @override
   Future<void> update(Map<Object, Object?> data) {
     return _delegate
-        .update(_CodecUtility.replaceValueWithDelegatesInMap(data)!);
+        .update(_CodecUtility.replaceValueWithDelegatesInMapFieldPath(data)!);
   }
 
   @override

--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
@@ -38,8 +38,10 @@ abstract class DocumentReference<T extends Object?> {
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
+  /// Objects key can be a String or a FieldPath.
+  ///
   /// If no document exists yet, the update will fail.
-  Future<void> update(Map<String, Object?> data);
+  Future<void> update(Map<Object, Object?> data);
 
   /// Reads the document referenced by this [DocumentReference].
   ///
@@ -170,7 +172,7 @@ class _JsonDocumentReference
   }
 
   @override
-  Future<void> update(Map<String, Object?> data) {
+  Future<void> update(Map<Object, Object?> data) {
     return _delegate
         .update(_CodecUtility.replaceValueWithDelegatesInMap(data)!);
   }
@@ -282,7 +284,7 @@ class _WithConverterDocumentReference<T extends Object?>
   }
 
   @override
-  Future<void> update(Map<String, Object?> data) {
+  Future<void> update(Map<Object, Object?> data) {
     return _originalDocumentReference.update(data);
   }
 

--- a/packages/cloud_firestore/cloud_firestore/lib/src/utils/codec_utility.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/utils/codec_utility.dart
@@ -16,6 +16,27 @@ class _CodecUtility {
     return output;
   }
 
+  static Map<FieldPath, dynamic>? replaceValueWithDelegatesInMapFieldPath(
+    Map<dynamic, dynamic>? data,
+  ) {
+    if (data == null) {
+      return null;
+    }
+    Map<FieldPath, dynamic> output = <FieldPath, dynamic>{};
+    data.forEach((key, value) {
+      if (key is FieldPath) {
+        output[key] = valueEncode(value);
+      } else if (key is String) {
+        output[FieldPath.fromString(key)] = valueEncode(value);
+      } else {
+        throw StateError(
+          'Invalid key type for map. Expected String or FieldPath, but got $key: ${key.runtimeType}.',
+        );
+      }
+    });
+    return output;
+  }
+
   static List<dynamic>? replaceValueWithDelegatesInArray(List<dynamic>? data) {
     if (data == null) {
       return null;

--- a/packages/cloud_firestore/cloud_firestore/lib/src/utils/codec_utility.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/utils/codec_utility.dart
@@ -17,7 +17,7 @@ class _CodecUtility {
   }
 
   static Map<FieldPath, dynamic>? replaceValueWithDelegatesInMapFieldPath(
-    Map<dynamic, dynamic>? data,
+    Map<Object, dynamic>? data,
   ) {
     if (data == null) {
       return null;

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_document_reference.dart
@@ -47,7 +47,7 @@ class MethodChannelDocumentReference extends DocumentReferencePlatform {
   }
 
   @override
-  Future<void> update(Map<String, dynamic> data) async {
+  Future<void> update(Map<Object, dynamic> data) async {
     try {
       await MethodChannelFirebaseFirestore.channel.invokeMethod<void>(
         'DocumentReference#update',

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_document_reference.dart
@@ -47,7 +47,7 @@ class MethodChannelDocumentReference extends DocumentReferencePlatform {
   }
 
   @override
-  Future<void> update(Map<Object, dynamic> data) async {
+  Future<void> update(Map<FieldPath, dynamic> data) async {
     try {
       await MethodChannelFirebaseFirestore.channel.invokeMethod<void>(
         'DocumentReference#update',

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_document_reference.dart
@@ -92,7 +92,7 @@ abstract class DocumentReferencePlatform extends PlatformInterface {
   /// special sentinel [FieldValuePlatform] type.
   ///
   /// If no document exists yet, the update will fail.
-  Future<void> update(Map<Object, dynamic> data) {
+  Future<void> update(Map<FieldPath, dynamic> data) {
     throw UnimplementedError('update() is not implemented');
   }
 

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_document_reference.dart
@@ -92,7 +92,7 @@ abstract class DocumentReferencePlatform extends PlatformInterface {
   /// special sentinel [FieldValuePlatform] type.
   ///
   /// If no document exists yet, the update will fail.
-  Future<void> update(Map<String, dynamic> data) {
+  Future<void> update(Map<Object, dynamic> data) {
     throw UnimplementedError('update() is not implemented');
   }
 

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_tests/method_channel_document_reference_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_tests/method_channel_document_reference_test.dart
@@ -47,9 +47,9 @@ void main() {
 
     test('update', () async {
       bool isMethodCalled = false;
-      final Map<String, dynamic> data = {
-        'test': 'test',
-        'fieldValue': mockFieldValue
+      final Map<FieldPath, dynamic> data = {
+        FieldPath.fromString('test'): 'test',
+        FieldPath.fromString('fieldValue'): mockFieldValue
       };
       handleMethodCall((call) {
         if (call.method == 'DocumentReference#update') {

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/utils/test_firestore_message_codec.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/utils/test_firestore_message_codec.dart
@@ -3,13 +3,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:cloud_firestore_platform_interface/src/method_channel/method_channel_firestore.dart';
 import 'package:cloud_firestore_platform_interface/src/method_channel/method_channel_query.dart';
+import 'package:cloud_firestore_platform_interface/src/method_channel/utils/firestore_message_codec.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
-
-import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
-import 'package:cloud_firestore_platform_interface/src/method_channel/utils/firestore_message_codec.dart';
 
 /// This codec is able to decode FieldValues.
 /// This ability is only required in tests, hence why
@@ -24,6 +23,7 @@ class TestFirestoreMessageCodec extends FirestoreMessageCodec {
   static const int _kDelete = 134;
   static const int _kServerTimestamp = 135;
   static const int _kFirestoreInstance = 144;
+  static const int _kFieldPath = 140;
   static const int _kFirestoreQuery = 145;
   static const int _kFirestoreSettings = 146;
 
@@ -77,6 +77,13 @@ class TestFirestoreMessageCodec extends FirestoreMessageCodec {
             readValue(buffer)! as MethodChannelFirebaseFirestore;
         String path = readValue(buffer)! as String;
         return firestore.doc(path);
+      case _kFieldPath:
+        final int size = readSize(buffer);
+        final List<String> segments = <String>[];
+        for (int i = 0; i < size; i++) {
+          segments.add(readValue(buffer)! as String);
+        }
+        return FieldPath(segments);
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/document_reference_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/document_reference_web.dart
@@ -38,7 +38,7 @@ class DocumentReferenceWeb extends DocumentReferencePlatform {
   }
 
   @override
-  Future<void> update(Map<String, dynamic> data) {
+  Future<void> update(Map<Object, dynamic> data) {
     return convertWebExceptions(
         () => _delegate.update(EncodeUtility.encodeMapData(data)!));
   }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/document_reference_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/document_reference_web.dart
@@ -40,7 +40,7 @@ class DocumentReferenceWeb extends DocumentReferencePlatform {
   @override
   Future<void> update(Map<Object, dynamic> data) {
     return convertWebExceptions(
-        () => _delegate.update(EncodeUtility.encodeMapData(data)!));
+        () => _delegate.update(EncodeUtility.encodeMapDataFieldPath(data)!));
   }
 
   @override

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -366,7 +366,7 @@ class DocumentReference
     return handleThenable(jsObjectSet);
   }
 
-  Future<void> update(Map<String, dynamic> data) =>
+  Future<void> update(Map<FieldPath, dynamic> data) =>
       handleThenable(firestore_interop.updateDoc(jsObject, jsify(data)));
 }
 

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/encode_utility.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/encode_utility.dart
@@ -21,6 +21,18 @@ class EncodeUtility {
     return output;
   }
 
+  static Map<FieldPath, dynamic>? encodeMapDataFieldPath(
+      Map<Object, dynamic>? data) {
+    if (data == null) {
+      return null;
+    }
+    Map<FieldPath, dynamic> output = <FieldPath, dynamic>{};
+    data.forEach((key, value) {
+      output[valueEncode(key)] = valueEncode(value);
+    });
+    return output;
+  }
+
   /// Encodes an Array of values from their proper types to a serialized version.
   static List<dynamic>? encodeArrayData(List<dynamic>? data) {
     if (data == null) {

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/encode_utility.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/encode_utility.dart
@@ -5,14 +5,14 @@
 
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 
-import '../interop/firestore.dart' as firestore_interop;
 import '../document_reference_web.dart';
 import '../field_value_web.dart';
+import '../interop/firestore.dart' as firestore_interop;
 
 /// Class containing static utility methods to encode/decode firestore data.
 class EncodeUtility {
   /// Encodes a Map of values from their proper types to a serialized version.
-  static Map<String, dynamic>? encodeMapData(Map<String, dynamic>? data) {
+  static Map<String, dynamic>? encodeMapData(Map<Object, dynamic>? data) {
     if (data == null) {
       return null;
     }


### PR DESCRIPTION
## Description

This PR allows users to use FieldPath when running `DocumentReference.update`.
All the String are now turned into FieldPath before being send to native in order to minimise the number of cases to handle on the native side.

## Related Issues

closes #10367

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
