### PR TITLE
feat(functions): add support for 2nd gen functions

### DIFF
--- a/.github/workflows/scripts/functions/package-lock.json
+++ b/.github/workflows/scripts/functions/package-lock.json
@@ -7,8 +7,8 @@
       "name": "functions",
       "hasInstallScript": true,
       "dependencies": {
-        "firebase-admin": "^11.4.1",
-        "firebase-functions": "^3.24.1"
+        "firebase-admin": "^11.5.0",
+        "firebase-functions": "^4.2.1"
       },
       "devDependencies": {
         "firebase-functions-test": "^0.2.0",
@@ -19,9 +19,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
-      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
+      "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
       "optional": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -42,75 +42,71 @@
       }
     },
     "node_modules/@firebase/app-types": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.7.0.tgz",
-      "integrity": "sha512-6fbHQwDv2jp/v6bXhBw2eSRbNBpxHcd1NBF864UksSMVIqIyri9qpJB1Mn6sGZE+bnDsSQBC5j2TbMxYsJQkQg=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
+      "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q=="
     },
     "node_modules/@firebase/auth-interop-types": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
-      "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==",
-      "peerDependencies": {
-        "@firebase/app-types": "0.x",
-        "@firebase/util": "1.x"
-      }
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.1.tgz",
+      "integrity": "sha512-VOaGzKp65MY6P5FI84TfYKBXEPi6LmOCSMMzys6o2BN2LOsqy7pCuZCup7NYnfbk5OkkQKzvIfHOzTm0UDpkyg=="
     },
     "node_modules/@firebase/component": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.17.tgz",
-      "integrity": "sha512-mTM5CBSIlmI+i76qU4+DhuExnWtzcPS3cVgObA3VAjliPPr3GrUlTaaa8KBGfxsD27juQxMsYA0TvCR5X+GQ3Q==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.3.tgz",
+      "integrity": "sha512-rnhq5SOsB5nuJphZF50iwqnBiuuyg9kdnlUn1rBrKfu7/cUVJZF5IG1cWrL0rXXyiZW1WBI/J2pmTvVO8dStGQ==",
       "dependencies": {
-        "@firebase/util": "1.6.3",
+        "@firebase/util": "1.9.2",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.13.6.tgz",
-      "integrity": "sha512-5IZIBw2LT50Z8mwmKYmdX37p+Gg2HgeJsrruZmRyOSVgbfoY4Pg87n1uFx6qWqDmfL6HwQgwcrrQfVIXE3C5SA==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.14.3.tgz",
+      "integrity": "sha512-J76W6N7JiVkLaAtPyjaGRkrsIu9pi6iZikuGGtGjqvV19vkn7oiL4Hbo5uTYCMd4waTUWoL9iI08eX184W+5GQ==",
       "dependencies": {
-        "@firebase/auth-interop-types": "0.1.6",
-        "@firebase/component": "0.5.17",
-        "@firebase/logger": "0.3.3",
-        "@firebase/util": "1.6.3",
+        "@firebase/auth-interop-types": "0.2.1",
+        "@firebase/component": "0.6.3",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.2",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.2.6.tgz",
-      "integrity": "sha512-Ls1BAODaiDYgeJljrIgSuC7JkFIY/HNhhNYebzZSoGQU62RuvnaO3Qgp2EH6h2LzHyRnycNadfh1suROtPaUIA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.3.3.tgz",
+      "integrity": "sha512-r+L9jTbvsnb7sD+xz6UKU39DgBWqB2pyjzPNdBeriGC9Ssa2MAZe0bIqjCQg51RRXYc/aa/zK1Q2/4uesZeVgQ==",
       "dependencies": {
-        "@firebase/component": "0.5.17",
-        "@firebase/database": "0.13.6",
-        "@firebase/database-types": "0.9.13",
-        "@firebase/logger": "0.3.3",
-        "@firebase/util": "1.6.3",
+        "@firebase/component": "0.6.3",
+        "@firebase/database": "0.14.3",
+        "@firebase/database-types": "0.10.3",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.2",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "0.9.13",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.13.tgz",
-      "integrity": "sha512-dIJ1zGe3EHMhwcvukTOPzYlFYFIG1Et5Znl7s7y/ZTN2/toARRNnsv1qCKvqevIMYKvIrRsYOYfOXDS8l1YIJA==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.10.3.tgz",
+      "integrity": "sha512-Hu34CDhHYZsd2eielr0jeaWrTJk8Hz0nd7WsnYDnXtQX4i49ppgPesUzPdXVBdIBLJmT0ZZRvT7qWHknkOT+zg==",
       "dependencies": {
-        "@firebase/app-types": "0.7.0",
-        "@firebase/util": "1.6.3"
+        "@firebase/app-types": "0.9.0",
+        "@firebase/util": "1.9.2"
       }
     },
     "node_modules/@firebase/logger": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.3.3.tgz",
-      "integrity": "sha512-POTJl07jOKTOevLXrTvJD/VZ0M6PnJXflbAh5J9VGkmtXPXNG6MdZ9fmRgqYhXKTaDId6AQenQ262uwgpdtO0Q==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.0.tgz",
+      "integrity": "sha512-eRKSeykumZ5+cJPdxxJRgAC3G5NknY2GwEbKfymdnXtnT0Ucm4pspfR6GT4MUQEDuJwRVbVcSx85kgJulMoFFA==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.6.3.tgz",
-      "integrity": "sha512-FujteO6Zjv6v8A4HS+t7c+PjU0Kaxj+rOnka0BsI/twUaCC9t8EQPmXpWZdk7XfszfahJn2pqsflUWUhtUkRlg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.2.tgz",
+      "integrity": "sha512-9l0uMGPGw3GsoD5khjMmYCCcMq/OR/OOSViiWMN+s2Q0pxM+fYzrii1H+r8qC/uoMjSVXomjLZt0vZIyryCqtQ==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -230,14 +226,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@panva/asn1.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
-      "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -344,9 +332,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.31",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
-      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
+      "version": "4.17.33",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
+      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -354,9 +342,9 @@
       }
     },
     "node_modules/@types/jsonwebtoken": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
-      "integrity": "sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
+      "integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1114,16 +1102,16 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/firebase-admin": {
-      "version": "11.4.1",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-11.4.1.tgz",
-      "integrity": "sha512-t5+Pf8rC01TW1KPD5U8Q45AEn7eK+FJaHlpzYStFb62J+MQmN/kB/PWUEsNn+7MNAQ0DZxFUCgJoi+bRmf83oQ==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-11.5.0.tgz",
+      "integrity": "sha512-bBdlYtNvXx8yZGdCd00NrfZl1o1A0aXOw5h8q5PwC8RXikOLNXq8vYtSKW44dj8zIaafVP6jFdcUXZem/LMsHA==",
       "dependencies": {
         "@fastify/busboy": "^1.1.0",
-        "@firebase/database-compat": "^0.2.6",
-        "@firebase/database-types": "^0.9.13",
+        "@firebase/database-compat": "^0.3.0",
+        "@firebase/database-types": "^0.10.0",
         "@types/node": ">=12.12.47",
         "jsonwebtoken": "^9.0.0",
-        "jwks-rsa": "^2.1.4",
+        "jwks-rsa": "^3.0.1",
         "node-forge": "^1.3.1",
         "uuid": "^9.0.0"
       },
@@ -1136,31 +1124,30 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.24.1.tgz",
-      "integrity": "sha512-GYhoyOV0864HFMU1h/JNBXYNmDk2MlbvU7VO/5qliHX6u/6vhSjTJjlyCG4leDEI8ew8IvmkIC5QquQ1U8hAuA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-4.2.1.tgz",
+      "integrity": "sha512-+NjbI6TD3ivuoT7B3oC4iwRlt41QDTcYowo3TO88ZyMHmjCzlrbiuAjiPzz/zfwgi3+GCoP1tztHOQHhDGYE5w==",
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
         "cors": "^2.8.5",
         "express": "^4.17.1",
-        "lodash": "^4.17.14",
         "node-fetch": "^2.6.7"
       },
       "bin": {
         "firebase-functions": "lib/bin/firebase-functions.js"
       },
       "engines": {
-        "node": "^8.13.0 || >=10.10.0"
+        "node": ">=14.10.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+        "firebase-admin": "^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/firebase-functions-test": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/firebase-functions-test/-/firebase-functions-test-0.2.2.tgz",
-      "integrity": "sha512-SlHLnpKRn5nMsg4Y0CUTGs/R8NatghJCYZGw3fHzaS/5xDqwWPWuxmdHHc+MSuxrSrUROEwOrDTwrbjmRaSNjw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/firebase-functions-test/-/firebase-functions-test-0.2.3.tgz",
+      "integrity": "sha512-zYX0QTm53wCazuej7O0xqbHl90r/v1PTXt/hwa0jo1YF8nDM+iBKnLDlkIoW66MDd0R6aGg4BvKzTTdJpvigUA==",
       "dev": true,
       "dependencies": {
         "@types/lodash": "^4.14.104",
@@ -1168,6 +1155,10 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "firebase-admin": ">=6.0.0",
+        "firebase-functions": ">=2.0.0"
       }
     },
     "node_modules/forwarded": {
@@ -1496,15 +1487,9 @@
       "optional": true
     },
     "node_modules/jose": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.6.tgz",
