### PR TITLE
Stop passing nullable values to Future<nn-type>.value

### DIFF
--- a/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
@@ -63,12 +63,12 @@ void main() {
     ],
   );
 
-  MockUserPlatform? mockUserPlatform;
-  MockUserCredentialPlatform? mockUserCredPlatform;
-  MockConfirmationResultPlatform? mockConfirmationResultPlatform;
-  MockRecaptchaVerifier? mockVerifier;
-  AdditionalUserInfo? mockAdditionalUserInfo;
-  EmailAuthCredential? mockCredential;
+  MockUserPlatform mockUserPlatform;
+  MockUserCredentialPlatform mockUserCredPlatform;
+  MockConfirmationResultPlatform mockConfirmationResultPlatform;
+  late MockRecaptchaVerifier mockVerifier;
+  AdditionalUserInfo mockAdditionalUserInfo;
+  EmailAuthCredential mockCredential;
 
   MockFirebaseAuth mockAuthPlatform = MockFirebaseAuth();
 
@@ -109,14 +109,14 @@ void main() {
       ) as EmailAuthCredential;
       mockUserCredPlatform = MockUserCredentialPlatform(
         FirebaseAuthPlatform.instance,
-        mockAdditionalUserInfo!,
-        mockCredential!,
-        mockUserPlatform!,
+        mockAdditionalUserInfo,
+        mockCredential,
+        mockUserPlatform,
       );
       mockVerifier = MockRecaptchaVerifier();
 
       when(mockAuthPlatform.signInAnonymously())
-          .thenAnswer((_) async => mockUserCredPlatform!);
+          .thenAnswer((_) async => mockUserCredPlatform);
 
       when(mockAuthPlatform.signInWithCredential(any)).thenAnswer(
           (_) => Future<UserCredentialPlatform>.value(mockUserCredPlatform));
@@ -138,39 +138,39 @@ void main() {
       )).thenAnswer((_) => mockAuthPlatform);
 
       when(mockAuthPlatform.createUserWithEmailAndPassword(any, any))
-          .thenAnswer((_) async => mockUserCredPlatform!);
+          .thenAnswer((_) async => mockUserCredPlatform);
 
       when(mockAuthPlatform.getRedirectResult())
-          .thenAnswer((_) async => mockUserCredPlatform!);
+          .thenAnswer((_) async => mockUserCredPlatform);
 
       when(mockAuthPlatform.signInWithCustomToken(any))
-          .thenAnswer((_) async => mockUserCredPlatform!);
+          .thenAnswer((_) async => mockUserCredPlatform);
 
       when(mockAuthPlatform.signInWithEmailAndPassword(any, any))
-          .thenAnswer((_) async => mockUserCredPlatform!);
+          .thenAnswer((_) async => mockUserCredPlatform);
 
       when(mockAuthPlatform.signInWithEmailLink(any, any))
-          .thenAnswer((_) async => mockUserCredPlatform!);
+          .thenAnswer((_) async => mockUserCredPlatform);
 
       when(mockAuthPlatform.signInWithPhoneNumber(any, any))
-          .thenAnswer((_) async => mockConfirmationResultPlatform!);
+          .thenAnswer((_) async => mockConfirmationResultPlatform);
 
-      when(mockVerifier!.delegate).thenReturn(mockVerifier!.mockDelegate);
+      when(mockVerifier.delegate).thenReturn(mockVerifier.mockDelegate);
 
       when(mockAuthPlatform.signInWithPopup(any))
