### PR TITLE
fix(performance, ios): fix a crash that could occur with httpMetricStart when disabling collection

### DIFF
--- a/packages/firebase_performance/firebase_performance/example/integration_test/firebase_performance_e2e_test.dart
+++ b/packages/firebase_performance/firebase_performance/example/integration_test/firebase_performance_e2e_test.dart
@@ -167,6 +167,20 @@ void main() {
         });
       });
 
+      test('test all Http method values with collection disabled', () async {
+        FirebasePerformance performance = FirebasePerformance.instance;
+        await performance.setPerformanceCollectionEnabled(false);
+
+        await Future.forEach(HttpMethod.values, (HttpMethod method) async {
+          final HttpMetric testMetric = performance.newHttpMetric(
+            'https://www.google.com/',
+            method,
+          );
+          await testMetric.start();
+          await testMetric.stop();
+        });
+      });
+
       test('putAttribute works correctly', () {
         testHttpMetric.putAttribute('apple', 'sauce');
         testHttpMetric.putAttribute('banana', 'pie');

--- a/packages/firebase_performance/firebase_performance/ios/Classes/FLTFirebasePerformancePlugin.m
+++ b/packages/firebase_performance/firebase_performance/ios/Classes/FLTFirebasePerformancePlugin.m
@@ -84,6 +84,11 @@ NSString *const kFLTFirebasePerformanceChannelName = @"plugins.flutter.io/fireba
   FIRHTTPMethod method = [FLTFirebasePerformancePlugin parseHttpMethod:arguments[@"httpMethod"]];
   NSURL *url = [NSURL URLWithString:arguments[@"url"]];
   FIRHTTPMetric *httpMetric = [[FIRHTTPMetric alloc] initWithURL:url HTTPMethod:method];
+  if (httpMetric == nil) {
+    // Performance collection is disabled
+    result.success(nil);
+    return;
+  }
 
   [httpMetric start];
   _httpMetricHandle = [NSNumber numberWithInt:[_httpMetricHandle intValue] + 1];


### PR DESCRIPTION

## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

closes #10326

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
