### PR TITLE
feat(ui_shared): extract common widgets to a shared library

### DIFF
--- a/packages/firebase_ui_auth/example/pubspec.yaml
+++ b/packages/firebase_ui_auth/example/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   firebase_ui_oauth_twitter: ^1.0.24
 dev_dependencies:
   drive: ^1.0.0-1.0.nullsafety.1
+  firebase_ui_shared: ^1.0.0
   flutter_facebook_auth: ^4.4.1
   flutter_driver:
     sdk: flutter

--- a/packages/firebase_ui_auth/example/pubspec_overrides.yaml
+++ b/packages/firebase_ui_auth/example/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth,firebase_ui_oauth_apple,firebase_ui_oauth_facebook,firebase_ui_oauth_google,firebase_ui_oauth_twitter
+# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth,firebase_ui_oauth_apple,firebase_ui_oauth_facebook,firebase_ui_oauth_google,firebase_ui_oauth_twitter,firebase_ui_shared
 dependency_overrides:
   intl: ^0.18.0
   _flutterfire_internals:
@@ -33,3 +33,5 @@ dependency_overrides:
     path: ../../firebase_ui_oauth_google
   firebase_ui_oauth_twitter:
     path: ../../firebase_ui_oauth_twitter
+  firebase_ui_shared:
+    path: ../../firebase_ui_shared

--- a/packages/firebase_ui_auth/example/test_driver/email_form_test.dart
+++ b/packages/firebase_ui_auth/example/test_driver/email_form_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';

--- a/packages/firebase_ui_auth/lib/firebase_ui_auth.dart
+++ b/packages/firebase_ui_auth/lib/firebase_ui_auth.dart
@@ -7,6 +7,8 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_ui_oauth/firebase_ui_oauth.dart';
 import 'package:flutter/widgets.dart';
 
+export 'package:firebase_ui_shared/firebase_ui_shared.dart' show ButtonVariant;
+
 import 'src/actions.dart';
 import 'src/oauth_providers.dart';
 import 'src/providers/auth_provider.dart';
@@ -37,7 +39,6 @@ export 'src/flows/phone_auth_flow.dart';
 export 'src/flows/universal_email_sign_in_flow.dart';
 // ignore_for_file: use_build_context_synchronously
 
-export 'src/loading_indicator.dart';
 export 'src/mfa.dart' show startMFAVerification;
 export 'src/navigation/authentication.dart';
 export 'src/navigation/forgot_password.dart';
@@ -84,7 +85,6 @@ export 'src/widgets/error_text.dart' show ErrorText;
 export 'src/widgets/forgot_password_button.dart';
 export 'src/widgets/internal/oauth_provider_button.dart'
     show OAuthProviderButton, OAuthButtonVariant;
-export 'src/widgets/internal/universal_button.dart' show ButtonVariant;
 export 'src/widgets/layout_flow_aware_padding.dart';
 export 'src/widgets/password_input.dart';
 export 'src/widgets/phone_input.dart' show PhoneInputState, PhoneInput;

--- a/packages/firebase_ui_auth/lib/src/screens/email_link_sign_in_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/email_link_sign_in_screen.dart
@@ -3,12 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart' hide EmailAuthProvider;
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
 import 'internal/provider_screen.dart';
 import 'internal/responsive_page.dart';
-import '../widgets/internal/universal_scaffold.dart';
 
 /// {@template ui.auth.screens.email_link_sign_in_screen}
 /// A screen that provides a UI for authentication using email link.

--- a/packages/firebase_ui_auth/lib/src/screens/email_verification_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/email_verification_screen.dart
@@ -3,15 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart' hide Title;
 import 'package:flutter/scheduler.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 
-import '../widgets/internal/loading_button.dart';
 import '../widgets/internal/title.dart';
-import '../widgets/internal/universal_button.dart';
-import '../widgets/internal/universal_scaffold.dart';
 
 import 'internal/responsive_page.dart';
 

--- a/packages/firebase_ui_auth/lib/src/screens/forgot_password_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/forgot_password_screen.dart
@@ -2,11 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
-import '../widgets/internal/universal_scaffold.dart';
 import 'internal/responsive_page.dart';
 
 /// A password reset screen.

--- a/packages/firebase_ui_auth/lib/src/screens/internal/login_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/internal/login_screen.dart
@@ -2,11 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
-
-import '../../widgets/internal/universal_scaffold.dart';
 
 import 'responsive_page.dart';
 

--- a/packages/firebase_ui_auth/lib/src/screens/phone_input_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/phone_input_screen.dart
@@ -4,13 +4,12 @@
 
 import 'package:firebase_auth/firebase_auth.dart'
     show FirebaseAuth, MultiFactorSession, PhoneMultiFactorInfo;
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/widgets.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 
-import '../widgets/internal/universal_button.dart';
 import '../widgets/internal/universal_page_route.dart';
-import '../widgets/internal/universal_scaffold.dart';
 
 import 'internal/responsive_page.dart';
 

--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -11,7 +11,7 @@ import 'package:firebase_auth/firebase_auth.dart'
         PhoneAuthCredential,
         PhoneMultiFactorGenerator,
         User;
-import 'package:firebase_ui_auth/src/widgets/internal/universal_icon.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart' hide Title;
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:flutter/material.dart' hide Title;
@@ -20,8 +20,6 @@ import 'package:firebase_ui_oauth/firebase_ui_oauth.dart'
     hide OAuthProviderButtonBase;
 import 'package:flutter/services.dart';
 
-import '../widgets/internal/loading_button.dart';
-import '../widgets/internal/universal_button.dart';
 import '../widgets/internal/rebuild_scope.dart';
 import '../widgets/internal/subtitle.dart';
 import '../widgets/internal/universal_icon_button.dart';

--- a/packages/firebase_ui_auth/lib/src/screens/sms_code_input_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/sms_code_input_screen.dart
@@ -3,12 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 
-import '../widgets/internal/universal_button.dart';
-import '../widgets/internal/universal_scaffold.dart';
 import '../screens/internal/responsive_page.dart';
 
 /// A screen displaying a UI which allows users to enter an SMS validation code

