### PR TITLE
fix(ui_auth_google): bump google_sign_in version

### DIFF
--- a/packages/firebase_ui_auth/example/macos/Podfile
+++ b/packages/firebase_ui_auth/example/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.13'
+platform :osx, '10.14'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/firebase_ui_auth/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/firebase_ui_auth/example/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -272,6 +272,7 @@
 		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/packages/firebase_ui_auth/example/pubspec.yaml
+++ b/packages/firebase_ui_auth/example/pubspec.yaml
@@ -44,7 +44,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.0
-  google_sign_in: ^5.4.2
+  google_sign_in: ^6.0.1
   http: ^0.13.4
   integration_test:
     sdk: flutter

--- a/packages/firebase_ui_oauth_google/pubspec.yaml
+++ b/packages/firebase_ui_oauth_google/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   firebase_ui_oauth: ^1.1.14
   flutter:
     sdk: flutter
-  google_sign_in: ^5.4.4
+  google_sign_in: ^6.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Related Issues

Closes #10519

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

Even though `google_sign_in` has a major version bump, it affects only web, `firebase_ui_auth` doesn't use it on web.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
