### PR TITLE
fix(firebase_auth, Android): Remove implicit default locale used in error message

### DIFF
--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/PhoneNumberVerificationStreamHandler.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/PhoneNumberVerificationStreamHandler.java
@@ -20,6 +20,7 @@ import com.google.firebase.auth.PhoneMultiFactorInfo;
 import io.flutter.plugin.common.EventChannel.EventSink;
 import io.flutter.plugin.common.EventChannel.StreamHandler;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -105,7 +106,11 @@ public class PhoneNumberVerificationStreamHandler implements StreamHandler {
                 FlutterFirebaseAuthPluginException.parserExceptionToFlutter(e);
             error.put(
                 "code",
-                flutterError.code.replaceAll("ERROR_", "").toLowerCase().replaceAll("_", "-"));
+                flutterError
+                    .code
+                    .replaceAll("ERROR_", "")
+                    .toLowerCase(Locale.ROOT)
+                    .replaceAll("_", "-"));
             error.put("message", flutterError.getMessage());
             error.put("details", flutterError.details);
             event.put("error", error);

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/PhoneNumberVerificationStreamHandler.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/PhoneNumberVerificationStreamHandler.java
@@ -105,10 +105,10 @@ public class PhoneNumberVerificationStreamHandler implements StreamHandler {
             GeneratedAndroidFirebaseAuth.FlutterError flutterError =
                 FlutterFirebaseAuthPluginException.parserExceptionToFlutter(e);
             error.put("code", flutterError
-                      .code
-                      .replaceAll("ERROR_", "")
-                      .toLowerCase(Locale.ROOT)
-                      .replaceAll("_", "-"));
+                .code
+                .replaceAll("ERROR_", "")
+                .toLowerCase(Locale.ROOT)
+                .replaceAll("_", "-"));
             error.put("message", flutterError.getMessage());
             error.put("details", flutterError.details);
             event.put("error", error);

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/PhoneNumberVerificationStreamHandler.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/PhoneNumberVerificationStreamHandler.java
@@ -104,11 +104,13 @@ public class PhoneNumberVerificationStreamHandler implements StreamHandler {
             Map<String, Object> error = new HashMap<>();
             GeneratedAndroidFirebaseAuth.FlutterError flutterError =
                 FlutterFirebaseAuthPluginException.parserExceptionToFlutter(e);
-            error.put("code", flutterError
-                .code
-                .replaceAll("ERROR_", "")
-                .toLowerCase(Locale.ROOT)
-                .replaceAll("_", "-"));
+            error.put(
+                "code",
+                flutterError
+                    .code
+                    .replaceAll("ERROR_", "")
+                    .toLowerCase(Locale.ROOT)
+                    .replaceAll("_", "-"));
             error.put("message", flutterError.getMessage());
             error.put("details", flutterError.details);
             event.put("error", error);

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/PhoneNumberVerificationStreamHandler.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/PhoneNumberVerificationStreamHandler.java
@@ -104,13 +104,11 @@ public class PhoneNumberVerificationStreamHandler implements StreamHandler {
             Map<String, Object> error = new HashMap<>();
             GeneratedAndroidFirebaseAuth.FlutterError flutterError =
                 FlutterFirebaseAuthPluginException.parserExceptionToFlutter(e);
-            error.put(
-                "code",
-                flutterError
-                    .code
-                    .replaceAll("ERROR_", "")
-                    .toLowerCase(Locale.ROOT)
-                    .replaceAll("_", "-"));
+            error.put("code", flutterError
+                      .code
+                      .replaceAll("ERROR_", "")
+                      .toLowerCase(Locale.ROOT)
+                      .replaceAll("_", "-"));
             error.put("message", flutterError.getMessage());
             error.put("details", flutterError.details);
             event.put("error", error);


### PR DESCRIPTION
Implicitly using the default locale is a common source of bugs: Use toLowerCase(Locale) instead. For strings meant to be internal use Locale.ROOT.


## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [0] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
