### PR TITLE
fix(core, web): fix wrong toString js interop in TrustedTypes

### DIFF
--- a/packages/firebase_core/firebase_core_web/lib/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/firebase_core_web.dart
@@ -8,6 +8,7 @@ library firebase_core_web;
 import 'dart:async';
 import 'dart:html';
 import 'dart:js';
+import 'dart:js_util';
 
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
 import 'package:firebase_core_web/src/interop/js.dart';

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -128,7 +128,8 @@ class FirebaseCoreWeb extends FirebasePlatform {
     script.crossOrigin = 'anonymous';
     script.text = '''
       window.ff_trigger_$windowVar = async (callback) => {
-        callback(await import("${trustedUrl?.toString() ?? src}"));
+        console.debug("Initializing Firebase $windowVar");
+        callback(await import("${trustedUrl != null ? callMethod(trustedUrl, 'toString', []) : src}"));
       };
     ''';
 


### PR DESCRIPTION
## Description

Calling `toString` on the object would use the dart `toString` instead of the JS `toString`.
This fix will use the proper `toString` method.

We currently don't have the proper testing env for this. Should be investigated in another ticket.

Was manually tested.

## Related Issues

closes #10474 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
