### PR TITLE
fix(messaging, ios): badge is in the `message`, not the `notification`

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -946,8 +946,8 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 
         // Apple only
         // message.notification.apple.badge
-        if (apsAlertDict[@"badge"] != nil) {
-          notificationIOS[@"badge"] = apsAlertDict[@"badge"];
+        if(apsDict[@"badge"] != nil){
+          notificationIOS[@"badge"] = [NSString stringWithFormat:@"%@", apsDict[@"badge"]];
         }
       }
 


### PR DESCRIPTION
## Description

Print out the message in Xcode. You can see the badge is in the `message`, not the `alert` dictionary.
<img width="991" alt="Screenshot 2023-02-16 at 10 16 14" src="https://user-images.githubusercontent.com/16018629/219351436-7548f1ba-1761-4e58-8f14-a95abc993c32.png">

To test, I sent a message with a badge:
```js
admin
.messaging()
.sendToDevice(
  [iosToken],
  {
    data: {
      something:'else',
    },
    notification: {
      title: 'A great title',
      body: 'Great content',
      badge: '3'
    },
  },
  {
    // Required for background/terminated app state messages on iOS
    contentAvailable: true,
    // Required for background/terminated app state messages on Android
    priority: 'high',
  }
)
```

Print out `print('${message.notification?.apple?.toMap()}');` on the incoming message from `onMessage`. You can see the `badge` is now correctly on the `AppleNotification` instance.
```
{badge: 3, subtitle: null, subtitleLocArgs: [], subtitleLocKey: null, imageUrl: null, sound: null}
```

I also had to convert the `int` type to a `string` in the underlying implementation as `badge` is a `String?` type and the encoding silently fails if I don't. [See implementation]()



## Related Issues

closes https://github.com/firebase/flutterfire/issues/9533

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
