### PR TITLE
fix: Modify input files for xcode15

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/crashlytics_add_upload_symbols
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/crashlytics_add_upload_symbols
@@ -75,7 +75,13 @@ project.targets.each do |target|
         if (phase.nil?)
             phase = target.new_shell_script_build_phase("[firebase_crashlytics] Crashlytics Upload Symbols")
             phase.shell_script = "\"$PODS_ROOT/FirebaseCrashlytics/upload-symbols\" #{upload_symbols_args}"
-            phase.input_paths = ["\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}\"", "\"$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)\""]
+            phase.input_paths = [
+                "\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}\"",
+                "\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/\"",
+                "\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist\"",
+                "\"$(BUILT_PRODUCTS_DIR)/$(EXECUTABLE_PATH)\"",
+                "\"$(PROJECT_DIR)/firebase_app_id_file.json\"",
+            ]
             project.save()
         end
     end


### PR DESCRIPTION
### Description

Related to https://github.com/firebase/firebase-ios-sdk/issues/11400, Xcode 15 enforces tighter requirements on Input Files for Run Scripts. This automatically includes Crashlytics Input Files.