### PR TITLE
feat(cloud_firestore_odm_generator): Support Sets as well as Lists for query method generation

### DIFF
--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/integration_test/collection_reference_test.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/integration_test/collection_reference_test.dart
@@ -381,13 +381,25 @@ void main() {
           final collection = await initializeTest(MovieCollectionReference());
 
           await collection.add(
-            createMovie(title: 'A', genre: ['foo', 'unrelated']),
+            createMovie(
+              title: 'A',
+              genre: ['foo', 'unrelated'],
+              tags: {'funny', 'unrelated'},
+            ),
           );
           await collection.add(
-            createMovie(title: 'B', genre: ['bar', 'unrelated']),
+            createMovie(
+              title: 'B',
+              genre: ['bar', 'unrelated'],
+              tags: {'serious', 'unrelated'},
+            ),
           );
           await collection.add(
-            createMovie(title: 'C', genre: ['bar', 'unrelated']),
+            createMovie(
+              title: 'C',
+              genre: ['bar', 'unrelated'],
+              tags: {'serious', 'unrelated'},
+            ),
           );
 
           final querySnap = await collection
@@ -402,19 +414,44 @@ void main() {
             querySnap.docs.map((e) => e.data.title),
             ['B', 'C'],
           );
+
+          final querySnap2 = await collection
+              .whereFieldPath(
+                FieldPath.fromString('tags'),
+                arrayContains: 'serious',
+              )
+              .orderByTitle()
+              .get();
+
+          expect(
+            querySnap2.docs.map((e) => e.data.title),
+            ['B', 'C'],
+          );
         });
 
         test('supports whereProperty', () async {
           final collection = await initializeTest(MovieCollectionReference());
 
           await collection.add(
-            createMovie(title: 'A', genre: ['foo', 'unrelated']),
+            createMovie(
+              title: 'A',
+              genre: ['foo', 'unrelated'],
+              tags: {'funny', 'unrelated'},
+            ),
           );
           await collection.add(
-            createMovie(title: 'B', genre: ['bar', 'unrelated']),
+            createMovie(
+              title: 'B',
+              genre: ['bar', 'unrelated'],
+              tags: {'serious', 'unrelated'},
+            ),
           );
           await collection.add(
-            createMovie(title: 'C', genre: ['bar', 'unrelated']),
+            createMovie(
+              title: 'C',
+              genre: ['bar', 'unrelated'],
+              tags: {'serious', 'unrelated'},
+            ),
           );
 
           final querySnap = await collection
@@ -424,6 +461,16 @@ void main() {
 
           expect(
             querySnap.docs.map((e) => e.data.title),
+            ['B', 'C'],
+          );
+
+          final querySnap2 = await collection
+              .whereTags(arrayContains: 'serious')
+              .orderByTitle()
+              .get();
+          
+          expect(
+            querySnap2.docs.map((e) => e.data.title),
             ['B', 'C'],
           );
         });

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/integration_test/collection_reference_test.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/integration_test/collection_reference_test.dart
@@ -468,7 +468,7 @@ void main() {
               .whereTags(arrayContains: 'serious')
               .orderByTitle()
               .get();
-          
+
           expect(
             querySnap2.docs.map((e) => e.data.title),
             ['B', 'C'],

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/integration_test/common.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/integration_test/common.dart
@@ -24,6 +24,7 @@ Future<T>
 
 Movie createMovie({
   List<String> genre = const [],
+  Set<String> tags = const {},
   int likes = 0,
   String poster = '',
   String rated = '',
@@ -34,6 +35,7 @@ Movie createMovie({
 }) {
   return Movie(
     genre: genre,
+    tags: tags,
     likes: likes,
     poster: poster,
     rated: rated,

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/integration/freezed.freezed.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/integration/freezed.freezed.dart
@@ -1,7 +1,3 @@
-// Copyright 2022, the Chromium project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
-
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/integration/freezed.freezed.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/integration/freezed.freezed.dart
@@ -1,3 +1,7 @@
+// Copyright 2022, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/movie.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/movie.dart
@@ -12,6 +12,7 @@ part 'movie.g.dart';
 class Movie {
   Movie({
     this.genre,
+    this.tags,
     required this.likes,
     required this.poster,
     required this.rated,
@@ -34,6 +35,7 @@ class Movie {
   final String runtime;
   final String rated;
   final List<String>? genre;
+  final Set<String>? tags;
 }
 
 @Collection<Movie>('firestore-example-app')

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/movie.g.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/example/lib/movie.g.dart
@@ -147,6 +147,8 @@ abstract class MovieDocumentReference
     FieldValue ratedFieldValue,
     List<String>? genre,
     FieldValue genreFieldValue,
+    Set<String>? tags,
+    FieldValue tagsFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -168,6 +170,8 @@ abstract class MovieDocumentReference
     FieldValue ratedFieldValue,
     List<String>? genre,
     FieldValue genreFieldValue,
+    Set<String>? tags,
+    FieldValue tagsFieldValue,
   });
 }
 
@@ -218,6 +222,8 @@ class _$MovieDocumentReference
     FieldValue? ratedFieldValue,
     Object? genre = _sentinel,
     FieldValue? genreFieldValue,
+    Object? tags = _sentinel,
+    FieldValue? tagsFieldValue,
   }) async {
     assert(
       poster == _sentinel || posterFieldValue == null,
@@ -247,6 +253,10 @@ class _$MovieDocumentReference
       genre == _sentinel || genreFieldValue == null,
       "Cannot specify both genre and genreFieldValue",
     );
+    assert(
+      tags == _sentinel || tagsFieldValue == null,
+      "Cannot specify both tags and tagsFieldValue",
+    );
     final json = {
       if (poster != _sentinel) _$MovieFieldMap['poster']!: poster as String,
       if (posterFieldValue != null)
@@ -264,6 +274,8 @@ class _$MovieDocumentReference
       if (ratedFieldValue != null) _$MovieFieldMap['rated']!: ratedFieldValue,
       if (genre != _sentinel) _$MovieFieldMap['genre']!: genre as List<String>?,
       if (genreFieldValue != null) _$MovieFieldMap['genre']!: genreFieldValue,
+      if (tags != _sentinel) _$MovieFieldMap['tags']!: tags as Set<String>?,
+      if (tagsFieldValue != null) _$MovieFieldMap['tags']!: tagsFieldValue,
     };
 
     return reference.update(json);
@@ -285,6 +297,8 @@ class _$MovieDocumentReference
     FieldValue? ratedFieldValue,
     Object? genre = _sentinel,
     FieldValue? genreFieldValue,
+    Object? tags = _sentinel,
+    FieldValue? tagsFieldValue,
   }) {
     assert(
       poster == _sentinel || posterFieldValue == null,
@@ -314,6 +328,10 @@ class _$MovieDocumentReference
       genre == _sentinel || genreFieldValue == null,
       "Cannot specify both genre and genreFieldValue",
     );
+    assert(
+      tags == _sentinel || tagsFieldValue == null,
+      "Cannot specify both tags and tagsFieldValue",
+    );
     final json = {
       if (poster != _sentinel) _$MovieFieldMap['poster']!: poster as String,
       if (posterFieldValue != null)
@@ -331,6 +349,8 @@ class _$MovieDocumentReference
       if (ratedFieldValue != null) _$MovieFieldMap['rated']!: ratedFieldValue,
       if (genre != _sentinel) _$MovieFieldMap['genre']!: genre as List<String>?,
       if (genreFieldValue != null) _$MovieFieldMap['genre']!: genreFieldValue,
+      if (tags != _sentinel) _$MovieFieldMap['tags']!: tags as Set<String>?,
+      if (tagsFieldValue != null) _$MovieFieldMap['tags']!: tagsFieldValue,
     };
 
     transaction.update(reference, json);
@@ -508,6 +528,17 @@ abstract class MovieQuery implements QueryReference<Movie, MovieQuerySnapshot> {
     String? arrayContains,
     List<String>? arrayContainsAny,
   });
+  MovieQuery whereTags({
+    Set<String>? isEqualTo,
+    Set<String>? isNotEqualTo,
+    Set<String>? isLessThan,
+    Set<String>? isLessThanOrEqualTo,
+    Set<String>? isGreaterThan,
+    Set<String>? isGreaterThanOrEqualTo,
+    bool? isNull,
+    String? arrayContains,
+    Set<String>? arrayContainsAny,
+  });
 
   MovieQuery orderByDocumentId({
     bool descending = false,
@@ -599,6 +630,18 @@ abstract class MovieQuery implements QueryReference<Movie, MovieQuerySnapshot> {
     List<String>? startAfter,
     List<String>? endAt,
     List<String>? endBefore,
+    MovieDocumentSnapshot? startAtDocument,
+    MovieDocumentSnapshot? endAtDocument,
+    MovieDocumentSnapshot? endBeforeDocument,
+    MovieDocumentSnapshot? startAfterDocument,
+  });
+
+  MovieQuery orderByTags({
+    bool descending = false,
+    Set<String>? startAt,
+    Set<String>? startAfter,
+    Set<String>? endAt,
+    Set<String>? endBefore,
     MovieDocumentSnapshot? startAtDocument,
     MovieDocumentSnapshot? endAtDocument,
     MovieDocumentSnapshot? endBeforeDocument,
@@ -971,6 +1014,35 @@ class _$MovieQuery extends QueryReference<Movie, MovieQuerySnapshot>
       _collection,
       $referenceWithoutCursor: $referenceWithoutCursor.where(
         _$MovieFieldMap['genre']!,
+        isEqualTo: isEqualTo,
+        isNotEqualTo: isNotEqualTo,
+        isLessThan: isLessThan,
+        isLessThanOrEqualTo: isLessThanOrEqualTo,
+        isGreaterThan: isGreaterThan,
+        isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
+        isNull: isNull,
+        arrayContains: arrayContains,
+        arrayContainsAny: arrayContainsAny,
+      ),
+      $queryCursor: $queryCursor,
+    );
+  }
+
+  MovieQuery whereTags({
+    Set<String>? isEqualTo,
+    Set<String>? isNotEqualTo,
+    Set<String>? isLessThan,
+    Set<String>? isLessThanOrEqualTo,
+    Set<String>? isGreaterThan,
+    Set<String>? isGreaterThanOrEqualTo,
+    bool? isNull,
+    String? arrayContains,
+    Set<String>? arrayContainsAny,
+  }) {
+    return _$MovieQuery(
+      _collection,
+      $referenceWithoutCursor: $referenceWithoutCursor.where(
+        _$MovieFieldMap['tags']!,
         isEqualTo: isEqualTo,
         isNotEqualTo: isNotEqualTo,
         isLessThan: isLessThan,
@@ -1501,6 +1573,78 @@ class _$MovieQuery extends QueryReference<Movie, MovieQuerySnapshot>
     MovieDocumentSnapshot? startAfterDocument,
   }) {
     final query = $referenceWithoutCursor.orderBy(_$MovieFieldMap['genre']!,
+        descending: descending);
+    var queryCursor = $queryCursor;
+
+    if (startAtDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        startAt: const [],
+        startAtDocumentSnapshot: startAtDocument.snapshot,
+      );
+    }
+    if (startAfterDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        startAfter: const [],
+        startAfterDocumentSnapshot: startAfterDocument.snapshot,
+      );
+    }
+    if (endAtDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        endAt: const [],
+        endAtDocumentSnapshot: endAtDocument.snapshot,
+      );
+    }
+    if (endBeforeDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        endBefore: const [],
+        endBeforeDocumentSnapshot: endBeforeDocument.snapshot,
+      );
+    }
+
+    if (startAt != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        startAt: [...queryCursor.startAt, startAt],
+        startAtDocumentSnapshot: null,
+      );
+    }
+    if (startAfter != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        startAfter: [...queryCursor.startAfter, startAfter],
+        startAfterDocumentSnapshot: null,
+      );
+    }
+    if (endAt != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        endAt: [...queryCursor.endAt, endAt],
+        endAtDocumentSnapshot: null,
+      );
+    }
+    if (endBefore != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        endBefore: [...queryCursor.endBefore, endBefore],
+        endBeforeDocumentSnapshot: null,
+      );
+    }
+
+    return _$MovieQuery(
+      _collection,
+      $referenceWithoutCursor: query,
+      $queryCursor: queryCursor,
+    );
+  }
+
+  MovieQuery orderByTags({
+    bool descending = false,
+    Object? startAt = _sentinel,
+    Object? startAfter = _sentinel,
+    Object? endAt = _sentinel,
+    Object? endBefore = _sentinel,
+    MovieDocumentSnapshot? startAtDocument,
+    MovieDocumentSnapshot? endAtDocument,
+    MovieDocumentSnapshot? endBeforeDocument,
+    MovieDocumentSnapshot? startAfterDocument,
+  }) {
+    final query = $referenceWithoutCursor.orderBy(_$MovieFieldMap['tags']!,
         descending: descending);
     var queryCursor = $queryCursor;
 
@@ -2603,6 +2747,7 @@ void _$assertMovie(Movie instance) {
 Movie _$MovieFromJson(Map<String, dynamic> json) => Movie(
       genre:
           (json['genre'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      tags: (json['tags'] as List<dynamic>?)?.map((e) => e as String).toSet(),
       likes: json['likes'] as int,
       poster: json['poster'] as String,
       rated: json['rated'] as String,
@@ -2621,6 +2766,7 @@ const _$MovieFieldMap = <String, String>{
   'runtime': 'runtime',
   'rated': 'rated',
   'genre': 'genre',
+  'tags': 'tags',
 };
 
 Map<String, dynamic> _$MovieToJson(Movie instance) => <String, dynamic>{
@@ -2632,6 +2778,7 @@ Map<String, dynamic> _$MovieToJson(Movie instance) => <String, dynamic>{
       'runtime': instance.runtime,
       'rated': instance.rated,
       'genre': instance.genre,
+      'tags': instance.tags?.toList(),
     };
 
 Comment _$CommentFromJson(Map<String, dynamic> json) => Comment(

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.dart
@@ -46,6 +46,7 @@ class Nested {
     required this.numList,
     required this.objectList,
     required this.dynamicList,
+    required this.boolSet,
   });
 
   factory Nested.fromJson(Map<String, Object?> json) => _$NestedFromJson(json);
@@ -60,6 +61,7 @@ class Nested {
   final List<num>? numList;
   final List<Object?>? objectList;
   final List<dynamic>? dynamicList;
+  final Set<bool>? boolSet;
 }
 
 @Collection<Nested>('nested')

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/cloud_firestore_odm_generator_integration_test/lib/simple.g.dart
@@ -1678,6 +1678,8 @@ abstract class NestedDocumentReference
     FieldValue objectListFieldValue,
     List<dynamic>? dynamicList,
     FieldValue dynamicListFieldValue,
+    Set<bool>? boolSet,
+    FieldValue boolSetFieldValue,
   });
 
   /// Updates fields in the current document using the transaction API.
@@ -1697,6 +1699,8 @@ abstract class NestedDocumentReference
     FieldValue objectListFieldValue,
     List<dynamic>? dynamicList,
     FieldValue dynamicListFieldValue,
+    Set<bool>? boolSet,
+    FieldValue boolSetFieldValue,
   });
 }
 
@@ -1741,6 +1745,8 @@ class _$NestedDocumentReference
     FieldValue? objectListFieldValue,
     Object? dynamicList = _sentinel,
     FieldValue? dynamicListFieldValue,
+    Object? boolSet = _sentinel,
+    FieldValue? boolSetFieldValue,
   }) async {
     assert(
       simple == _sentinel || simpleFieldValue == null,
@@ -1766,6 +1772,10 @@ class _$NestedDocumentReference
       dynamicList == _sentinel || dynamicListFieldValue == null,
       "Cannot specify both dynamicList and dynamicListFieldValue",
     );
+    assert(
+      boolSet == _sentinel || boolSetFieldValue == null,
+      "Cannot specify both boolSet and boolSetFieldValue",
+    );
     final json = {
       if (simple != _sentinel) _$NestedFieldMap['simple']!: simple as int?,
       if (simpleFieldValue != null)
@@ -1790,6 +1800,10 @@ class _$NestedDocumentReference
         _$NestedFieldMap['dynamicList']!: dynamicList as List<dynamic>?,
       if (dynamicListFieldValue != null)
         _$NestedFieldMap['dynamicList']!: dynamicListFieldValue,
+      if (boolSet != _sentinel)
+        _$NestedFieldMap['boolSet']!: boolSet as Set<bool>?,
+      if (boolSetFieldValue != null)
+        _$NestedFieldMap['boolSet']!: boolSetFieldValue,
     };
 
     return reference.update(json);
@@ -1809,6 +1823,8 @@ class _$NestedDocumentReference
     FieldValue? objectListFieldValue,
     Object? dynamicList = _sentinel,
     FieldValue? dynamicListFieldValue,
+    Object? boolSet = _sentinel,
+    FieldValue? boolSetFieldValue,
   }) {
     assert(
       simple == _sentinel || simpleFieldValue == null,
@@ -1834,6 +1850,10 @@ class _$NestedDocumentReference
       dynamicList == _sentinel || dynamicListFieldValue == null,
       "Cannot specify both dynamicList and dynamicListFieldValue",
     );
+    assert(
+      boolSet == _sentinel || boolSetFieldValue == null,
+      "Cannot specify both boolSet and boolSetFieldValue",
+    );
     final json = {
       if (simple != _sentinel) _$NestedFieldMap['simple']!: simple as int?,
       if (simpleFieldValue != null)
@@ -1858,6 +1878,10 @@ class _$NestedDocumentReference
         _$NestedFieldMap['dynamicList']!: dynamicList as List<dynamic>?,
       if (dynamicListFieldValue != null)
         _$NestedFieldMap['dynamicList']!: dynamicListFieldValue,
+      if (boolSet != _sentinel)
+        _$NestedFieldMap['boolSet']!: boolSet as Set<bool>?,
+      if (boolSetFieldValue != null)
+        _$NestedFieldMap['boolSet']!: boolSetFieldValue,
     };
 
     transaction.update(reference, json);
@@ -2025,6 +2049,17 @@ abstract class NestedQuery
     dynamic arrayContains,
     List<dynamic>? arrayContainsAny,
   });
