### PR TITLE
feat(firebase_ui_auth): Add "Go Back" button to EmailLinkSignInView

### DIFF
--- a/packages/firebase_ui_auth/lib/src/views/email_link_sign_in_view.dart
+++ b/packages/firebase_ui_auth/lib/src/views/email_link_sign_in_view.dart
@@ -83,6 +83,14 @@ class _EmailLinkSignInViewState extends State<EmailLinkSignInView> {
               ),
             ],
             const SizedBox(height: 8),
+            UniversalButton(
+              text: l.goBackButtonLabel,
+              variant: ButtonVariant.text,
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+            const SizedBox(height: 8),
             if (state is AuthFailed) ErrorText(exception: state.exception),
           ],
         );


### PR DESCRIPTION
Add "Go back" button to EmailLinkSignInView

## Description

This PR adds a "Go back" button to EmailLinkSignInView. Other views and screens in firebase_ui_auth have 
a similar button already, but EmailLinkSignInView does not, so users can get stuck if they got there by mistake,
mistyped their email address, etc. This button code was copied from SMSCodeInputScreen, so it should be
consistent with other auth flows in the package.

## Related Issues

Feature request is here: https://github.com/firebase/flutterfire/discussions/11366

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
