### PR TITLE
chore(firebase_remote_config): activate the values after real time update for example

### DIFF
--- a/packages/firebase_remote_config/firebase_remote_config/example/lib/home_page.dart
+++ b/packages/firebase_remote_config/firebase_remote_config/example/lib/home_page.dart
@@ -89,7 +89,11 @@ class _HomePageState extends State<HomePage> {
                   return 'Listening cancelled';
                 }
                 setState(() {
-                  subscription = remoteConfig.onConfigUpdated.listen((event) {
+                  subscription =
+                      remoteConfig.onConfigUpdated.listen((event) async {
+                    // Make new values available to the app.
+                    await remoteConfig.activate();
+
                     setState(() {
                       update = event;
                     });


### PR DESCRIPTION
## Description

https://github.com/firebase/flutterfire/blob/fe0f20cf6d2f5db754fa1be7d9991d51ef3a4d2c/docs/remote-config/_get-started.md#L145-L154

The docs show that you need to call `remoteConfig.activate()` before using the values. I added the missing line in the example of the `firebase_remote_config`.

## Related Issues

Fixes #11104

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
