### PR TITLE
fix(cloud_firestore): Temporal workaround for snapshot.exists false negative

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_snapshot.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_snapshot.dart
@@ -114,7 +114,8 @@ class _WithConverterDocumentSnapshot<T> implements DocumentSnapshot<T> {
 
   @override
   T? data() {
-    if (!_originalDocumentSnapshot.exists) return null;
+    // use data() instead of exists until https://github.com/firebase/flutterfire/issues/10331 is resolved
+    if (_originalDocumentSnapshot.data() == null) return null;
 
     return _fromFirestore(_originalDocumentSnapshot, null);
   }


### PR DESCRIPTION
## Description

The ongoing issue #10331 causes the `snapshot.exists` to be unreliable, and because `exists` is internally used for Firestore collection converters, there no workaround if we still want to use the converter

## Related Issues

#10331 


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
