### PR TITLE
docs(auth): update the incorrect "getting started" link 

### DIFF
--- a/packages/firebase_auth/firebase_auth/README.md
+++ b/packages/firebase_auth/firebase_auth/README.md
@@ -9,7 +9,7 @@ To learn more about Firebase Auth, please visit the [Firebase website](https://f
 
 ## Getting Started
 
-To get started with Firebase Auth for Flutter, please [see the documentation](https://firebase.flutter.dev/docs/auth/overview).
+To get started with Firebase Auth for Flutter, please [see the documentation](https://firebase.google.com/docs/auth/flutter/start).
 
 ## Usage
 


### PR DESCRIPTION
## Description

Simple update of the "getting started" link to point to the latest documentation instead of the archived one

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
