### PR TITLE
fix(firestore, apple): issue where setting persistence caused a crash. `kFIRFirestoreCacheSizeUnlimited` no longer usable.

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
@@ -280,7 +280,8 @@ void runInstanceTests() {
           (widgetTester) async {
         FirebaseFirestore.instance.settings = const Settings(
             persistenceEnabled: true,
-            cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED);
+            cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED,
+        );
         // Used to trigger settings
         await FirebaseFirestore.instance
             .collection('flutter-tests')

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
@@ -279,8 +279,8 @@ void runInstanceTests() {
           'Settings() - `persistenceEnabled` & `cacheSizeBytes` with `Settings.CACHE_SIZE_UNLIMITED`',
           (widgetTester) async {
         FirebaseFirestore.instance.settings = const Settings(
-            persistenceEnabled: true,
-            cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED,
+          persistenceEnabled: true,
+          cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED,
         );
         // Used to trigger settings
         await FirebaseFirestore.instance

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
@@ -260,6 +260,49 @@ void runInstanceTests() {
         await FirebaseFirestore.setLoggingEnabled(true);
         await FirebaseFirestore.setLoggingEnabled(false);
       });
+
+      testWidgets(
+          'Settings() - `persistenceEnabled` & `cacheSizeBytes` with acceptable number',
+          (widgetTester) async {
+        FirebaseFirestore.instance.settings =
+            const Settings(persistenceEnabled: true, cacheSizeBytes: 10000000);
+        // Used to trigger settings
+        await FirebaseFirestore.instance
+            .collection('flutter-tests')
+            .doc('new-doc')
+            .set(
+          {'some': 'data'},
+        );
+      });
+
+      testWidgets(
+          'Settings() - `persistenceEnabled` & `cacheSizeBytes` with `Settings.CACHE_SIZE_UNLIMITED`',
+          (widgetTester) async {
+        FirebaseFirestore.instance.settings = const Settings(
+            persistenceEnabled: true,
+            cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED);
+        // Used to trigger settings
+        await FirebaseFirestore.instance
+            .collection('flutter-tests')
+            .doc('new-doc')
+            .set(
+          {'some': 'data'},
+        );
+      });
+
+      testWidgets(
+          'Settings() - `persistenceEnabled` & without `cacheSizeBytes`',
+          (widgetTester) async {
+        FirebaseFirestore.instance.settings =
+            const Settings(persistenceEnabled: true);
+        // Used to trigger settings
+        await FirebaseFirestore.instance
+            .collection('flutter-tests')
+            .doc('new-doc')
+            .set(
+          {'some': 'data'},
+        );
+      });
     },
   );
 }

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestoreReader.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestoreReader.m
@@ -95,14 +95,19 @@
 
   if (![values[@"persistenceEnabled"] isEqual:[NSNull null]]) {
     bool persistEnabled = [((NSNumber *)values[@"persistenceEnabled"]) boolValue];
-    int size = [((NSNumber *)values[@"cacheSizeBytes"]) intValue];
+
+    // This is the maximum amount of cache allowed. We use the same number on android.
+    // This now causes an exception: kFIRFirestoreCacheSizeUnlimited
+    NSNumber *size = @104857600;
+
+    if (![values[@"cacheSizeBytes"] isEqual:[NSNull null]]) {
+      if ([size intValue] != -1) {
+        size = ((NSNumber *)values[@"cacheSizeBytes"]);
+      }
+    }
 
     if (persistEnabled) {
-      NSNumber *unlimitedPersistence =
-          [NSNumber numberWithLongLong:kFIRFirestoreCacheSizeUnlimited];
-      settings.cacheSettings = [[FIRPersistentCacheSettings alloc]
-          initWithSizeBytes:size == -1 ? unlimitedPersistence
-                                       : ((NSNumber *)values[@"cacheSizeBytes"])];
+      settings.cacheSettings = [[FIRPersistentCacheSettings alloc] initWithSizeBytes:size];
     } else {
       settings.cacheSettings = [[FIRMemoryCacheSettings alloc]
           initWithGarbageCollectorSettings:[[FIRMemoryLRUGCSettings alloc] init]];

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestoreReader.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestoreReader.m
@@ -101,8 +101,9 @@
     NSNumber *size = @104857600;
 
     if (![values[@"cacheSizeBytes"] isEqual:[NSNull null]]) {
-      if ([size intValue] != -1) {
-        size = ((NSNumber *)values[@"cacheSizeBytes"]);
+      NSNumber *cacheSizeBytes = ((NSNumber *)values[@"cacheSizeBytes"]);
+      if ([cacheSizeBytes intValue] != -1) {
+        size = cacheSizeBytes;
       }
     }
 

--- a/packages/cloud_firestore/cloud_firestore/test/query_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/query_test.dart
@@ -419,7 +419,8 @@ void main() {
         // Happy paths
         expect(() => configureCache(null), returnsNormally);
         expect(() => configureCache(Settings.CACHE_SIZE_UNLIMITED),
-            returnsNormally);
+            returnsNormally,
+        );
         expect(() => configureCache(5000000), returnsNormally);
         expect(() => configureCache(1048577), returnsNormally);
         expect(() => configureCache(104857600), returnsNormally);

--- a/packages/cloud_firestore/cloud_firestore/test/query_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/query_test.dart
@@ -403,5 +403,34 @@ void main() {
         );
       });
     });
