### PR TITLE
fix(firestore): allow 30 conjunctive & disjunctive queries for "in" & "array-contains-any" via where() API

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
@@ -2268,202 +2268,128 @@ void runQueryTests() {
         skip: kIsWeb,
       );
 
-      // TODO(russellwheatley): Firestore allows up to 30 disjunctive queries but testing on android & iOS reveals it only allows 10 when using where() with "arrayContainsAny", "whereIn" & "whereNotIn"
-      // testWidgets(
-      //     'allow multiple disjunctive queries for "arrayContainsAny" using ".where() API"',
-      //     (_) async {
-      //   CollectionReference<Map<String, dynamic>> collection =
-      //       await initializeTest('multiple-disjunctive-where');
-      //
-      //   await Future.wait([
-      //     collection.doc('doc1').set({
-      //       'genre': ['Not', 'Here'],
-      //       'number': 1
-      //     }),
-      //     collection.doc('doc2').set({
-      //       'genre': ['Animation', 'Another'],
-      //       'number': 2
-      //     }),
-      //     collection.doc('doc3').set({
-      //       'genre': ['Adventure', 'Another'],
-      //       'number': 3
-      //     }),
-      //   ]);
-      //   final genres = [
-      //     'Action',
-      //     'Adventure',
-      //     'Animation',
-      //     'Biography',
-      //     'Comedy',
-      //     'Crime',
-      //     'Drama',
-      //     'Documentary',
-      //     'Family',
-      //     'Fantasy',
-      //     'Film-Noir',
-      //     // 'History',
-      //     // 'Horror',
-      //     // 'Music',
-      //     // 'Musical',
-      //     // 'Mystery',
-      //     // 'Romance',
-      //     // 'Sci-Fi',
-      //     // 'Sport',
-      //     // 'Thriller',
-      //     // 'War',
-      //     // 'Western',
-      //     // 'Epic',
-      //     // 'Tragedy',
-      //     // 'Satire',
-      //     // 'Romantic Comedy',
-      //     // 'Black Comedy',
-      //     // 'Paranormal',
-      //     // 'Non-fiction',
-      //     // 'Realism',
-      //   ];
-      //
-      //   final results = await collection
-      //       .where(
-      //         'genre',
-      //         arrayContainsAny: genres,
-      //       )
-      //       .orderBy('number')
-      //       .get();
-      //
-      //   expect(results.docs.length, equals(2));
-      //   expect(results.docs[0].id, equals('doc2'));
-      //   expect(results.docs[1].id, equals('doc3'));
-      // });
-      //
-      // testWidgets(
-      //     'allow multiple disjunctive queries for "whereIn" using ".where() API"',
-      //         (_) async {
-      //       CollectionReference<Map<String, dynamic>> collection =
-      //       await initializeTest('multiple-disjunctive-where');
-      //
-      //       await Future.wait([
-      //         collection.doc('doc1').set({
-      //           'genre': 'Not this',
-      //           'number': 1
-      //         }),
-      //         collection.doc('doc2').set({
-      //           'genre': 'Animation',
-      //           'number': 2
-      //         }),
-      //         collection.doc('doc3').set({
-      //           'genre': 'Adventure',
-      //           'number': 3
-      //         }),
-      //       ]);
-      //       final genres = [
-      //         'Action',
-      //         'Adventure',
-      //         'Animation',
-      //         'Biography',
-      //         'Comedy',
-      //         'Crime',
-      //         'Drama',
-      //         'Documentary',
-      //         'Family',
-      //         'Fantasy',
-      //         'Film-Noir',
-      //         'History',
-      //         'Horror',
-      //         'Music',
-      //         'Musical',
-      //         'Mystery',
-      //         'Romance',
-      //         'Sci-Fi',
-      //         'Sport',
-      //         'Thriller',
-      //         'War',
-      //         'Western',
-      //         'Epic',
-      //         'Tragedy',
-      //         'Satire',
-      //         'Romantic Comedy',
-      //         'Black Comedy',
-      //         'Paranormal',
-      //         'Non-fiction',
-      //         'Realism',
-      //       ];
-      //
-      //       final results = await collection
-      //           .where(
-      //         'genre',
-      //         whereIn: genres,
-      //       )
-      //           .orderBy('number')
-      //           .get();
-      //
-      //       expect(results.docs.length, equals(2));
-      //       expect(results.docs[0].id, equals('doc2'));
-      //       expect(results.docs[1].id, equals('doc3'));
-      //     });
-      //
-      // testWidgets(
-      //     'allow multiple disjunctive queries for "whereNotIn" using ".where() API"',
-      //         (_) async {
-      //       CollectionReference<Map<String, dynamic>> collection =
-      //       await initializeTest('multiple-disjunctive-where-not-in');
-      //
-      //       await Future.wait([
-      //         collection.doc('doc1').set({
-      //           'genre': 'Action',
-      //           'number': 1
-      //         }),
-      //         collection.doc('doc2').set({
-      //           'genre': 'Animation',
-      //           'number': 2
-      //         }),
-      //         collection.doc('doc3').set({
-      //           'genre': 'Adventure',
-      //           'number': 3
-      //         }),
-      //       ]);
-      //       final genres = [
-      //         'Action',
-      //         'Biography',
-      //         'Comedy',
-      //         'Crime',
-      //         'Drama',
-      //         'Documentary',
-      //         'Family',
-      //         'Fantasy',
-      //         'Film-Noir',
-      //         'History',
-      //         'Horror',
-      //         'Music',
-      //         'Musical',
-      //         'Mystery',
-      //         'Romance',
-      //         'Sci-Fi',
-      //         'Sport',
-      //         'Thriller',
-      //         'War',
-      //         'Western',
-      //         'Epic',
-      //         'Tragedy',
-      //         'Satire',
-      //         'Romantic Comedy',
-      //         'Black Comedy',
-      //         'Paranormal',
-      //         'Non-fiction',
-      //         'Realism',
-      //       ];
-      //
-      //       final results = await collection
-      //           .where(
-      //         'genre',
-      //         whereNotIn: genres,
-      //       )
-      //           .orderBy('genre')
-      //           .get();
-      //
-      //       expect(results.docs.length, equals(2));
-      //       expect(results.docs[0].id, equals('doc3'));
-      //       expect(results.docs[1].id, equals('doc2'));
-      //     });
+      testWidgets(
+          'allow multiple disjunctive queries for "arrayContainsAny" using ".where() API"',
+          (_) async {
+        CollectionReference<Map<String, dynamic>> collection =
+            await initializeTest('multiple-disjunctive-where');
+
+        await Future.wait([
+          collection.doc('doc1').set({
+            'genre': ['Not', 'Here'],
+            'number': 1
+          }),
+          collection.doc('doc2').set({
+            'genre': ['Animation', 'Another'],
+            'number': 2
+          }),
+          collection.doc('doc3').set({
+            'genre': ['Adventure', 'Another'],
+            'number': 3
+          }),
+        ]);
+        final genres = [
+          'Action',
+          'Adventure',
+          'Animation',
+          'Biography',
+          'Comedy',
+          'Crime',
+          'Drama',
+          'Documentary',
+          'Family',
+          'Fantasy',
+          'Film-Noir',
+          'History',
+          'Horror',
+          'Music',
+          'Musical',
+          'Mystery',
+          'Romance',
+          'Sci-Fi',
+          'Sport',
+          'Thriller',
+          'War',
+          'Western',
+          'Epic',
+          'Tragedy',
+          'Satire',
+          'Romantic Comedy',
+          'Black Comedy',
+          'Paranormal',
+          'Non-fiction',
+          'Realism',
+        ];
+
+        final results = await collection
+            .where(
+              'genre',
+              arrayContainsAny: genres,
+            )
+            .orderBy('number')
+            .get();
+
+        expect(results.docs.length, equals(2));
+        expect(results.docs[0].id, equals('doc2'));
+        expect(results.docs[1].id, equals('doc3'));
+      });
+
+      testWidgets(
+          'allow multiple disjunctive queries for "whereIn" using ".where() API"',
+          (_) async {
+        CollectionReference<Map<String, dynamic>> collection =
+            await initializeTest('multiple-disjunctive-where');
+
+        await Future.wait([
+          collection.doc('doc1').set({'genre': 'Not this', 'number': 1}),
+          collection.doc('doc2').set({'genre': 'Animation', 'number': 2}),
+          collection.doc('doc3').set({'genre': 'Adventure', 'number': 3}),
+        ]);
+        final genres = [
+          'Action',
+          'Adventure',
+          'Animation',
+          'Biography',
+          'Comedy',
+          'Crime',
+          'Drama',
+          'Documentary',
+          'Family',
+          'Fantasy',
+          'Film-Noir',
+          'History',
+          'Horror',
+          'Music',
+          'Musical',
+          'Mystery',
+          'Romance',
+          'Sci-Fi',
+          'Sport',
+          'Thriller',
+          'War',
+          'Western',
+          'Epic',
+          'Tragedy',
+          'Satire',
+          'Romantic Comedy',
+          'Black Comedy',
+          'Paranormal',
+          'Non-fiction',
+          'Realism',
+        ];
+
+        final results = await collection
+            .where(
+              'genre',
+              whereIn: genres,
+            )
+            .orderBy('number')
+            .get();
+
+        expect(results.docs.length, equals(2));
+        expect(results.docs[0].id, equals('doc2'));
+        expect(results.docs[1].id, equals('doc3'));
+      });
 
       testWidgets('isEqualTo filter', (_) async {
         CollectionReference<Map<String, dynamic>> collection =

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -730,9 +730,17 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
           value is Iterable,
           "A non-empty [Iterable] is required for '$operator' filters.",
         );
+        // This assert checks every operator other than "in" or "array-contains-any" have 10 or less filters
         assert(
-          (value as Iterable).length <= 10,
+          (operator == 'in' || operator == 'array-contains-any') ||
+              (value as Iterable).length <= 10,
           "'$operator' filters support a maximum of 10 elements in the value [Iterable].",
+        );
+        // This assert checks whether "in" or "array-contains-any" have 30 or less filters
+        assert(
+          (operator != 'in' && operator != 'array-contains-any') ||
+              (value as Iterable).length <= 30,
+          "'$operator' filters support a maximum of 30 elements in the value [Iterable].",
         );
         assert(
           (value as Iterable).isNotEmpty,

--- a/packages/cloud_firestore/cloud_firestore/test/query_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/query_test.dart
@@ -116,19 +116,30 @@ void main() {
         );
       });
 
-      test('throws if whereIn query length is greater than 10', () {
+      test('throws if whereIn query length is greater than 30', () {
+        List<int> numbers = List.generate(31, (i) => i + 1);
         expect(
-          () => query!
-              .where('foo.bar', whereIn: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+          () => query!.where('foo.bar', whereIn: numbers),
           throwsAssertionError,
         );
       });
 
-      test('throws if arrayContainsAny query length is greater than 10', () {
+      test('throws if arrayContainsAny query length is greater than 30', () {
+        List<int> numbers = List.generate(31, (i) => i + 1);
         expect(
           () => query!.where(
             'foo',
-            arrayContainsAny: [1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 9],
+            arrayContainsAny: numbers,
+          ),
+          throwsAssertionError,
+        );
+      });
+
+      test('throws if whereNotIn query length is greater than 10', () {
+        expect(
+          () => query!.where(
+            'foo',
+            whereNotIn: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
           ),
           throwsAssertionError,
         );


### PR DESCRIPTION
## Description

Circled back to this and it seems the response has changed. I've reinserted commented out tests, and allowed "in" & "array-contains-any" queries to have up to 30 filters.

## Related Issues

closes https://github.com/firebase/flutterfire/issues/11085

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
