### PR TITLE
fix(auth): deprecate `FirebaseAuth.instanceFor`'s `persistence` parameter

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -15,10 +15,6 @@ class FirebaseAuth extends FirebasePluginPlatform {
   // instance with the default app before a user specifies an app.
   FirebaseAuthPlatform? _delegatePackingProperty;
 
-  // To set "persistence" on web, it is now required on the v9.0.0 or above Firebase JS SDK to pass the value on calling `initializeAuth()`.
-  /// https://firebase.google.com/docs/reference/js/auth.md#initializeauth
-  Persistence? _persistence;
-
   /// Returns the underlying delegate implementation.
   ///
   /// If called and no [_delegatePackingProperty] exists, it will first be
@@ -27,7 +23,6 @@ class FirebaseAuth extends FirebasePluginPlatform {
     _delegatePackingProperty ??= FirebaseAuthPlatform.instanceFor(
       app: app,
       pluginConstants: pluginConstants,
-      persistence: _persistence,
     );
     return _delegatePackingProperty!;
   }
@@ -35,9 +30,8 @@ class FirebaseAuth extends FirebasePluginPlatform {
   /// The [FirebaseApp] for this current Auth instance.
   FirebaseApp app;
 
-  FirebaseAuth._({required this.app, Persistence? persistence})
-      : _persistence = persistence,
-        super(app.name, 'plugins.flutter.io/firebase_auth');
+  FirebaseAuth._({required this.app})
+      : super(app.name, 'plugins.flutter.io/firebase_auth');
 
   /// Returns an instance using the default [FirebaseApp].
   static FirebaseAuth get instance {
@@ -47,11 +41,15 @@ class FirebaseAuth extends FirebasePluginPlatform {
   }
 
   /// Returns an instance using a specified [FirebaseApp].
-  /// Note that persistence can only be used on Web and is not supported on other platforms.
-  factory FirebaseAuth.instanceFor(
-      {required FirebaseApp app, Persistence? persistence}) {
+  factory FirebaseAuth.instanceFor({
+    required FirebaseApp app,
+    @Deprecated(
+      'Will be removed in future release. Use setPersistence() instead.',
+    )
+    Persistence? persistence,
+  }) {
     return _firebaseAuthInstances.putIfAbsent(app.name, () {
-      return FirebaseAuth._(app: app, persistence: persistence);
+      return FirebaseAuth._(app: app);
     });
   }
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_firebase_auth.dart
@@ -189,8 +189,7 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
   ///
   /// Instances are cached and reused for incoming event handlers.
   @override
-  FirebaseAuthPlatform delegateFor(
-      {required FirebaseApp app, Persistence? persistence}) {
+  FirebaseAuthPlatform delegateFor({required FirebaseApp app}) {
     return methodChannelFirebaseAuthInstances.putIfAbsent(app.name, () {
       return MethodChannelFirebaseAuth(app: app);
     });

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_firebase_auth.dart
@@ -51,7 +51,6 @@ abstract class FirebaseAuthPlatform extends PlatformInterface {
   factory FirebaseAuthPlatform.instanceFor({
     required FirebaseApp app,
     required Map<dynamic, dynamic> pluginConstants,
-    Persistence? persistence,
   }) {
     var currentUser = pluginConstants['APP_CURRENT_USER'];
 
@@ -59,9 +58,7 @@ abstract class FirebaseAuthPlatform extends PlatformInterface {
       currentUser as List<Object?>;
       currentUser = PigeonUserDetails.decode(currentUser);
     }
-    return FirebaseAuthPlatform.instance
-        .delegateFor(app: app, persistence: persistence)
-        .setInitialValues(
+    return FirebaseAuthPlatform.instance.delegateFor(app: app).setInitialValues(
           languageCode: pluginConstants['APP_LANGUAGE_CODE'],
           currentUser: currentUser,
         );
@@ -89,8 +86,7 @@ abstract class FirebaseAuthPlatform extends PlatformInterface {
   ///
   /// Setting a [persistence] type is only available on web based platforms.
   @protected
-  FirebaseAuthPlatform delegateFor(
-      {required FirebaseApp app, Persistence? persistence}) {
+  FirebaseAuthPlatform delegateFor({required FirebaseApp app}) {
     throw UnimplementedError('delegateFor() is not implemented');
   }
 

--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -34,14 +34,8 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
 
   Completer<void> _initialized = Completer();
 
-  // To set "persistence" on web, it is now required on the v9.0.0 or above Firebase JS SDK to pass the value on calling `initializeAuth()`.
-  // https://firebase.google.com/docs/reference/js/auth.md#initializeauth
-  Persistence? _persistence;
-
   /// The entry point for the [FirebaseAuthWeb] class.
-  FirebaseAuthWeb({required FirebaseApp app, Persistence? persistence})
-      : super(appInstance: app) {
-    _persistence = persistence;
+  FirebaseAuthWeb({required FirebaseApp app}) : super(appInstance: app) {
     // Create a app instance broadcast stream for both delegate listener events
     _userChangesListeners[app.name] =
         StreamController<UserPlatform?>.broadcast();
@@ -147,16 +141,14 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   auth_interop.Auth? _webAuth;
 
   auth_interop.Auth get delegate {
-    _webAuth ??= auth_interop.getAuthInstance(core_interop.app(app.name),
-        persistence: _persistence);
+    _webAuth ??= auth_interop.getAuthInstance(core_interop.app(app.name));
 
     return _webAuth!;
   }
 
   @override
-  FirebaseAuthPlatform delegateFor(
-      {required FirebaseApp app, Persistence? persistence}) {
-    return FirebaseAuthWeb(app: app, persistence: persistence);
+  FirebaseAuthPlatform delegateFor({required FirebaseApp app}) {
+    return FirebaseAuthWeb(app: app);
   }
 
   @override

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -20,31 +20,7 @@ import 'utils/utils.dart';
 export 'auth_interop.dart';
 
 /// Given an AppJSImp, return the Auth instance.
-Auth getAuthInstance(App app, {Persistence? persistence}) {
-  if (persistence != null) {
-    auth_interop.Persistence setPersistence;
-    switch (persistence) {
-      case Persistence.LOCAL:
-        setPersistence = auth_interop.browserLocalPersistence;
-        break;
-      case Persistence.INDEXED_DB:
-        setPersistence = auth_interop.indexedDBLocalPersistence;
-        break;
-      case Persistence.SESSION:
-        setPersistence = auth_interop.browserSessionPersistence;
-        break;
-      case Persistence.NONE:
-        setPersistence = auth_interop.inMemoryPersistence;
-        break;
-    }
-    return Auth.getInstance(auth_interop.initializeAuth(
-        app.jsObject,
-        jsify({
-          'errorMap': auth_interop.debugErrorMap,
-          'persistence': setPersistence,
-          'popupRedirectResolver': auth_interop.browserPopupRedirectResolver
-        })));
-  }
+Auth getAuthInstance(App app) {
   return Auth.getInstance(auth_interop.initializeAuth(
       app.jsObject,
       jsify({


### PR DESCRIPTION
## Description

When the plugin is initialised by Flutter, initialise `FirebaseAuth` without any persistence. This causes a error to be thrown when calling `FirebaseAuth.instanceFor` with a persistence value as firebase_auth tries to reinitialise the auth instance with a new persistence. 

We cannot use `setPersistence` to fix this since it's a `Future` and `instanceFor` is synchronous, and the user cannot provide the persistence they want before the plugin is initialised. Therefore, the `persistence` parameter is being deprecated and users are expected to call `setPersistence` separately to set the `persistence` of the auth object.

Only affects web

## Related Issues

Fixes #10961

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
