### PR TITLE
fix(firestore, ios): clean up event listeners on engine detach only

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestorePlugin.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestorePlugin.m
@@ -77,7 +77,7 @@ FlutterStandardMethodCodec *_codec;
 
 + (void)initialize {
   _codec =
-  [FlutterStandardMethodCodec codecWithReaderWriter:[FLTFirebaseFirestoreReaderWriter new]];
+      [FlutterStandardMethodCodec codecWithReaderWriter:[FLTFirebaseFirestoreReaderWriter new]];
 }
 
 #pragma mark - FlutterPlugin
@@ -111,12 +111,12 @@ FlutterStandardMethodCodec *_codec;
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   FlutterMethodChannel *channel =
-  [FlutterMethodChannel methodChannelWithName:kFLTFirebaseFirestoreChannelName
-                              binaryMessenger:[registrar messenger]
-                                        codec:_codec];
+      [FlutterMethodChannel methodChannelWithName:kFLTFirebaseFirestoreChannelName
+                                  binaryMessenger:[registrar messenger]
+                                            codec:_codec];
 
   FLTFirebaseFirestorePlugin *instance =
-  [[FLTFirebaseFirestorePlugin alloc] init:[registrar messenger]];
+      [[FLTFirebaseFirestorePlugin alloc] init:[registrar messenger]];
   [registrar addMethodCallDelegate:instance channel:channel];
 
 #if TARGET_OS_OSX

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestorePlugin.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestorePlugin.m
@@ -246,7 +246,6 @@ FlutterStandardMethodCodec *_codec;
 #pragma mark - FLTFirebasePlugin
 
 - (void)didReinitializeFirebaseCore:(void (^)(void))completion {
-  NSLog(@"didReinitializeFirebaseCore 111111");
   [self cleanupEventListeners];
   [self cleanupFirestoreInstances:completion];
 }

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestorePlugin.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestorePlugin.m
@@ -77,7 +77,7 @@ FlutterStandardMethodCodec *_codec;
 
 + (void)initialize {
   _codec =
-      [FlutterStandardMethodCodec codecWithReaderWriter:[FLTFirebaseFirestoreReaderWriter new]];
+  [FlutterStandardMethodCodec codecWithReaderWriter:[FLTFirebaseFirestoreReaderWriter new]];
 }
 
 #pragma mark - FlutterPlugin
@@ -111,12 +111,12 @@ FlutterStandardMethodCodec *_codec;
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   FlutterMethodChannel *channel =
-      [FlutterMethodChannel methodChannelWithName:kFLTFirebaseFirestoreChannelName
-                                  binaryMessenger:[registrar messenger]
-                                            codec:_codec];
+  [FlutterMethodChannel methodChannelWithName:kFLTFirebaseFirestoreChannelName
+                              binaryMessenger:[registrar messenger]
+                                        codec:_codec];
 
   FLTFirebaseFirestorePlugin *instance =
-      [[FLTFirebaseFirestorePlugin alloc] init:[registrar messenger]];
+  [[FLTFirebaseFirestorePlugin alloc] init:[registrar messenger]];
   [registrar addMethodCallDelegate:instance channel:channel];
 
 #if TARGET_OS_OSX
@@ -126,7 +126,7 @@ FlutterStandardMethodCodec *_codec;
 #endif
 }
 
-- (void)cleanupWithCompletion:(void (^)(void))completion {
+- (void)cleanupEventListeners {
   for (FlutterEventChannel *channel in self->_eventChannels) {
     [channel setStreamHandler:nil];
   }
@@ -139,7 +139,9 @@ FlutterStandardMethodCodec *_codec;
   @synchronized(self->_transactions) {
     [self->_transactions removeAllObjects];
   }
+}
 
+- (void)cleanupFirestoreInstances:(void (^)(void))completion {
   __block int instancesTerminated = 0;
   NSUInteger numberOfApps = [[FIRApp allApps] count];
   void (^firestoreTerminateInstanceCompletion)(NSError *) = ^void(NSError *error) {
@@ -165,7 +167,7 @@ FlutterStandardMethodCodec *_codec;
 }
 
 - (void)detachFromEngineForRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
-  [self cleanupWithCompletion:nil];
+  [self cleanupEventListeners];
 }
 
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)flutterResult {
@@ -244,7 +246,9 @@ FlutterStandardMethodCodec *_codec;
 #pragma mark - FLTFirebasePlugin
 
 - (void)didReinitializeFirebaseCore:(void (^)(void))completion {
-  [self cleanupWithCompletion:completion];
+  NSLog(@"didReinitializeFirebaseCore 111111");
+  [self cleanupEventListeners];
+  [self cleanupFirestoreInstances:completion];
 }
 
 - (NSDictionary *_Nonnull)pluginConstantsForFIRApp:(FIRApp *)firebase_app {


### PR DESCRIPTION
## Description

As observed by this [user's comment](https://github.com/firebase/flutterfire/issues/10504#issuecomment-1458911747), there is a difference between iOS and android clean up implementation for Firestore.

## Previous behaviour
iOS cleans up Firestore instances & event listeners on Flutter engine detachment & reinitialisation of core. 

android cleans up event listeners only on Flutter engine detachment. Firestore instances & event listeners are cleaned up on reinitialisation of core.

## New behaviour
Made iOS the same as android. 


## Is this correct?
I've had a play, hot reloading and putting phone into background state. It doesn't affect the behaviour. I couldn't find anything more comprehensive on situations when the Flutter engine is detached which might make this implementation a problem. If there are any concerns about this then please comment on the PR.

## Related Issues

closes https://github.com/firebase/flutterfire/issues/10504

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
