### PR TITLE
fix(firebase_ui_auth): pass breakpoint from RegisterScreen to LoginScreen

### DIFF
--- a/packages/firebase_ui_auth/lib/src/screens/register_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/register_screen.dart
@@ -126,6 +126,7 @@ class RegisterScreen extends MultiProviderScreen {
         showAuthActionSwitch: showAuthActionSwitch,
         subtitleBuilder: subtitleBuilder,
         footerBuilder: footerBuilder,
+        breakpoint: breakpoint,
       ),
     );
   }


### PR DESCRIPTION
## Description

Pass the breakpoint from RegisterScreen to LoginScreen.
Changing the breakpoint had no effect on the RegisterScreen.

## Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.