-          .thenAnswer((_) async => mockUserCredPlatform!);
+          .thenAnswer((_) async => mockUserCredPlatform);
 
       when(mockAuthPlatform.signInWithRedirect(any))
           .thenAnswer((_) async => mockUserCredPlatform);
 
       when(mockAuthPlatform.authStateChanges()).thenAnswer((_) =>
-          Stream<UserPlatform>.fromIterable(<UserPlatform>[mockUserPlatform!]));
+          Stream<UserPlatform>.fromIterable(<UserPlatform>[mockUserPlatform]));
 
       when(mockAuthPlatform.idTokenChanges()).thenAnswer((_) =>
-          Stream<UserPlatform>.fromIterable(<UserPlatform>[mockUserPlatform!]));
+          Stream<UserPlatform>.fromIterable(<UserPlatform>[mockUserPlatform]));
 
       when(mockAuthPlatform.userChanges()).thenAnswer((_) =>
-          Stream<UserPlatform>.fromIterable(<UserPlatform>[mockUserPlatform!]));
+          Stream<UserPlatform>.fromIterable(<UserPlatform>[mockUserPlatform]));
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(MethodChannelFirebaseAuth.channel,

--- a/packages/firebase_auth/firebase_auth/test/user_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/user_test.dart
@@ -29,7 +29,7 @@ Map<String, dynamic> kMockUser1 = <String, dynamic>{
 void main() {
   setupFirebaseAuthMocks();
 
-  FirebaseAuth? auth;
+  late FirebaseAuth auth;
 
   final kMockIdTokenResult = PigeonIdTokenResult(
     token: '12345',
@@ -68,8 +68,8 @@ void main() {
       }
     ],
   );
-  MockUserPlatform? mockUserPlatform;
-  MockUserCredentialPlatform? mockUserCredPlatform;
+  late MockUserPlatform mockUserPlatform;
+  late MockUserCredentialPlatform mockUserCredPlatform;
 
   AdditionalUserInfo mockAdditionalInfo = AdditionalUserInfo(
     isNewUser: false,
@@ -85,7 +85,7 @@ void main() {
   var mockAuthPlatform = MockFirebaseAuth();
 
   group('$User', () {
-    PigeonUserDetails? user;
+    late PigeonUserDetails user;
 
     // used to generate a unique application name for each test
     var testCount = 0;
@@ -108,13 +108,13 @@ void main() {
 
       user = kMockUser;
 
-      mockUserPlatform = MockUserPlatform(mockAuthPlatform, user!);
+      mockUserPlatform = MockUserPlatform(mockAuthPlatform, user);
 
       mockUserCredPlatform = MockUserCredentialPlatform(
         FirebaseAuthPlatform.instance,
         mockAdditionalInfo,
         mockCredential,
-        mockUserPlatform!,
+        mockUserPlatform,
       );
 
       when(mockAuthPlatform.signInAnonymously()).thenAnswer(
@@ -145,42 +145,42 @@ void main() {
 
     setUp(() async {
       user = kMockUser;
-      await auth!.signInAnonymously();
+      await auth.signInAnonymously();
     });
 
     test('delete()', () async {
       // Necessary as we otherwise get a "null is not a Future<void>" error
-      when(mockUserPlatform!.delete()).thenAnswer((i) async {});
+      when(mockUserPlatform.delete()).thenAnswer((i) async {});
 
-      await auth!.currentUser!.delete();
+      await auth.currentUser!.delete();
 
-      verify(mockUserPlatform!.delete());
+      verify(mockUserPlatform.delete());
     });
 
     test('getIdToken()', () async {
       // Necessary as we otherwise get a "null is not a Future<void>" error
-      when(mockUserPlatform!.getIdToken(any)).thenAnswer((_) async => 'token');
+      when(mockUserPlatform.getIdToken(any)).thenAnswer((_) async => 'token');
 
-      final token = await auth!.currentUser!.getIdToken(true);
+      final token = await auth.currentUser!.getIdToken(true);
 
-      verify(mockUserPlatform!.getIdToken(true));
+      verify(mockUserPlatform.getIdToken(true));
       expect(token, isA<String>());
     });
 
     test('getIdTokenResult()', () async {
-      when(mockUserPlatform!.getIdTokenResult(any))
+      when(mockUserPlatform.getIdTokenResult(any))
           .thenAnswer((_) async => IdTokenResult(kMockIdTokenResult));
 
-      final idTokenResult = await auth!.currentUser!.getIdTokenResult(true);
+      final idTokenResult = await auth.currentUser!.getIdTokenResult(true);
 
-      verify(mockUserPlatform!.getIdTokenResult(true));
+      verify(mockUserPlatform.getIdTokenResult(true));
       expect(idTokenResult, isA<IdTokenResult>());
     });
 
     group('linkWithCredential()', () {
       setUp(() {
-        when(mockUserPlatform!.linkWithCredential(any))
-            .thenAnswer((_) async => mockUserCredPlatform!);
+        when(mockUserPlatform.linkWithCredential(any))
+            .thenAnswer((_) async => mockUserCredPlatform);
       });
 
       test('should call linkWithCredential()', () async {
@@ -189,15 +189,15 @@ void main() {
             EmailAuthProvider.credential(email: newEmail, password: 'test')
                 as EmailAuthCredential;
 
-        await auth!.currentUser!.linkWithCredential(credential);
+        await auth.currentUser!.linkWithCredential(credential);
 
-        verify(mockUserPlatform!.linkWithCredential(credential));
+        verify(mockUserPlatform.linkWithCredential(credential));
       });
     });
 
     group('reauthenticateWithCredential()', () {
       setUp(() {
-        when(mockUserPlatform!.reauthenticateWithCredential(any))
+        when(mockUserPlatform.reauthenticateWithCredential(any))
             .thenAnswer((_) => Future.value(mockUserCredPlatform));
       });
       test('should call reauthenticateWithCredential()', () async {
@@ -206,91 +206,91 @@ void main() {
             EmailAuthProvider.credential(email: newEmail, password: 'test')
                 as EmailAuthCredential;
 
-        await auth!.currentUser!.reauthenticateWithCredential(credential);
+        await auth.currentUser!.reauthenticateWithCredential(credential);
 
-        verify(mockUserPlatform!.reauthenticateWithCredential(credential));
+        verify(mockUserPlatform.reauthenticateWithCredential(credential));
       });
     });
 
     test('reload()', () async {
       // Necessary as we otherwise get a "null is not a Future<void>" error
-      when(mockUserPlatform!.reload()).thenAnswer((i) async {});
+      when(mockUserPlatform.reload()).thenAnswer((i) async {});
 
-      await auth!.currentUser!.reload();
+      await auth.currentUser!.reload();
 
-      verify(mockUserPlatform!.reload());
+      verify(mockUserPlatform.reload());
     });
 
     test('sendEmailVerification()', () async {
       // Necessary as we otherwise get a "null is not a Future<void>" error
-      when(mockUserPlatform!.sendEmailVerification(any))
+      when(mockUserPlatform.sendEmailVerification(any))
           .thenAnswer((i) async {});
 
       final ActionCodeSettings actionCodeSettings =
           ActionCodeSettings(url: 'test');
 
-      await auth!.currentUser!.sendEmailVerification(actionCodeSettings);
+      await auth.currentUser!.sendEmailVerification(actionCodeSettings);
 
-      verify(mockUserPlatform!.sendEmailVerification(actionCodeSettings));
+      verify(mockUserPlatform.sendEmailVerification(actionCodeSettings));
     });
 
     group('unlink()', () {
       setUp(() {
-        when(mockUserPlatform!.unlink(any))
+        when(mockUserPlatform.unlink(any))
             .thenAnswer((_) => Future.value(mockUserPlatform));
       });
       test('should call unlink()', () async {
         const String providerId = 'providerId';
 
-        await auth!.currentUser!.unlink(providerId);
+        await auth.currentUser!.unlink(providerId);
 
-        verify(mockUserPlatform!.unlink(providerId));
+        verify(mockUserPlatform.unlink(providerId));
       });
     });
     group('updateEmail()', () {
       test('should call updateEmail()', () async {
         // Necessary as we otherwise get a "null is not a Future<void>" error
-        when(mockUserPlatform!.updateEmail(any)).thenAnswer((i) async {});
+        when(mockUserPlatform.updateEmail(any)).thenAnswer((i) async {});
 
         const String newEmail = 'newEmail';
 
-        await auth!.currentUser!.updateEmail(newEmail);
+        await auth.currentUser!.updateEmail(newEmail);
 
-        verify(mockUserPlatform!.updateEmail(newEmail));
+        verify(mockUserPlatform.updateEmail(newEmail));
       });
     });
 
     group('updatePassword()', () {
       test('should call updatePassword()', () async {
         // Necessary as we otherwise get a "null is not a Future<void>" error
-        when(mockUserPlatform!.updatePassword(any)).thenAnswer((i) async {});
+        when(mockUserPlatform.updatePassword(any)).thenAnswer((i) async {});
 
         const String newPassword = 'newPassword';
 
-        await auth!.currentUser!.updatePassword(newPassword);
+        await auth.currentUser!.updatePassword(newPassword);
 
-        verify(mockUserPlatform!.updatePassword(newPassword));
+        verify(mockUserPlatform.updatePassword(newPassword));
       });
     });
     group('updatePhoneNumber()', () {
       test('should call updatePhoneNumber()', () async {
         // Necessary as we otherwise get a "null is not a Future<void>" error
-        when(mockUserPlatform!.updatePhoneNumber(any)).thenAnswer((i) async {});
+        when(mockUserPlatform.updatePhoneNumber(any)).thenAnswer((i) async {});
 
         PhoneAuthCredential phoneAuthCredential = PhoneAuthProvider.credential(
           verificationId: 'test',
           smsCode: 'test',
         );
 
-        await auth!.currentUser!.updatePhoneNumber(phoneAuthCredential);
+        await auth.currentUser!.updatePhoneNumber(phoneAuthCredential);
 
-        verify(mockUserPlatform!.updatePhoneNumber(phoneAuthCredential));
+        verify(mockUserPlatform.updatePhoneNumber(phoneAuthCredential));
       });
     });
 
     test('updateProfile()', () async {
       // Necessary as we otherwise get a "null is not a Future<void>" error
-      when(mockUserPlatform!.updateProfile(any)).thenAnswer((i) async {});
+      when(mockUserPlatform.updateProfile(any)).thenAnswer((i) async {});
 
       const String displayName = 'updatedName';
       const String photoURL = 'testUrl';
@@ -299,33 +299,33 @@ void main() {
         'photoURL': photoURL
       };
 
-      await auth!.currentUser!
+      await auth.currentUser!
           // ignore: deprecated_member_use_from_same_package
           .updateProfile(displayName: displayName, photoURL: photoURL);
 
-      verify(mockUserPlatform!.updateProfile(data));
+      verify(mockUserPlatform.updateProfile(data));
     });
 
     group('verifyBeforeUpdateEmail()', () {
       test('should call verifyBeforeUpdateEmail()', () async {
         // Necessary as we otherwise get a "null is not a Future<void>" error
-        when(mockUserPlatform!.verifyBeforeUpdateEmail(any, any))
+        when(mockUserPlatform.verifyBeforeUpdateEmail(any, any))
             .thenAnswer((i) async {});
 
         const newEmail = 'new@email.com';
         ActionCodeSettings actionCodeSettings = ActionCodeSettings(url: 'test');
 
-        await auth!.currentUser!
+        await auth.currentUser!
             .verifyBeforeUpdateEmail(newEmail, actionCodeSettings);
 
-        verify(mockUserPlatform!
+        verify(mockUserPlatform
             .verifyBeforeUpdateEmail(newEmail, actionCodeSettings));
       });
     });
 
     test('toString()', () async {
       when(mockAuthPlatform.currentUser).thenReturn(TestUserPlatform(
-          mockAuthPlatform, TestMultiFactorPlatform(mockAuthPlatform), user!));
+          mockAuthPlatform, TestMultiFactorPlatform(mockAuthPlatform), user));
 
       const userInfo = 'UserInfo('
           'displayName: Flutter Test User, '
@@ -340,7 +340,7 @@ void main() {
           'lastSignInTime: ${DateTime.fromMillisecondsSinceEpoch(kMockLastSignInTimestamp, isUtc: true)})';
 
       expect(
-        auth!.currentUser.toString(),
+        auth.currentUser.toString(),
         'User('
         'displayName: displayName, '
         'email: null, '


### PR DESCRIPTION
## Description

This is cleanup work required to start enforcing this with static analysis, as per https://github.com/dart-lang/sdk/issues/53253.

Real quick this issue is that this code is unsafe:

```dart
void f(Completer<int> c, int? i) {
  Future<int>.value(i); // Ouch!
  c.complete(i);        // Ouch!
}
```

The fixes here are generally to make local test variables `late` instead of nullable.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