--- a/packages/firebase_ui_auth/lib/src/screens/universal_email_sign_in_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/universal_email_sign_in_screen.dart
@@ -3,10 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import '../widgets/internal/universal_page_route.dart';
-import '../widgets/internal/universal_scaffold.dart';
 import 'internal/multi_provider_screen.dart';
 
 /// A screen that allows to resolve previously used providers for a given email.

--- a/packages/firebase_ui_auth/lib/src/views/email_link_sign_in_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/email_link_sign_in_view.dart
@@ -3,11 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/widgets.dart' hide Title;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 
-import '../widgets/internal/loading_button.dart';
 import '../widgets/internal/title.dart';
 
 /// {@template ui.auth.views.email_link_sign_in_view}

--- a/packages/firebase_ui_auth/lib/src/views/find_providers_for_email_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/find_providers_for_email_view.dart
@@ -3,10 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart' hide Title;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
-import '../widgets/internal/loading_button.dart';
 
 import '../widgets/internal/title.dart';
 

--- a/packages/firebase_ui_auth/lib/src/views/forgot_password_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/forgot_password_view.dart
@@ -2,15 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart' hide Title;
 
 import 'package:firebase_auth/firebase_auth.dart'
     show ActionCodeSettings, FirebaseAuth, FirebaseAuthException;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
-import '../widgets/internal/universal_button.dart';
-
-import '../widgets/internal/loading_button.dart';
 import '../widgets/internal/title.dart';
 
 /// {@template ui.auth.views.forgot_password_view}

--- a/packages/firebase_ui_auth/lib/src/views/phone_input_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/phone_input_view.dart
@@ -3,10 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/widgets.dart' hide Title;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
-import '../widgets/internal/universal_button.dart';
 
 import '../widgets/internal/title.dart';
 

--- a/packages/firebase_ui_auth/lib/src/views/sms_code_input_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/sms_code_input_view.dart
@@ -3,12 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
-
-import '../widgets/internal/universal_button.dart';
 
 typedef SMSCodeSubmitCallback = void Function(String smsCode);
 

--- a/packages/firebase_ui_auth/lib/src/widgets/delete_account_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/delete_account_button.dart
@@ -6,10 +6,9 @@ import 'package:firebase_auth/firebase_auth.dart'
     show FirebaseAuth, FirebaseAuthException;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-
-import '../widgets/internal/loading_button.dart';
 
 typedef DeleteFailedCallback = void Function(Exception exception);
 typedef SignInRequiredCallback = Future<bool> Function();
