### PR TITLE
Fix: Update getting started link to reflect latest version

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/README.md
+++ b/packages/firebase_crashlytics/firebase_crashlytics/README.md
@@ -10,7 +10,7 @@ To learn more about Crashlytics, please visit the [Firebase website](https://fir
 
 ## Getting Started
 
-To get started with Crashlytics for Flutter, please [see the documentation](https://firebase.flutter.dev/docs/crashlytics/overview).
+To get started with Crashlytics for Flutter, please [see the documentation](https://firebase.google.com/docs/crashlytics/get-started?platform=flutter).
 
 ## Usage
 


### PR DESCRIPTION
## Description

*The current page which the getting started(To get started with using crashlytics) link points to is archived and might not reflect the latest version of the FlutterFire plugins.*

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
