### PR TITLE
fix(firebase_auth/firebase_auth_web): Update the position of the auth parameter in the interop code to reflect changes in firebase-js-sdk

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -1077,9 +1077,9 @@ class RecaptchaVerifier
       container, Map<String, dynamic> parameters, Auth auth) {
     return RecaptchaVerifier.fromJsObject(
       auth_interop.RecaptchaVerifierJsImpl(
+        auth.jsObject,
         container,
         jsify(parameters),
-        auth.jsObject,
       ),
     );
   }

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
@@ -488,9 +488,9 @@ abstract class ApplicationVerifierJsImpl {
 @JS('RecaptchaVerifier')
 class RecaptchaVerifierJsImpl extends ApplicationVerifierJsImpl {
   external factory RecaptchaVerifierJsImpl(
+    AuthJsImpl authExtern,
     containerOrId,
     Object parameters,
-    AuthJsImpl authExtern,
   );
   external void clear();
   external PromiseJsImpl<num> render();


### PR DESCRIPTION
## Description

The position of the auth parameter in the RecaptchaVerifier was changed on the firebase-js-sdk (see: https://github.com/firebase/firebase-js-sdk/pull/7326/files), this PR updates the interop code to reflect that.

## Related Issues

Phone sign-in on web is currently broken due to the above issue. 
Fixes: https://github.com/firebase/flutterfire/issues/11485

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