+  NestedQuery whereBoolSet({
+    Set<bool>? isEqualTo,
+    Set<bool>? isNotEqualTo,
+    Set<bool>? isLessThan,
+    Set<bool>? isLessThanOrEqualTo,
+    Set<bool>? isGreaterThan,
+    Set<bool>? isGreaterThanOrEqualTo,
+    bool? isNull,
+    bool? arrayContains,
+    Set<bool>? arrayContainsAny,
+  });
 
   NestedQuery orderByDocumentId({
     bool descending = false,
@@ -2104,6 +2139,18 @@ abstract class NestedQuery
     List<dynamic>? startAfter,
     List<dynamic>? endAt,
     List<dynamic>? endBefore,
+    NestedDocumentSnapshot? startAtDocument,
+    NestedDocumentSnapshot? endAtDocument,
+    NestedDocumentSnapshot? endBeforeDocument,
+    NestedDocumentSnapshot? startAfterDocument,
+  });
+
+  NestedQuery orderByBoolSet({
+    bool descending = false,
+    Set<bool>? startAt,
+    Set<bool>? startAfter,
+    Set<bool>? endAt,
+    Set<bool>? endBefore,
     NestedDocumentSnapshot? startAtDocument,
     NestedDocumentSnapshot? endAtDocument,
     NestedDocumentSnapshot? endBeforeDocument,
@@ -2447,6 +2494,35 @@ class _$NestedQuery extends QueryReference<Nested, NestedQuerySnapshot>
       _collection,
       $referenceWithoutCursor: $referenceWithoutCursor.where(
         _$NestedFieldMap['dynamicList']!,
+        isEqualTo: isEqualTo,
+        isNotEqualTo: isNotEqualTo,
+        isLessThan: isLessThan,
+        isLessThanOrEqualTo: isLessThanOrEqualTo,
+        isGreaterThan: isGreaterThan,
+        isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
+        isNull: isNull,
+        arrayContains: arrayContains,
+        arrayContainsAny: arrayContainsAny,
+      ),
+      $queryCursor: $queryCursor,
+    );
+  }
+
+  NestedQuery whereBoolSet({
+    Set<bool>? isEqualTo,
+    Set<bool>? isNotEqualTo,
+    Set<bool>? isLessThan,
+    Set<bool>? isLessThanOrEqualTo,
+    Set<bool>? isGreaterThan,
+    Set<bool>? isGreaterThanOrEqualTo,
+    bool? isNull,
+    bool? arrayContains,
+    Set<bool>? arrayContainsAny,
+  }) {
+    return _$NestedQuery(
+      _collection,
+      $referenceWithoutCursor: $referenceWithoutCursor.where(
+        _$NestedFieldMap['boolSet']!,
         isEqualTo: isEqualTo,
         isNotEqualTo: isNotEqualTo,
         isLessThan: isLessThan,
@@ -2906,6 +2982,78 @@ class _$NestedQuery extends QueryReference<Nested, NestedQuerySnapshot>
   }) {
     final query = $referenceWithoutCursor
         .orderBy(_$NestedFieldMap['dynamicList']!, descending: descending);
+    var queryCursor = $queryCursor;
+
+    if (startAtDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        startAt: const [],
+        startAtDocumentSnapshot: startAtDocument.snapshot,
+      );
+    }
+    if (startAfterDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        startAfter: const [],
+        startAfterDocumentSnapshot: startAfterDocument.snapshot,
+      );
+    }
+    if (endAtDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        endAt: const [],
+        endAtDocumentSnapshot: endAtDocument.snapshot,
+      );
+    }
+    if (endBeforeDocument != null) {
+      queryCursor = queryCursor.copyWith(
+        endBefore: const [],
+        endBeforeDocumentSnapshot: endBeforeDocument.snapshot,
+      );
+    }
+
+    if (startAt != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        startAt: [...queryCursor.startAt, startAt],
+        startAtDocumentSnapshot: null,
+      );
+    }
+    if (startAfter != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        startAfter: [...queryCursor.startAfter, startAfter],
+        startAfterDocumentSnapshot: null,
+      );
+    }
+    if (endAt != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        endAt: [...queryCursor.endAt, endAt],
+        endAtDocumentSnapshot: null,
+      );
+    }
+    if (endBefore != _sentinel) {
+      queryCursor = queryCursor.copyWith(
+        endBefore: [...queryCursor.endBefore, endBefore],
+        endBeforeDocumentSnapshot: null,
+      );
+    }
+
+    return _$NestedQuery(
+      _collection,
+      $referenceWithoutCursor: query,
+      $queryCursor: queryCursor,
+    );
+  }
+
+  NestedQuery orderByBoolSet({
+    bool descending = false,
+    Object? startAt = _sentinel,
+    Object? startAfter = _sentinel,
+    Object? endAt = _sentinel,
+    Object? endBefore = _sentinel,
+    NestedDocumentSnapshot? startAtDocument,
+    NestedDocumentSnapshot? endAtDocument,
+    NestedDocumentSnapshot? endBeforeDocument,
+    NestedDocumentSnapshot? startAfterDocument,
+  }) {
+    final query = $referenceWithoutCursor.orderBy(_$NestedFieldMap['boolSet']!,
+        descending: descending);
     var queryCursor = $queryCursor;
 
     if (startAtDocument != null) {
@@ -11706,6 +11854,8 @@ Nested _$NestedFromJson(Map<String, dynamic> json) => Nested(
           (json['numList'] as List<dynamic>?)?.map((e) => e as num).toList(),
       objectList: json['objectList'] as List<dynamic>?,
       dynamicList: json['dynamicList'] as List<dynamic>?,
+      boolSet:
+          (json['boolSet'] as List<dynamic>?)?.map((e) => e as bool).toSet(),
     );
 
 const _$NestedFieldMap = <String, String>{
@@ -11717,6 +11867,7 @@ const _$NestedFieldMap = <String, String>{
   'numList': 'numList',
   'objectList': 'objectList',
   'dynamicList': 'dynamicList',
+  'boolSet': 'boolSet',
 };
 
 Map<String, dynamic> _$NestedToJson(Nested instance) => <String, dynamic>{
@@ -11728,6 +11879,7 @@ Map<String, dynamic> _$NestedToJson(Nested instance) => <String, dynamic>{
       'numList': instance.numList,
       'objectList': instance.objectList,
       'dynamicList': instance.dynamicList,
+      'boolSet': instance.boolSet?.toList(),
     };
 
 EmptyModel _$EmptyModelFromJson(Map<String, dynamic> json) => EmptyModel();

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/collection_data.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/collection_data.dart
@@ -346,7 +346,7 @@ represents the content of the collection must be in the same file.
         type.isDartCoreInt ||
         type.isDartCoreDouble ||
         type.isDartCoreBool ||
-        type.isPrimitiveIterable ||
+        type.isSupportedPrimitiveIterable ||
         type.isJsonDocumentReference ||
         dateTimeChecker.isAssignableFromType(type) ||
         timestampChecker.isAssignableFromType(type) ||
@@ -445,7 +445,7 @@ extension DartTypeExtension on DartType {
       _coreListChecker.isExactlyType(this) ||
       _coreSetChecker.isExactlyType(this);
 
-  bool get isPrimitiveIterable {
+  bool get isSupportedPrimitiveIterable {
     if (!isSupportedIterable) return false;
 
     final generic = (this as InterfaceType).typeArguments.single;

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/collection_data.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/collection_data.dart
@@ -429,6 +429,9 @@ extension on String {
   }
 }
 
+const _coreListChecker = TypeChecker.fromUrl('dart:core#List');
+const _coreSetChecker = TypeChecker.fromUrl('dart:core#Set');
+
 extension DartTypeExtension on DartType {
   bool get isJsonDocumentReference {
     return element?.librarySource?.uri.scheme == 'package' &&
@@ -438,11 +441,12 @@ extension DartTypeExtension on DartType {
         (this as InterfaceType).typeArguments.single.isDartCoreMap;
   }
 
-  bool get isIterable =>
-      (this as InterfaceType).allSupertypes.any((e) => e.isDartCoreIterable);
+  bool get isSupportedIterable =>
+      _coreListChecker.isExactlyType(this) ||
+      _coreSetChecker.isExactlyType(this);
 
   bool get isPrimitiveIterable {
-    if (!isIterable) return false;
+    if (!isSupportedIterable) return false;
 
     final generic = (this as InterfaceType).typeArguments.single;
 

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/collection_data.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/collection_data.dart
@@ -346,7 +346,7 @@ represents the content of the collection must be in the same file.
         type.isDartCoreInt ||
         type.isDartCoreDouble ||
         type.isDartCoreBool ||
-        type.isPrimitiveList ||
+        type.isPrimitiveIterable ||
         type.isJsonDocumentReference ||
         dateTimeChecker.isAssignableFromType(type) ||
         timestampChecker.isAssignableFromType(type) ||
@@ -429,7 +429,7 @@ extension on String {
   }
 }
 
-extension on DartType {
+extension DartTypeExtension on DartType {
   bool get isJsonDocumentReference {
     return element?.librarySource?.uri.scheme == 'package' &&
         const {'cloud_firestore'}
@@ -438,8 +438,11 @@ extension on DartType {
         (this as InterfaceType).typeArguments.single.isDartCoreMap;
   }
 
-  bool get isPrimitiveList {
-    if (!isDartCoreList) return false;
+  bool get isIterable =>
+      (this as InterfaceType).allSupertypes.any((e) => e.isDartCoreIterable);
+
+  bool get isPrimitiveIterable {
+    if (!isIterable) return false;
 
     final generic = (this as InterfaceType).typeArguments.single;
 

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/query_reference.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/query_reference.dart
@@ -388,7 +388,7 @@ class ${data.queryReferenceImplName}
         'isGreaterThan': nullableType,
         'isGreaterThanOrEqualTo': nullableType,
         'isNull': 'bool?',
-        if (field.type.isDartCoreList) ...{
+        if (field.type.isIterable) ...{
           'arrayContains': data.libraryElement.typeProvider
               .asNullable((field.type as InterfaceType).typeArguments.first),
           'arrayContainsAny': nullableType,

--- a/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/query_reference.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm_generator/lib/src/templates/query_reference.dart
@@ -388,7 +388,7 @@ class ${data.queryReferenceImplName}
         'isGreaterThan': nullableType,
         'isGreaterThanOrEqualTo': nullableType,
         'isNull': 'bool?',
-        if (field.type.isIterable) ...{
+        if (field.type.isSupportedIterable) ...{
           'arrayContains': data.libraryElement.typeProvider
               .asNullable((field.type as InterfaceType).typeArguments.first),
           'arrayContainsAny': nullableType,


### PR DESCRIPTION
## Description

Support generating query methods for Sets.

## Related Issues

#11344

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
