### PR TITLE
docs: updated readme with no broken link

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -60,3 +60,4 @@ Timur Dyushaliev <timurdyushaliev@gmail.com>
 Maaku Saito <maaku0810@gmail.com>
 Markus Köhne <markus@koehne.dev>
 Max Steffen <git@max-steffen.dev>
+Enrique Clerici <enrique_cle97@hotmail.com>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and open source.
 
 - [Add Firebase to your Flutter app](https://firebase.google.com/docs/flutter/setup)
 - [Available plugins](https://firebase.google.com/docs/flutter/setup#available-plugins)
-- [FlutterFire UI](./packages/flutterfire_ui/README.md) (beta)
+- [FlutterFire UI](https://pub.dev/packages/flutterfire_ui) (beta)
 - [Firestore ODM](./packages/cloud_firestore_odm/README.md) (alpha)
 
 ---


### PR DESCRIPTION
## Description

Changed the link so it sends you to he official flutterfire_ui explanation and what to use.

## Related Issues

Flutterfire github repo's readMe has broken link #10459

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
