### PR TITLE
docs(dynamic-links): update Firebase documentation on how to receive link from terminated state

### DIFF
--- a/docs/dynamic-links/receive.md
+++ b/docs/dynamic-links/receive.md
@@ -135,19 +135,38 @@ To handle a Dynamic Link in your application, two scenarios require implementing
 
 ### Terminated State
 
-If the application is terminated, the `FirebaseDynamicLinks.getInitialLink`
-method allows you to retrieve the Dynamic Link that opened the application.
+Set up the following methods:
+ 1. `FirebaseDynamicLinks.getInitialLink` - returns a Future<PendingDynamicLinkData?>
+ 2. `FirebaseDynamicLinks.onLink` - event handler that returns a `Stream` containing a `PendingDynamicLinkData?`
 
-This is an asynchronous request, so it makes sense to handle a link before rendering application logic, such as
-a navigator. For example, you could handle this in the `main` function:
+Android will always receive the link via `FirebaseDynamicLinks.getInitialLink` from a terminated state,
+but on iOS, it is not guaranteed. Therefore, it is worth setting them both up in the following order
+to ensure your application receives the link:
 
 ```dart
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseConfig.platformOptions);
 
-  // Get any initial links
+  // Check if you received the link via `getInitialLink` first
   final PendingDynamicLinkData? initialLink = await FirebaseDynamicLinks.instance.getInitialLink();
+
+  if (initialLink != null) {
+    final Uri deepLink = initialLink.link;
+    // Example of using the dynamic link to push the user to a different screen
+    Navigator.pushNamed(context, deepLink.path);
+  }
+
+  FirebaseDynamicLinks.instance.onLink.listen(
+        (pendingDynamicLinkData) {
+          // Set up the `onLink` event listener next as it may be received here
+          if (pendingDynamicLinkData != null) {
+            final Uri deepLink = pendingDynamicLinkData.link;
+            // Example of using the dynamic link to push the user to a different screen
+            Navigator.pushNamed(context, deepLink.path);
+          }
+        },
+      );
 
   runApp(MyApp(initialLink));
 }
@@ -163,19 +182,10 @@ if (initialLink != null) {
 }
 ```
 
-Alternatively, if you wish to identify if an exact Dynamic Link was used to open the application, pass it to
-the `getDynamicLink` method instead:
-
-```dart
-String link = 'https://dynamic-link-domain/ke2Qa';
-
-final PendingDynamicLinkData? initialLink = await FirebaseDynamicLinks.instance.getDynamicLink(Uri.parse(link));
-```
-
 ### Background / Foreground State
 
-Whilst the application is open, or in the background, you may listen to Dynamic Links events using a stream handler. The `FirebaseDynamicLinks.onLink`
-getter returns a `Stream` containing a `PendingDynamicLinkData`:
+Whilst the application is open, or in the background, use The `FirebaseDynamicLinks.onLink`
+getter:
 
 ```dart
 FirebaseDynamicLinks.instance.onLink.listen((dynamicLinkData) {
@@ -183,6 +193,15 @@ FirebaseDynamicLinks.instance.onLink.listen((dynamicLinkData) {
 }).onError((error) {
   // Handle errors
 });
+```
+
+Alternatively, if you wish to identify if an exact Dynamic Link was used to open the application, pass it to
+the `getDynamicLink` method instead:
+
+```dart
+String link = 'https://dynamic-link-domain/ke2Qa';
+
+final PendingDynamicLinkData? initialLink = await FirebaseDynamicLinks.instance.getDynamicLink(Uri.parse(link));
 ```
 
 ### Testing A Dynamic Link On iOS Platform


### PR DESCRIPTION
## Description

As [reported by this user](https://github.com/firebase/flutterfire/issues/7546#issuecomment-1432042420), the iOS app could receive the link from a terminated state from either the `getInitialLink` method call or the event listener `onLink`. I believe the user can call `getInitialLink` before it has been passed to the app and therefore I have updated the documentation to reflect this.


If you wish to test this yourself, you can:

1. Run the app in release mode.
2. Open the app from a terminated state using a Dynamic Link you're created in the Firebase console and configured for your app.
3. Use the below noted, crude code snippet in your `main.dart` file. Open the app and note the success rate of `getInitialLink`. It doesn't always successfully retrieve the Dynamic Link upon app opening. It is more successful when you uncomment the `Future.delayed`. The `onLink` will always receive the opening Dynamic Link.

```dart
import 'dart:async';

import 'package:firebase_core/firebase_core.dart';
import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
import 'package:flutter/material.dart';

import 'firebase_options.dart';

Future<void> main() async {
  WidgetsFlutterBinding.ensureInitialized();
  await Firebase.initializeApp(
    options: DefaultFirebaseOptions.currentPlatform,
  );
  runApp(MyApp());
}

class MyApp extends StatefulWidget {
  MyApp({Key? key}) : super(key: key);

  @override
  _MyAppState createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  String _linkMessage = 'no-state';

  @override
  void initState() {
    super.initState();
    initDL();
  }

  Future initDL() async {
    // FirebaseDynamicLinks.instance.onLink.listen(
    //   (event) {
    //     setState(() {
    //       _linkMessage = event.link.toString() + ' onLink';
    //     });
    //   },
    // );
    // await Future.delayed(const Duration(milliseconds: 3000));
    final initialLink = await FirebaseDynamicLinks.instance.getInitialLink();

    if(initialLink != null){
      setState(() {
        _linkMessage = initialLink.link.toString() + ' getInitialLink';
      });
    } else {
      setState(() {
        _linkMessage = 'nothing' + ' getInitialLink';
      });
    }
  }

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
          appBar: AppBar(
            title: const Text('Testing Something'),
          ),
          body: Column(
            children: [
              ElevatedButton(
                  onPressed: () {
                    setState(() {
                      _linkMessage = 'reset';
                    });
                  },
                  child: const Text('reset link')),
              Text(_linkMessage),
            ],
          )),
    );
  }
}


```

## Related Issues

closes https://github.com/firebase/flutterfire/issues/7546

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
