### PR TITLE
docs: fix broken links to "firebase_ui" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ and open source.
 - [Add Firebase to your Flutter app](https://firebase.google.com/docs/flutter/setup)
 - [Available plugins](https://firebase.google.com/docs/flutter/setup#available-plugins)
 - Firebase UI
-  - [Firebase UI for Authentication](./packages/firebase_ui_auth/README.md)
-  - [Firebase UI for Realtime Database](./packages/firebase_ui_database/README.md)
-  - [Firebase UI for Cloud Firestore](./packages/firebase_ui_firestore/README.md)
+  - [Firebase UI for Authentication](https://github.com/firebase/FirebaseUI-Flutter/blob/main/packages/firebase_ui_auth/README.md)
+  - [Firebase UI for Realtime Database](https://github.com/firebase/FirebaseUI-Flutter/blob/main/packages/firebase_ui_database/README.md)
+  - [Firebase UI for Cloud Firestore](https://github.com/firebase/FirebaseUI-Flutter/blob/main/packages/firebase_ui_firestore/README.md)
 - [Firestore ODM](./packages/cloud_firestore_odm/README.md) (alpha)
 
 ---


### PR DESCRIPTION
## Description

Since #11493 moved the "firebase_ui" packages to https://github.com/firebase/FirebaseUI-Flutter, we need also to update the links in the README.md

## Related Issues

No issue.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
