### PR TITLE
fix(crashlytics, ios): fix Crashlytics obfuscation for iOS on the Flutter side

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/utils.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/utils.dart
@@ -5,9 +5,6 @@
 
 import 'package:stack_trace/stack_trace.dart';
 
-final _obfuscatedStackTraceLineRegExp =
-    RegExp(r'^(\s*#\d{2} abs )([\da-f]+)((?: virt [\da-f]+)?(?: .*)?)$');
-
 /// Returns a [List] containing detailed output of each line in a stack trace.
 List<Map<String, String>> getStackTraceElements(StackTrace stackTrace) {
   final Trace trace = Trace.parseVM(stackTrace.toString()).terse;
@@ -15,24 +12,18 @@ List<Map<String, String>> getStackTraceElements(StackTrace stackTrace) {
 
   for (final Frame frame in trace.frames) {
     if (frame is UnparsedFrame) {
-      if (_obfuscatedStackTraceLineRegExp.hasMatch(frame.member)) {
-        // Same exceptions should be grouped in Crashlytics Console.
-        // Crashlytics Console groups issues with same stack trace.
-        // Obfuscated stack traces contains abs address, virt address
-        // and symbol name + offset. abs addresses are different across
-        // sessions, so same error can create different issues in Console.
-        // We replace abs address with '0' so that Crashlytics Console can
-        // group same exceptions. Also we don't need abs addresses for
-        // deobfuscating, if we have virt address or symbol name + offset.
-        final String method = frame.member.replaceFirstMapped(
-            _obfuscatedStackTraceLineRegExp,
-            (match) => '${match.group(1)}0${match.group(3)}');
-        elements.add(<String, String>{
-          'file': '',
-          'line': '0',
-          'method': method,
-        });
-      }
+      // Same exceptions should be grouped in Crashlytics Console.
+      // Crashlytics Console groups issues with same stack trace.
+      // Obfuscated stack traces contains abs address, virt address
+      // and symbol name + offset. abs addresses are different across
+      // sessions, Crashlytics is smart enough to grouping those errors
+      // in the same issue. For iOS we use abs address for symbolication
+      // and for Android we use virt address.
+      elements.add(<String, String>{
+        'file': '',
+        'line': '0',
+        'method': frame.member,
+      });
     } else {
       final Map<String, String> element = <String, String>{
         'file': frame.library,

--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/utils.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/utils.dart
@@ -20,7 +20,7 @@ List<Map<String, String>> getStackTraceElements(StackTrace stackTrace) {
         // Crashlytics Console groups issues with same stack trace.
         // Obfuscated stack traces contains abs address, virt address
         // and symbol name + offset. abs addresses are different across
-        // sessions, Crashlytics is smart enough to grouping those errors
+        // sessions, Crashlytics is smart enough to group exceptions
         // in the same issue. For iOS we use abs address for symbolication
         // and for Android we use virt address.
         elements.add(<String, String>{

--- a/packages/firebase_crashlytics/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -266,7 +266,7 @@ void main() {
         expect(elements.length, 1);
         expect(elements.first, <String, String>{
           'method':
-              '    #00 abs 0 virt 00000000001af27b _kDartIsolateSnapshotInstructions+0x1a127b',
+              '    #00 abs 000075f17833027b virt 00000000001af27b _kDartIsolateSnapshotInstructions+0x1a127b',
           'file': '',
           'line': '0',
         });
@@ -286,7 +286,8 @@ void main() {
         final List<Map<String, String>> elements = getStackTraceElements(trace);
         expect(elements.length, 1);
         expect(elements.first, <String, String>{
-          'method': '    #00 abs 0 _kDartIsolateSnapshotInstructions+0x1a127b',
+          'method':
+            '    #00 abs 000075f17833027b _kDartIsolateSnapshotInstructions+0x1a127b',
           'file': '',
           'line': '0',
         });

--- a/packages/firebase_crashlytics/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -287,7 +287,7 @@ void main() {
         expect(elements.length, 1);
         expect(elements.first, <String, String>{
           'method':
-            '    #00 abs 000075f17833027b _kDartIsolateSnapshotInstructions+0x1a127b',
+              '    #00 abs 000075f17833027b _kDartIsolateSnapshotInstructions+0x1a127b',
           'file': '',
           'line': '0',
         });


### PR DESCRIPTION
## Description

Make plugin  to send abs address to Crashlytics to make deobfuscation works on iOS.
Crashlytics is smart enough to grouping same errors with different abs addresses  in the same issue.

## Related Issues
#8934 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
