### PR TITLE
fix(firebase_ui_auth): Error added in ProfileScreen in firebase_ui_auth 1.4.0

### DIFF
--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -390,9 +390,9 @@ class _EmailVerificationBadgeState extends State<_EmailVerificationBadge> {
           ),
           const SizedBox(height: 16),
           if (state == EmailVerificationState.pending)
-            const Row(
+            Row(
               mainAxisAlignment: MainAxisAlignment.center,
-              children: [
+              children: const [
                 LoadingIndicator(size: 16, borderWidth: 0.5),
                 SizedBox(width: 16),
                 Text('Waiting for email verification'),

--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -390,12 +390,13 @@ class _EmailVerificationBadgeState extends State<_EmailVerificationBadge> {
           ),
           const SizedBox(height: 16),
           if (state == EmailVerificationState.pending)
+            // ignore: prefer_const_constructors
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
-              children: const [
+              children: [
                 LoadingIndicator(size: 16, borderWidth: 0.5),
-                SizedBox(width: 16),
-                Text('Waiting for email verification'),
+                const SizedBox(width: 16),
+                const Text('Waiting for email verification'),
               ],
             )
           else

--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -393,10 +393,10 @@ class _EmailVerificationBadgeState extends State<_EmailVerificationBadge> {
             // ignore: prefer_const_constructors
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
-              children: [
+              children: const [
                 LoadingIndicator(size: 16, borderWidth: 0.5),
-                const SizedBox(width: 16),
-                const Text('Waiting for email verification'),
+                SizedBox(width: 16),
+                Text('Waiting for email verification'),
               ],
             )
           else


### PR DESCRIPTION
## Description

firebase_ui_auth throws an error when building for version 1.4.0.:
`../../.pub-cache/hosted/pub.dev/firebase_ui_auth-1.4.0/lib/src/screens/profile_screen.dart:393:19: Error: Cannot invoke a non-'const' constructor where a const expression is expected. Try using a constructor or factory that is 'const'. const Row( ^^^`

## Related Issues

[Issue](https://github.com/firebase/flutterfire/issues/10954)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ x] All existing and new tests are passing.
- [x ] I updated/added relevant documentation (doc comments with `///`).
- [x ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ x] I read and followed the [Flutter Style Guide].
- [ x] I signed the [CLA].
- [ x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
