### PR TITLE
fix: Update FLTAppCheckProvider.m

### DIFF
--- a/packages/firebase_app_check/firebase_app_check/ios/Classes/FLTAppCheckProvider.m
+++ b/packages/firebase_app_check/firebase_app_check/ios/Classes/FLTAppCheckProvider.m
@@ -16,11 +16,11 @@
 
 - (void)configure:(FIRApp *)app providerName:(NSString *)providerName {
   if ([providerName isEqualToString:@"debug"]) {
-    self.delegateProvider = [[FIRAppCheckDebugProvider new] initWithApp:app];
+    self.delegateProvider = [[FIRAppCheckDebugProvider alloc] initWithApp:app];
   }
 
   if ([providerName isEqualToString:@"deviceCheck"]) {
-    self.delegateProvider = [[FIRDeviceCheckProvider new] initWithApp:app];
+    self.delegateProvider = [[FIRDeviceCheckProvider alloc] initWithApp:app];
   }
 
   if ([providerName isEqualToString:@"appAttest"]) {
@@ -28,7 +28,7 @@
       self.delegateProvider = [[FIRAppAttestProvider alloc] initWithApp:app];
     } else {
       // This is not a valid environment, setup debug provider.
-      self.delegateProvider = [[FIRAppCheckDebugProvider new] initWithApp:app];
+      self.delegateProvider = [[FIRAppCheckDebugProvider alloc] initWithApp:app];
     }
   }
 


### PR DESCRIPTION
use "alloc" instead of "new" to fix the error:
Semantic Issue (Xcode): 'new' is unavailable

## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
