### PR TITLE
fix(firebase_ui_oauth_apple): Enables Android as a supported platform

### DIFF
--- a/packages/firebase_ui_oauth_apple/lib/src/provider.dart
+++ b/packages/firebase_ui_oauth_apple/lib/src/provider.dart
@@ -66,6 +66,7 @@ class AppleProvider extends OAuthProvider {
   @override
   bool supportsPlatform(TargetPlatform platform) {
     return kIsWeb ||
+        platform == TargetPlatform.android ||
         platform == TargetPlatform.iOS ||
         platform == TargetPlatform.macOS;
   }


### PR DESCRIPTION
## Description

Enables Android as a supported platform for AppleProvider. The Apple provider works on Android and is document as in the [package description](https://pub.dev/packages/firebase_ui_auth).
For some reason it is not enabled in the provider.


## Related Issues

fixes #10788

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
  - I can't see any related tests
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.