### PR TITLE
fix(cloud_firestore): Loosen up the string checking for index error handling

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreException.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreException.java
@@ -79,8 +79,7 @@ public class FlutterFirebaseFirestoreException extends Exception {
             break;
           case "FAILED_PRECONDITION":
             code = "failed-precondition";
-            if (foundMessage.contains("query requires an index")
-                || foundMessage.contains("ensure it has been indexed")) {
+            if (foundMessage.contains("index")) {
               message = foundMessage;
             } else {
               message = ERROR_FAILED_PRECONDITION;

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestoreUtils.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestoreUtils.m
@@ -100,9 +100,7 @@ NSMutableDictionary<NSString *, FIRFirestore *> *firestoreInstanceCache;
       break;
     case FIRFirestoreErrorCodeFailedPrecondition:
       code = @"failed-precondition";
-      if ([error.localizedDescription containsString:@"query requires an index"] ||
-          [error.localizedDescription containsString:@"requires a COLLECTION_GROUP_DESC index"] ||
-          [error.localizedDescription containsString:@"requires a COLLECTION_GROUP_ASC index"]) {
+      if ([error.localizedDescription containsString:@"index"]) {
         message = error.localizedDescription;
       } else {
         message = @"Operation was rejected because the system is not in a state required for the "


### PR DESCRIPTION

## Description

This currently misses several types of index errors that can occur, and hides the index creation URL from the user. This is an extension of https://github.com/firebase/flutterfire/pull/7087


## Related Issues

https://github.com/firebase/flutterfire/issues/7010

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
