### PR TITLE
docs(firebase_remote_config): Remove comment about defaults in `RemoteConfigSettings`

### DIFF
--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/lib/src/remote_config_settings.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/lib/src/remote_config_settings.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: require_trailing_commas
 /// Defines the options for the corresponding Remote Config instance.
 class RemoteConfigSettings {
   /// Constructs an instance of [RemoteConfigSettings] with given [fetchTimeout]
@@ -13,10 +12,9 @@ class RemoteConfigSettings {
   });
 
   /// Maximum Duration to wait for a response when fetching configuration from
-  /// the Remote Config server. Defaults to one minute.
+  /// the Remote Config server.
   Duration fetchTimeout;
 
-  /// Maximum age of a cached config before it is considered stale. Defaults
-  /// to twelve hours.
+  /// Maximum age of a cached config before it is considered stale.
   Duration minimumFetchInterval;
 }


### PR DESCRIPTION
## Description

Removes the dartdocs mentioning defaults in the `RemoteConfigSettings`, since there currently aren't any defaults applied.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
