### PR TITLE
fix(messaging): Method channel handlers were not created if `FirebaseMessaging.instance.*` is not invoked beforehand

### DIFF
--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/method_channel/method_channel_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/method_channel/method_channel_messaging.dart
@@ -68,41 +68,10 @@ void _firebaseMessagingCallbackDispatcher() {
 class MethodChannelFirebaseMessaging extends FirebaseMessagingPlatform {
   /// Create an instance of [MethodChannelFirebaseMessaging] with optional [FirebaseApp]
   MethodChannelFirebaseMessaging({required FirebaseApp app})
-      : super(appInstance: app) {
-    if (_initialized) return;
-    channel.setMethodCallHandler((MethodCall call) async {
-      switch (call.method) {
-        case 'Messaging#onTokenRefresh':
-          _tokenStreamController.add(call.arguments as String);
-          break;
-        case 'Messaging#onMessage':
-          Map<String, dynamic> messageMap =
-              Map<String, dynamic>.from(call.arguments);
-          FirebaseMessagingPlatform.onMessage
-              .add(RemoteMessage.fromMap(messageMap));
-          break;
-        case 'Messaging#onMessageOpenedApp':
-          Map<String, dynamic> messageMap =
-              Map<String, dynamic>.from(call.arguments);
-          FirebaseMessagingPlatform.onMessageOpenedApp
-              .add(RemoteMessage.fromMap(messageMap));
-          break;
-        case 'Messaging#onBackgroundMessage':
-          // Apple only. Android calls via separate background channel.
-          Map<String, dynamic> messageMap =
-              Map<String, dynamic>.from(call.arguments);
-          return FirebaseMessagingPlatform.onBackgroundMessage
-              ?.call(RemoteMessage.fromMap(messageMap));
-        default:
-          throw UnimplementedError('${call.method} has not been implemented');
-      }
-    });
-    _initialized = true;
-  }
+      : super(appInstance: app);
 
   late bool _autoInitEnabled;
 
-  static bool _initialized = false;
   static bool _bgHandlerInitialized = false;
 
   /// Returns a stub instance to allow the platform interface to access
@@ -117,13 +86,11 @@ class MethodChannelFirebaseMessaging extends FirebaseMessagingPlatform {
   /// then initialized via the [delegateFor] method.
   MethodChannelFirebaseMessaging._() : super(appInstance: null);
 
-  /// The [MethodChannel] to which calls will be delegated.
-  @visibleForTesting
   static const MethodChannel channel = MethodChannel(
     'plugins.flutter.io/firebase_messaging',
   );
 
-  final StreamController<String> _tokenStreamController =
+  static StreamController<String> tokenStreamController =
       StreamController<String>.broadcast();
 
   @override
@@ -305,7 +272,7 @@ class MethodChannelFirebaseMessaging extends FirebaseMessagingPlatform {
 
   @override
   Stream<String> get onTokenRefresh {
-    return _tokenStreamController.stream;
+    return tokenStreamController.stream;
   }
 
   @override

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/method_channel/method_channel_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/method_channel/method_channel_messaging.dart
@@ -86,6 +86,38 @@ class MethodChannelFirebaseMessaging extends FirebaseMessagingPlatform {
   /// then initialized via the [delegateFor] method.
   MethodChannelFirebaseMessaging._() : super(appInstance: null);
 
+  static void setMethodCallHandlers() {
+    MethodChannelFirebaseMessaging.channel
+        .setMethodCallHandler((MethodCall call) async {
+      switch (call.method) {
+        case 'Messaging#onTokenRefresh':
+          MethodChannelFirebaseMessaging.tokenStreamController
+              .add(call.arguments as String);
+          break;
+        case 'Messaging#onMessage':
+          Map<String, dynamic> messageMap =
+              Map<String, dynamic>.from(call.arguments);
+          FirebaseMessagingPlatform.onMessage
+              .add(RemoteMessage.fromMap(messageMap));
+          break;
+        case 'Messaging#onMessageOpenedApp':
+          Map<String, dynamic> messageMap =
+              Map<String, dynamic>.from(call.arguments);
+          FirebaseMessagingPlatform.onMessageOpenedApp
+              .add(RemoteMessage.fromMap(messageMap));
+          break;
+        case 'Messaging#onBackgroundMessage':
+          // Apple only. Android calls via separate background channel.
+          Map<String, dynamic> messageMap =
+              Map<String, dynamic>.from(call.arguments);
+          return FirebaseMessagingPlatform.onBackgroundMessage
+              ?.call(RemoteMessage.fromMap(messageMap));
+        default:
+          throw UnimplementedError('${call.method} has not been implemented');
+      }
+    });
+  }
+
   static const MethodChannel channel = MethodChannel(
     'plugins.flutter.io/firebase_messaging',
   );

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/method_channel/method_channel_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/method_channel/method_channel_messaging.dart
@@ -90,6 +90,7 @@ class MethodChannelFirebaseMessaging extends FirebaseMessagingPlatform {
     'plugins.flutter.io/firebase_messaging',
   );
 
+  // ignore: close_sinks, never closed
   static StreamController<String> tokenStreamController =
       StreamController<String>.broadcast();
 

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
@@ -8,7 +8,6 @@ import 'dart:async';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging_platform_interface/firebase_messaging_platform_interface.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -48,38 +47,6 @@ abstract class FirebaseMessagingPlatform extends PlatformInterface {
 
   static FirebaseMessagingPlatform? _instance;
 
-  static void setMethodCallHandlers() {
-    MethodChannelFirebaseMessaging.channel
-        .setMethodCallHandler((MethodCall call) async {
-      switch (call.method) {
-        case 'Messaging#onTokenRefresh':
-          MethodChannelFirebaseMessaging.tokenStreamController
-              .add(call.arguments as String);
-          break;
-        case 'Messaging#onMessage':
-          Map<String, dynamic> messageMap =
-              Map<String, dynamic>.from(call.arguments);
-          FirebaseMessagingPlatform.onMessage
-              .add(RemoteMessage.fromMap(messageMap));
-          break;
-        case 'Messaging#onMessageOpenedApp':
-          Map<String, dynamic> messageMap =
-              Map<String, dynamic>.from(call.arguments);
-          FirebaseMessagingPlatform.onMessageOpenedApp
-              .add(RemoteMessage.fromMap(messageMap));
-          break;
-        case 'Messaging#onBackgroundMessage':
-          // Apple only. Android calls via separate background channel.
-          Map<String, dynamic> messageMap =
-              Map<String, dynamic>.from(call.arguments);
-          return FirebaseMessagingPlatform.onBackgroundMessage
-              ?.call(RemoteMessage.fromMap(messageMap));
-        default:
-          throw UnimplementedError('${call.method} has not been implemented');
-      }
-    });
-  }
-
   /// The current default [FirebaseMessagingPlatform] instance.
   ///
   /// It will always default to [MethodChannelFirebaseMessaging]
@@ -87,7 +54,7 @@ abstract class FirebaseMessagingPlatform extends PlatformInterface {
   static FirebaseMessagingPlatform get instance {
     if (_instance == null) {
       // This is only called for method channels since Web is setting the instance before we use `get`
-      setMethodCallHandlers();
+      MethodChannelFirebaseMessaging.setMethodCallHandlers();
     }
     return _instance ??= MethodChannelFirebaseMessaging.instance;
   }

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
@@ -86,7 +86,7 @@ abstract class FirebaseMessagingPlatform extends PlatformInterface {
   /// if no other implementation was provided.
   static FirebaseMessagingPlatform get instance {
     if (_instance == null) {
-      // This is only called for method channels
+      // This is only called for method channels since Web is setting the instance before we use `get`
       setMethodCallHandlers();
     }
     return _instance ??= MethodChannelFirebaseMessaging.instance;

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging_platform_interface/firebase_messaging_platform_interface.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -46,11 +48,47 @@ abstract class FirebaseMessagingPlatform extends PlatformInterface {
 
   static FirebaseMessagingPlatform? _instance;
 
+  static void setMethodCallHandlers() {
+    MethodChannelFirebaseMessaging.channel
+        .setMethodCallHandler((MethodCall call) async {
+      switch (call.method) {
+        case 'Messaging#onTokenRefresh':
+          MethodChannelFirebaseMessaging.tokenStreamController
+              .add(call.arguments as String);
+          break;
+        case 'Messaging#onMessage':
+          Map<String, dynamic> messageMap =
+              Map<String, dynamic>.from(call.arguments);
+          FirebaseMessagingPlatform.onMessage
+              .add(RemoteMessage.fromMap(messageMap));
+          break;
+        case 'Messaging#onMessageOpenedApp':
+          Map<String, dynamic> messageMap =
+              Map<String, dynamic>.from(call.arguments);
+          FirebaseMessagingPlatform.onMessageOpenedApp
+              .add(RemoteMessage.fromMap(messageMap));
+          break;
+        case 'Messaging#onBackgroundMessage':
+          // Apple only. Android calls via separate background channel.
+          Map<String, dynamic> messageMap =
+              Map<String, dynamic>.from(call.arguments);
+          return FirebaseMessagingPlatform.onBackgroundMessage
+              ?.call(RemoteMessage.fromMap(messageMap));
+        default:
+          throw UnimplementedError('${call.method} has not been implemented');
+      }
+    });
+  }
+
   /// The current default [FirebaseMessagingPlatform] instance.
   ///
   /// It will always default to [MethodChannelFirebaseMessaging]
   /// if no other implementation was provided.
   static FirebaseMessagingPlatform get instance {
+    if (_instance == null) {
+      // This is only called for method channels
+      setMethodCallHandlers();
+    }
     return _instance ??= MethodChannelFirebaseMessaging.instance;
   }
 


### PR DESCRIPTION
## Description
For example, imagine we had this setup, and no other FirebaseMessaging API calls. None of the event handlers would ever fire on native platforms. If the line `FirebaseMessaging.instance.isAutoInitEnabled` is uncommented, they will work because it will instantiate `MethodChannelFirebaseMessaging` that creates the method channels necessary for them to work. 

This PR will always create the method channel handlers before `MethodChannelFirebaseMessaging` is instantiated.

```dart
Future<void> main() async {
  WidgetsFlutterBinding.ensureInitialized();
  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);

  // Uncomment the line below and the event listeners will fire.
  // FirebaseMessaging.instance.isAutoInitEnabled;
  FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);

  FirebaseMessaging.onMessage.listen((RemoteMessage message){
    
  });
  FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
    
  });

  runApp(MessagingExampleApp());
}
```

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/11008
fixes https://github.com/firebase/flutterfire/issues/11410
fixes https://github.com/firebase/flutterfire/issues/10043

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
