### PR TITLE
docs(firebase_remote_config): add documentation what is returned when the key does not exist for `getBool`, `getInt`, `getDouble` and `getString`

### DIFF
--- a/packages/firebase_remote_config/firebase_remote_config/lib/src/firebase_remote_config.dart
+++ b/packages/firebase_remote_config/firebase_remote_config/lib/src/firebase_remote_config.dart
@@ -98,21 +98,29 @@ class FirebaseRemoteConfig extends FirebasePluginPlatform with ChangeNotifier {
   }
 
   /// Gets the value for a given key as a bool.
+  ///
+  /// Returns `false` if the key does not exist.
   bool getBool(String key) {
     return _delegate.getBool(key);
   }
 
   /// Gets the value for a given key as an int.
+  ///
+  /// Returns `0` if the key does not exist.
   int getInt(String key) {
     return _delegate.getInt(key);
   }
 
   /// Gets the value for a given key as a double.
+  ///
+  /// Returns `0.0` if the key does not exist.
   double getDouble(String key) {
     return _delegate.getDouble(key);
   }
 
   /// Gets the value for a given key as a String.
+  ///
+  /// Returns an empty String if the key does not exist.
   String getString(String key) {
     return _delegate.getString(key);
   }

--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/lib/src/platform_interface/platform_interface_firebase_remote_config.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/lib/src/platform_interface/platform_interface_firebase_remote_config.dart
@@ -135,21 +135,29 @@ abstract class FirebaseRemoteConfigPlatform extends PlatformInterface {
   }
 
   /// Gets the value for a given key as a bool.
+  ///
+  /// Returns `false` if the key does not exist.
   bool getBool(String key) {
     throw UnimplementedError('getBool() is not implemented');
   }
 
   /// Gets the value for a given key as an int.
+  ///
+  /// Returns `0` if the key does not exist.
   int getInt(String key) {
     throw UnimplementedError('getInt() is not implemented');
   }
 
   /// Gets the value for a given key as a double.
+  ///
+  /// Returns `0.0` if the key does not exist.
   double getDouble(String key) {
     throw UnimplementedError('getDouble() is not implemented');
   }
 
   /// Gets the value for a given key as a String.
+  ///
+  /// Returns an empty String if the key does not exist.
   String getString(String key) {
     throw UnimplementedError('getString() is not implemented');
   }

--- a/packages/firebase_remote_config/firebase_remote_config_web/lib/firebase_remote_config_web.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_web/lib/firebase_remote_config_web.dart
@@ -124,24 +124,32 @@ class FirebaseRemoteConfigWeb extends FirebaseRemoteConfigPlatform {
   }
 
   /// Gets the value for a given key as a bool.
+  ///
+  /// Returns `false` if the key does not exist.
   @override
   bool getBool(String key) {
     return _delegate.getBoolean(key);
   }
 
   /// Gets the value for a given key as an int.
+  ///
+  /// Returns `0` if the key does not exist.
   @override
   int getInt(String key) {
     return _delegate.getNumber(key).toInt();
   }
 
   /// Gets the value for a given key as a double.
+  ///
+  /// Returns `0.0` if the key does not exist.
   @override
   double getDouble(String key) {
     return _delegate.getNumber(key).toDouble();
   }
 
   /// Gets the value for a given key as a String.
+  ///
+  /// Returns an empty String if the key does not exist.
   @override
   String getString(String key) {
     return _delegate.getString(key);


### PR DESCRIPTION
## Description

You might expect that the methods are returning `null` or throwing an exception. But Firebase returns default values. Therefore, I added the values which are returned when the key for the methods does not exist.

Got the values from here:https://firebase.google.com/docs/reference/android/com/google/firebase/remoteconfig/FirebaseRemoteConfig

Zapp Online Demo for default values: https://zapp.run/edit/firebaseremoteconfig-3014-zd6206xrd630?entry=lib/main.dart&file=lib/main.dart

## Related Issues

...

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
