### PR TITLE
chore(firebase_remote_config): fix to link to merged pull request in `CHANGELOG.md`

### DIFF
--- a/packages/firebase_remote_config/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/firebase_remote_config/CHANGELOG.md
@@ -3,7 +3,7 @@
 > Note: This release has breaking changes.
 
  - **BREAKING** **FEAT**: This PR is a breaking change for Remote Config since we're removing the ChangeNotifier mixin that came with FirebaseRemoteConfig. You should handle the state of the RemoteConfig using your own state provider.
- - **FEAT**: add support for `onConfigUpdated`to listen to config updates ([#10647)](https://github.com/firebase/flutterfire/commit/f702869e6120f10a368c1b32e9f27d615df99641))
+ - **FEAT**: add support for `onConfigUpdated`to listen to config updates ([#10647](https://github.com/firebase/flutterfire/commit/f702869e6120f10a368c1b32e9f27d615df99641))
  - **FEAT**: bump dart sdk constraint to 2.18 ([#10618](https://github.com/firebase/flutterfire/issues/10618)). ([f80948a2](https://github.com/firebase/flutterfire/commit/f80948a28b62eead358bdb900d5a0dfb97cebb33))
 
 ## 3.0.15


### PR DESCRIPTION
## Description

There was round bracket `)` too much in the changelog of the `firebase_remote_config` package.

Before:

<img width="1061" alt="Screenshot 2023-04-04 at 19 52 07" src="https://user-images.githubusercontent.com/24459435/229876994-087c7843-22ea-4a6f-9121-51d49500fc8d.png">

After:

<img width="1065" alt="Screenshot 2023-04-04 at 19 51 54" src="https://user-images.githubusercontent.com/24459435/229877038-5de7bd44-b378-4043-bb85-6add23a98e96.png">

## Related Issues

See https://github.com/firebase/flutterfire/pull/10692#discussion_r1157233107

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
