### PR TITLE
docs(firebase_analytics): add more documentation for `logEvent`

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
@@ -75,7 +75,34 @@ class FirebaseAnalytics extends FirebasePluginPlatform {
     return _delegate.getAppInstanceId();
   }
 
-  /// Logs a custom Flutter Analytics event with the given [name] and event [parameters].
+  /// Logs a custom Flutter Analytics event with the given [name] and event
+  /// [parameters].
+  ///
+  /// The event can have up to 25 [parameters]. Events with the same [name] must
+  /// have the same [parameters]. Up to 500 event names are supported.
+  ///
+  /// The [name] of the event. Should contain 1 to 40 alphanumeric characters or
+  /// underscores. The name must start with an alphabetic character. Some event
+  /// names are reserved. See [FirebaseAnalytics.Event][1] for the list of reserved
+  /// event names. The "firebase_", "google_" and "ga_" prefixes are reserved
+  /// and should not be used. Note that event names are case-sensitive and that
+  /// logging two events whose names differ only in case will result in two
+  /// distinct events.
+  ///
+  /// The map of event [parameters]. Passing null indicates that the event has no
+  /// parameters. Parameter names can be up to 40 characters long and must start
+  /// with an alphabetic character and contain only alphanumeric characters and
+  /// underscores. String, long and double param types are supported. String
+  /// parameter values can be up to 100 characters long. The "firebase_",
+  /// "google_" and "ga_" prefixes are reserved and should not be used for
+  /// parameter names.
+  ///
+  /// See also:
+  ///
+  ///   * https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics#public-void-logevent-string-name,-bundle-params
+  ///   * https://firebase.google.com/docs/reference/swift/firebaseanalytics/api/reference/Classes/Analytics#logevent_:parameters:
+  ///
+  /// [1]: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event
   Future<void> logEvent({
     required String name,
     Map<String, Object?>? parameters,

--- a/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
@@ -83,19 +83,19 @@ class FirebaseAnalytics extends FirebasePluginPlatform {
   ///
   /// The [name] of the event. Should contain 1 to 40 alphanumeric characters or
   /// underscores. The name must start with an alphabetic character. Some event
-  /// names are reserved. See [FirebaseAnalytics.Event][1] for the list of reserved
-  /// event names. The "firebase_", "google_" and "ga_" prefixes are reserved
-  /// and should not be used. Note that event names are case-sensitive and that
-  /// logging two events whose names differ only in case will result in two
-  /// distinct events.
+  /// names are reserved. See [FirebaseAnalytics.Event][1] for the list of
+  /// reserved event names. The "firebase_", "google_" and "ga_" prefixes are
+  /// reserved and should not be used. Note that event names are case-sensitive
+  /// and that logging two events whose names differ only in case will result in
+  /// two distinct events.
   ///
-  /// The map of event [parameters]. Passing null indicates that the event has no
-  /// parameters. Parameter names can be up to 40 characters long and must start
-  /// with an alphabetic character and contain only alphanumeric characters and
-  /// underscores. String, long and double param types are supported. String
-  /// parameter values can be up to 100 characters long. The "firebase_",
-  /// "google_" and "ga_" prefixes are reserved and should not be used for
-  /// parameter names.
+  /// The map of event [parameters]. Passing null indicates that the event has
+  /// no parameters. Parameter names can be up to 40 characters long and must
+  /// start with an alphabetic character and contain only alphanumeric
+  /// characters and underscores. String, long and double param types are
+  /// supported. String parameter values can be up to 100 characters long. The
+  /// "firebase_", "google_" and "ga_" prefixes are reserved and should not be
+  /// used for parameter names.
   ///
   /// See also:
   ///

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/lib/src/platform_interface/platform_interface_firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/lib/src/platform_interface/platform_interface_firebase_analytics.dart
@@ -74,7 +74,34 @@ abstract class FirebaseAnalyticsPlatform extends PlatformInterface {
     throw UnimplementedError('getAppInstanceId() is not implemented');
   }
 
-  /// Logs the given event [name] with the given [parameters].
+  /// Logs a custom Flutter Analytics event with the given [name] and event
+  /// [parameters].
+  ///
+  /// The event can have up to 25 [parameters]. Events with the same [name] must
+  /// have the same [parameters]. Up to 500 event names are supported.
+  ///
+  /// The [name] of the event. Should contain 1 to 40 alphanumeric characters or
+  /// underscores. The name must start with an alphabetic character. Some event
+  /// names are reserved. See [FirebaseAnalytics.Event][1] for the list of
+  /// reserved event names. The "firebase_", "google_" and "ga_" prefixes are
+  /// reserved and should not be used. Note that event names are case-sensitive
+  /// and that logging two events whose names differ only in case will result in
+  /// two distinct events.
+  ///
+  /// The map of event [parameters]. Passing null indicates that the event has
+  /// no parameters. Parameter names can be up to 40 characters long and must
+  /// start with an alphabetic character and contain only alphanumeric
+  /// characters and underscores. String, long and double param types are
+  /// supported. String parameter values can be up to 100 characters long. The
+  /// "firebase_", "google_" and "ga_" prefixes are reserved and should not be
+  /// used for parameter names.
+  ///
+  /// See also:
+  ///
+  ///   * https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics#public-void-logevent-string-name,-bundle-params
+  ///   * https://firebase.google.com/docs/reference/swift/firebaseanalytics/api/reference/Classes/Analytics#logevent_:parameters:
+  ///
+  /// [1]: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event
   Future<void> logEvent({
     required String name,
     Map<String, Object?>? parameters,


### PR DESCRIPTION
## Description

When I used `logEvent` I tried to get Dart documentation about the limitations of `logEvent`. However, there was no helpful information (like length of `name`, reversed names, data types for `parameters`). Therefore, I copied the documentation from firebase.google.com/docs into the Dart source code.

Copied from: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics#public-void-logevent-string-name,-bundle-params

## Related Issues

...

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
