### PR TITLE
docs(firebase_ui_auth): fix phone provider's widget example

### DIFF
--- a/packages/firebase_ui_auth/doc/providers/phone.md
+++ b/packages/firebase_ui_auth/doc/providers/phone.md
@@ -163,7 +163,7 @@ class MyCustomWidget extends StatelessWidget {
         }
       },
       builder: (context, state, ctrl, child) {
-        if (state is AwaitingPhoneNumber) {
+        if (state is AwaitingPhoneNumber || state is SMSCodeRequested) {
           return PhoneInput(
             initialCountryCode: 'US',
             onSubmit: (phoneNumber) {


### PR DESCRIPTION
Added handling for the auth state of SMSCodeRequested in the custom AuthFlowBuilder example, matching the implementation of the PhoneInputView.

## Description

This PR includes only a small documentation edit for the phone auth provider in the firebase_ui_auth package.
The [example](https://github.com/firebase/flutterfire/blob/master/packages/firebase_ui_auth/doc/providers/phone.md#building-a-custom-widget-with-authflowbuilder) for building a custom widget with AuthFlowBuilder, doesn't handle the auth state for SMSCodeRequested. When copy-pasting this example, it temporarily returns an unknown state text widget during login (see image below). I've fixed the example, modifying it based on the condition in the [PhoneInputView](https://github.com/firebase/flutterfire/blob/master/packages/firebase_ui_auth/lib/src/views/phone_input_view.dart) widget.

![image](https://user-images.githubusercontent.com/48316647/236535163-794ec19d-24e9-494d-83c8-1b36e223ce3d.png)


## Related Issues

None.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
