### PR TITLE
fix(auth, web): fix an issue preventing Web to properly parse providerData

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_web_user.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_web_user.dart
@@ -48,6 +48,10 @@ class UserWeb extends UserPlatform {
                   .map((auth_interop.UserInfo webUserInfo) => <String, dynamic>{
                         'displayName': webUserInfo.displayName,
                         'email': webUserInfo.email,
+                        // isAnonymous is always false for providerData
+                        'isAnonymous': false,
+                        // isEmailVerified is always true for providerData
+                        'isEmailVerified': true,
                         'phoneNumber': webUserInfo.phoneNumber,
                         'providerId': webUserInfo.providerId,
                         'photoUrl': webUserInfo.photoURL,

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -90,7 +90,7 @@ class UserInfo<T extends auth_interop.UserInfoJsImpl>
 
 /// User account.
 ///
-/// See: <https://firebase.google.com/docs/reference/js/firebase.User>.
+/// See: <https://firebase.google.com/docs/reference/js/auth.user>.
 class User extends UserInfo<auth_interop.UserJsImpl> {
   static final _expando = Expando<User>();
 


### PR DESCRIPTION
## Description

`isAnonymous` and `isEmailVerified` is not provided in ProviderData since they are always respectively `false` and `true`.

## Related Issues

closes #11289 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
