### PR TITLE
test(firebase_remote_config): add test for default values when key does not exist

### DIFF
--- a/tests/integration_test/firebase_remote_config/firebase_remote_config_e2e_test.dart
+++ b/tests/integration_test/firebase_remote_config/firebase_remote_config_e2e_test.dart
@@ -122,6 +122,17 @@ void main() {
           Duration.zero,
         );
       });
+
+      test('default values', () async {
+        // Ensure that the default values are returned when no values are set.
+        //
+        // We test this to be sure that the behaviour is consistent across
+        // platforms.
+        expect(FirebaseRemoteConfig.instance.getString('does-not-exit'), '');
+        expect(FirebaseRemoteConfig.instance.getBool('does-not-exit'), isFalse);
+        expect(FirebaseRemoteConfig.instance.getInt('does-not-exit'), 0);
+        expect(FirebaseRemoteConfig.instance.getDouble('does-not-exit'), 0.0);
+      });
     },
   );
 }


### PR DESCRIPTION
## Description

As mentioned in https://github.com/firebase/flutterfire/pull/10573#issuecomment-1495906895 it would be great to be sure that the default values for keys that does not exit are the same before merging #10573.

## Related Issues

.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
