### PR TITLE
fix(firestore): supports Iterable in queries instead of List

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
@@ -1256,6 +1256,69 @@ void runQueryTests() {
         });
       });
 
+      test('returns with in filter using Iterable', () async {
+        CollectionReference<Map<String, dynamic>> collection =
+            await initializeTest('where-in-iterable');
+
+        await Future.wait([
+          collection.doc('doc1').set({
+            'status': 'Ordered',
+          }),
+          collection.doc('doc2').set({
+            'status': 'Ready to Ship',
+          }),
+          collection.doc('doc3').set({
+            'status': 'Ready to Ship',
+          }),
+          collection.doc('doc4').set({
+            'status': 'Incomplete',
+          }),
+        ]);
+
+        QuerySnapshot<Map<String, dynamic>> snapshot = await collection
+            .where(
+              'status',
+              // To force the list to be an iterable
+              whereIn: ['Ready to Ship', 'Ordered'].map((e) => e),
+            )
+            .get();
+
+        expect(snapshot.docs.length, equals(3));
+        snapshot.docs.forEach((doc) {
+          String status = doc.data()['status'];
+          expect(status == 'Ready to Ship' || status == 'Ordered', isTrue);
+        });
+      });
+
+      test('returns with in filter using Set', () async {
+        CollectionReference<Map<String, dynamic>> collection =
+            await initializeTest('where-in');
+
+        await Future.wait([
+          collection.doc('doc1').set({
+            'status': 'Ordered',
+          }),
+          collection.doc('doc2').set({
+            'status': 'Ready to Ship',
+          }),
+          collection.doc('doc3').set({
+            'status': 'Ready to Ship',
+          }),
+          collection.doc('doc4').set({
+            'status': 'Incomplete',
+          }),
+        ]);
+
+        QuerySnapshot<Map<String, dynamic>> snapshot = await collection
+            .where('status', whereIn: {'Ready to Ship', 'Ordered'}).get();
+
+        expect(snapshot.docs.length, equals(3));
+        snapshot.docs.forEach((doc) {
+          String status = doc.data()['status'];
+          expect(status == 'Ready to Ship' || status == 'Ordered', isTrue);
+        });
+      });
+
       test('returns with in filter', () async {
         CollectionReference<Map<String, dynamic>> collection =
             await initializeTest('where-in');

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
@@ -367,6 +367,40 @@ void runQueryTests() {
         expect(snapshot2.docs[1].id, equals('doc2'));
       });
 
+      test('ends at string field paths with Iterable', () async {
+        CollectionReference<Map<String, dynamic>> collection =
+            await initializeTest('endAt-string');
+        await Future.wait([
+          collection.doc('doc1').set({
+            'foo': 1,
+            'bar': {'value': 1}
+          }),
+          collection.doc('doc2').set({
+            'foo': 2,
+            'bar': {'value': 2}
+          }),
+          collection.doc('doc3').set({
+            'foo': 3,
+            'bar': {'value': 3}
+          }),
+        ]);
+
+        QuerySnapshot<Map<String, dynamic>> snapshot = await collection
+            .orderBy('bar.value', descending: true)
+            .endAt({2}).get();
+
+        expect(snapshot.docs.length, equals(2));
+        expect(snapshot.docs[0].id, equals('doc3'));
+        expect(snapshot.docs[1].id, equals('doc2'));
+
+        QuerySnapshot<Map<String, dynamic>> snapshot2 =
+            await collection.orderBy('foo').endAt([2]).get();
+
+        expect(snapshot2.docs.length, equals(2));
+        expect(snapshot2.docs[0].id, equals('doc1'));
+        expect(snapshot2.docs[1].id, equals('doc2'));
+      });
+
       test('ends at field paths', () async {
         CollectionReference<Map<String, dynamic>> collection =
             await initializeTest('endAt-field-path');
@@ -497,6 +531,40 @@ void runQueryTests() {
         expect(snapshot2.docs[1].id, equals('doc3'));
       });
 
+      test('starts at string field paths with Iterable', () async {
+        CollectionReference<Map<String, dynamic>> collection =
+            await initializeTest('startAt-string');
+        await Future.wait([
+          collection.doc('doc1').set({
+            'foo': 1,
+            'bar': {'value': 1}
+          }),
+          collection.doc('doc2').set({
+            'foo': 2,
+            'bar': {'value': 2}
+          }),
+          collection.doc('doc3').set({
+            'foo': 3,
+            'bar': {'value': 3}
+          }),
+        ]);
+
+        QuerySnapshot<Map<String, dynamic>> snapshot = await collection
+            .orderBy('bar.value', descending: true)
+            .startAt([2]).get();
+
+        expect(snapshot.docs.length, equals(2));
+        expect(snapshot.docs[0].id, equals('doc2'));
+        expect(snapshot.docs[1].id, equals('doc1'));
+
+        QuerySnapshot<Map<String, dynamic>> snapshot2 =
+            await collection.orderBy('foo').startAt({2}).get();
+
+        expect(snapshot2.docs.length, equals(2));
+        expect(snapshot2.docs[0].id, equals('doc2'));
+        expect(snapshot2.docs[1].id, equals('doc3'));
+      });
+
       test('starts at field paths', () async {
         CollectionReference<Map<String, dynamic>> collection =
             await initializeTest('startAt-field-path');
@@ -614,6 +682,40 @@ void runQueryTests() {
         QuerySnapshot<Map<String, dynamic>> snapshot = await collection
             .orderBy('bar.value', descending: true)
             .endBefore([1]).get();
+
+        expect(snapshot.docs.length, equals(2));
+        expect(snapshot.docs[0].id, equals('doc3'));
+        expect(snapshot.docs[1].id, equals('doc2'));
+
+        QuerySnapshot<Map<String, dynamic>> snapshot2 =
+            await collection.orderBy('foo').endBefore([3]).get();
+
+        expect(snapshot2.docs.length, equals(2));
+        expect(snapshot2.docs[0].id, equals('doc1'));
+        expect(snapshot2.docs[1].id, equals('doc2'));
+      });
+
+      test('ends before string field paths with Iterable', () async {
+        CollectionReference<Map<String, dynamic>> collection =
+            await initializeTest('endBefore-string');
+        await Future.wait([
+          collection.doc('doc1').set({
+            'foo': 1,
+            'bar': {'value': 1}
+          }),
+          collection.doc('doc2').set({
+            'foo': 2,
+            'bar': {'value': 2}
+          }),
+          collection.doc('doc3').set({
+            'foo': 3,
+            'bar': {'value': 3}
+          }),
+        ]);
+
+        QuerySnapshot<Map<String, dynamic>> snapshot = await collection
+            .orderBy('bar.value', descending: true)
+            .endBefore({1}).get();
 
         expect(snapshot.docs.length, equals(2));
         expect(snapshot.docs[0].id, equals('doc3'));

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
@@ -1319,35 +1319,6 @@ void runQueryTests() {
         });
       });
 
-      test('returns with in filter', () async {
-        CollectionReference<Map<String, dynamic>> collection =
-            await initializeTest('where-in');
-
-        await Future.wait([
-          collection.doc('doc1').set({
-            'status': 'Ordered',
-          }),
-          collection.doc('doc2').set({
-            'status': 'Ready to Ship',
-          }),
-          collection.doc('doc3').set({
-            'status': 'Ready to Ship',
-          }),
-          collection.doc('doc4').set({
-            'status': 'Incomplete',
-          }),
-        ]);
-
-        QuerySnapshot<Map<String, dynamic>> snapshot = await collection
-            .where('status', whereIn: ['Ready to Ship', 'Ordered']).get();
-
-        expect(snapshot.docs.length, equals(3));
-        snapshot.docs.forEach((doc) {
-          String status = doc.data()['status'];
-          expect(status == 'Ready to Ship' || status == 'Ordered', isTrue);
-        });
-      });
-
       test('returns with not-in filter', () async {
         CollectionReference<Map<String, dynamic>> collection =
             await initializeTest('where-not-in');

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -704,19 +704,19 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
           isNotIn(operator)) {
         assert(
           value is Iterable,
-          "A non-empty [List] is required for '$operator' filters.",
+          "A non-empty [Iterable] is required for '$operator' filters.",
         );
         assert(
           (value as Iterable).length <= 10,
-          "'$operator' filters support a maximum of 10 elements in the value [List].",
+          "'$operator' filters support a maximum of 10 elements in the value [Iterable].",
         );
         assert(
           (value as Iterable).isNotEmpty,
-          "'$operator' filters require a non-empty [List].",
+          "'$operator' filters require a non-empty [Iterable].",
         );
         assert(
           (value as Iterable).where((value) => value == null).isEmpty,
-          "'$operator' filters cannot contain 'null' in the [List].",
+          "'$operator' filters cannot contain 'null' in the [Iterable].",
         );
       }
 

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -46,7 +46,7 @@ abstract class Query<T extends Object?> {
   /// The [values] must be in order of [orderBy] filters.
   ///
   /// Calling this method will replace any existing cursor "end" query modifiers.
-  Query<T> endAt(List<Object?> values);
+  Query<T> endAt(Iterable<Object?> values);
 
   /// Creates and returns a new [Query] that ends before the provided document
   /// snapshot (exclusive). The end position is relative to the order of the query.
@@ -65,7 +65,7 @@ abstract class Query<T extends Object?> {
   /// The [values] must be in order of [orderBy] filters.
   ///
   /// Calling this method will replace any existing cursor "end" query modifiers.
-  Query<T> endBefore(List<Object?> values);
+  Query<T> endBefore(Iterable<Object?> values);
 
   /// Fetch the documents for this query.
   ///
@@ -116,7 +116,7 @@ abstract class Query<T extends Object?> {
   /// The [values] must be in order of [orderBy] filters.
   ///
   /// Calling this method will replace any existing cursor "start" query modifiers.
-  Query<T> startAfter(List<Object?> values);
+  Query<T> startAfter(Iterable<Object?> values);
 
   /// Creates and returns a new [Query] that starts at the provided document
   /// (inclusive). The starting position is relative to the order of the query.
@@ -135,7 +135,7 @@ abstract class Query<T extends Object?> {
   /// The [values] must be in order of [orderBy] filters.
   ///
   /// Calling this method will replace any existing cursor "start" query modifiers.
-  Query<T> startAt(List<Object?> values);
+  Query<T> startAt(Iterable<Object?> values);
 
   /// Creates and returns a new [Query] with additional filter on specified
   /// [field]. [field] refers to a field in a document.
@@ -157,9 +157,9 @@ abstract class Query<T extends Object?> {
     Object? isGreaterThan,
     Object? isGreaterThanOrEqualTo,
     Object? arrayContains,
-    List<Object?>? arrayContainsAny,
-    List<Object?>? whereIn,
-    List<Object?>? whereNotIn,
+    Iterable<Object?>? arrayContainsAny,
+    Iterable<Object?>? whereIn,
+    Iterable<Object?>? whereNotIn,
     bool? isNull,
   });
 
@@ -297,7 +297,7 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
   }
 
   /// Common handler for all non-document based cursor queries.
-  List<dynamic> _assertQueryCursorValues(List<Object?> fields) {
+  Iterable<dynamic> _assertQueryCursorValues(Iterable<Object?> fields) {
     List<List<Object?>> orders = List.from(parameters['orderBy']);
 
     assert(
@@ -347,7 +347,7 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
   ///
   /// Calling this method will replace any existing cursor "end" query modifiers.
   @override
-  Query<Map<String, dynamic>> endAt(List<Object?> values) {
+  Query<Map<String, dynamic>> endAt(Iterable<Object?> values) {
     _assertQueryCursorValues(values);
     return _JsonQuery(firestore, _delegate.endAt(values));
   }
@@ -376,7 +376,7 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
   ///
   /// Calling this method will replace any existing cursor "end" query modifiers.
   @override
-  Query<Map<String, dynamic>> endBefore(List<Object?> values) {
+  Query<Map<String, dynamic>> endBefore(Iterable<Object?> values) {
     _assertQueryCursorValues(values);
     return _JsonQuery(
       firestore,
@@ -542,7 +542,7 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
   ///
   /// Calling this method will replace any existing cursor "start" query modifiers.
   @override
-  Query<Map<String, dynamic>> startAfter(List<Object?> values) {
+  Query<Map<String, dynamic>> startAfter(Iterable<Object?> values) {
     _assertQueryCursorValues(values);
     return _JsonQuery(firestore, _delegate.startAfter(values));
   }
@@ -572,7 +572,7 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
   ///
   /// Calling this method will replace any existing cursor "start" query modifiers.
   @override
-  Query<Map<String, dynamic>> startAt(List<Object?> values) {
+  Query<Map<String, dynamic>> startAt(Iterable<Object?> values) {
     _assertQueryCursorValues(values);
     return _JsonQuery(firestore, _delegate.startAt(values));
   }
@@ -598,9 +598,9 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
     Object? isGreaterThan,
     Object? isGreaterThanOrEqualTo,
     Object? arrayContains,
-    List<Object?>? arrayContainsAny,
-    List<Object?>? whereIn,
-    List<Object?>? whereNotIn,
+    Iterable<Object?>? arrayContainsAny,
+    Iterable<Object?>? whereIn,
+    Iterable<Object?>? whereNotIn,
     bool? isNull,
   }) {
     _assertValidFieldType(field);
@@ -703,19 +703,19 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
           operator == 'array-contains-any' ||
           isNotIn(operator)) {
         assert(
-          value is List,
+          value is Iterable,
           "A non-empty [List] is required for '$operator' filters.",
         );
         assert(
-          (value as List).length <= 10,
+          (value as Iterable).length <= 10,
           "'$operator' filters support a maximum of 10 elements in the value [List].",
         );
         assert(
-          (value as List).isNotEmpty,
+          (value as Iterable).isNotEmpty,
           "'$operator' filters require a non-empty [List].",
         );
         assert(
-          (value as List).where((value) => value == null).isEmpty,
+          (value as Iterable).where((value) => value == null).isEmpty,
           "'$operator' filters cannot contain 'null' in the [List].",
         );
       }
@@ -870,7 +870,7 @@ class _WithConverterQuery<T extends Object?> implements Query<T> {
   }
 
   @override
-  Query<T> endAt(List<Object?> values) {
+  Query<T> endAt(Iterable<Object?> values) {
     return _mapQuery(_originalQuery.endAt(values));
   }
 
@@ -880,7 +880,7 @@ class _WithConverterQuery<T extends Object?> implements Query<T> {
   }
 
   @override
-  Query<T> endBefore(List<Object?> values) {
+  Query<T> endBefore(Iterable<Object?> values) {
     return _mapQuery(_originalQuery.endBefore(values));
   }
 
@@ -905,7 +905,7 @@ class _WithConverterQuery<T extends Object?> implements Query<T> {
   }
 
   @override
-  Query<T> startAfter(List<Object?> values) {
+  Query<T> startAfter(Iterable<Object?> values) {
     return _mapQuery(_originalQuery.startAfter(values));
   }
 
@@ -915,7 +915,7 @@ class _WithConverterQuery<T extends Object?> implements Query<T> {
   }
 
   @override
-  Query<T> startAt(List<Object?> values) {
+  Query<T> startAt(Iterable<Object?> values) {
     return _mapQuery(_originalQuery.startAt(values));
   }
 
@@ -934,9 +934,9 @@ class _WithConverterQuery<T extends Object?> implements Query<T> {
     Object? isGreaterThan,
     Object? isGreaterThanOrEqualTo,
     Object? arrayContains,
-    List<Object?>? arrayContainsAny,
-    List<Object?>? whereIn,
-    List<Object?>? whereNotIn,
+    Iterable<Object?>? arrayContainsAny,
+    Iterable<Object?>? whereIn,
+    Iterable<Object?>? whereNotIn,
     bool? isNull,
   }) {
     return _mapQuery(

--- a/packages/cloud_firestore/cloud_firestore/lib/src/utils/codec_utility.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/utils/codec_utility.dart
@@ -37,7 +37,8 @@ class _CodecUtility {
     return output;
   }
 
-  static List<dynamic>? replaceValueWithDelegatesInArray(List<dynamic>? data) {
+  static List<dynamic>? replaceValueWithDelegatesInArray(
+      Iterable<dynamic>? data) {
     if (data == null) {
       return null;
     }
@@ -71,7 +72,7 @@ class _CodecUtility {
   static dynamic valueEncode(dynamic value) {
     if (value is DocumentReference) {
       return value._delegate;
-    } else if (value is List) {
+    } else if (value is Iterable) {
       return replaceValueWithDelegatesInArray(value);
     } else if (value is Map<dynamic, dynamic>) {
       return replaceValueWithDelegatesInMap(value);

--- a/packages/cloud_firestore/cloud_firestore/lib/src/utils/codec_utility.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/utils/codec_utility.dart
@@ -38,7 +38,8 @@ class _CodecUtility {
   }
 
   static List<dynamic>? replaceValueWithDelegatesInArray(
-      Iterable<dynamic>? data) {
+    Iterable<dynamic>? data,
+  ) {
     if (data == null) {
       return null;
     }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query.dart
@@ -66,7 +66,7 @@ class MethodChannelQuery extends QueryPlatform {
   }
 
   @override
-  QueryPlatform endAt(List<dynamic> fields) {
+  QueryPlatform endAt(Iterable<dynamic> fields) {
     return _copyWithParameters(<String, dynamic>{
       'endAt': fields,
       'endBefore': null,
@@ -74,7 +74,8 @@ class MethodChannelQuery extends QueryPlatform {
   }
 
   @override
-  QueryPlatform endBeforeDocument(List<dynamic> orders, List<dynamic> values) {
+  QueryPlatform endBeforeDocument(
+      Iterable<dynamic> orders, Iterable<dynamic> values) {
     return _copyWithParameters(<String, dynamic>{
       'orderBy': orders,
       'endAt': null,
@@ -83,7 +84,7 @@ class MethodChannelQuery extends QueryPlatform {
   }
 
   @override
-  QueryPlatform endBefore(List<dynamic> fields) {
+  QueryPlatform endBefore(Iterable<dynamic> fields) {
     return _copyWithParameters(<String, dynamic>{
       'endAt': null,
       'endBefore': fields,
@@ -176,7 +177,7 @@ class MethodChannelQuery extends QueryPlatform {
   }
 
   @override
-  QueryPlatform orderBy(List<List<dynamic>> orders) {
+  QueryPlatform orderBy(Iterable<List<dynamic>> orders) {
     return _copyWithParameters(<String, dynamic>{'orderBy': orders});
   }
 
@@ -190,7 +191,7 @@ class MethodChannelQuery extends QueryPlatform {
   }
 
   @override
-  QueryPlatform startAfter(List<dynamic> fields) {
+  QueryPlatform startAfter(Iterable<dynamic> fields) {
     return _copyWithParameters(<String, dynamic>{
       'startAt': null,
       'startAfter': fields,
@@ -198,7 +199,8 @@ class MethodChannelQuery extends QueryPlatform {
   }
 
   @override
-  QueryPlatform startAtDocument(List<dynamic> orders, List<dynamic> values) {
+  QueryPlatform startAtDocument(
+      Iterable<dynamic> orders, Iterable<dynamic> values) {
     return _copyWithParameters(<String, dynamic>{
       'orderBy': orders,
       'startAt': values,
@@ -207,7 +209,7 @@ class MethodChannelQuery extends QueryPlatform {
   }
 
   @override
-  QueryPlatform startAt(List<dynamic> fields) {
+  QueryPlatform startAt(Iterable<dynamic> fields) {
     return _copyWithParameters(<String, dynamic>{
       'startAt': fields,
       'startAfter': null,
@@ -215,7 +217,7 @@ class MethodChannelQuery extends QueryPlatform {
   }
 
   @override
-  QueryPlatform where(List<List<dynamic>> conditions) {
+  QueryPlatform where(Iterable<List<dynamic>> conditions) {
     return _copyWithParameters(<String, dynamic>{
       'where': conditions,
     });

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/utils/firestore_message_codec.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/utils/firestore_message_codec.dart
@@ -109,6 +109,8 @@ class FirestoreMessageCodec extends StandardMessageCodec {
     } else if (value is Settings) {
       buffer.putUint8(_kFirestoreSettings);
       writeValue(buffer, value.asMap);
+    } else if (value is Iterable && value is! List) {
+      super.writeValue(buffer, value.toList());
     } else if (value == double.nan) {
       buffer.putUint8(_kNaN);
     } else if (value == double.infinity) {

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_query.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_query.dart
@@ -77,7 +77,7 @@ abstract class QueryPlatform extends PlatformInterface {
   /// Cannot be used in combination with [endBefore], [endBeforeDocument], or
   /// [endAtDocument], but can be used in combination with [startAt],
   /// [startAfter], [startAtDocument] and [startAfterDocument].
-  QueryPlatform endAt(List<dynamic> fields) {
+  QueryPlatform endAt(Iterable<dynamic> fields) {
     throw UnimplementedError('endAt() is not implemented');
   }
 
@@ -95,7 +95,8 @@ abstract class QueryPlatform extends PlatformInterface {
   ///  * [startAfterDocument] for a query that starts after document.
   ///  * [startAtDocument] for a query that starts at a document.
   ///  * [endAtDocument] for a query that ends at a document.
-  QueryPlatform endBeforeDocument(List<dynamic> orders, List<dynamic> values) {
+  QueryPlatform endBeforeDocument(
+      Iterable<dynamic> orders, Iterable<dynamic> values) {
     throw UnimplementedError('endBeforeDocument() is not implemented');
   }
 
@@ -107,7 +108,7 @@ abstract class QueryPlatform extends PlatformInterface {
   /// Cannot be used in combination with [endAt], [endBeforeDocument], or
   /// [endBeforeDocument], but can be used in combination with [startAt],
   /// [startAfter], [startAtDocument] and [startAfterDocument].
-  QueryPlatform endBefore(List<dynamic> fields) {
+  QueryPlatform endBefore(Iterable<dynamic> fields) {
     throw UnimplementedError('endBefore() is not implemented');
   }
 
@@ -148,7 +149,7 @@ abstract class QueryPlatform extends PlatformInterface {
   /// using [startAfterDocument], [startAtDocument], [endBeforeDocument],
   /// or [endAtDocument] because the order by clause on the document id
   /// is added by these methods implicitly.
-  QueryPlatform orderBy(List<List<dynamic>> orders) {
+  QueryPlatform orderBy(Iterable<List<dynamic>> orders) {
     throw UnimplementedError('orderBy() is not implemented');
   }
 
@@ -178,7 +179,7 @@ abstract class QueryPlatform extends PlatformInterface {
   /// Cannot be used in combination with [startAt], [startAfterDocument], or
   /// [startAtDocument], but can be used in combination with [endAt],
   /// [endBefore], [endAtDocument] and [endBeforeDocument].
-  QueryPlatform startAfter(List<dynamic> fields) {
+  QueryPlatform startAfter(Iterable<dynamic> fields) {
     throw UnimplementedError('startAfter() is not implemented');
   }
 
@@ -196,7 +197,8 @@ abstract class QueryPlatform extends PlatformInterface {
   ///  * [startAfterDocument] for a query that starts after a document.
   ///  * [endAtDocument] for a query that ends at a document.
   ///  * [endBeforeDocument] for a query that ends before a document.
-  QueryPlatform startAtDocument(List<dynamic> orders, List<dynamic> values) {
+  QueryPlatform startAtDocument(
+      Iterable<dynamic> orders, Iterable<dynamic> values) {
     throw UnimplementedError('startAtDocument() is not implemented');
   }
 
@@ -208,7 +210,7 @@ abstract class QueryPlatform extends PlatformInterface {
   /// Cannot be used in combination with [startAfter], [startAfterDocument],
   /// or [startAtDocument], but can be used in combination with [endAt],
   /// [endBefore], [endAtDocument] and [endBeforeDocument].
-  QueryPlatform startAt(List<dynamic> fields) {
+  QueryPlatform startAt(Iterable<dynamic> fields) {
     throw UnimplementedError('startAt() is not implemented');
   }
 

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
@@ -120,7 +120,7 @@ class QueryWeb extends QueryPlatform {
   }
 
   @override
-  QueryPlatform endAt(List<dynamic> fields) {
+  QueryPlatform endAt(Iterable<dynamic> fields) {
     return _copyWithParameters(<String, dynamic>{
       'endAt': fields,
       'endBefore': null,
@@ -128,7 +128,8 @@ class QueryWeb extends QueryPlatform {
   }
 
   @override
-  QueryPlatform endBeforeDocument(List<dynamic> orders, List<dynamic> values) {
+  QueryPlatform endBeforeDocument(
+      Iterable<dynamic> orders, Iterable<dynamic> values) {
     return _copyWithParameters(<String, dynamic>{
       'orderBy': orders,
       'endAt': null,
@@ -137,7 +138,7 @@ class QueryWeb extends QueryPlatform {
   }
 
   @override
-  QueryPlatform endBefore(List<dynamic> fields) {
+  QueryPlatform endBefore(Iterable<dynamic> fields) {
     return _copyWithParameters(<String, dynamic>{
       'endAt': null,
       'endBefore': fields,
@@ -196,7 +197,7 @@ class QueryWeb extends QueryPlatform {
   }
 
   @override
-  QueryPlatform orderBy(List<List<dynamic>> orders) {
+  QueryPlatform orderBy(Iterable<List<dynamic>> orders) {
     return _copyWithParameters(<String, dynamic>{'orderBy': orders});
   }
 
@@ -210,7 +211,7 @@ class QueryWeb extends QueryPlatform {
   }
 
   @override
-  QueryPlatform startAfter(List<dynamic> fields) {
+  QueryPlatform startAfter(Iterable<dynamic> fields) {
     return _copyWithParameters(<String, dynamic>{
       'startAt': null,
       'startAfter': fields,
@@ -218,7 +219,8 @@ class QueryWeb extends QueryPlatform {
   }
 
   @override
-  QueryPlatform startAtDocument(List<dynamic> orders, List<dynamic> values) {
+  QueryPlatform startAtDocument(
+      Iterable<dynamic> orders, Iterable<dynamic> values) {
     return _copyWithParameters(<String, dynamic>{
       'orderBy': orders,
       'startAt': values,
@@ -227,7 +229,7 @@ class QueryWeb extends QueryPlatform {
   }
 
   @override
-  QueryPlatform startAt(List<dynamic> fields) {
+  QueryPlatform startAt(Iterable<dynamic> fields) {
     return _copyWithParameters(<String, dynamic>{
       'startAt': fields,
       'startAfter': null,
@@ -235,7 +237,7 @@ class QueryWeb extends QueryPlatform {
   }
 
   @override
-  QueryPlatform where(List<List<dynamic>> conditions) {
+  QueryPlatform where(Iterable<List<dynamic>> conditions) {
     return _copyWithParameters(<String, dynamic>{
       'where': conditions,
     });


### PR DESCRIPTION
## Description

We should support Iterable instead of List to make the API easier for the end user.

## Related Issues

closes #10407 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
