### PR TITLE
fix(firestore, web): fix a casting error with the update method

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -366,8 +366,15 @@ class DocumentReference
     return handleThenable(jsObjectSet);
   }
 
-  Future<void> update(Map<FieldPath, dynamic> data) =>
-      handleThenable(firestore_interop.updateDoc(jsObject, jsify(data)));
+  Future<void> update(Map<firestore_interop.FieldPath, dynamic> data) {
+    final alternatingFieldValues =
+        data.keys.map((e) => [e, data[e]]).expand((e) => e).toList();
+
+    return handleThenable(callMethod(firestore_interop.updateDoc, 'apply', [
+      null,
+      [jsObject, ...alternatingFieldValues]
+    ]));
+  }
 }
 
 class Query<T extends firestore_interop.QueryJsImpl>

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore_interop.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore_interop.dart
@@ -216,8 +216,10 @@ external PromiseJsImpl<void> terminate(FirestoreJsImpl firestore);
 @JS()
 external PromiseJsImpl<void> updateDoc(
   DocumentReferenceJsImpl reference,
-  dynamic data,
-);
+  /*string | FieldPath*/ dynamic field,
+  dynamic value, [
+  dynamic moreFieldsAndValues,
+]);
 
 @JS()
 external PromiseJsImpl<void> waitForPendingWrites(FirestoreJsImpl firestore);

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/encode_utility.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/encode_utility.dart
@@ -21,12 +21,12 @@ class EncodeUtility {
     return output;
   }
 
-  static Map<FieldPath, dynamic>? encodeMapDataFieldPath(
+  static Map<firestore_interop.FieldPath, dynamic>? encodeMapDataFieldPath(
       Map<Object, dynamic>? data) {
     if (data == null) {
       return null;
     }
-    Map<FieldPath, dynamic> output = <FieldPath, dynamic>{};
+    final output = <firestore_interop.FieldPath, dynamic>{};
     data.forEach((key, value) {
       output[valueEncode(key)] = valueEncode(value);
     });


### PR DESCRIPTION
## Description

With the added support of updating fields containing a "." using FieldPath in update, a mistake was done during the casting of FieldPath.

This PR does not add tests because the case was already covered. There is an issue with the Firestore CI not catching the error. The method is properly failing on master locally before those changes.

CI being fixed here: https://github.com/firebase/flutterfire/pull/10461

## Related Issues

fixes #10451 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
