### PR TITLE
fix(firestore): allow `FieldPath.documentId` as a field argument in queries

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
@@ -1935,6 +1935,53 @@ void runQueryTests() {
         expect(results.docs[1].data()['genre'], equals(['sci-fi', 'action']));
       });
 
+      testWidgets('allow FieldPathType for Filter queries', (_) async {
+        CollectionReference<Map<String, dynamic>> collection =
+            await initializeTest('filter-path-type');
+
+        await Future.wait([
+          collection.doc('doc1').set({
+            'genre': ['fantasy', 'action'],
+            'rating': 4.5,
+          }),
+          collection.doc('doc2').set({
+            'genre': ['sci-fi', 'thriller'],
+            'rating': 3.8,
+          }),
+          collection.doc('doc3').set({
+            'genre': ['sci-fi', 'action'],
+            'rating': 4.2,
+          }),
+          collection.doc('doc4').set({
+            'genre': ['mystery', 'action'],
+            'rating': 4.7,
+          }),
+        ]);
+
+        final results = await collection
+            .where(
+              Filter.or(
+                Filter.and(
+                  Filter(FieldPath.documentId, isEqualTo: 'doc1'),
+                  Filter('rating', isEqualTo: 4.5),
+                ),
+                Filter.and(
+                  Filter(FieldPath.documentId, isEqualTo: 'doc2'),
+                  Filter('rating', isEqualTo: 3.8),
+                ),
+              ),
+            )
+            .orderBy(FieldPath.documentId, descending: false)
+            .get();
+
+        expect(results.docs.length, equals(2));
+        expect(results.docs[0].id, equals('doc1'));
+        expect(results.docs[0].data()['rating'], equals(4.5));
+
+        expect(results.docs[1].id, equals('doc2'));
+        expect(results.docs[1].data()['rating'], equals(3.8));
+      });
+
       testWidgets('allow multiple conjunctive queries', (_) async {
         CollectionReference<Map<String, dynamic>> collection =
             await initializeTest('multiple-conjunctive-queries');

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/filters.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/filters.dart
@@ -118,7 +118,8 @@ class Filter {
           'Exactly one operator must be specified',
         ),
         assert(
-            field is String || field is FieldPath || field is FieldPathType) {
+          field is String || field is FieldPath || field is FieldPathType,
+        ) {
     final _field = (field is String ? FieldPath.fromString(field) : field);
 
     _filterQuery = _FilterQuery(

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/filters.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/filters.dart
@@ -4,6 +4,8 @@
 
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 
+import 'internal/field_path_type.dart';
+
 class _FilterObject {
   Map<String, Object?> build() {
     throw UnimplementedError();
@@ -11,9 +13,10 @@ class _FilterObject {
 }
 
 class _FilterQuery extends _FilterObject {
-  _FilterQuery(this._field, this._operator, this._value);
+  _FilterQuery(this._field, this._operator, this._value)
+      : assert(_field is FieldPathType || _field is FieldPath);
 
-  final FieldPath _field;
+  final Object _field;
   final String _operator;
   final Object? _value;
 
@@ -114,9 +117,9 @@ class Filter {
           }(),
           'Exactly one operator must be specified',
         ),
-        assert(field is String || field is FieldPath) {
-    final _field =
-        field is String ? FieldPath.fromString(field) : field as FieldPath;
+        assert(
+            field is String || field is FieldPath || field is FieldPathType) {
+    final _field = (field is String ? FieldPath.fromString(field) : field);
 
     _filterQuery = _FilterQuery(
       _field,


### PR DESCRIPTION
## Description

see title.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/11422

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
