### PR TITLE
test(messaging, android): reinstate subscription to topics e2e tests

### DIFF
--- a/tests/integration_test/firebase_messaging/firebase_messaging_e2e_test.dart
+++ b/tests/integration_test/firebase_messaging/firebase_messaging_e2e_test.dart
@@ -191,21 +191,27 @@ void main() {
       });
 
       group('subscribeToTopic()', () {
-        test('successfully subscribes from topic', () async {
-          const topic = 'test-topic';
-          await messaging.subscribeToTopic(topic);
-        },
-            // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
-            skip: kIsWeb || defaultTargetPlatform == TargetPlatform.macOS);
+        test(
+          'successfully subscribes from topic',
+          () async {
+            const topic = 'test-topic';
+            await messaging.subscribeToTopic(topic);
+          },
+          // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
+          skip: kIsWeb || defaultTargetPlatform == TargetPlatform.macOS,
+        );
       });
 
       group('unsubscribeFromTopic()', () {
-        test('successfully unsubscribes from topic', () async {
-          const topic = 'test-topic';
-          await messaging.unsubscribeFromTopic(topic);
-        },
-            // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
-            skip: kIsWeb || defaultTargetPlatform == TargetPlatform.macOS);
+        test(
+          'successfully unsubscribes from topic',
+          () async {
+            const topic = 'test-topic';
+            await messaging.unsubscribeFromTopic(topic);
+          },
+          // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
+          skip: kIsWeb || defaultTargetPlatform == TargetPlatform.macOS,
+        );
       });
 
       group('setDeliveryMetricsExportToBigQuery()', () {

--- a/tests/integration_test/firebase_messaging/firebase_messaging_e2e_test.dart
+++ b/tests/integration_test/firebase_messaging/firebase_messaging_e2e_test.dart
@@ -191,33 +191,21 @@ void main() {
       });
 
       group('subscribeToTopic()', () {
-        test(
-          'successfully subscribes from topic',
-          () async {
-            const topic = 'test-topic';
-            await messaging.subscribeToTopic(topic);
-          },
-          // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
-          // Android skipped because it times out with a likelihood of 98%. See: https://github.com/firebase/flutterfire/issues/9651
-          skip: kIsWeb ||
-              defaultTargetPlatform == TargetPlatform.macOS ||
-              defaultTargetPlatform == TargetPlatform.android,
-        );
+        test('successfully subscribes from topic', () async {
+          const topic = 'test-topic';
+          await messaging.subscribeToTopic(topic);
+        },
+            // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
+            skip: kIsWeb || defaultTargetPlatform == TargetPlatform.macOS);
       });
 
       group('unsubscribeFromTopic()', () {
-        test(
-          'successfully unsubscribes from topic',
-          () async {
-            const topic = 'test-topic';
-            await messaging.unsubscribeFromTopic(topic);
-          },
-          // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
-          // Android skipped because it times out with a likelihood of 98%. See: https://github.com/firebase/flutterfire/issues/9650
-          skip: kIsWeb ||
-              defaultTargetPlatform == TargetPlatform.macOS ||
-              defaultTargetPlatform == TargetPlatform.android,
-        );
+        test('successfully unsubscribes from topic', () async {
+          const topic = 'test-topic';
+          await messaging.unsubscribeFromTopic(topic);
+        },
+            // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
+            skip: kIsWeb || defaultTargetPlatform == TargetPlatform.macOS);
       });
 
       group('setDeliveryMetricsExportToBigQuery()', () {


### PR DESCRIPTION
## Description

see title

## Related Issues

closes https://github.com/firebase/flutterfire/issues/9651
closes https://github.com/firebase/flutterfire/issues/9650

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
