### PR TITLE
fix(firebase_storage_web): fix `Error: Unexpected null value.` when `metadata.timeCreated` or `metadata.updated`

### DIFF
--- a/packages/firebase_storage/firebase_storage_web/lib/src/utils/metadata.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/utils/metadata.dart
@@ -24,8 +24,8 @@ FullMetadata fbFullMetadataToFullMetadata(
     'metageneration': metadata.metageneration,
     'name': metadata.name,
     'size': metadata.size,
-    'creationTimeMillis': metadata.timeCreated!.millisecondsSinceEpoch,
-    'updatedTimeMillis': metadata.updated!.millisecondsSinceEpoch,
+    'creationTimeMillis': metadata.timeCreated?.millisecondsSinceEpoch,
+    'updatedTimeMillis': metadata.updated?.millisecondsSinceEpoch,
   });
 }
 


### PR DESCRIPTION
## Description

I had the issue when uploading a file and accessing `taskSnapshot.metadata` that a `Error: Unexpected null value.` was thrown. With a bit debugging I found out that at the beginning of the upload the `metadata.timeCreated` and (or? I'm not sure) `metadata.updated` are null. Because of the `!` the was `Error: Unexpected null value.` thrown.

## Related Issues

.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
