### PR TITLE
Fix documentation issue #11084

### DIFF
--- a/docs/cloud-messaging/topic-messaging.md
+++ b/docs/cloud-messaging/topic-messaging.md
@@ -64,6 +64,10 @@ await FirebaseMessaging.instance.subscribeToTopic("topic");
 
 To unsubscribe, call `unsubscribeFromTopic()` with the topic name.
 
+`subscribeToTopic()` is not supported on the web clients. To learn how to manage subscriptions for web users, visit: [official Firebase documentation](https://firebase.google.com/docs/cloud-messaging/js/topic-messaging)
+
+      
+
 
 ## Next steps
 


### PR DESCRIPTION
## Description

This Pr is modifying the documentation of the cloud-messaging plugin to add the message that the function 'subscribeToTopic()' is not supported on the web clients and links the firebase documentation for the users who want to implement it for the web.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: 
