### PR TITLE
fix(app-check): fix 'Semantic Issue (Xcode): `new` is unavailable' on XCode 14.3

### DIFF
--- a/packages/firebase_app_check/firebase_app_check/example/ios/Podfile
+++ b/packages/firebase_app_check/firebase_app_check/example/ios/Podfile
@@ -38,4 +38,13 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
   end
+
+  installer.generated_projects.each do |project|
+    project.targets.each do |target|
+        target.build_configurations.each do |config|
+            config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
+         end
+    end
+  end  
 end
+

--- a/packages/firebase_app_check/firebase_app_check/ios/Classes/FLTAppCheckProvider.m
+++ b/packages/firebase_app_check/firebase_app_check/ios/Classes/FLTAppCheckProvider.m
@@ -16,11 +16,11 @@
 
 - (void)configure:(FIRApp *)app providerName:(NSString *)providerName {
   if ([providerName isEqualToString:@"debug"]) {
-    self.delegateProvider = [[FIRAppCheckDebugProvider new] initWithApp:app];
+    self.delegateProvider = [[FIRAppCheckDebugProvider alloc] initWithApp:app];
   }
 
   if ([providerName isEqualToString:@"deviceCheck"]) {
-    self.delegateProvider = [[FIRDeviceCheckProvider new] initWithApp:app];
+    self.delegateProvider = [[FIRDeviceCheckProvider alloc] initWithApp:app];
   }
 
   if ([providerName isEqualToString:@"appAttest"]) {
@@ -28,7 +28,7 @@
       self.delegateProvider = [[FIRAppAttestProvider alloc] initWithApp:app];
     } else {
       // This is not a valid environment, setup debug provider.
-      self.delegateProvider = [[FIRAppCheckDebugProvider new] initWithApp:app];
+      self.delegateProvider = [[FIRAppCheckDebugProvider alloc] initWithApp:app];
     }
   }
 


### PR DESCRIPTION
## Description

The Podfile modifications cannot be moved to the podspec (and are unrelated to AppCheck) since it concerns another library.

## Related Issues

fixes #10694 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
