### PR TITLE
fix(auth): fix an issue where unenroll would not throw a FirebaseException

### DIFF
--- a/packages/firebase_auth/firebase_auth/example/lib/auth.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/auth.dart
@@ -178,6 +178,8 @@ class _AuthGateState extends State<AuthGate> {
                                     hintText: 'Email',
                                     border: OutlineInputBorder(),
                                   ),
+                                  keyboardType: TextInputType.emailAddress,
+                                  autofillHints: const [AutofillHints.email],
                                   validator: (value) =>
                                       value != null && value.isNotEmpty
                                           ? null

--- a/packages/firebase_auth/firebase_auth/example/lib/profile.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/profile.dart
@@ -102,143 +102,162 @@ class _ProfilePageState extends State<ProfilePage> {
             Center(
               child: SizedBox(
                 width: 400,
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Stack(
-                      children: [
-                        CircleAvatar(
-                          maxRadius: 60,
-                          backgroundImage: NetworkImage(
-                            user.photoURL ?? placeholderImage,
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Stack(
+                        children: [
+                          CircleAvatar(
+                            maxRadius: 60,
+                            backgroundImage: NetworkImage(
+                              user.photoURL ?? placeholderImage,
+                            ),
                           ),
-                        ),
-                        Positioned.directional(
-                          textDirection: Directionality.of(context),
-                          end: 0,
-                          bottom: 0,
-                          child: Material(
-                            clipBehavior: Clip.antiAlias,
-                            color: Theme.of(context).colorScheme.secondary,
-                            borderRadius: BorderRadius.circular(40),
-                            child: InkWell(
-                              onTap: () async {
-                                final photoURL = await getPhotoURLFromUser();
+                          Positioned.directional(
+                            textDirection: Directionality.of(context),
+                            end: 0,
+                            bottom: 0,
+                            child: Material(
+                              clipBehavior: Clip.antiAlias,
+                              color: Theme.of(context).colorScheme.secondary,
+                              borderRadius: BorderRadius.circular(40),
+                              child: InkWell(
+                                onTap: () async {
+                                  final photoURL = await getPhotoURLFromUser();
 
-                                if (photoURL != null) {
-                                  await user.updatePhotoURL(photoURL);
-                                }
-                              },
-                              radius: 50,
-                              child: const SizedBox(
-                                width: 35,
-                                height: 35,
-                                child: Icon(Icons.edit),
+                                  if (photoURL != null) {
+                                    await user.updatePhotoURL(photoURL);
+                                  }
+                                },
+                                radius: 50,
+                                child: const SizedBox(
+                                  width: 35,
+                                  height: 35,
+                                  child: Icon(Icons.edit),
+                                ),
                               ),
                             ),
-                          ),
-                        )
-                      ],
-                    ),
-                    const SizedBox(height: 10),
-                    TextField(
-                      textAlign: TextAlign.center,
-                      controller: controller,
-                      decoration: const InputDecoration(
-                        border: InputBorder.none,
-                        floatingLabelBehavior: FloatingLabelBehavior.never,
-                        alignLabelWithHint: true,
-                        label: Center(
-                          child: Text(
-                            'Click to add a display name',
+                          )
+                        ],
+                      ),
+                      const SizedBox(height: 10),
+                      TextField(
+                        textAlign: TextAlign.center,
+                        controller: controller,
+                        decoration: const InputDecoration(
+                          border: InputBorder.none,
+                          floatingLabelBehavior: FloatingLabelBehavior.never,
+                          alignLabelWithHint: true,
+                          label: Center(
+                            child: Text(
+                              'Click to add a display name',
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                    Text(user.email ?? user.phoneNumber ?? 'User'),
-                    const SizedBox(height: 10),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        if (userProviders.contains('phone'))
-                          const Icon(Icons.phone),
-                        if (userProviders.contains('password'))
-                          const Icon(Icons.mail),
-                        if (userProviders.contains('google.com'))
-                          SizedBox(
-                            width: 24,
-                            child: Image.network(
-                              'https://upload.wikimedia.org/wikipedia/commons/0/09/IOS_Google_icon.png',
+                      Text(user.email ?? user.phoneNumber ?? 'User'),
+                      const SizedBox(height: 10),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          if (userProviders.contains('phone'))
+                            const Icon(Icons.phone),
+                          if (userProviders.contains('password'))
+                            const Icon(Icons.mail),
+                          if (userProviders.contains('google.com'))
+                            SizedBox(
+                              width: 24,
+                              child: Image.network(
+                                'https://upload.wikimedia.org/wikipedia/commons/0/09/IOS_Google_icon.png',
+                              ),
                             ),
-                          ),
-                      ],
-                    ),
-                    const SizedBox(height: 20),
-                    TextButton(
-                      onPressed: () {
-                        user.sendEmailVerification();
-                      },
-                      child: const Text('Verify Email'),
-                    ),
-                    const SizedBox(height: 20),
-                    TextButton(
-                      onPressed: () async {
-                        final a = await user.multiFactor.getEnrolledFactors();
-                        print(a);
-                      },
-                      child: const Text('Get enrolled factors'),
-                    ),
-                    const SizedBox(height: 20),
-                    TextFormField(
-                      controller: phoneController,
-                      decoration: const InputDecoration(
-                        icon: Icon(Icons.phone),
-                        hintText: '+33612345678',
-                        labelText: 'Phone number',
+                        ],
                       ),
-                    ),
-                    const SizedBox(height: 20),
-                    TextButton(
-                      onPressed: () async {
-                        final session = await user.multiFactor.getSession();
-                        await auth.verifyPhoneNumber(
-                          multiFactorSession: session,
-                          phoneNumber: phoneController.text,
-                          verificationCompleted: (_) {},
-                          verificationFailed: print,
-                          codeSent:
-                              (String verificationId, int? resendToken) async {
-                            final smsCode = await getSmsCodeFromUser(context);
+                      const SizedBox(height: 20),
+                      TextButton(
+                        onPressed: () {
+                          user.sendEmailVerification();
+                        },
+                        child: const Text('Verify Email'),
+                      ),
+                      TextButton(
+                        onPressed: () async {
+                          final a = await user.multiFactor.getEnrolledFactors();
+                          print(a);
+                        },
+                        child: const Text('Get enrolled factors'),
+                      ),
+                      TextFormField(
+                        controller: phoneController,
+                        decoration: const InputDecoration(
+                          icon: Icon(Icons.phone),
+                          hintText: '+33612345678',
+                          labelText: 'Phone number',
+                        ),
+                      ),
+                      const SizedBox(height: 20),
+                      TextButton(
+                        onPressed: () async {
+                          final session = await user.multiFactor.getSession();
+                          await auth.verifyPhoneNumber(
+                            multiFactorSession: session,
+                            phoneNumber: phoneController.text,
+                            verificationCompleted: (_) {},
+                            verificationFailed: print,
+                            codeSent: (
+                              String verificationId,
+                              int? resendToken,
+                            ) async {
+                              final smsCode = await getSmsCodeFromUser(context);
 
-                            if (smsCode != null) {
-                              // Create a PhoneAuthCredential with the code
-                              final credential = PhoneAuthProvider.credential(
-                                verificationId: verificationId,
-                                smsCode: smsCode,
-                              );
-
-                              try {
-                                await user.multiFactor.enroll(
-                                  PhoneMultiFactorGenerator.getAssertion(
-                                    credential,
-                                  ),
+                              if (smsCode != null) {
+                                // Create a PhoneAuthCredential with the code
+                                final credential = PhoneAuthProvider.credential(
+                                  verificationId: verificationId,
+                                  smsCode: smsCode,
                                 );
-                              } on FirebaseAuthException catch (e) {
-                                print(e.message);
+
+                                try {
+                                  await user.multiFactor.enroll(
+                                    PhoneMultiFactorGenerator.getAssertion(
+                                      credential,
+                                    ),
+                                  );
+                                } on FirebaseAuthException catch (e) {
+                                  print(e.message);
+                                }
                               }
-                            }
-                          },
-                          codeAutoRetrievalTimeout: print,
-                        );
-                      },
-                      child: const Text('Verify Number For MFA'),
-                    ),
-                    const SizedBox(height: 20),
-                    TextButton(
-                      onPressed: _signOut,
-                      child: const Text('Sign out'),
-                    ),
-                  ],
+                            },
+                            codeAutoRetrievalTimeout: print,
+                          );
+                        },
+                        child: const Text('Verify Number For MFA'),
+                      ),
+                      TextButton(
+                        onPressed: () async {
+                          try {
+                            final enrolledFactors =
+                                await user.multiFactor.getEnrolledFactors();
+
+                            await user.multiFactor.unenroll(
+                              factorUid: enrolledFactors.first.uid,
+                            );
+                            // Show snackbar
+                            ScaffoldSnackbar.of(context).show('MFA unenrolled');
+                          } catch (e) {
+                            print(e);
+                          }
+                        },
+                        child: const Text('Unenroll MFA'),
+                      ),
+                      const Divider(),
+                      TextButton(
+                        onPressed: _signOut,
+                        child: const Text('Sign out'),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/packages/firebase_auth/firebase_auth/lib/src/multi_factor.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/multi_factor.dart
@@ -36,7 +36,7 @@ class MultiFactor {
     assert(
       (factorUid != null && multiFactorInfo == null) ||
           (factorUid == null && multiFactorInfo != null),
-      'Exactly one of factorUid or multiFactorInfo must be provided',
+      'Exactly one of `factorUid` or `multiFactorInfo` must be provided',
     );
     return _delegate.unenroll(
       factorUid: factorUid,

--- a/packages/firebase_auth/firebase_auth/lib/src/multi_factor.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/multi_factor.dart
@@ -33,6 +33,11 @@ class MultiFactor {
   /// [multiFactorInfo] is the [MultiFactorInfo] of the second factor to unenroll.
   /// Only one of [factorUid] or [multiFactorInfo] should be provided.
   Future<void> unenroll({String? factorUid, MultiFactorInfo? multiFactorInfo}) {
+    assert(
+      (factorUid != null && multiFactorInfo == null) ||
+          (factorUid == null && multiFactorInfo != null),
+      'Exactly one of factorUid or multiFactorInfo must be provided',
+    );
     return _delegate.unenroll(
       factorUid: factorUid,
       multiFactorInfo: multiFactorInfo,

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_multi_factor.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_multi_factor.dart
@@ -67,7 +67,7 @@ class MethodChannelMultiFactor extends MultiFactorPlatform {
   Future<void> unenroll({
     String? factorUid,
     MultiFactorInfo? multiFactorInfo,
-  }) {
+  }) async {
     final uidToUnenroll = factorUid ?? multiFactorInfo?.uid;
     if (uidToUnenroll == null) {
       throw ArgumentError(
@@ -76,7 +76,7 @@ class MethodChannelMultiFactor extends MultiFactorPlatform {
     }
 
     try {
-      return _api.unenroll(
+      await _api.unenroll(
         auth.app.name,
         uidToUnenroll,
       );

--- a/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_web_multi_factor.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_web_multi_factor.dart
@@ -50,7 +50,7 @@ class MultiFactorWeb extends MultiFactorPlatform {
   Future<void> unenroll({
     String? factorUid,
     MultiFactorInfo? multiFactorInfo,
-  }) {
+  }) async {
     final uidToUnenroll = factorUid ?? multiFactorInfo?.uid;
     if (uidToUnenroll == null) {
       throw ArgumentError(
@@ -59,7 +59,7 @@ class MultiFactorWeb extends MultiFactorPlatform {
     }
 
     try {
-      return _webMultiFactorUser.unenroll(
+      await _webMultiFactorUser.unenroll(
         uidToUnenroll,
       );
     } catch (e) {

--- a/tests/integration_test/firebase_auth/firebase_auth_multi_factor_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_multi_factor_e2e_test.dart
@@ -173,7 +173,8 @@ void main() {
         test(
           'should enroll and throw if trying to unenroll an unknown factor',
           () async {
-            String testPhoneNumber = '+441444555666';
+            final email = generateRandomEmail();
+            String testPhoneNumber = '+441444555667';
             User? user;
             UserCredential userCredential;
 
@@ -266,13 +267,12 @@ void main() {
             expect(enrolledFactors.length, 1);
             expect(enrolledFactors.first.displayName, 'My phone number');
 
-            try {
-              await user.multiFactor.unenroll(
+            await expectLater(
+              user.multiFactor.unenroll(
                 factorUid: 'unknown',
-              );
-            } catch (e) {
-              expect(e, isA<FirebaseAuthException>());
-            }
+              ),
+              throwsA(isA<FirebaseAuthException>()),
+            );
 
             final enrolledFactorsAfter = await multiFactor.getEnrolledFactors();
 

--- a/tests/integration_test/firebase_auth/firebase_auth_multi_factor_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_multi_factor_e2e_test.dart
@@ -272,7 +272,6 @@ void main() {
               );
             } catch (e) {
               expect(e, isA<FirebaseAuthException>());
-              expect((e as FirebaseAuthException).code, 'unenroll-failed');
             }
 
             final enrolledFactorsAfter = await multiFactor.getEnrolledFactors();

--- a/tests/integration_test/firebase_auth/firebase_auth_multi_factor_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_multi_factor_e2e_test.dart
@@ -279,6 +279,7 @@ void main() {
             // Assertions
             expect(enrolledFactorsAfter.length, 1);
           },
+          // iOS is skipped due to Recaptcha trying to load on a simulator in CI
           skip: kIsWeb || defaultTargetPlatform != TargetPlatform.android,
         );
 


### PR DESCRIPTION
## Description

By returning directly the Future and not await it, the error will never be catched by firebase.

## Related Issues

closes #10543 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