-      "integrity": "sha512-FVoPY7SflDodE4lknJmbAHSUjLCzE2H1F6MS0RYKMQ8SR+lNccpMf8R4eqkNYyyUjR5qZReOzZo5C5YiHOCjjg==",
-      "dependencies": {
-        "@panva/asn1.js": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.13.0 < 13 || >=13.7.0"
-      },
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.13.0.tgz",
+      "integrity": "sha512-v6BN7fuPVfG9XIxcPT2jzyAg5EmA/mtNeJEXJ7d31Wz7fFOqOZeN8mPtNJYQmnuAIxJII7EcURcbZ7qXs9a4kA==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -1602,28 +1587,28 @@
       }
     },
     "node_modules/jwks-rsa": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-2.1.5.tgz",
-      "integrity": "sha512-IODtn1SwEm7n6GQZnQLY0oxKDrMh7n/jRH1MzE8mlxWMrh2NnMyOsXTebu8vJ1qCpmuTJcL4DdiE0E4h8jnwsA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.0.1.tgz",
+      "integrity": "sha512-UUOZ0CVReK1QVU3rbi9bC7N5/le8ziUj0A2ef1Q0M7OPD2KvjEYizptqIxGIo6fSLYDkqBrazILS18tYuRc8gw==",
       "dependencies": {
         "@types/express": "^4.17.14",
-        "@types/jsonwebtoken": "^8.5.9",
+        "@types/jsonwebtoken": "^9.0.0",
         "debug": "^4.3.4",
-        "jose": "^2.0.6",
+        "jose": "^4.10.4",
         "limiter": "^1.1.5",
         "lru-memoizer": "^2.1.4"
       },
       "engines": {
-        "node": ">=10 < 13 || >=14"
+        "node": ">=14"
       }
     },
     "node_modules/jwks-rsa/node_modules/@types/express": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
-      "integrity": "sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==",
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
+      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.31",
+        "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
@@ -1708,9 +1693,9 @@
       }
     },
     "node_modules/lru-memoizer": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.4.tgz",
-      "integrity": "sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.2.0.tgz",
+      "integrity": "sha512-QfOZ6jNkxCcM/BkIPnFsqDhtrazLRsghi9mBwFAzol5GCvj4EkFT899Za3+QwikCg5sRX8JstioBDwOxEyzaNw==",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "~4.0.0"
@@ -2499,9 +2484,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -2528,9 +2513,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2731,9 +2716,9 @@
   },
   "dependencies": {
     "@babel/parser": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
-      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
+      "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
       "optional": true
     },
     "@fastify/busboy": {
@@ -2745,72 +2730,71 @@
       }
     },
     "@firebase/app-types": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.7.0.tgz",
-      "integrity": "sha512-6fbHQwDv2jp/v6bXhBw2eSRbNBpxHcd1NBF864UksSMVIqIyri9qpJB1Mn6sGZE+bnDsSQBC5j2TbMxYsJQkQg=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
+      "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q=="
     },
     "@firebase/auth-interop-types": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
-      "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==",
-      "requires": {}
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.1.tgz",
+      "integrity": "sha512-VOaGzKp65MY6P5FI84TfYKBXEPi6LmOCSMMzys6o2BN2LOsqy7pCuZCup7NYnfbk5OkkQKzvIfHOzTm0UDpkyg=="
     },
     "@firebase/component": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.17.tgz",
-      "integrity": "sha512-mTM5CBSIlmI+i76qU4+DhuExnWtzcPS3cVgObA3VAjliPPr3GrUlTaaa8KBGfxsD27juQxMsYA0TvCR5X+GQ3Q==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.3.tgz",
+      "integrity": "sha512-rnhq5SOsB5nuJphZF50iwqnBiuuyg9kdnlUn1rBrKfu7/cUVJZF5IG1cWrL0rXXyiZW1WBI/J2pmTvVO8dStGQ==",
       "requires": {
-        "@firebase/util": "1.6.3",
+        "@firebase/util": "1.9.2",
         "tslib": "^2.1.0"
       }
     },
     "@firebase/database": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.13.6.tgz",
-      "integrity": "sha512-5IZIBw2LT50Z8mwmKYmdX37p+Gg2HgeJsrruZmRyOSVgbfoY4Pg87n1uFx6qWqDmfL6HwQgwcrrQfVIXE3C5SA==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.14.3.tgz",
+      "integrity": "sha512-J76W6N7JiVkLaAtPyjaGRkrsIu9pi6iZikuGGtGjqvV19vkn7oiL4Hbo5uTYCMd4waTUWoL9iI08eX184W+5GQ==",
       "requires": {
-        "@firebase/auth-interop-types": "0.1.6",
-        "@firebase/component": "0.5.17",
-        "@firebase/logger": "0.3.3",
-        "@firebase/util": "1.6.3",
+        "@firebase/auth-interop-types": "0.2.1",
+        "@firebase/component": "0.6.3",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.2",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       }
     },
     "@firebase/database-compat": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.2.6.tgz",
-      "integrity": "sha512-Ls1BAODaiDYgeJljrIgSuC7JkFIY/HNhhNYebzZSoGQU62RuvnaO3Qgp2EH6h2LzHyRnycNadfh1suROtPaUIA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.3.3.tgz",
+      "integrity": "sha512-r+L9jTbvsnb7sD+xz6UKU39DgBWqB2pyjzPNdBeriGC9Ssa2MAZe0bIqjCQg51RRXYc/aa/zK1Q2/4uesZeVgQ==",
       "requires": {
-        "@firebase/component": "0.5.17",
-        "@firebase/database": "0.13.6",
-        "@firebase/database-types": "0.9.13",
-        "@firebase/logger": "0.3.3",
-        "@firebase/util": "1.6.3",
+        "@firebase/component": "0.6.3",
+        "@firebase/database": "0.14.3",
+        "@firebase/database-types": "0.10.3",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.2",
         "tslib": "^2.1.0"
       }
     },
     "@firebase/database-types": {
-      "version": "0.9.13",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.13.tgz",
-      "integrity": "sha512-dIJ1zGe3EHMhwcvukTOPzYlFYFIG1Et5Znl7s7y/ZTN2/toARRNnsv1qCKvqevIMYKvIrRsYOYfOXDS8l1YIJA==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.10.3.tgz",
+      "integrity": "sha512-Hu34CDhHYZsd2eielr0jeaWrTJk8Hz0nd7WsnYDnXtQX4i49ppgPesUzPdXVBdIBLJmT0ZZRvT7qWHknkOT+zg==",
       "requires": {
-        "@firebase/app-types": "0.7.0",
-        "@firebase/util": "1.6.3"
+        "@firebase/app-types": "0.9.0",
+        "@firebase/util": "1.9.2"
       }
     },
     "@firebase/logger": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.3.3.tgz",
