### PR TITLE
fix(ui): removed const usage for Row for compatibility before 3.10

### DIFF
--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -392,7 +392,7 @@ class _EmailVerificationBadgeState extends State<_EmailVerificationBadge> {
           if (state == EmailVerificationState.pending)
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
-              children: [
+              children: const [
                 LoadingIndicator(size: 16, borderWidth: 0.5),
                 SizedBox(width: 16),
                 Text('Waiting for email verification'),

--- a/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
+++ b/packages/firebase_ui_auth/lib/src/screens/profile_screen.dart
@@ -390,7 +390,7 @@ class _EmailVerificationBadgeState extends State<_EmailVerificationBadge> {
           ),
           const SizedBox(height: 16),
           if (state == EmailVerificationState.pending)
-            const Row(
+            Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 LoadingIndicator(size: 16, borderWidth: 0.5),


### PR DESCRIPTION
## Description

The current code triggers an error due to using a non-constant constructor in a const context. Removing the const keyword from the Row widget resolves this error, allowing the code to compile successfully.