@@ -29,8 +28,8 @@ class DeleteAccountButton extends StatefulWidget {
   /// A callback that is called if the account deletion fails.
   final DeleteFailedCallback? onDeleteFailed;
 
-  /// {@macro ui.auth.widgets.button_variant}
-  final ButtonVariant? variant;
+  /// {@macro ui.shared.widgets.button_variant}
+  final ButtonVariant variant;
 
   /// {@macro ui.auth.widgets.delete_account_button}
   const DeleteAccountButton({
@@ -38,7 +37,7 @@ class DeleteAccountButton extends StatefulWidget {
     this.auth,
     this.onSignInRequired,
     this.onDeleteFailed,
-    this.variant,
+    this.variant = ButtonVariant.filled,
   }) : super(key: key);
 
   @override

--- a/packages/firebase_ui_auth/lib/src/widgets/different_method_sign_in_dialog.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/different_method_sign_in_dialog.dart
@@ -3,12 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart' hide Title;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 
 import '../widgets/internal/title.dart';
-import 'internal/universal_button.dart';
 
 /// {@template ui.auth.widgets.different_method_sign_in_dialog}
 /// A dialog that is shown when the user tries to sign in with a provider that

--- a/packages/firebase_ui_auth/lib/src/widgets/editable_user_display_name.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/editable_user_display_name.dart
@@ -3,8 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:flutter/material.dart';
 

--- a/packages/firebase_ui_auth/lib/src/widgets/email_form.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/email_form.dart
@@ -5,9 +5,9 @@
 import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart';
 
-import '../widgets/internal/loading_button.dart';
 import '../validators.dart';
 
 /// {@template ui.auth.widgets.email_form.forgot_password_action}
@@ -56,7 +56,7 @@ typedef EmailFormSubmitCallback = void Function(String email, String password);
 /// {@endtemplate}
 class EmailFormStyle extends FirebaseUIStyle {
   /// A [ButtonVariant] that should be used for the sign in button.
-  final ButtonVariant? signInButtonVariant;
+  final ButtonVariant signInButtonVariant;
 
   /// An override of the global [ThemeData.inputDecorationTheme].
   final InputDecorationTheme? inputDecorationTheme;

--- a/packages/firebase_ui_auth/lib/src/widgets/email_link_sign_in_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/email_link_sign_in_button.dart
@@ -3,12 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 
-import 'internal/universal_button.dart';
 import 'internal/universal_page_route.dart';
 
 /// {@template ui.auth.widget.email_link_sign_in_button}

--- a/packages/firebase_ui_auth/lib/src/widgets/forgot_password_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/forgot_password_button.dart
@@ -2,11 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
-
-import 'internal/universal_button.dart';
 
 /// {@template ui.auth.widget.forgot_password_button}
 /// A button that has a localized "Forgot password" label.

--- a/packages/firebase_ui_auth/lib/src/widgets/internal/oauth_provider_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/internal/oauth_provider_button.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart' hide OAuthProvider;
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';

--- a/packages/firebase_ui_auth/lib/src/widgets/internal/subtitle.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/internal/subtitle.dart
@@ -2,10 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-
-import 'platform_widget.dart';
 
 class Subtitle extends PlatformWidget {
   final String text;

--- a/packages/firebase_ui_auth/lib/src/widgets/internal/title.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/internal/title.dart
@@ -2,10 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-
-import 'platform_widget.dart';
 
 class Title extends PlatformWidget {
   final String text;

--- a/packages/firebase_ui_auth/lib/src/widgets/internal/universal_icon_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/internal/universal_icon_button.dart
@@ -2,10 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-
-import 'platform_widget.dart';
 
 class UniversalIconButton extends PlatformWidget {
   final IconData cupertinoIcon;

--- a/packages/firebase_ui_auth/lib/src/widgets/internal/universal_text_form_field.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/internal/universal_text_form_field.dart
@@ -2,10 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'platform_widget.dart';
 
 /// {@template ui.auth.widgets.internal.universal_text_form_field}
 /// Uses [TextFormField] under mateiral library and [CupertinoTextFormFieldRow]

--- a/packages/firebase_ui_auth/lib/src/widgets/phone_verification_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/phone_verification_button.dart
@@ -3,10 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/material.dart';
-import '../widgets/internal/universal_button.dart';
 
 /// {@template ui.auth.widgets.phone_verification_button}
 /// A button that triggers phone verification flow.

--- a/packages/firebase_ui_auth/lib/src/widgets/reauthenticate_dialog.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/reauthenticate_dialog.dart
@@ -3,12 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/material.dart' hide Title;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 
 import 'internal/title.dart';
-import 'internal/universal_button.dart';
 
 /// {@template ui.auth.widgets.reauthenticate_dialog}
 /// A dialog that prompts the user to re-authenticate their account

--- a/packages/firebase_ui_auth/lib/src/widgets/sign_out_button.dart
+++ b/packages/firebase_ui_auth/lib/src/widgets/sign_out_button.dart
@@ -3,12 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:firebase_ui_localizations/firebase_ui_localizations.dart';
 import 'package:flutter/material.dart';
-
-import '../widgets/internal/universal_button.dart';
 
 /// {@template ui.auth.widgets.sign_out_button}
 /// A button that signs out the user when pressed.
@@ -17,14 +16,14 @@ class SignOutButton extends StatelessWidget {
   /// {@macro ui.auth.auth_controller.auth}
   final FirebaseAuth? auth;
 
-  /// {@macro ui.auth.widgets.button_variant}
-  final ButtonVariant? variant;
+  /// {@macro ui.shared.widgets.button_variant}
+  final ButtonVariant variant;
 
   /// {@macro ui.auth.widgets.sign_out_button}
   const SignOutButton({
     Key? key,
     this.auth,
-    this.variant,
+    this.variant = ButtonVariant.filled,
   }) : super(key: key);
 
   @override

--- a/packages/firebase_ui_auth/pubspec.yaml
+++ b/packages/firebase_ui_auth/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   firebase_dynamic_links: ^5.0.17
   firebase_ui_localizations: ^1.2.0
   firebase_ui_oauth: ^1.1.17
+  firebase_ui_shared: ^1.0.0
   flutter:
     sdk: flutter
   flutter_localizations:

--- a/packages/firebase_ui_auth/pubspec_overrides.yaml
+++ b/packages/firebase_ui_auth/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_localizations,firebase_ui_oauth
+# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_localizations,firebase_ui_oauth,firebase_ui_shared
 dependency_overrides:
   intl: ^0.18.0
   _flutterfire_internals:
@@ -23,3 +23,5 @@ dependency_overrides:
     path: ../firebase_ui_localizations
   firebase_ui_oauth:
     path: ../firebase_ui_oauth
+  firebase_ui_shared:
+    path: ../firebase_ui_shared

--- a/packages/firebase_ui_localizations/example/pubspec_overrides.yaml
+++ b/packages/firebase_ui_localizations/example/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth
+# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth,firebase_ui_shared
 dependency_overrides:
   intl: ^0.18.0
   _flutterfire_internals:
@@ -25,3 +25,5 @@ dependency_overrides:
     path: ..
   firebase_ui_oauth:
     path: ../../firebase_ui_oauth
+  firebase_ui_shared:
+    path: ../../firebase_ui_shared

--- a/packages/firebase_ui_oauth/example/pubspec_overrides.yaml
+++ b/packages/firebase_ui_oauth/example/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth,firebase_ui_oauth_apple,firebase_ui_oauth_facebook,firebase_ui_oauth_google,firebase_ui_oauth_twitter
+# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth,firebase_ui_oauth_apple,firebase_ui_oauth_facebook,firebase_ui_oauth_google,firebase_ui_oauth_twitter,firebase_ui_shared
 dependency_overrides:
   intl: ^0.18.0
   _flutterfire_internals:
@@ -33,3 +33,5 @@ dependency_overrides:
     path: ../../firebase_ui_oauth_google
   firebase_ui_oauth_twitter:
     path: ../../firebase_ui_oauth_twitter
+  firebase_ui_shared:
+    path: ../../firebase_ui_shared

--- a/packages/firebase_ui_oauth/lib/firebase_ui_oauth.dart
+++ b/packages/firebase_ui_oauth/lib/firebase_ui_oauth.dart
@@ -15,3 +15,6 @@ export './src/oauth_provider_button_style.dart';
 
 export 'package:firebase_ui_auth/firebase_ui_auth.dart'
     show AuthAction, AuthCancelledException;
+
+export 'package:firebase_ui_shared/firebase_ui_shared.dart'
+    show ThemedColor, ThemedIconSrc;

--- a/packages/firebase_ui_oauth/lib/src/oauth_provider_button_style.dart
+++ b/packages/firebase_ui_oauth/lib/src/oauth_provider_button_style.dart
@@ -4,39 +4,7 @@
 
 import 'package:flutter/services.dart';
 
-/// {@template ui.oauth.themed_value}
-/// An object that is used to resolve the value base on the current theme
-/// brightness.
-/// {@endtemplate}
-class ThemedValue<T> {
-  /// The value that should be used to when the dark theme is used.
-  final T dark;
-
-  /// The value that should be used to when the light theme is used.
-  final T light;
-
-  const ThemedValue(this.dark, this.light);
-
-  T getValue(Brightness brightness) {
-    switch (brightness) {
-      case Brightness.dark:
-        return dark;
-      case Brightness.light:
-        return light;
-    }
-  }
-}
-
-class ThemedColor extends ThemedValue<Color> {
-  const ThemedColor(Color dark, Color light) : super(dark, light);
-}
-
-class ThemedIconSrc extends ThemedValue<String> {
-  const ThemedIconSrc(
-    String dark,
-    String light,
-  ) : super(dark, light);
-}
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 
 /// {@template ui.oauth.themed_oauth_provider_button_style}
 /// An object that is being used to resolve a style of the button.

--- a/packages/firebase_ui_oauth/pubspec_overrides.yaml
+++ b/packages/firebase_ui_oauth/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth_google
+# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth_google,firebase_ui_shared
 dependency_overrides:
   intl: ^0.18.0
   _flutterfire_internals:
@@ -25,3 +25,5 @@ dependency_overrides:
     path: ../firebase_ui_localizations
   firebase_ui_oauth_google:
     path: ../firebase_ui_oauth_google
+  firebase_ui_shared:
+    path: ../firebase_ui_shared

--- a/packages/firebase_ui_oauth_apple/pubspec_overrides.yaml
+++ b/packages/firebase_ui_oauth_apple/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth
+# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth,firebase_ui_shared
 dependency_overrides:
   intl: ^0.18.0
   _flutterfire_internals:
@@ -25,3 +25,5 @@ dependency_overrides:
     path: ../firebase_ui_localizations
   firebase_ui_oauth:
     path: ../firebase_ui_oauth
+  firebase_ui_shared:
+    path: ../firebase_ui_shared

--- a/packages/firebase_ui_oauth_facebook/pubspec_overrides.yaml
+++ b/packages/firebase_ui_oauth_facebook/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth
+# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth,firebase_ui_shared
 dependency_overrides:
   intl: ^0.18.0
   _flutterfire_internals:
@@ -25,3 +25,5 @@ dependency_overrides:
     path: ../firebase_ui_localizations
   firebase_ui_oauth:
     path: ../firebase_ui_oauth
+  firebase_ui_shared:
+    path: ../firebase_ui_shared

--- a/packages/firebase_ui_oauth_google/pubspec_overrides.yaml
+++ b/packages/firebase_ui_oauth_google/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth
+# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth,firebase_ui_shared
 dependency_overrides:
   intl: ^0.18.0
   _flutterfire_internals:
@@ -25,3 +25,5 @@ dependency_overrides:
     path: ../firebase_ui_localizations
   firebase_ui_oauth:
     path: ../firebase_ui_oauth
+  firebase_ui_shared:
+    path: ../firebase_ui_shared

--- a/packages/firebase_ui_oauth_twitter/pubspec_overrides.yaml
+++ b/packages/firebase_ui_oauth_twitter/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth
+# melos_managed_dependency_overrides: _flutterfire_internals,firebase_auth,firebase_auth_platform_interface,firebase_auth_web,firebase_core,firebase_core_platform_interface,firebase_core_web,firebase_dynamic_links,firebase_dynamic_links_platform_interface,firebase_ui_auth,firebase_ui_localizations,firebase_ui_oauth,firebase_ui_shared
 dependency_overrides:
   intl: ^0.18.0
   _flutterfire_internals:
@@ -25,3 +25,5 @@ dependency_overrides:
     path: ../firebase_ui_localizations
   firebase_ui_oauth:
     path: ../firebase_ui_oauth
+  firebase_ui_shared:
+    path: ../firebase_ui_shared

--- a/packages/firebase_ui_shared/.gitignore
+++ b/packages/firebase_ui_shared/.gitignore
@@ -1,0 +1,30 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.packages
+build/

--- a/packages/firebase_ui_shared/.metadata
+++ b/packages/firebase_ui_shared/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: c07f7888888435fd9df505aa2efc38d3cf65681b
+  channel: stable
+
+project_type: package

--- a/packages/firebase_ui_shared/CHANGELOG.md
+++ b/packages/firebase_ui_shared/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.0.1
+## 1.0.0
 
-* TODO: Describe initial release.
+- initial release

--- a/packages/firebase_ui_shared/CHANGELOG.md
+++ b/packages/firebase_ui_shared/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+* TODO: Describe initial release.

--- a/packages/firebase_ui_shared/LICENSE
+++ b/packages/firebase_ui_shared/LICENSE
@@ -1,0 +1,1 @@
+TODO: Add your license here.

--- a/packages/firebase_ui_shared/LICENSE
+++ b/packages/firebase_ui_shared/LICENSE
@@ -1,1 +1,26 @@
-TODO: Add your license here.
+Copyright 2017, the Chromium project authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/firebase_ui_shared/README.md
+++ b/packages/firebase_ui_shared/README.md
@@ -1,0 +1,39 @@
+<!--
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages).
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages).
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder.
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to
+contribute to the package, how to file issues, what response they can expect
+from the package authors, and more.

--- a/packages/firebase_ui_shared/README.md
+++ b/packages/firebase_ui_shared/README.md
@@ -1,39 +1,19 @@
-<!--
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
+## Firebase UI Shared
 
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/guides/libraries/writing-package-pages).
-
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-library-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/developing-packages).
--->
-
-TODO: Put a short description of the package here that helps potential users
-know whether this package might be useful for them.
-
-## Features
-
-TODO: List what your package can do. Maybe include images, gifs, or videos.
+A library of shared components used across Firebase UI packages
 
 ## Getting started
 
-TODO: List prerequisites and provide or point to information on how to
-start using the package.
+Add dependency
+
+```sh
+flutter pub add firebase_ui_shared
+```
 
 ## Usage
 
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder.
+See [API docs](https://pub.dev/documentation/firebase_ui_shared/latest/)
 
-```dart
-const like = 'sample';
-```
+## License
 
-## Additional information
-
-TODO: Tell users more about the package: where to find more information, how to
-contribute to the package, how to file issues, what response they can expect
-from the package authors, and more.
+MIT

--- a/packages/firebase_ui_shared/analysis_options.yaml
+++ b/packages/firebase_ui_shared/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/packages/firebase_ui_shared/lib/firebase_ui_shared.dart
+++ b/packages/firebase_ui_shared/lib/firebase_ui_shared.dart
@@ -1,0 +1,1 @@
+export 'src/themed.dart' show ThemedValue, ThemedColor, ThemedIconSrc;

--- a/packages/firebase_ui_shared/lib/firebase_ui_shared.dart
+++ b/packages/firebase_ui_shared/lib/firebase_ui_shared.dart
@@ -1,1 +1,7 @@
 export 'src/themed.dart' show ThemedValue, ThemedColor, ThemedIconSrc;
+export 'src/platform_widget.dart' show PlatformWidget;
+export 'src/loading_indicator.dart' show LoadingIndicator;
+export 'src/universal_scaffold.dart' show UniversalScaffold;
+export 'src/universal_icon.dart' show UniversalIcon;
+export 'src/universal_button.dart' show UniversalButton, ButtonVariant;
+export 'src/loading_button.dart' show LoadingButton;

--- a/packages/firebase_ui_shared/lib/src/loading_button.dart
+++ b/packages/firebase_ui_shared/lib/src/loading_button.dart
@@ -44,13 +44,30 @@ class _LoadingButtonContent extends StatelessWidget {
   }
 }
 
+/// Button widget that uses [CupertinoButton] under [CupertinoApp] and
+/// [TextButton], [ElevatedButton] or [OutlinedButton] under [MaterialApp]
+/// which is also capable of displaying a loading indicator when [isLoading] is
+/// set to true.
 class LoadingButton extends StatelessWidget {
+  /// Indicates that a loading indicator should be displayed.
   final bool isLoading;
+
+  /// The text to display in the button.
   final String label;
+
+  /// The icon to display in the button.
   final IconData? icon;
+
+  /// The color of the button background.
   final Color? color;
+
+  /// The color of the button content.
   final Color? labelColor;
+
+  /// A callback that is called when the button is pressed.
   final VoidCallback onTap;
+
+  /// The variant of the button. See [ButtonVariant] for more information.
   final ButtonVariant variant;
 
   const LoadingButton({

--- a/packages/firebase_ui_shared/lib/src/loading_button.dart
+++ b/packages/firebase_ui_shared/lib/src/loading_button.dart
@@ -2,11 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_ui_auth/firebase_ui_auth.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-
-import 'universal_button.dart';
 
 class _LoadingButtonContent extends StatelessWidget {
   final String label;
@@ -53,7 +51,7 @@ class LoadingButton extends StatelessWidget {
   final Color? color;
   final Color? labelColor;
   final VoidCallback onTap;
-  final ButtonVariant? variant;
+  final ButtonVariant variant;
 
   const LoadingButton({
     Key? key,

--- a/packages/firebase_ui_shared/lib/src/loading_indicator.dart
+++ b/packages/firebase_ui_shared/lib/src/loading_indicator.dart
@@ -2,11 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
-import './widgets/internal/platform_widget.dart';
-
+/// A loading indicator that uses [CupertinoActivityIndicator] under
+/// [CupertinoApp] and [CircularProgressIndicator] under [MaterialApp].
+///
+/// Centered by default.
 class LoadingIndicator extends PlatformWidget {
   final double size;
   final double borderWidth;

--- a/packages/firebase_ui_shared/lib/src/loading_indicator.dart
+++ b/packages/firebase_ui_shared/lib/src/loading_indicator.dart
@@ -11,8 +11,15 @@ import 'package:flutter/material.dart';
 ///
 /// Centered by default.
 class LoadingIndicator extends PlatformWidget {
+  /// The size of the loading indicator.
   final double size;
+
+  /// The width of the loading indicator's border.
+  /// This is only used for [CircularProgressIndicator] under [MaterialApp].
   final double borderWidth;
+
+  /// The color of the loading indicator.
+  /// This is only used for [CircularProgressIndicator] under [MaterialApp].
   final Color? color;
 
   const LoadingIndicator({

--- a/packages/firebase_ui_shared/lib/src/platform_widget.dart
+++ b/packages/firebase_ui_shared/lib/src/platform_widget.dart
@@ -3,7 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
+/// Platform-aware widget that renders a different widget depending on the
+/// type of the app. Requires implementation of [buildCupertino] if
+/// [CupertinoApp] is used, and [buildMaterial] if [MaterialApp] is used.
+/// Optionally, [buildWrapper] can be implemented to have a common wrapper
+/// widget for both types of apps.
 abstract class PlatformWidget extends StatelessWidget {
   const PlatformWidget({Key? key}) : super(key: key);
 

--- a/packages/firebase_ui_shared/lib/src/themed.dart
+++ b/packages/firebase_ui_shared/lib/src/themed.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-/// {@template ui.oauth.themed_value}
-/// An object that is used to resolve the value base on the current theme
-/// brightness.
+/// {@template ui.shared.themed_value}
+/// Helper class that helps to resolve a value based on the current app
+/// [Brightness].
 /// {@endtemplate}
 class ThemedValue<T> {
   /// The value that should be used to when the dark theme is used.
@@ -24,10 +24,29 @@ class ThemedValue<T> {
   }
 }
 
+/// A [ThemedValue] that resolves to [Color].
+///
+/// ```dart
+/// final textColor = ThemedColor(Colors.white, Colors.black);
+///
+/// color.getValue(Brightness.dark); // Colors.black
+/// color.getValue(Brightness.light); // Colors.white
+/// ```
 class ThemedColor extends ThemedValue<Color> {
   const ThemedColor(super.dark, super.light);
 }
 
+/// A [ThemedValue] that resolves to [String].
+///
+/// ```dart
+/// final iconSrc = ThemedIconSrc(
+///   'assets/icon_light.png',
+///   'assets/icon_dark.png',
+/// );
+///
+/// iconSrc.getValue(Brightness.dark); // 'assets/icon_light.png'
+/// iconSrc.getValue(Brightness.light); // 'assets/icon_dark.png'
+/// ```
 class ThemedIconSrc extends ThemedValue<String> {
   const ThemedIconSrc(super.dark, super.light);
 }

--- a/packages/firebase_ui_shared/lib/src/themed.dart
+++ b/packages/firebase_ui_shared/lib/src/themed.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+/// {@template ui.oauth.themed_value}
+/// An object that is used to resolve the value base on the current theme
+/// brightness.
+/// {@endtemplate}
+class ThemedValue<T> {
+  /// The value that should be used to when the dark theme is used.
+  final T dark;
+
+  /// The value that should be used to when the light theme is used.
+  final T light;
+
+  const ThemedValue(this.dark, this.light);
+
+  T getValue(Brightness brightness) {
+    switch (brightness) {
+      case Brightness.dark:
+        return dark;
+      case Brightness.light:
+        return light;
+    }
+  }
+}
+
+class ThemedColor extends ThemedValue<Color> {
+  const ThemedColor(super.dark, super.light);
+}
+
+class ThemedIconSrc extends ThemedValue<String> {
+  const ThemedIconSrc(super.dark, super.light);
+}

--- a/packages/firebase_ui_shared/lib/src/universal_button.dart
+++ b/packages/firebase_ui_shared/lib/src/universal_button.dart
@@ -2,12 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
-import 'platform_widget.dart';
-
-/// {@template ui.auth.widgets.button_variant}
+/// {@template ui.shared.widgets.button_variant}
 /// An enumeration of the possible button variants.
 /// {@endtemplate}
 enum ButtonVariant {
@@ -21,14 +20,36 @@ enum ButtonVariant {
   outlined,
 }
 
+/// Button widget that uses [CupertinoButton] under [CupertinoApp] and
+/// [TextButton], [ElevatedButton] or [OutlinedButton] under [MaterialApp]
+/// depending on provided [variant].
 class UniversalButton extends PlatformWidget {
+  /// A callback that is called when the button is pressed.
   final VoidCallback? onPressed;
+
+  /// The text to display in the button.
+  /// If [child] is provided, this will be ignored.
   final String? text;
+
+  /// The child to display in the button.
   final Widget? child;
+
+  /// The icon to display in the button.
   final IconData? icon;
+
+  /// Defines the order of the icon and the label.
+  /// Icon will be placed on the left if [TextDirection.ltr] and on the right
+  /// if [TextDirection.rtl].
   final TextDirection? direction;
-  final ButtonVariant? variant;
+
+  /// The variant of the button.
+  /// If not provided, [ButtonVariant.filled] will be used.
+  final ButtonVariant variant;
+
+  /// The color of the button background.
   final Color? color;
+
+  /// The color of the button content.
   final Color? contentColor;
 
   const UniversalButton({
@@ -38,15 +59,11 @@ class UniversalButton extends PlatformWidget {
     this.onPressed,
     this.icon,
     this.direction = TextDirection.ltr,
-    this.variant,
+    this.variant = ButtonVariant.filled,
     this.color,
     this.contentColor,
   })  : assert(text != null || child != null),
         super(key: key);
-
-  ButtonVariant get _variant {
-    return variant ?? ButtonVariant.filled;
-  }
 
   @override
   Widget buildCupertino(BuildContext context) {
@@ -65,7 +82,7 @@ class UniversalButton extends PlatformWidget {
       ],
     );
 
-    if (_variant == ButtonVariant.text || _variant == ButtonVariant.outlined) {
+    if (variant == ButtonVariant.text || variant == ButtonVariant.outlined) {
       button = CupertinoButton(
         padding: EdgeInsets.zero,
         onPressed: onPressed,
@@ -115,7 +132,7 @@ class UniversalButton extends PlatformWidget {
     }
 
     if (icon != null) {
-      switch (_variant) {
+      switch (variant) {
         case ButtonVariant.text:
           return TextButton.icon(
             icon: Icon(icon, color: contentColor),
@@ -139,7 +156,7 @@ class UniversalButton extends PlatformWidget {
           );
       }
     } else {
-      switch (_variant) {
+      switch (variant) {
         case ButtonVariant.text:
           return TextButton(
             onPressed: onPressed,

--- a/packages/firebase_ui_shared/lib/src/universal_icon.dart
+++ b/packages/firebase_ui_shared/lib/src/universal_icon.dart
@@ -2,9 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_ui_auth/src/widgets/internal/platform_widget.dart';
-import 'package:flutter/widgets.dart';
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 
+/// An icon widget that chooses between [cupertinoIcon] and [materialIcon]
+/// depending on the type of App widget used ([CupertinoApp] or [MaterialApp]).
 class UniversalIcon extends PlatformWidget {
   final IconData cupertinoIcon;
   final IconData materialIcon;

--- a/packages/firebase_ui_shared/lib/src/universal_scaffold.dart
+++ b/packages/firebase_ui_shared/lib/src/universal_scaffold.dart
@@ -2,12 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
-import 'platform_widget.dart';
-
+/// Utility Scaffold that uses [CupertinoPageScaffold] under [CupertinoApp] and
+/// [Scaffold] under [MaterialApp].
 class UniversalScaffold extends PlatformWidget {
+  /// See [CupertinoPageScaffold.child] and [Scaffold.body]
   final Widget body;
 
   /// See [Scaffold.resizeToAvoidBottomInset]

--- a/packages/firebase_ui_shared/pubspec.yaml
+++ b/packages/firebase_ui_shared/pubspec.yaml
@@ -16,39 +16,4 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^2.0.0
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/packages/firebase_ui_shared/pubspec.yaml
+++ b/packages/firebase_ui_shared/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 homepage: https://github.com/firebase/flutterfire/packages/firebase_ui_shared
 
 environment:
-  sdk: '>=2.19.2 <3.0.0'
+  sdk: '>=2.18.0 <3.0.0'
   flutter: '>=1.17.0'
 
 dependencies:

--- a/packages/firebase_ui_shared/pubspec.yaml
+++ b/packages/firebase_ui_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_ui_shared
 description: Abstractions and widgets that are used across Firebase UI packages.
 version: 1.0.0
-homepage:
+homepage: https://github.com/firebase/flutterfire/packages/firebase_ui_shared
 
 environment:
   sdk: '>=2.19.2 <3.0.0'

--- a/packages/firebase_ui_shared/pubspec.yaml
+++ b/packages/firebase_ui_shared/pubspec.yaml
@@ -1,18 +1,13 @@
-name: firebase_ui_oauth
-description: Firebase UI widgets for authentication & OAuth
-version: 1.1.17
-homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_ui_oauth
+name: firebase_ui_shared
+description: Abstractions and widgets that are used across Firebase UI packages.
+version: 1.0.0
+homepage:
 
 environment:
-  sdk: '>=2.17.6 <3.0.0'
+  sdk: '>=2.19.2 <3.0.0'
   flutter: '>=1.17.0'
 
 dependencies:
-  desktop_webview_auth: ^0.0.11
-  firebase_auth: ^4.3.0
-  firebase_ui_auth: ^1.1.17
-  firebase_ui_shared: ^1.0.0
-  flutter_svg: ^1.1.2
   flutter:
     sdk: flutter
 
@@ -20,15 +15,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.0
-  firebase_ui_oauth_google: ^1.0.24
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
-
-false_secrets:
-  - '/example/**/google-services.json'
-  - '/example/**/firebase_options.dart'
-  - '/example/**/GoogleService-Info.plist'
-  - '/example/lib/config.dart'
 
 # The following section is specific to Flutter packages.
 flutter:

--- a/packages/firebase_ui_shared/test/loading_button_test.dart
+++ b/packages/firebase_ui_shared/test/loading_button_test.dart
@@ -1,0 +1,109 @@
+import 'dart:async';
+
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LoadingButton', () {
+    testWidgets('shows label', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: LoadingButton(
+              label: 'label',
+              onTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('label'), findsOneWidget);
+    });
+
+    testWidgets(
+      'shows loading indicator when isLoading = true',
+      (tester) async {
+        var isLoading = false;
+        var completer = Completer<void>();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (context, setState) => LoadingButton(
+                  label: 'button',
+                  onTap: () async {
+                    setState(() {
+                      isLoading = !isLoading;
+                    });
+
+                    await completer.future;
+
+                    setState(() {
+                      isLoading = !isLoading;
+                    });
+                  },
+                  isLoading: isLoading,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+        await tester.tap(find.text('button'));
+        await tester.pump();
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+        completer.complete();
+        await tester.pump();
+
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+      },
+    );
+
+    testWidgets('works under CupertinoApp', (tester) async {
+      var isLoading = false;
+      var completer = Completer<void>();
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Scaffold(
+            body: StatefulBuilder(
+              builder: (context, setState) => LoadingButton(
+                label: 'button',
+                onTap: () async {
+                  setState(() {
+                    isLoading = !isLoading;
+                  });
+
+                  await completer.future;
+
+                  setState(() {
+                    isLoading = !isLoading;
+                  });
+                },
+                isLoading: isLoading,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(CupertinoActivityIndicator), findsNothing);
+
+      await tester.tap(find.text('button'));
+      await tester.pump();
+
+      expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+
+      completer.complete();
+      await tester.pump();
+
+      expect(find.byType(CupertinoActivityIndicator), findsNothing);
+    });
+  });
+}

--- a/packages/firebase_ui_shared/test/loading_indicator_test.dart
+++ b/packages/firebase_ui_shared/test/loading_indicator_test.dart
@@ -1,0 +1,42 @@
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const home = Scaffold(
+    body: LoadingIndicator(
+      size: 30,
+      borderWidth: 2,
+    ),
+  );
+
+  group('LoadingIndicator', () {
+    testWidgets(
+      'uses CircularProgressIndicator under MaterialApp',
+      (tester) async {
+        await tester.pumpWidget(const MaterialApp(home: home));
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'uses CupertinoActivityIndicator under MaterialApp',
+      (tester) async {
+        await tester.pumpWidget(const CupertinoApp(home: home));
+        expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'centered under both MaterialApp and CupertinoApp',
+      (tester) async {
+        await tester.pumpWidget(const MaterialApp(home: home));
+        expect(find.byType(Center), findsOneWidget);
+
+        await tester.pumpWidget(const CupertinoApp(home: home));
+        expect(find.byType(Center), findsOneWidget);
+      },
+    );
+  });
+}

--- a/packages/firebase_ui_shared/test/platform_widget_test.dart
+++ b/packages/firebase_ui_shared/test/platform_widget_test.dart
@@ -1,0 +1,80 @@
+import 'package:firebase_ui_shared/src/platform_widget.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class PlatformAware extends PlatformWidget {
+  const PlatformAware({super.key});
+
+  @override
+  Widget buildCupertino(BuildContext context) {
+    return const Text("Cupertino");
+  }
+
+  @override
+  Widget buildMaterial(BuildContext context) {
+    return const Text("Material");
+  }
+
+  @override
+  Widget? buildWrapper(BuildContext context, Widget child) {
+    return Container(
+      key: const ValueKey('wrapper'),
+      color: Colors.black,
+      child: child,
+    );
+  }
+}
+
+void main() {
+  group('PlatformWidget', () {
+    testWidgets(
+      'builds cupertino widget if CupertinoApp is used',
+      (tester) async {
+        await tester.pumpWidget(
+          const CupertinoApp(
+            home: PlatformAware(),
+          ),
+        );
+
+        expect(find.text('Cupertino'), findsOneWidget);
+        expect(find.text('Material'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'builds material widget if MaterialApp is used',
+      (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: PlatformAware(),
+          ),
+        );
+
+        expect(find.text('Cupertino'), findsNothing);
+        expect(find.text('Material'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'builds wrapper widget if it is implemented',
+      (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: PlatformAware(),
+          ),
+        );
+
+        expect(find.byKey(const ValueKey('wrapper')), findsOneWidget);
+
+        await tester.pumpWidget(
+          const CupertinoApp(
+            home: PlatformAware(),
+          ),
+        );
+
+        expect(find.byKey(const ValueKey('wrapper')), findsOneWidget);
+      },
+    );
+  });
+}

--- a/packages/firebase_ui_shared/test/themed_value_test.dart
+++ b/packages/firebase_ui_shared/test/themed_value_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
+
+void main() {
+  group('ThemedValue', () {
+    test('returns a value for light theme', () {
+      const themedValue = ThemedValue(Colors.white, Colors.black);
+      expect(themedValue.getValue(Brightness.light), Colors.black);
+    });
+
+    test('returns a value for dark theme', () {
+      const themedValue = ThemedValue(Colors.white, Colors.black);
+      expect(themedValue.getValue(Brightness.dark), Colors.white);
+    });
+  });
+
+  group('ThemedColor', () {
+    test('returns a color for light theme', () {
+      const themedColor = ThemedColor(Colors.white, Colors.black);
+      expect(themedColor.getValue(Brightness.light), Colors.black);
+    });
+
+    test('returns a color for dark theme', () {
+      const themedColor = ThemedColor(Colors.white, Colors.black);
+      expect(themedColor.getValue(Brightness.dark), Colors.white);
+    });
+  });
+
+  group('ThemedIconSrc', () {
+    test('returns an src for light theme', () {
+      const themedIconSrc = ThemedIconSrc('light.png', 'dark.png');
+      expect(themedIconSrc.getValue(Brightness.light), 'dark.png');
+    });
+
+    test('returns an src for dark theme', () {
+      const themedIconSrc = ThemedIconSrc('light.png', 'dark.png');
+      expect(themedIconSrc.getValue(Brightness.dark), 'light.png');
+    });
+  });
+}

--- a/packages/firebase_ui_shared/test/universal_button_test.dart
+++ b/packages/firebase_ui_shared/test/universal_button_test.dart
@@ -1,0 +1,199 @@
+import 'package:firebase_ui_shared/src/universal_button.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('UniversalButton', () {
+    testWidgets('renders text as content', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: UniversalButton(text: 'text'),
+          ),
+        ),
+      );
+
+      expect(find.text('text'), findsOneWidget);
+
+      await tester.pumpWidget(
+        const CupertinoApp(
+          home: Scaffold(
+            body: UniversalButton(text: 'text'),
+          ),
+        ),
+      );
+
+      expect(find.text('text'), findsOneWidget);
+    });
+
+    testWidgets('prefers child over text', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: UniversalButton(
+              text: 'text',
+              child: Text('child'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('text'), findsNothing);
+      expect(find.text('child'), findsOneWidget);
+
+      await tester.pumpWidget(
+        const CupertinoApp(
+          home: Scaffold(
+            body: UniversalButton(
+              text: 'text',
+              child: Text('child'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('text'), findsNothing);
+      expect(find.text('child'), findsOneWidget);
+    });
+
+    testWidgets(
+      'renders TextButton under MaterialApp when variant is ButtonVariant.text',
+      (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: UniversalButton(
+                text: 'text',
+                variant: ButtonVariant.text,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(TextButton), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'renders OutlinedButton under MaterialApp when variant '
+      'is ButtonVariant.text',
+      (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: UniversalButton(
+                text: 'text',
+                variant: ButtonVariant.outlined,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(OutlinedButton), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'renders ElevatedButton under MaterialApp when variant '
+      'is ButtonVariant.text',
+      (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: UniversalButton(
+                text: 'text',
+                variant: ButtonVariant.filled,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(ElevatedButton), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'renders CupertinoButton under CupertinoApp',
+      (tester) async {
+        await tester.pumpWidget(
+          const CupertinoApp(
+            home: Scaffold(
+              body: UniversalButton(
+                text: 'text',
+                variant: ButtonVariant.text,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(CupertinoButton), findsOneWidget);
+
+        await tester.pumpWidget(
+          const CupertinoApp(
+            home: Scaffold(
+              body: UniversalButton(
+                text: 'text',
+                variant: ButtonVariant.filled,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(CupertinoButton), findsOneWidget);
+
+        await tester.pumpWidget(
+          const CupertinoApp(
+            home: Scaffold(
+              body: UniversalButton(
+                text: 'text',
+                variant: ButtonVariant.outlined,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(CupertinoButton), findsOneWidget);
+      },
+    );
+
+    testWidgets('calls onPressed when button is tapped', (tester) async {
+      var pressed = 0;
+      void onPressed() {
+        pressed++;
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: UniversalButton(
+              text: 'press me',
+              onPressed: onPressed,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(UniversalButton));
+      await tester.pumpAndSettle();
+
+      expect(pressed, 1);
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Scaffold(
+            body: UniversalButton(
+              text: 'press me',
+              onPressed: onPressed,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(UniversalButton));
+      await tester.pumpAndSettle();
+
+      expect(pressed, 2);
+    });
+  });
+}

--- a/packages/firebase_ui_shared/test/universal_icon_test.dart
+++ b/packages/firebase_ui_shared/test/universal_icon_test.dart
@@ -1,0 +1,34 @@
+import 'package:firebase_ui_shared/firebase_ui_shared.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const icon = UniversalIcon(
+    cupertinoIcon: CupertinoIcons.check_mark,
+    materialIcon: Icons.check,
+  );
+  group('UniversalIcon', () {
+    testWidgets('uses cupertinoIcon under CupertinoApp', (tester) async {
+      await tester.pumpWidget(
+        const CupertinoApp(
+          home: UniversalScaffold(body: icon),
+        ),
+      );
+
+      expect(find.byIcon(CupertinoIcons.check_mark), findsOneWidget);
+      expect(find.byIcon(Icons.check), findsNothing);
+    });
+
+    testWidgets('uses materialIcon under MaterialApp', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: UniversalScaffold(body: icon),
+        ),
+      );
+
+      expect(find.byIcon(CupertinoIcons.check_mark), findsNothing);
+      expect(find.byIcon(Icons.check), findsOneWidget);
+    });
+  });
+}

--- a/packages/firebase_ui_shared/test/universal_scaffold_test.dart
+++ b/packages/firebase_ui_shared/test/universal_scaffold_test.dart
@@ -1,0 +1,35 @@
+import 'package:firebase_ui_shared/src/universal_scaffold.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('UniversalScaffold', () {
+    testWidgets('uses Scaffold under MaterialApp', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: UniversalScaffold(
+            body: Text('body'),
+          ),
+        ),
+      );
+
+      expect(find.byType(Scaffold), findsOneWidget);
+    });
+
+    testWidgets(
+      'uses CupertinoPageScaffold under CupertinoApp',
+      (tester) async {
+        await tester.pumpWidget(
+          const CupertinoApp(
+            home: UniversalScaffold(
+              body: Text('body'),
+            ),
+          ),
+        );
+
+        expect(find.byType(CupertinoPageScaffold), findsOneWidget);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description

This PR introduces a new library: `firebase_ui_shared`.
It is required for an upcoming `firebase_ui_storage` work, since many widgets previously used in `firebase_ui_auth` could
be reused in a `firebase_ui_stroage`

## Related Issues

Closes #10619

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