-      "integrity": "sha512-POTJl07jOKTOevLXrTvJD/VZ0M6PnJXflbAh5J9VGkmtXPXNG6MdZ9fmRgqYhXKTaDId6AQenQ262uwgpdtO0Q==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.0.tgz",
+      "integrity": "sha512-eRKSeykumZ5+cJPdxxJRgAC3G5NknY2GwEbKfymdnXtnT0Ucm4pspfR6GT4MUQEDuJwRVbVcSx85kgJulMoFFA==",
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "@firebase/util": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.6.3.tgz",
-      "integrity": "sha512-FujteO6Zjv6v8A4HS+t7c+PjU0Kaxj+rOnka0BsI/twUaCC9t8EQPmXpWZdk7XfszfahJn2pqsflUWUhtUkRlg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.2.tgz",
+      "integrity": "sha512-9l0uMGPGw3GsoD5khjMmYCCcMq/OR/OOSViiWMN+s2Q0pxM+fYzrii1H+r8qC/uoMjSVXomjLZt0vZIyryCqtQ==",
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -2904,11 +2888,6 @@
         "protobufjs": "^7.0.0",
         "yargs": "^16.2.0"
       }
-    },
-    "@panva/asn1.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
-      "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -3013,9 +2992,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.31",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
-      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
+      "version": "4.17.33",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
+      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -3023,9 +3002,9 @@
       }
     },
     "@types/jsonwebtoken": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
-      "integrity": "sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
+      "integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
       "requires": {
         "@types/node": "*"
       }
@@ -3632,39 +3611,38 @@
       }
     },
     "firebase-admin": {
-      "version": "11.4.1",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-11.4.1.tgz",
-      "integrity": "sha512-t5+Pf8rC01TW1KPD5U8Q45AEn7eK+FJaHlpzYStFb62J+MQmN/kB/PWUEsNn+7MNAQ0DZxFUCgJoi+bRmf83oQ==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-11.5.0.tgz",
+      "integrity": "sha512-bBdlYtNvXx8yZGdCd00NrfZl1o1A0aXOw5h8q5PwC8RXikOLNXq8vYtSKW44dj8zIaafVP6jFdcUXZem/LMsHA==",
       "requires": {
         "@fastify/busboy": "^1.1.0",
-        "@firebase/database-compat": "^0.2.6",
-        "@firebase/database-types": "^0.9.13",
+        "@firebase/database-compat": "^0.3.0",
+        "@firebase/database-types": "^0.10.0",
         "@google-cloud/firestore": "^6.4.0",
         "@google-cloud/storage": "^6.5.2",
         "@types/node": ">=12.12.47",
         "jsonwebtoken": "^9.0.0",
-        "jwks-rsa": "^2.1.4",
+        "jwks-rsa": "^3.0.1",
         "node-forge": "^1.3.1",
         "uuid": "^9.0.0"
       }
     },
     "firebase-functions": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.24.1.tgz",
-      "integrity": "sha512-GYhoyOV0864HFMU1h/JNBXYNmDk2MlbvU7VO/5qliHX6u/6vhSjTJjlyCG4leDEI8ew8IvmkIC5QquQ1U8hAuA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-4.2.1.tgz",
+      "integrity": "sha512-+NjbI6TD3ivuoT7B3oC4iwRlt41QDTcYowo3TO88ZyMHmjCzlrbiuAjiPzz/zfwgi3+GCoP1tztHOQHhDGYE5w==",
       "requires": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
         "cors": "^2.8.5",
         "express": "^4.17.1",
-        "lodash": "^4.17.14",
         "node-fetch": "^2.6.7"
       }
     },
     "firebase-functions-test": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/firebase-functions-test/-/firebase-functions-test-0.2.2.tgz",
-      "integrity": "sha512-SlHLnpKRn5nMsg4Y0CUTGs/R8NatghJCYZGw3fHzaS/5xDqwWPWuxmdHHc+MSuxrSrUROEwOrDTwrbjmRaSNjw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/firebase-functions-test/-/firebase-functions-test-0.2.3.tgz",
+      "integrity": "sha512-zYX0QTm53wCazuej7O0xqbHl90r/v1PTXt/hwa0jo1YF8nDM+iBKnLDlkIoW66MDd0R6aGg4BvKzTTdJpvigUA==",
       "dev": true,
       "requires": {
         "@types/lodash": "^4.14.104",
@@ -3918,12 +3896,9 @@
       "optional": true
     },
     "jose": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.6.tgz",
-      "integrity": "sha512-FVoPY7SflDodE4lknJmbAHSUjLCzE2H1F6MS0RYKMQ8SR+lNccpMf8R4eqkNYyyUjR5qZReOzZo5C5YiHOCjjg==",
-      "requires": {
-        "@panva/asn1.js": "^1.0.0"
-      }
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.13.0.tgz",
+      "integrity": "sha512-v6BN7fuPVfG9XIxcPT2jzyAg5EmA/mtNeJEXJ7d31Wz7fFOqOZeN8mPtNJYQmnuAIxJII7EcURcbZ7qXs9a4kA=="
     },
     "js2xmlparser": {
       "version": "4.0.2",
@@ -4010,25 +3985,25 @@
       }
     },
     "jwks-rsa": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-2.1.5.tgz",
-      "integrity": "sha512-IODtn1SwEm7n6GQZnQLY0oxKDrMh7n/jRH1MzE8mlxWMrh2NnMyOsXTebu8vJ1qCpmuTJcL4DdiE0E4h8jnwsA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.0.1.tgz",
+      "integrity": "sha512-UUOZ0CVReK1QVU3rbi9bC7N5/le8ziUj0A2ef1Q0M7OPD2KvjEYizptqIxGIo6fSLYDkqBrazILS18tYuRc8gw==",
       "requires": {
         "@types/express": "^4.17.14",
-        "@types/jsonwebtoken": "^8.5.9",
+        "@types/jsonwebtoken": "^9.0.0",
         "debug": "^4.3.4",
-        "jose": "^2.0.6",
+        "jose": "^4.10.4",
         "limiter": "^1.1.5",
         "lru-memoizer": "^2.1.4"
       },
       "dependencies": {
         "@types/express": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
-          "integrity": "sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==",
+          "version": "4.17.17",
+          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
+          "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
           "requires": {
             "@types/body-parser": "*",
-            "@types/express-serve-static-core": "^4.17.31",
+            "@types/express-serve-static-core": "^4.17.33",
             "@types/qs": "*",
             "@types/serve-static": "*"
           }
@@ -4109,9 +4084,9 @@
       }
     },
     "lru-memoizer": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.4.tgz",
