### PR TITLE
docs(firestore): improve wording of what `set()` API does

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
@@ -59,7 +59,7 @@ abstract class DocumentReference<T extends Object?> {
   /// Sets data on the document, overwriting any existing data. If the document
   /// does not yet exist, it will be created.
   ///
-  /// If [SetOptions] are provided, the data will be merged into an existing
+  /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
   Future<void> set(T data, [SetOptions? options]);
 

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/lib/src/firestore_reference.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/lib/src/firestore_reference.dart
@@ -79,7 +79,7 @@ abstract class FirestoreDocumentReference<Model,
   /// Sets data on the document, overwriting any existing data. If the document
   /// does not yet exist, it will be created.
   ///
-  /// If [SetOptions] are provided, the data will be merged into an existing
+  /// If [SetOptions] are provided, the data can be merged into an existing
   /// document instead of overwriting.
   Future<void> set(Model model, [SetOptions? setOptions]) {
     return reference.set(model, setOptions);


### PR DESCRIPTION
## Description

See title.

## Related Issues

closes https://github.com/firebase/flutterfire/issues/10471

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
