### PR TITLE
feat(core, windows): Add api to access firebase cpp objects

### DIFF
--- a/packages/firebase_core/firebase_core/windows/CMakeLists.txt
+++ b/packages/firebase_core/firebase_core/windows/CMakeLists.txt
@@ -100,7 +100,7 @@ foreach(firebase_lib IN ITEMS ${FIREBASE_LIBS})
     )
 endforeach()
 
-set(ADDITIONAL_LIBS advapi32 ws2_32 crypt32 rpcrt4 ole32)
+set(ADDITIONAL_LIBS advapi32 ws2_32 crypt32 rpcrt4 ole32 icu)
 
 target_link_libraries(${PLUGIN_NAME} PRIVATE "${FIREBASE_LIBS}" "${ADDITIONAL_LIBS}")
 

--- a/packages/firebase_core/firebase_core/windows/CMakeLists.txt
+++ b/packages/firebase_core/firebase_core/windows/CMakeLists.txt
@@ -4,7 +4,7 @@
 # customers of the plugin.
 cmake_minimum_required(VERSION 3.14)
 
-set(FIREBASE_SDK_VERSION "10.5.0")
+set(FIREBASE_SDK_VERSION "11.2.0")
 
 if (EXISTS $ENV{FIREBASE_CPP_SDK_DIR}/include/firebase/version.h)
     file(READ "$ENV{FIREBASE_CPP_SDK_DIR}/include/firebase/version.h" existing_version)
@@ -90,8 +90,8 @@ set(MSVC_RUNTIME_MODE MD)
 add_subdirectory(${FIREBASE_CPP_SDK_DIR} bin/ EXCLUDE_FROM_ALL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${FIREBASE_CPP_SDK_DIR}/include")
-set(firebase_libs firebase_auth firebase_database firebase_app)
-foreach(firebase_lib IN ITEMS ${firebase_libs})
+set(FIREBASE_LIBS firebase_app firebase_auth firebase_remote_config)
+foreach(firebase_lib IN ITEMS ${FIREBASE_LIBS})
     get_target_property(firebase_lib_path ${firebase_lib} IMPORTED_LOCATION)
     string(REPLACE "Debug" "Release" firebase_lib_release_path ${firebase_lib_path})
     set_target_properties(${firebase_lib} PROPERTIES
@@ -100,7 +100,9 @@ foreach(firebase_lib IN ITEMS ${firebase_libs})
     )
 endforeach()
 
-target_link_libraries(${PLUGIN_NAME} PRIVATE "${firebase_libs}")
+set(ADDITIONAL_LIBS advapi32 ws2_32 crypt32 rpcrt4 ole32)
+
+target_link_libraries(${PLUGIN_NAME} PRIVATE "${FIREBASE_LIBS}" "${ADDITIONAL_LIBS}")
 
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")

--- a/packages/firebase_core/firebase_core/windows/firebase_core_plugin.h
+++ b/packages/firebase_core/firebase_core/windows/firebase_core_plugin.h
@@ -21,6 +21,9 @@ class FirebaseCorePlugin : public flutter::Plugin,
                            public FirebaseAppHostApi {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
+  static void *GetFirebaseApp(std::string appName);
+  static void *GetFirebaseAuth(std::string appName);
+  static void *GetFirebaseRemoteConfig(std::string appName);
 
   FirebaseCorePlugin();
 

--- a/packages/firebase_core/firebase_core/windows/firebase_core_plugin_c_api.cpp
+++ b/packages/firebase_core/firebase_core/windows/firebase_core_plugin_c_api.cpp
@@ -14,3 +14,16 @@ void FirebaseCorePluginCApiRegisterWithRegistrar(
       flutter::PluginRegistrarManager::GetInstance()
           ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
 }
+
+void* GetFirebaseApp(std::string appName) {
+  return firebase_core_windows::FirebaseCorePlugin::GetFirebaseApp(appName);
+}
+
+void* GetFirebaseAuth(std::string appName) {
+  return firebase_core_windows::FirebaseCorePlugin::GetFirebaseAuth(appName);
+}
+
+void* GetFirebaseRemoteConfig(std::string appName) {
+  return firebase_core_windows::FirebaseCorePlugin::GetFirebaseRemoteConfig(
+      appName);
+}

--- a/packages/firebase_core/firebase_core/windows/include/firebase_core/firebase_core_plugin_c_api.h
+++ b/packages/firebase_core/firebase_core/windows/include/firebase_core/firebase_core_plugin_c_api.h
@@ -9,6 +9,8 @@
 
 #include <flutter_plugin_registrar.h>
 
+#include <string>
+
 #ifdef FLUTTER_PLUGIN_IMPL
 #define FLUTTER_PLUGIN_EXPORT __declspec(dllexport)
 #else
@@ -21,6 +23,12 @@ extern "C" {
 
 FLUTTER_PLUGIN_EXPORT void FirebaseCorePluginCApiRegisterWithRegistrar(
     FlutterDesktopPluginRegistrarRef registrar);
+
+FLUTTER_PLUGIN_EXPORT void* GetFirebaseApp(std::string appName);
+
+FLUTTER_PLUGIN_EXPORT void* GetFirebaseAuth(std::string appName);
+
+FLUTTER_PLUGIN_EXPORT void* GetFirebaseRemoteConfig(std::string appName);
 
 #if defined(__cplusplus)
 }  // extern "C"


### PR DESCRIPTION
## Description

Add apis to firebase_core windows to access firebase cpp object like App*, Auth* etc.

## Related Issues

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