-      "integrity": "sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.2.0.tgz",
+      "integrity": "sha512-QfOZ6jNkxCcM/BkIPnFsqDhtrazLRsghi9mBwFAzol5GCvj4EkFT899Za3+QwikCg5sRX8JstioBDwOxEyzaNw==",
       "requires": {
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "~4.0.0"
@@ -4711,9 +4686,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -4734,9 +4709,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "uc.micro": {

--- a/.github/workflows/scripts/functions/package.json
+++ b/.github/workflows/scripts/functions/package.json
@@ -14,8 +14,8 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "firebase-admin": "^11.4.1",
-    "firebase-functions": "^3.24.1"
+    "firebase-admin": "^11.5.0",
+    "firebase-functions": "^4.2.1"
   },
   "devDependencies": {
     "firebase-functions-test": "^0.2.0",

--- a/.github/workflows/scripts/functions/src/index.ts
+++ b/.github/workflows/scripts/functions/src/index.ts
@@ -1,9 +1,14 @@
 import * as assert from 'assert';
 import * as functions from 'firebase-functions';
+import * as functionsv2 from 'firebase-functions/v2';
 
 // For example app.
 // noinspection JSUnusedGlobalSymbols
 export const listFruit = functions.https.onCall(() => {
+  return ['Apple', 'Banana', 'Cherry', 'Date', 'Fig', 'Grapes'];
+});
+
+export const listfruits2ndgen = functionsv2.https.onCall(() => {
   return ['Apple', 'Banana', 'Cherry', 'Date', 'Fig', 'Grapes'];
 });
 

--- a/packages/cloud_functions/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/functions/FlutterFirebaseFunctionsPlugin.java
+++ b/packages/cloud_functions/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/functions/FlutterFirebaseFunctionsPlugin.java
@@ -23,6 +23,7 @@ import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugins.firebase.core.FlutterFirebasePlugin;
 import java.io.IOException;
 import java.io.InterruptedIOException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -69,7 +70,8 @@ public class FlutterFirebaseFunctionsPlugin
 
             FirebaseFunctions firebaseFunctions = getFunctions(arguments);
 
-            String functionName = (String) Objects.requireNonNull(arguments.get("functionName"));
+            String functionName = (String) arguments.get("functionName");
+            String functionUri = (String) arguments.get("functionUri");
             String origin = (String) arguments.get("origin");
             Integer timeout = (Integer) arguments.get("timeout");
             Object parameters = arguments.get("parameters");
@@ -79,8 +81,15 @@ public class FlutterFirebaseFunctionsPlugin
               firebaseFunctions.useEmulator(originUri.getHost(), originUri.getPort());
             }
 
-            HttpsCallableReference httpsCallableReference =
-                firebaseFunctions.getHttpsCallable(functionName);
+            HttpsCallableReference httpsCallableReference;
+
+            if (functionName != null) {
+              httpsCallableReference = firebaseFunctions.getHttpsCallable(functionName);
+            } else if (functionUri != null) {
+              httpsCallableReference = firebaseFunctions.getHttpsCallableFromUrl(new URL(functionUri));
+            } else {
+              throw new IllegalArgumentException("Either functionName or functionUri must be set");
+            }
 
             if (timeout != null) {
               httpsCallableReference.setTimeout(timeout.longValue(), TimeUnit.MILLISECONDS);

--- a/packages/cloud_functions/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/functions/FlutterFirebaseFunctionsPlugin.java
+++ b/packages/cloud_functions/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/functions/FlutterFirebaseFunctionsPlugin.java
@@ -86,7 +86,8 @@ public class FlutterFirebaseFunctionsPlugin
             if (functionName != null) {
               httpsCallableReference = firebaseFunctions.getHttpsCallable(functionName);
             } else if (functionUri != null) {
-              httpsCallableReference = firebaseFunctions.getHttpsCallableFromUrl(new URL(functionUri));
+              httpsCallableReference =
+                  firebaseFunctions.getHttpsCallableFromUrl(new URL(functionUri));
             } else {
               throw new IllegalArgumentException("Either functionName or functionUri must be set");
             }

--- a/packages/cloud_functions/cloud_functions/example/android/app/build.gradle
+++ b/packages/cloud_functions/cloud_functions/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/cloud_functions/cloud_functions/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/cloud_functions/cloud_functions/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -216,6 +216,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -268,6 +269,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/packages/cloud_functions/cloud_functions/example/ios/Runner/Info.plist
+++ b/packages/cloud_functions/cloud_functions/example/ios/Runner/Info.plist
@@ -48,5 +48,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/packages/cloud_functions/cloud_functions/example/lib/main.dart
+++ b/packages/cloud_functions/cloud_functions/example/lib/main.dart
@@ -62,7 +62,7 @@ class _MyAppState extends State<MyApp> {
               children: [
                 FloatingActionButton.extended(
                   onPressed: () async {
-                    // See index.js in .github/workflows/scripts for the example function we
+                    // See .github/workflows/scripts/functions/src/index.ts for the example function we
                     // are using for this example
                     HttpsCallable callable =
                         FirebaseFunctions.instance.httpsCallable(
@@ -81,7 +81,7 @@ class _MyAppState extends State<MyApp> {
                 const SizedBox(height: 10),
                 FloatingActionButton.extended(
                   onPressed: () async {
-                    // See index.js in .github/workflows/scripts for the example function we
+                    // See .github/workflows/scripts/functions/src/index.ts for the example function we
                     // are using for this example
                     HttpsCallable callable =
                         FirebaseFunctions.instance.httpsCallable(

--- a/packages/cloud_functions/cloud_functions/example/lib/main.dart
+++ b/packages/cloud_functions/cloud_functions/example/lib/main.dart
@@ -49,40 +49,75 @@ class _MyAppState extends State<MyApp> {
             },
           ),
         ),
-        floatingActionButton: Builder(
-          builder: (context) => FloatingActionButton.extended(
-            onPressed: () async {
-              // See index.js in .github/workflows/scripts for the example function we
-              // are using for this example
-              HttpsCallable callable = FirebaseFunctions.instance.httpsCallable(
-                'listFruit',
-                options: HttpsCallableOptions(
-                  timeout: const Duration(seconds: 5),
-                ),
-              );
-
-              try {
-                final result = await callable();
-                setState(() {
-                  fruit.clear();
-                  result.data.forEach((f) {
-                    fruit.add(f);
-                  });
-                });
-              } catch (e) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text('ERROR: $e'),
+        floatingActionButton: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            FloatingActionButton.extended(
+              onPressed: () async {
+                // See index.js in .github/workflows/scripts for the example function we
+                // are using for this example
+                HttpsCallable callable =
+                    FirebaseFunctions.instance.httpsCallable(
+                  Uri.parse(
+                    'http://localhost:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
+                  ),
+                  options: HttpsCallableOptions(
+                    timeout: const Duration(seconds: 5),
                   ),
                 );
-              }
-            },
-            label: const Text('Call Function'),
-            icon: const Icon(Icons.cloud),
-            backgroundColor: Colors.deepOrange,
-          ),
+
+                await callingFunction(callable, context);
+              },
+              label: const Text('Call Function'),
+              icon: const Icon(Icons.cloud),
+              backgroundColor: Colors.deepOrange,
+            ),
+            const SizedBox(height: 10),
+            FloatingActionButton.extended(
+              onPressed: () async {
+                // See index.js in .github/workflows/scripts for the example function we
+                // are using for this example
+                HttpsCallable callable =
+                    FirebaseFunctions.instance.httpsCallable(
+                  Uri.parse(
+                    'http://localhost:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
+                  ),
+                  options: HttpsCallableOptions(
+                    timeout: const Duration(seconds: 5),
+                  ),
+                );
+
+                await callingFunction(callable, context);
+              },
+              label: const Text('Call 2nd Gen Function'),
+              icon: const Icon(Icons.cloud),
+              backgroundColor: Colors.deepOrange,
+            ),
+          ],
         ),
       ),
     );
+  }
+
+  Future<void> callingFunction(
+    HttpsCallable callable,
+    BuildContext context,
+  ) async {
+    try {
+      final result = await callable();
+      setState(() {
+        fruit.clear();
+        result.data.forEach((f) {
+          fruit.add(f);
+        });
+      });
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('ERROR: $e'),
+        ),
+      );
+    }
   }
 }

--- a/packages/cloud_functions/cloud_functions/example/lib/main.dart
+++ b/packages/cloud_functions/cloud_functions/example/lib/main.dart
@@ -3,10 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:core';
+import 'dart:io';
 
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:cloud_functions_example/firebase_options.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 Future<void> main() async {
@@ -34,6 +36,9 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
+    final localhostMapped =
+        kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
+
     return MaterialApp(
       home: Scaffold(
         appBar: AppBar(
@@ -49,52 +54,54 @@ class _MyAppState extends State<MyApp> {
             },
           ),
         ),
-        floatingActionButton: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.end,
-          children: [
-            FloatingActionButton.extended(
-              onPressed: () async {
-                // See index.js in .github/workflows/scripts for the example function we
-                // are using for this example
-                HttpsCallable callable =
-                    FirebaseFunctions.instance.httpsCallable(
-                  Uri.parse(
-                    'http://localhost:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
-                  ),
-                  options: HttpsCallableOptions(
-                    timeout: const Duration(seconds: 5),
-                  ),
-                );
+        floatingActionButton: Builder(
+          builder: (context) {
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                FloatingActionButton.extended(
+                  onPressed: () async {
+                    // See index.js in .github/workflows/scripts for the example function we
+                    // are using for this example
+                    HttpsCallable callable =
+                        FirebaseFunctions.instance.httpsCallable(
+                      'listFruit',
+                      options: HttpsCallableOptions(
+                        timeout: const Duration(seconds: 5),
+                      ),
+                    );
 
-                await callingFunction(callable, context);
-              },
-              label: const Text('Call Function'),
-              icon: const Icon(Icons.cloud),
-              backgroundColor: Colors.deepOrange,
-            ),
-            const SizedBox(height: 10),
-            FloatingActionButton.extended(
-              onPressed: () async {
-                // See index.js in .github/workflows/scripts for the example function we
-                // are using for this example
-                HttpsCallable callable =
-                    FirebaseFunctions.instance.httpsCallable(
-                  Uri.parse(
-                    'http://localhost:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
-                  ),
-                  options: HttpsCallableOptions(
-                    timeout: const Duration(seconds: 5),
-                  ),
-                );
+                    await callingFunction(callable, context);
+                  },
+                  label: const Text('Call Function'),
+                  icon: const Icon(Icons.cloud),
+                  backgroundColor: Colors.deepOrange,
+                ),
+                const SizedBox(height: 10),
+                FloatingActionButton.extended(
+                  onPressed: () async {
+                    // See index.js in .github/workflows/scripts for the example function we
+                    // are using for this example
+                    HttpsCallable callable =
+                        FirebaseFunctions.instance.httpsCallable(
+                      Uri.parse(
+                        'http://$localhostMapped:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
+                      ),
+                      options: HttpsCallableOptions(
+                        timeout: const Duration(seconds: 5),
+                      ),
+                    );
 
-                await callingFunction(callable, context);
-              },
-              label: const Text('Call 2nd Gen Function'),
-              icon: const Icon(Icons.cloud),
-              backgroundColor: Colors.deepOrange,
-            ),
-          ],
+                    await callingFunction(callable, context);
+                  },
+                  label: const Text('Call 2nd Gen Function'),
+                  icon: const Icon(Icons.cloud),
+                  backgroundColor: Colors.deepOrange,
+                ),
+              ],
+            );
+          },
         ),
       ),
     );

