### PR TITLE
refactor(firestore): Dart 3 compatibility: change _Updatable to be an actual `mixin`

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -683,7 +683,7 @@ class Transaction extends JsObjectWrapper<firestore_interop.TransactionJsImpl>
 /// Mixin class for all classes with the [update()] method. We need to call
 /// [_wrapUpdateFunctionCall()] in all [update()] methods to fix that Dart
 /// doesn't support varargs - we need to use [List] to call js function.
-abstract class _Updatable {
+mixin _Updatable {
   /// Calls js [:update():] method on [jsObject] with [data] or list of
   /// [fieldsAndValues] and optionally [documentRef].
   T? _wrapUpdateFunctionCall<T>(jsObject, Map<String, dynamic> data,


### PR DESCRIPTION
This is a private definition and is only ever used in a `with` clause. It should just be changed to `mixin` to become compatible with Dart language 3.0.

This is *not* a breaking change.