+
+    group('Settings()', () {
+      test('Test the assert for setting `cacheSizeBytes` minimum and maximum',
+          () {
+        void configureCache(int? cacheSizeBytes) {
+          assert(
+            cacheSizeBytes == null ||
+                cacheSizeBytes == Settings.CACHE_SIZE_UNLIMITED ||
+                (cacheSizeBytes >= 1048576 && cacheSizeBytes <= 104857600),
+            'Cache size, if specified, must be either CACHE_SIZE_UNLIMITED or between 1048576 bytes (inclusive) and 104857600 bytes (inclusive).',
+          );
+        }
+
+        // Happy paths
+        expect(() => configureCache(null), returnsNormally);
+        expect(() => configureCache(Settings.CACHE_SIZE_UNLIMITED),
+            returnsNormally);
+        expect(() => configureCache(5000000), returnsNormally);
+        expect(() => configureCache(1048577), returnsNormally);
+        expect(() => configureCache(104857600), returnsNormally);
+        expect(() => configureCache(104857500), returnsNormally);
+
+        // Assertion triggers
+        expect(() => configureCache(1), throwsA(isA<AssertionError>()));
+        expect(() => configureCache(1000), throwsA(isA<AssertionError>()));
+        expect(() => configureCache(200000000), throwsA(isA<AssertionError>()));
+        expect(() => configureCache(500000), throwsA(isA<AssertionError>()));
+      });
+    });
   });
 }

--- a/packages/cloud_firestore/cloud_firestore/test/query_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/query_test.dart
@@ -418,8 +418,9 @@ void main() {
 
         // Happy paths
         expect(() => configureCache(null), returnsNormally);
-        expect(() => configureCache(Settings.CACHE_SIZE_UNLIMITED),
-            returnsNormally,
+        expect(
+          () => configureCache(Settings.CACHE_SIZE_UNLIMITED),
+          returnsNormally,
         );
         expect(() => configureCache(5000000), returnsNormally);
         expect(() => configureCache(1048577), returnsNormally);

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/settings.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/settings.dart
@@ -69,15 +69,23 @@ class Settings {
     bool? sslEnabled,
     int? cacheSizeBytes,
     bool? ignoreUndefinedProperties,
-  }) =>
-      Settings(
-        persistenceEnabled: persistenceEnabled ?? this.persistenceEnabled,
-        host: host ?? this.host,
-        sslEnabled: sslEnabled ?? this.sslEnabled,
-        cacheSizeBytes: cacheSizeBytes ?? this.cacheSizeBytes,
-        ignoreUndefinedProperties:
-            ignoreUndefinedProperties ?? this.ignoreUndefinedProperties,
-      );
+  }) {
+    assert(
+        cacheSizeBytes == null ||
+            cacheSizeBytes == CACHE_SIZE_UNLIMITED ||
+            // 1mb and 100mb. minimum and maximum inclusive range.
+            (cacheSizeBytes >= 1048576 && cacheSizeBytes <= 104857600),
+        'Cache size must be between 1048576 bytes (inclusive) and 104857600 bytes (inclusive)');
+
+    return Settings(
+      persistenceEnabled: persistenceEnabled ?? this.persistenceEnabled,
+      host: host ?? this.host,
+      sslEnabled: sslEnabled ?? this.sslEnabled,
+      cacheSizeBytes: cacheSizeBytes ?? this.cacheSizeBytes,
+      ignoreUndefinedProperties:
+          ignoreUndefinedProperties ?? this.ignoreUndefinedProperties,
+    );
+  }
 
   @override
   bool operator ==(Object other) =>


### PR DESCRIPTION
## Description

A few things to note.

1. `kFIRFirestoreCacheSizeUnlimited ` & anything more/less than acceptable cache size (1mb/100mb) was crashing apple apps.
2. I've created an assertion within the `copy()` function of `Settings`, cannot do on creation of `Settings` as it would change the user facing API from `const Settings` to `Settings(cacheSizeBytes: 10000000)`.
3. Wrote tests for assertion as it is a tricky one. also wrote a few e2e tests.

## Related Issues

fix: https://github.com/firebase/flutterfire/issues/11138

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
