### PR TITLE
fix(auth, ios): fix scoping of import for message.g.h, could cause incompatibility with other packages

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/Classes/Private/FLTPhoneNumberVerificationStreamHandler.h
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/Private/FLTPhoneNumberVerificationStreamHandler.h
@@ -11,7 +11,7 @@
 #endif
 
 #import <Firebase/Firebase.h>
-#import "messages.g.h"
+#import <firebase_auth/messages.g.h>
 
 #import <Foundation/Foundation.h>
 

--- a/packages/firebase_auth/firebase_auth/ios/Classes/Private/PigeonParser.h
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/Private/PigeonParser.h
@@ -6,7 +6,7 @@
 
 #import <Firebase/Firebase.h>
 #import <Foundation/Foundation.h>
-#import "messages.g.h"
+#import <firebase_auth/messages.g.h>
 
 @interface PigeonParser : NSObject
 

--- a/packages/firebase_auth/firebase_auth/ios/Classes/Public/FLTFirebaseAuthPlugin.h
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/Public/FLTFirebaseAuthPlugin.h
@@ -14,7 +14,7 @@
 #import <AuthenticationServices/AuthenticationServices.h>
 #import <Foundation/Foundation.h>
 #import <firebase_core/FLTFirebasePlugin.h>
-#import "messages.g.h"
+#import <firebase_auth/messages.g.h>
 
 @interface FLTFirebaseAuthPlugin
     : FLTFirebasePlugin <FlutterPlugin,


### PR DESCRIPTION
## Description

Importing messages.g.h could cause issues in other packages if they are using the same file name.

## Related Issues

closes #11825

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