--- a/packages/cloud_functions/cloud_functions/example/lib/main.dart
+++ b/packages/cloud_functions/cloud_functions/example/lib/main.dart
@@ -84,7 +84,7 @@ class _MyAppState extends State<MyApp> {
                     // See .github/workflows/scripts/functions/src/index.ts for the example function we
                     // are using for this example
                     HttpsCallable callable =
-                        FirebaseFunctions.instance.httpsCallable(
+                        FirebaseFunctions.instance.httpsCallableFromUrl(
                       'http://$localhostMapped:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
                       options: HttpsCallableOptions(
                         timeout: const Duration(seconds: 5),

--- a/packages/cloud_functions/cloud_functions/example/lib/main.dart
+++ b/packages/cloud_functions/cloud_functions/example/lib/main.dart
@@ -85,9 +85,7 @@ class _MyAppState extends State<MyApp> {
                     // are using for this example
                     HttpsCallable callable =
                         FirebaseFunctions.instance.httpsCallable(
-                      Uri.parse(
-                        'http://$localhostMapped:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
-                      ),
+                      'http://$localhostMapped:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
                       options: HttpsCallableOptions(
                         timeout: const Duration(seconds: 5),
                       ),

--- a/packages/cloud_functions/cloud_functions/ios/Classes/FLTFirebaseFunctionsPlugin.m
+++ b/packages/cloud_functions/cloud_functions/ios/Classes/FLTFirebaseFunctionsPlugin.m
@@ -81,6 +81,7 @@ NSString *const kFLTFirebaseFunctionsChannelName = @"plugins.flutter.io/firebase
 - (void)httpsFunctionCall:(id)arguments withMethodCallResult:(FLTFirebaseMethodCallResult *)result {
   NSString *appName = arguments[@"appName"];
   NSString *functionName = arguments[@"functionName"];
+  NSString *functionUri = arguments[@"functionUri"];
   NSString *origin = arguments[@"origin"];
   NSString *region = arguments[@"region"];
   NSNumber *timeout = arguments[@"timeout"];
@@ -93,7 +94,17 @@ NSString *const kFLTFirebaseFunctionsChannelName = @"plugins.flutter.io/firebase
     [functions useEmulatorWithHost:[url host] port:[[url port] intValue]];
   }
 
-  FIRHTTPSCallable *function = [functions HTTPSCallableWithName:functionName];
+  FIRHTTPSCallable *function;
+
+  if (functionName != nil) {
+    function = [functions HTTPSCallableWithName:functionName];
+  } else if (functionUri != nil) {
+    function = [functions HTTPSCallableWithURL:[NSURL URLWithString:functionUri]];
+  } else {
+    result.error(@"WRONG_ARGUMENT", @"Either functionName or functionUri should be provided", nil,
+                 nil);
+    return;
+  }
   if (timeout != nil && ![timeout isEqual:[NSNull null]]) {
     function.timeoutInterval = timeout.doubleValue / 1000;
   }

--- a/packages/cloud_functions/cloud_functions/ios/Classes/FLTFirebaseFunctionsPlugin.m
+++ b/packages/cloud_functions/cloud_functions/ios/Classes/FLTFirebaseFunctionsPlugin.m
@@ -96,9 +96,9 @@ NSString *const kFLTFirebaseFunctionsChannelName = @"plugins.flutter.io/firebase
 
   FIRHTTPSCallable *function;
 
-  if (functionName != nil) {
+  if (![functionName isEqual:[NSNull null]]) {
     function = [functions HTTPSCallableWithName:functionName];
-  } else if (functionUri != nil) {
+  } else if (![functionUri isEqual:[NSNull null]]) {
     function = [functions HTTPSCallableWithURL:[NSURL URLWithString:functionUri]];
   } else {
     result.error(@"WRONG_ARGUMENT", @"Either functionName or functionUri should be provided", nil,

--- a/packages/cloud_functions/cloud_functions/ios/Classes/FLTFirebaseFunctionsPlugin.m
+++ b/packages/cloud_functions/cloud_functions/ios/Classes/FLTFirebaseFunctionsPlugin.m
@@ -101,8 +101,8 @@ NSString *const kFLTFirebaseFunctionsChannelName = @"plugins.flutter.io/firebase
   } else if (![functionUri isEqual:[NSNull null]]) {
     function = [functions HTTPSCallableWithURL:[NSURL URLWithString:functionUri]];
   } else {
-    result.error(@"WRONG_ARGUMENT", @"Either functionName or functionUri should be provided", nil,
-                 nil);
+    result.error(@"IllegalArgumentException", @"Either functionName or functionUri must be set",
+                 nil, nil);
     return;
   }
   if (timeout != nil && ![timeout isEqual:[NSNull null]]) {

--- a/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
+++ b/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
@@ -70,7 +70,14 @@ class FirebaseFunctions extends FirebasePluginPlatform {
     assert(nameOrUri is String || nameOrUri is Uri);
     assert(nameOrUri is Uri || (nameOrUri as String).isNotEmpty);
     options ??= HttpsCallableOptions();
-    return HttpsCallable._(delegate.httpsCallable(_origin, name, options));
+    if (nameOrUri is String) {
+      return HttpsCallable._(
+          delegate.httpsCallable(_origin, nameOrUri, options));
+    } else if (nameOrUri is Uri) {
+      return HttpsCallable._(
+          delegate.httpsCallableWithURI(_origin, nameOrUri, options));
+    }
+    throw ArgumentError.value(nameOrUri, 'nameOrUri must be a String or Uri');
   }
 
   /// Changes this instance to point to a Cloud Functions emulator running locally.

--- a/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
+++ b/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
@@ -60,8 +60,15 @@ class FirebaseFunctions extends FirebasePluginPlatform {
   String? _origin;
 
   /// A reference to the Callable HTTPS trigger with the given name.
-  HttpsCallable httpsCallable(String name, {HttpsCallableOptions? options}) {
-    assert(name.isNotEmpty);
+  ///
+  /// Should be the name of the Callable function in Firebase
+  /// or the URI of the 2nd gen Callable function in Firebase.
+  HttpsCallable httpsCallable(
+    Object nameOrUri, {
+    HttpsCallableOptions? options,
+  }) {
+    assert(nameOrUri is String || nameOrUri is Uri);
+    assert(nameOrUri is Uri || (nameOrUri as String).isNotEmpty);
     options ??= HttpsCallableOptions();
     return HttpsCallable._(delegate.httpsCallable(_origin, name, options));
   }

--- a/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
+++ b/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
@@ -75,7 +75,7 @@ class FirebaseFunctions extends FirebasePluginPlatform {
           delegate.httpsCallable(_origin, nameOrUri, options));
     } else if (nameOrUri is Uri) {
       return HttpsCallable._(
-          delegate.httpsCallableWithURI(_origin, nameOrUri, options));
+          delegate.httpsCallableWithUri(_origin, nameOrUri, options));
     }
     throw ArgumentError.value(nameOrUri, 'nameOrUri must be a String or Uri');
   }

--- a/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
+++ b/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
@@ -64,18 +64,12 @@ class FirebaseFunctions extends FirebasePluginPlatform {
   /// Should be the name of the Callable function in Firebase
   /// or the URL of the 2nd gen Callable function in Firebase.
   HttpsCallable httpsCallable(
-    String nameOrUri, {
+    String name, {
     HttpsCallableOptions? options,
   }) {
-    assert(nameOrUri.isNotEmpty);
-    final uri = Uri.tryParse(nameOrUri);
+    assert(name.isNotEmpty);
     options ??= HttpsCallableOptions();
-    if (uri == null || uri.scheme.isEmpty) {
-      return HttpsCallable._(
-          delegate.httpsCallable(_origin, nameOrUri, options));
-    }
-    return HttpsCallable._(
-        delegate.httpsCallableWithUri(_origin, uri, options));
+    return HttpsCallable._(delegate.httpsCallable(_origin, name, options));
   }
 
   /// A reference to the Callable HTTPS trigger with the given URL.

--- a/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
+++ b/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
@@ -69,7 +69,7 @@ class FirebaseFunctions extends FirebasePluginPlatform {
   }) {
     final uri = Uri.tryParse(nameOrUri);
     options ??= HttpsCallableOptions();
-    if (uri == null) {
+    if (uri == null || uri.scheme.isEmpty) {
       return HttpsCallable._(
           delegate.httpsCallable(_origin, nameOrUri, options));
     }

--- a/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
+++ b/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
@@ -62,22 +62,44 @@ class FirebaseFunctions extends FirebasePluginPlatform {
   /// A reference to the Callable HTTPS trigger with the given name.
   ///
   /// Should be the name of the Callable function in Firebase
-  /// or the URI of the 2nd gen Callable function in Firebase.
+  /// or the URL of the 2nd gen Callable function in Firebase.
   HttpsCallable httpsCallable(
-    Object nameOrUri, {
+    String nameOrUri, {
     HttpsCallableOptions? options,
   }) {
-    assert(nameOrUri is String || nameOrUri is Uri);
-    assert(nameOrUri is Uri || (nameOrUri as String).isNotEmpty);
+    final uri = Uri.tryParse(nameOrUri);
     options ??= HttpsCallableOptions();
-    if (nameOrUri is String) {
+    if (uri == null) {
       return HttpsCallable._(
           delegate.httpsCallable(_origin, nameOrUri, options));
-    } else if (nameOrUri is Uri) {
-      return HttpsCallable._(
-          delegate.httpsCallableWithUri(_origin, nameOrUri, options));
     }
-    throw ArgumentError.value(nameOrUri, 'nameOrUri must be a String or Uri');
+    return HttpsCallable._(
+        delegate.httpsCallableWithUri(_origin, uri, options));
+  }
+
+  /// A reference to the Callable HTTPS trigger with the given URL.
+  ///
+  /// Should be URL of the 2nd gen Callable function in Firebase.
+  HttpsCallable httpsCallableFromUrl(
+    String url, {
+    HttpsCallableOptions? options,
+  }) {
+    final uri = Uri.parse(url);
+    options ??= HttpsCallableOptions();
+    return HttpsCallable._(
+        delegate.httpsCallableWithUri(_origin, uri, options));
+  }
+
+  /// A reference to the Callable HTTPS trigger with the given Uri.
+  ///
+  /// Should be Uri of the 2nd gen Callable function in Firebase.
+  HttpsCallable httpsCallableFromUri(
+    Uri uri, {
+    HttpsCallableOptions? options,
+  }) {
+    options ??= HttpsCallableOptions();
+    return HttpsCallable._(
+        delegate.httpsCallableWithUri(_origin, uri, options));
   }
 
   /// Changes this instance to point to a Cloud Functions emulator running locally.

--- a/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
+++ b/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
@@ -67,6 +67,7 @@ class FirebaseFunctions extends FirebasePluginPlatform {
     String nameOrUri, {
     HttpsCallableOptions? options,
   }) {
+    assert(nameOrUri.isNotEmpty);
     final uri = Uri.tryParse(nameOrUri);
     options ??= HttpsCallableOptions();
     if (uri == null || uri.scheme.isEmpty) {

--- a/packages/cloud_functions/cloud_functions/test/mock.dart
+++ b/packages/cloud_functions/cloud_functions/test/mock.dart
@@ -29,8 +29,8 @@ void resetFirebaseCoreMocks() {
 
 class MockHttpsCallablePlatform extends HttpsCallablePlatform {
   MockHttpsCallablePlatform(FirebaseFunctionsPlatform functions, String? origin,
-      String name, HttpsCallableOptions options)
-      : super(functions, origin, name, options);
+      String? name, HttpsCallableOptions options, Uri? uri)
+      : super(functions, origin, name, options, uri);
 
   @override
   Future<dynamic> call([dynamic parameters]) async {
@@ -47,7 +47,15 @@ class MockFirebaseFunctionsPlatform extends FirebaseFunctionsPlatform {
   HttpsCallablePlatform httpsCallable(
       String? origin, String name, HttpsCallableOptions options) {
     HttpsCallablePlatform httpsCallablePlatform =
-        MockHttpsCallablePlatform(this, origin, name, options);
+        MockHttpsCallablePlatform(this, origin, name, options, null);
+    return httpsCallablePlatform;
+  }
+
+  @override
+  HttpsCallablePlatform httpsCallableWithUri(
+      String? origin, Uri uri, HttpsCallableOptions options) {
+    HttpsCallablePlatform httpsCallablePlatform =
+        MockHttpsCallablePlatform(this, origin, null, options, uri);
     return httpsCallablePlatform;
   }
 

--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_firebase_functions.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_firebase_functions.dart
@@ -42,6 +42,12 @@ class MethodChannelFirebaseFunctions extends FirebaseFunctionsPlatform {
   @override
   HttpsCallablePlatform httpsCallable(
       String? origin, String name, HttpsCallableOptions options) {
-    return MethodChannelHttpsCallable(this, origin, name, options);
+    return MethodChannelHttpsCallable(this, origin, name, options, null);
+  }
+
+  @override
+  HttpsCallablePlatform httpsCallableWithUri(
+      String? origin, Uri uri, HttpsCallableOptions options) {
+    return MethodChannelHttpsCallable(this, origin, null, options, uri);
   }
 }

--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_https_callable.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_https_callable.dart
@@ -7,15 +7,14 @@ import 'dart:async';
 
 import '../../cloud_functions_platform_interface.dart';
 import 'method_channel_firebase_functions.dart';
-
 import 'utils/exception.dart';
 
 /// Method Channel delegate for [HttpsCallablePlatform].
 class MethodChannelHttpsCallable extends HttpsCallablePlatform {
   /// Creates a new [MethodChannelHttpsCallable] instance.
   MethodChannelHttpsCallable(FirebaseFunctionsPlatform functions,
-      String? origin, String name, HttpsCallableOptions options)
-      : super(functions, origin, name, options);
+      String? origin, String? name, HttpsCallableOptions options, Uri? uri)
+      : super(functions, origin, name, options, uri);
 
   @override
   Future<dynamic> call([Object? parameters]) async {
@@ -24,6 +23,7 @@ class MethodChannelHttpsCallable extends HttpsCallablePlatform {
           .invokeMethod('FirebaseFunctions#call', <String, dynamic>{
         'appName': functions.app!.name,
         'functionName': name,
+        'functionUri': uri?.toString(),
         'origin': origin,
         'region': functions.region,
         'timeout': options.timeout.inMilliseconds,

--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/platform_interface/platform_interface_firebase_functions.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/platform_interface/platform_interface_firebase_functions.dart
@@ -67,8 +67,8 @@ abstract class FirebaseFunctionsPlatform extends PlatformInterface {
     throw UnimplementedError('httpsCallable() is not implemented');
   }
 
-  /// Creates a [HttpsCallablePlatform] instance
-  HttpsCallablePlatform httpsCallableWithURI(
+  /// Creates a [HttpsCallablePlatform] instance from a [Uri]
+  HttpsCallablePlatform httpsCallableWithUri(
       String? origin, Uri uri, HttpsCallableOptions options) {
     throw UnimplementedError('httpsCallable() is not implemented');
   }

--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/platform_interface/platform_interface_firebase_functions.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/platform_interface/platform_interface_firebase_functions.dart
@@ -66,4 +66,10 @@ abstract class FirebaseFunctionsPlatform extends PlatformInterface {
       String? origin, String name, HttpsCallableOptions options) {
     throw UnimplementedError('httpsCallable() is not implemented');
   }
+
+  /// Creates a [HttpsCallablePlatform] instance
+  HttpsCallablePlatform httpsCallableWithURI(
+      String? origin, Uri uri, HttpsCallableOptions options) {
+    throw UnimplementedError('httpsCallable() is not implemented');
+  }
 }

--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/platform_interface/platform_interface_https_callable.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/platform_interface/platform_interface_https_callable.dart
@@ -14,8 +14,14 @@ import '../../cloud_functions_platform_interface.dart';
 /// A reference to a particular Callable HTTPS trigger in Cloud Functions.
 abstract class HttpsCallablePlatform extends PlatformInterface {
   /// Creates a new [HttpsCallablePlatform] instance.
-  HttpsCallablePlatform(this.functions, this.origin, this.name, this.options)
-      : super(token: _token);
+  HttpsCallablePlatform(
+    this.functions,
+    this.origin,
+    this.name,
+    this.options,
+    this.uri,
+  )   : assert(name != null || uri != null),
+        super(token: _token);
 
   static final Object _token = Object();
 
@@ -36,7 +42,10 @@ abstract class HttpsCallablePlatform extends PlatformInterface {
   final String? origin;
 
   /// The name of the function
-  final String name;
+  final String? name;
+
+  /// The URI of the function for 2nd gen functions
+  final Uri? uri;
 
   /// Used to set the options for this instance.
   HttpsCallableOptions options;

--- a/packages/cloud_functions/cloud_functions_platform_interface/test/method_channel/method_channel_https_callable_test.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/test/method_channel/method_channel_https_callable_test.dart
@@ -6,9 +6,10 @@
 import 'package:cloud_functions_platform_interface/cloud_functions_platform_interface.dart';
 import 'package:cloud_functions_platform_interface/src/method_channel/method_channel_firebase_functions.dart';
 import 'package:cloud_functions_platform_interface/src/method_channel/method_channel_https_callable.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:firebase_core/firebase_core.dart';
+
 import '../mock.dart';
 
 void main() {
@@ -22,6 +23,7 @@ void main() {
   bool mockPlatformExceptionThrown = false;
   bool mockExceptionThrown = false;
   String kName = 'test_name';
+  Uri kUri = Uri.parse('https://test.com');
   String kOrigin = 'test_origin';
   dynamic kParameters = {'foo': 'bar'};
   HttpsCallableOptions kOptions = HttpsCallableOptions();
@@ -55,6 +57,7 @@ void main() {
         kOrigin,
         kName,
         kOptions,
+        null,
       );
     });
 
@@ -111,6 +114,37 @@ void main() {
             arguments: <String, dynamic>{
               'appName': functions!.app!.name,
               'functionName': httpsCallable!.name,
+              'functionUri': null,
+              'origin': httpsCallable!.origin,
+              'region': functions!.region,
+              'timeout': httpsCallable!.options.timeout.inMilliseconds,
+              'parameters': kParameters,
+            },
+          ),
+        ]);
+      });
+
+      test('invokes native method with correct args with Uri', () async {
+        final httpsCallableWithUri = MethodChannelHttpsCallable(
+          functions!,
+          kOrigin,
+          null,
+          kOptions,
+          kUri,
+        );
+        final result = await httpsCallableWithUri.call(kParameters);
+
+        expect(result, isA<dynamic>());
+        expect(result['foo'], 'bar');
+
+        // check native method was called
+        expect(logger, <Matcher>[
+          isMethodCall(
+            'FirebaseFunctions#call',
+            arguments: <String, dynamic>{
+              'appName': functions!.app!.name,
+              'functionName': null,
+              'functionUri': 'https://test.com',
               'origin': httpsCallable!.origin,
               'region': functions!.region,
               'timeout': httpsCallable!.options.timeout.inMilliseconds,
@@ -130,6 +164,7 @@ void main() {
             arguments: <String, dynamic>{
               'appName': functions!.app!.name,
               'functionName': httpsCallable!.name,
+              'functionUri': null,
               'origin': httpsCallable!.origin,
               'region': functions!.region,
               'timeout': httpsCallable!.options.timeout.inMilliseconds,
@@ -149,6 +184,7 @@ void main() {
             arguments: <String, dynamic>{
               'appName': functions!.app!.name,
               'functionName': httpsCallable!.name,
+              'functionUri': null,
               'origin': httpsCallable!.origin,
               'region': functions!.region,
               'timeout': httpsCallable!.options.timeout.inMilliseconds,

--- a/packages/cloud_functions/cloud_functions_platform_interface/test/platform_interface/platform_interface_https_callable_test.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/test/platform_interface/platform_interface_https_callable_test.dart
@@ -51,7 +51,7 @@ void main() {
 
 class TestHttpsCallablePlatform extends HttpsCallablePlatform {
   TestHttpsCallablePlatform(FirebaseFunctionsPlatform functions)
-      : super(functions, null, 'function_name', HttpsCallableOptions());
+      : super(functions, null, 'function_name', HttpsCallableOptions(), null);
 }
 
 class TestFirebaseFunctionsPlatform extends FirebaseFunctionsPlatform {

--- a/packages/cloud_functions/cloud_functions_web/lib/cloud_functions_web.dart
+++ b/packages/cloud_functions/cloud_functions_web/lib/cloud_functions_web.dart
@@ -6,9 +6,10 @@
 import 'package:cloud_functions_platform_interface/cloud_functions_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_web/firebase_core_web.dart';
-import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:firebase_core_web/firebase_core_web_interop.dart'
     as core_interop;
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
 import 'https_callable_web.dart';
 import 'interop/functions.dart' as functions_interop;
 
@@ -53,6 +54,12 @@ class FirebaseFunctionsWeb extends FirebaseFunctionsPlatform {
   @override
   HttpsCallablePlatform httpsCallable(
       String? origin, String name, HttpsCallableOptions options) {
-    return HttpsCallableWeb(this, _delegate, origin, name, options);
+    return HttpsCallableWeb(this, _delegate, origin, name, options, null);
+  }
+
+  @override
+  HttpsCallablePlatform httpsCallableWithUri(
+      String? origin, Uri uri, HttpsCallableOptions options) {
+    return HttpsCallableWeb(this, _delegate, origin, null, options, uri);
   }
 }

--- a/packages/cloud_functions/cloud_functions_web/lib/https_callable_web.dart
+++ b/packages/cloud_functions/cloud_functions_web/lib/https_callable_web.dart
@@ -15,8 +15,8 @@ import 'utils.dart';
 class HttpsCallableWeb extends HttpsCallablePlatform {
   /// Constructor.
   HttpsCallableWeb(FirebaseFunctionsPlatform functions, this._webFunctions,
-      String? origin, String name, HttpsCallableOptions options)
-      : super(functions, origin, name, options);
+      String? origin, String? name, HttpsCallableOptions options, Uri? uri)
+      : super(functions, origin, name, options, uri);
 
   final functions_interop.Functions _webFunctions;
 
@@ -32,8 +32,15 @@ class HttpsCallableWeb extends HttpsCallablePlatform {
         functions_interop.HttpsCallableOptions(
             timeout: options.timeout.inMilliseconds);
 
-    functions_interop.HttpsCallable callable =
-        _webFunctions.httpsCallable(name, callableOptions);
+    late functions_interop.HttpsCallable callable;
+
+    if (name != null) {
+      callable = _webFunctions.httpsCallable(name!, callableOptions);
+    } else if (uri != null) {
+      callable = _webFunctions.httpsCallableUri(uri!, callableOptions);
+    } else {
+      throw ArgumentError('Either name or uri must be provided');
+    }
 
     functions_interop.HttpsCallableResult response;
     var input = parameters;

--- a/packages/cloud_functions/cloud_functions_web/lib/interop/functions.dart
+++ b/packages/cloud_functions/cloud_functions_web/lib/interop/functions.dart
@@ -48,6 +48,19 @@ class Functions extends JsObjectWrapper<functions_interop.FunctionsJsImpl> {
     return HttpsCallable.getInstance(httpCallableImpl);
   }
 
+  HttpsCallable httpsCallableUri(Uri uri,
+      [functions_interop.HttpsCallableOptions? options]) {
+    functions_interop.CustomFunction httpCallableImpl;
+    if (options != null) {
+      httpCallableImpl = functions_interop.httpsCallableFromURL(
+          jsObject, uri.toString(), options);
+    } else {
+      httpCallableImpl =
+          functions_interop.httpsCallableFromURL(jsObject, uri.toString());
+    }
+    return HttpsCallable.getInstance(httpCallableImpl);
+  }
+
   void useFunctionsEmulator(String host, int port) =>
       functions_interop.connectFunctionsEmulator(jsObject, host, port);
 }

--- a/packages/cloud_functions/cloud_functions_web/lib/interop/functions_interop.dart
+++ b/packages/cloud_functions/cloud_functions_web/lib/interop/functions_interop.dart
@@ -9,7 +9,6 @@
 library firebase_interop.functions;
 
 import 'package:firebase_core_web/firebase_core_web_interop.dart';
-
 import 'package:js/js.dart';
 
 @JS()
@@ -23,7 +22,6 @@ external void connectFunctionsEmulator(
 external CustomFunction httpsCallable(FunctionsJsImpl functions, String name,
     [HttpsCallableOptions? options]);
 
-//TODO - implement once web v9 SDK lands
 @JS()
 external CustomFunction httpsCallableFromURL(
     FunctionsJsImpl functions, String url,

--- a/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
+++ b/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
@@ -120,6 +120,18 @@ void main() {
           expect(result.data, isA<Map<String, dynamic>>());
         },
       );
+
+      test('can be called using an Uri', () async {
+        HttpsCallable callable = FirebaseFunctions.instance.httpsCallable(
+          Uri.parse(
+            'http://127.0.0.1:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
+          ),
+        );
+
+        HttpsCallableResult result = await callable();
+        print(result.data);
+        expect(result, isA<HttpsCallableResult>());
+      });
     });
 
     group('FirebaseFunctionsException', () {

--- a/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
+++ b/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
@@ -122,14 +124,16 @@ void main() {
       );
 
       test('can be called using an Uri', () async {
+        final localhostMapped =
+            kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
+
         HttpsCallable callable = FirebaseFunctions.instance.httpsCallable(
           Uri.parse(
-            'http://127.0.0.1:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
+            'http://$localhostMapped:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
           ),
         );
 
         HttpsCallableResult result = await callable();
-        print(result.data);
         expect(result, isA<HttpsCallableResult>());
       });
     });

--- a/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
+++ b/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
@@ -123,11 +123,39 @@ void main() {
         },
       );
 
-      test('can be called using an Uri', () async {
+      test(
+          'can be called using an String url with fallback using legacy function',
+          () async {
         final localhostMapped =
             kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
 
         HttpsCallable callable = FirebaseFunctions.instance.httpsCallable(
+          'http://$localhostMapped:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
+        );
+
+        HttpsCallableResult result = await callable();
+        expect(result, isA<HttpsCallableResult>());
+      });
+
+      test('can be called using an String url', () async {
+        final localhostMapped =
+            kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
+
+        HttpsCallable callable =
+            FirebaseFunctions.instance.httpsCallableFromUrl(
+          'http://$localhostMapped:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
+        );
+
+        HttpsCallableResult result = await callable();
+        expect(result, isA<HttpsCallableResult>());
+      });
+
+      test('can be called using an Uri url', () async {
+        final localhostMapped =
+            kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
+
+        HttpsCallable callable =
+            FirebaseFunctions.instance.httpsCallableFromUri(
           Uri.parse(
             'http://$localhostMapped:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
           ),

--- a/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
+++ b/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
@@ -123,20 +123,6 @@ void main() {
         },
       );
 
-      test(
-          'can be called using an String url with fallback using legacy function',
-          () async {
-        final localhostMapped =
-            kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
-
-        HttpsCallable callable = FirebaseFunctions.instance.httpsCallable(
-          'http://$localhostMapped:5001/flutterfire-e2e-tests/us-central1/listfruits2ndgen',
-        );
-
-        HttpsCallableResult result = await callable();
-        expect(result, isA<HttpsCallableResult>());
-      });
-
       test('can be called using an String url', () async {
         final localhostMapped =
             kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';

--- a/tests/integration_test/e2e_test.dart
+++ b/tests/integration_test/e2e_test.dart
@@ -32,17 +32,17 @@ void main() {
 
   group('FlutterFire', () {
     firebase_core.main();
-    firebase_database.main();
-    firebase_crashlytics.main();
-    firebase_auth.main();
-    firebase_analytics.main();
+    // firebase_database.main();
+    // firebase_crashlytics.main();
+    // firebase_auth.main();
+    // firebase_analytics.main();
     cloud_functions.main();
-    firebase_app_check.main();
-    firebase_app_installations.main();
-    firebase_dynamic_links.main();
-    firebase_messaging.main();
-    firebase_ml_model_downloader.main();
-    firebase_remote_config.main();
-    firebase_storage.main();
+    // firebase_app_check.main();
+    // firebase_app_installations.main();
+    // firebase_dynamic_links.main();
+    // firebase_messaging.main();
+    // firebase_ml_model_downloader.main();
+    // firebase_remote_config.main();
+    // firebase_storage.main();
   });
 }

--- a/tests/integration_test/e2e_test.dart
+++ b/tests/integration_test/e2e_test.dart
@@ -32,17 +32,17 @@ void main() {
 
   group('FlutterFire', () {
     firebase_core.main();
-    // firebase_database.main();
-    // firebase_crashlytics.main();
-    // firebase_auth.main();
-    // firebase_analytics.main();
+    firebase_database.main();
+    firebase_crashlytics.main();
+    firebase_auth.main();
+    firebase_analytics.main();
     cloud_functions.main();
-    // firebase_app_check.main();
-    // firebase_app_installations.main();
-    // firebase_dynamic_links.main();
-    // firebase_messaging.main();
-    // firebase_ml_model_downloader.main();
-    // firebase_remote_config.main();
-    // firebase_storage.main();
+    firebase_app_check.main();
+    firebase_app_installations.main();
+    firebase_dynamic_links.main();
+    firebase_messaging.main();
+    firebase_ml_model_downloader.main();
+    firebase_remote_config.main();
+    firebase_storage.main();
   });
 }


### PR DESCRIPTION
## Description

There are now 2 new functions, 
httpsCallableFromUrl and httpsCallableFromUri that can take a String Url or a parsed Uri to use a 2nd gen Cloud Function.

## Related Issues

#10541 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
