### PR TITLE
docs(messaging): illustrate how to use `getInitialMessage()` & `onMessageOpenedApp`

### DIFF
--- a/docs/cloud-messaging/first-message.md
+++ b/docs/cloud-messaging/first-message.md
@@ -75,7 +75,7 @@ Android apps.
 
 ## Handling interaction
 
-The default behavior for notifications (e.g. by pressing them) on both Android & iOS is to open the application. If the application is terminated,
+When users tap a notification, the default behavior on both Android & iOS is to open the application. If the application is terminated,
 it will be started, and if it is in the background, it will be brought to the foreground.
 
 Depending on the content of a notification, you may wish to handle the user's interaction when the application

--- a/docs/cloud-messaging/first-message.md
+++ b/docs/cloud-messaging/first-message.md
@@ -75,22 +75,21 @@ Android apps.
 
 ## Handling Interaction
 
-Since notifications are a visible cue, it is common for users to interact with it (by pressing them).
-The default behavior on both Android & iOS is to open the application. If the application is terminated
-it will be started, if it is in the background it will be brought to the foreground.
+Since notifications are a visible cue, it is common for users to interact with them (by pressing them).
+The default behavior on both Android & iOS is to open the application. If the application is terminated,
+it will be started, and if it is in the background, it will be brought to the foreground.
 
-Depending on the content of a notification, you may wish to handle the users interaction when the application
-opens. For example, if a new chat message is sent via a notification and the user presses it, you may want to
+Depending on the content of a notification, you may wish to handle the user's interaction when the application
+opens. For example, if a new chat message is sent using a notification and the user presses it, you may want to
  open the specific conversation when the application opens.
 
 The `firebase-messaging` package provides two ways to handle this interaction:
 
-1. `getInitialMessage()`: If the application is opened from a terminated state a `Future` containing a
-    `RemoteMessage` will be returned. Once consumed, the `RemoteMessage` will be removed.
+1. `getInitialMessage()`: If the application is opened from a terminated state, this method returns a `Future` containing a `RemoteMessage`. Once consumed, the `RemoteMessage` will be removed.
 2. `onMessageOpenedApp`: A `Stream` which posts a `RemoteMessage` when the application is opened from a
     background state.
 
-It is recommended that both scenarios are handled to ensure a smooth UX for your users. The code example
+To ensure a smooth UX for your users, you should handle both scenarios. The code example
 below outlines how this can be achieved:
 
 ```dart

--- a/docs/cloud-messaging/first-message.md
+++ b/docs/cloud-messaging/first-message.md
@@ -73,14 +73,13 @@ which records the number of messages sent and opened on Apple and Android
 devices, along with data for "impressions" (notifications seen by users) for
 Android apps.
 
-## Handling Interaction
+## Handling interaction
 
-Since notifications are a visible cue, it is common for users to interact with them (by pressing them).
-The default behavior on both Android & iOS is to open the application. If the application is terminated,
+The default behavior for notifications (e.g. by pressing them) on both Android & iOS is to open the application. If the application is terminated,
 it will be started, and if it is in the background, it will be brought to the foreground.
 
 Depending on the content of a notification, you may wish to handle the user's interaction when the application
-opens. For example, if a new chat message is sent using a notification and the user presses it, you may want to
+opens. For example, if a new chat message is sent using a notification and the user selects it, you may want to
  open the specific conversation when the application opens.
 
 The `firebase-messaging` package provides two ways to handle this interaction:
@@ -89,7 +88,7 @@ The `firebase-messaging` package provides two ways to handle this interaction:
 2. `onMessageOpenedApp`: A `Stream` which posts a `RemoteMessage` when the application is opened from a
     background state.
 
-To ensure a smooth UX for your users, you should handle both scenarios. The code example
+To ensure a smooth experience for your users, you should handle both scenarios. The code example
 below outlines how this can be achieved:
 
 ```dart

--- a/docs/cloud-messaging/first-message.md
+++ b/docs/cloud-messaging/first-message.md
@@ -73,6 +73,77 @@ which records the number of messages sent and opened on Apple and Android
 devices, along with data for "impressions" (notifications seen by users) for
 Android apps.
 
+## Handling Interaction
+
+Since notifications are a visible cue, it is common for users to interact with it (by pressing them).
+The default behavior on both Android & iOS is to open the application. If the application is terminated
+it will be started, if it is in the background it will be brought to the foreground.
+
+Depending on the content of a notification, you may wish to handle the users interaction when the application
+opens. For example, if a new chat message is sent via a notification and the user presses it, you may want to
+ open the specific conversation when the application opens.
+
+The `firebase-messaging` package provides two ways to handle this interaction:
+
+1. `getInitialMessage()`: If the application is opened from a terminated state a `Future` containing a
+    `RemoteMessage` will be returned. Once consumed, the `RemoteMessage` will be removed.
+2. `onMessageOpenedApp`: A `Stream` which posts a `RemoteMessage` when the application is opened from a
+    background state.
+
+It is recommended that both scenarios are handled to ensure a smooth UX for your users. The code example
+below outlines how this can be achieved:
+
+```dart
+class Application extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _Application();
+}
+
+class _Application extends State<Application> {
+  // It is assumed that all messages contain a data field with the key 'type'
+  Future<void> setupInteractedMessage() async {
+    // Get any messages which caused the application to open from
+    // a terminated state.
+    RemoteMessage? initialMessage =
+        await FirebaseMessaging.instance.getInitialMessage();
+
+    // If the message also contains a data property with a "type" of "chat",
+    // navigate to a chat screen
+    if (initialMessage != null) {
+      _handleMessage(initialMessage);
+    }
+
+    // Also handle any interaction when the app is in the background via a
+    // Stream listener
+    FirebaseMessaging.onMessageOpenedApp.listen(_handleMessage);
+  }
+
+  void _handleMessage(RemoteMessage message) {
+    if (message.data['type'] == 'chat') {
+      Navigator.pushNamed(context, '/chat',
+        arguments: ChatArguments(message),
+      );
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Run code required to handle interacted messages in an async function
+    // as initState() must not be async
+    setupInteractedMessage();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Text("...");
+  }
+}
+```
+
+How you handle interaction depends on your application setup, however the example above
+shows a basic example of using a StatefulWidget.
 
 ## Next steps
 

--- a/docs/cloud-messaging/first-message.md
+++ b/docs/cloud-messaging/first-message.md
@@ -98,7 +98,7 @@ class Application extends StatefulWidget {
 }
 
 class _Application extends State<Application> {
-  // It is assumed that all messages contain a data field with the key 'type'
+  // In this example, suppose that all messages contain a data field with the key 'type'.
   Future<void> setupInteractedMessage() async {
     // Get any messages which caused the application to open from
     // a terminated state.


### PR DESCRIPTION
## Description

Currently no documentation for `getInitialMessage()` & `onMessageOpenedApp`. Update docs to show their usage.

## Related Issues

closes https://github.com/firebase/flutterfire/issues/8795

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
