### PR TITLE
fix(firestore): remove assertion for `arrayContainsAny` & `whereIn` query combined

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
@@ -2391,6 +2391,42 @@ void runQueryTests() {
         expect(results.docs[1].id, equals('doc3'));
       });
 
+      testWidgets('"whereIn" query combined with "arrayContainsAny"',
+          (widgetTester) async {
+        CollectionReference<Map<String, dynamic>> collection =
+            await initializeTest('where-filter-arraycontainsany-in-combined');
+        await Future.wait([
+          collection.doc('doc1').set({
+            'value': [1, 2, 3],
+            'prop': 'foo',
+          }),
+          collection.doc('doc2').set({
+            'value': [2, 4, 5],
+            'prop': 'bar',
+          }),
+          collection.doc('doc3').set({
+            'value': [6, 7, 8],
+            'prop': 'basalt',
+          }),
+        ]);
+
+        final results = await collection
+            .where(
+              'value',
+              arrayContainsAny: [1, 7],
+            )
+            .where(
+              'prop',
+              whereIn: ['foo', 'basalt'],
+            )
+            .orderBy('prop')
+            .get();
+
+        expect(results.docs.length, equals(2));
+        expect(results.docs[0].id, equals('doc3'));
+        expect(results.docs[1].id, equals('doc1'));
+      });
+
       testWidgets('isEqualTo filter', (_) async {
         CollectionReference<Map<String, dynamic>> collection =
             await initializeTest('where-filter-isequalto');

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -792,13 +792,6 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
         hasArrayContainsAny = true;
       }
 
-      if (operator == 'array-contains-any' || operator == 'in') {
-        assert(
-          !(hasIn && hasArrayContainsAny),
-          "You cannot use 'in' filters with 'array-contains-any' filters.",
-        );
-      }
-
       if (operator == 'array-contains' || operator == 'array-contains-any') {
         assert(
           !(hasArrayContains && hasArrayContainsAny),

--- a/packages/cloud_firestore/cloud_firestore/test/query_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/query_test.dart
@@ -192,20 +192,6 @@ void main() {
           throwsAssertionError,
         );
         expect(
-          () => query!.where('foo', arrayContainsAny: [2, 3]).where(
-            'foo',
-            whereIn: [2, 3],
-          ),
-          throwsAssertionError,
-        );
-        expect(
-          () => query!.where('foo', whereIn: [2, 3]).where(
-            'foo',
-            arrayContainsAny: [2, 3],
-          ),
-          throwsAssertionError,
-        );
-        expect(
           () => query!
               .where('foo', whereIn: [2, 3])
               .where('foo', arrayContains: 1)


### PR DESCRIPTION
## Description

See title.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/11203

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
