### PR TITLE
fix: JS and dart toString name conflict

### DIFF
--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -128,7 +128,7 @@ class FirebaseCoreWeb extends FirebasePlatform {
     script.crossOrigin = 'anonymous';
     script.text = '''
       window.ff_trigger_$windowVar = async (callback) => {
-        callback(await import("${trustedUrl?.toString() ?? src}"));
+        callback(await import("${trustedUrl?.toStringJS() ?? src}"));
       };
     ''';
 

--- a/packages/firebase_core/firebase_core_web/lib/src/interop/js.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/interop/js.dart
@@ -126,6 +126,12 @@ extension DomTrustedTypePolicyExtension on DomTrustedTypePolicy {
 @anonymous
 abstract class DomTrustedScriptUrl {}
 
+/// (Some) methods of the [DomTrustedScriptUrl]
+extension DomTrustedScriptUrlExtension on DomTrustedScriptUrl {
+  @JS('toString')
+  external String toStringJS();
+}
+
 // Getters
 
 /// window.trustedTypes (may or may not be supported by the browser)

--- a/packages/firebase_core/firebase_core_web/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_core_web
 description: The web implementation of firebase_core
 homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_core/firebase_core_web
 repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_core/firebase_core_web
-version: 2.2.0
+version: 2.2.1
 
 environment:
   sdk: ">=2.16.0 <3.0.0"


### PR DESCRIPTION
- [ ] Closes #10477 

## ISSUE (up to flutter 3.7.3)

JavaScript `toString` conflict with dart `toString`, just use @JS('toString') annotation.