### PR TITLE
feat(cloud_firestore): Firestore query snapshot with changes only

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -62,3 +62,4 @@ Markus Köhne <markus@koehne.dev>
 Max Steffen <git@max-steffen.dev>
 Mohd Faheem Ansari <codefaheem@gmail.com>
 Om Phatak <everythingoutdated@gmail.com>
+Ben White <bwhite@swinetechnologies.com>

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreMessageCodec.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreMessageCodec.java
@@ -24,6 +24,7 @@ import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.QuerySnapshot;
 import com.google.firebase.firestore.SnapshotMetadata;
 import io.flutter.plugin.common.StandardMessageCodec;
+import io.flutter.plugins.firebase.firestore.streamhandler.QuerySnapshotWrapper;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -88,6 +89,8 @@ class FlutterFirebaseFirestoreMessageCodec extends StandardMessageCodec {
       writeDocumentSnapshot(stream, (DocumentSnapshot) value);
     } else if (value instanceof QuerySnapshot) {
       writeQuerySnapshot(stream, (QuerySnapshot) value);
+    } else if (value instanceof QuerySnapshotWrapper) {
+      writeQuerySnapshotWrapper(stream, (QuerySnapshotWrapper) value);
     } else if (value instanceof DocumentChange) {
       writeDocumentChange(stream, (DocumentChange) value);
     } else if (value instanceof LoadBundleTaskProgress) {
@@ -173,6 +176,15 @@ class FlutterFirebaseFirestoreMessageCodec extends StandardMessageCodec {
 
     FlutterFirebaseFirestorePlugin.serverTimestampBehaviorHashMap.remove(value.hashCode());
     writeValue(stream, querySnapshotMap);
+  }
+
+  private void writeQuerySnapshotWrapper(ByteArrayOutputStream stream, QuerySnapshotWrapper value) {
+    Map<String, Object> querySnapshotChangesMap = new HashMap<>();
+
+    querySnapshotChangesMap.put("documentChanges", value.getDocumentChanges());
+    querySnapshotChangesMap.put("metadata", value.getMetadata());
+
+    writeValue(stream, querySnapshotChangesMap);
   }
 
   private void writeLoadBundleTaskProgress(

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -39,6 +39,7 @@ import io.flutter.plugins.firebase.firestore.streamhandler.DocumentSnapshotsStre
 import io.flutter.plugins.firebase.firestore.streamhandler.LoadBundleStreamHandler;
 import io.flutter.plugins.firebase.firestore.streamhandler.OnTransactionResultListener;
 import io.flutter.plugins.firebase.firestore.streamhandler.QuerySnapshotsStreamHandler;
+import io.flutter.plugins.firebase.firestore.streamhandler.QuerySnapshotChangesStreamHandler;
 import io.flutter.plugins.firebase.firestore.streamhandler.SnapshotsInSyncStreamHandler;
 import io.flutter.plugins.firebase.firestore.streamhandler.TransactionStreamHandler;
 import io.flutter.plugins.firebase.firestore.utils.ExceptionConverter;
@@ -641,6 +642,11 @@ public class FlutterFirebaseFirestorePlugin
         result.success(
             registerEventChannel(
                 METHOD_CHANNEL_NAME + "/query", new QuerySnapshotsStreamHandler()));
+        return;
+      case "Query#snapshotChanges":
+        result.success(
+          registerEventChannel(
+            METHOD_CHANNEL_NAME + "/query", new QuerySnapshotChangesStreamHandler()));
         return;
       case "DocumentReference#snapshots":
         result.success(

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -38,8 +38,8 @@ import io.flutter.plugins.firebase.core.FlutterFirebasePluginRegistry;
 import io.flutter.plugins.firebase.firestore.streamhandler.DocumentSnapshotsStreamHandler;
 import io.flutter.plugins.firebase.firestore.streamhandler.LoadBundleStreamHandler;
 import io.flutter.plugins.firebase.firestore.streamhandler.OnTransactionResultListener;
-import io.flutter.plugins.firebase.firestore.streamhandler.QuerySnapshotsStreamHandler;
 import io.flutter.plugins.firebase.firestore.streamhandler.QuerySnapshotChangesStreamHandler;
+import io.flutter.plugins.firebase.firestore.streamhandler.QuerySnapshotsStreamHandler;
 import io.flutter.plugins.firebase.firestore.streamhandler.SnapshotsInSyncStreamHandler;
 import io.flutter.plugins.firebase.firestore.streamhandler.TransactionStreamHandler;
 import io.flutter.plugins.firebase.firestore.utils.ExceptionConverter;
@@ -645,8 +645,8 @@ public class FlutterFirebaseFirestorePlugin
         return;
       case "Query#snapshotChanges":
         result.success(
-          registerEventChannel(
-            METHOD_CHANNEL_NAME + "/query", new QuerySnapshotChangesStreamHandler()));
+            registerEventChannel(
+                METHOD_CHANNEL_NAME + "/query", new QuerySnapshotChangesStreamHandler()));
         return;
       case "DocumentReference#snapshots":
         result.success(

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/QuerySnapshotChangesStreamHandler.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/QuerySnapshotChangesStreamHandler.java
@@ -8,11 +8,11 @@ package io.flutter.plugins.firebase.firestore.streamhandler;
 
 import static io.flutter.plugins.firebase.firestore.FlutterFirebaseFirestorePlugin.DEFAULT_ERROR_CODE;
 
+import android.util.Log;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.ListenerRegistration;
 import com.google.firebase.firestore.MetadataChanges;
 import com.google.firebase.firestore.Query;
-import com.google.firebase.firestore.QuerySnapshot;
 import io.flutter.plugin.common.EventChannel.EventSink;
 import io.flutter.plugin.common.EventChannel.StreamHandler;
 import io.flutter.plugins.firebase.firestore.FlutterFirebaseFirestorePlugin;
@@ -20,7 +20,6 @@ import io.flutter.plugins.firebase.firestore.utils.ExceptionConverter;
 import io.flutter.plugins.firebase.firestore.utils.ServerTimestampBehaviorConverter;
 import java.util.Map;
 import java.util.Objects;
-import android.util.Log;
 
 public class QuerySnapshotChangesStreamHandler implements StreamHandler {
 
@@ -32,44 +31,44 @@ public class QuerySnapshotChangesStreamHandler implements StreamHandler {
     Map<String, Object> argumentsMap = (Map<String, Object>) arguments;
 
     MetadataChanges metadataChanges =
-      (Boolean) Objects.requireNonNull(argumentsMap.get("includeMetadataChanges"))
-        ? MetadataChanges.INCLUDE
-        : MetadataChanges.EXCLUDE;
+        (Boolean) Objects.requireNonNull(argumentsMap.get("includeMetadataChanges"))
+            ? MetadataChanges.INCLUDE
+            : MetadataChanges.EXCLUDE;
 
     Query query = (Query) argumentsMap.get("query");
     String serverTimestampBehaviorString = (String) argumentsMap.get("serverTimestampBehavior");
     DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior =
-      ServerTimestampBehaviorConverter.toServerTimestampBehavior(serverTimestampBehaviorString);
+        ServerTimestampBehaviorConverter.toServerTimestampBehavior(serverTimestampBehaviorString);
 
     if (query == null) {
       throw new IllegalArgumentException(
-        "An error occurred while parsing query arguments, see native logs for more information. Please report this issue.");
+          "An error occurred while parsing query arguments, see native logs for more information. Please report this issue.");
     }
 
     listenerRegistration =
-      query.addSnapshotListener(
-        metadataChanges,
-        (querySnapshot, exception) -> {
-          if (exception != null) {
-            Map<String, String> exceptionDetails = ExceptionConverter.createDetails(exception);
-            events.error(DEFAULT_ERROR_CODE, exception.getMessage(), exceptionDetails);
-            events.endOfStream();
+        query.addSnapshotListener(
+            metadataChanges,
+            (querySnapshot, exception) -> {
+              if (exception != null) {
+                Map<String, String> exceptionDetails = ExceptionConverter.createDetails(exception);
+                events.error(DEFAULT_ERROR_CODE, exception.getMessage(), exceptionDetails);
+                events.endOfStream();
 
-            Log.e(
-              "QuerySnapshotChangesStreamHandler",
-              "OnListen exception: " + exception.getMessage());
+                Log.e(
+                    "QuerySnapshotChangesStreamHandler",
+                    "OnListen exception: " + exception.getMessage());
 
-            onCancel(null);
-          } else {
-            if (querySnapshot != null) {
-              FlutterFirebaseFirestorePlugin.serverTimestampBehaviorHashMap.put(
-                querySnapshot.hashCode(), serverTimestampBehavior);
-            }
+                onCancel(null);
+              } else {
+                if (querySnapshot != null) {
+                  FlutterFirebaseFirestorePlugin.serverTimestampBehaviorHashMap.put(
+                      querySnapshot.hashCode(), serverTimestampBehavior);
+                }
 
-            QuerySnapshotWrapper wrappedQuerySnapshot = new QuerySnapshotWrapper(querySnapshot);
-            events.success((QuerySnapshotWrapper) wrappedQuerySnapshot);
-          }
-        });
+                QuerySnapshotWrapper wrappedQuerySnapshot = new QuerySnapshotWrapper(querySnapshot);
+                events.success((QuerySnapshotWrapper) wrappedQuerySnapshot);
+              }
+            });
   }
 
   @Override

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/QuerySnapshotChangesStreamHandler.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/QuerySnapshotChangesStreamHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ */
+
+package io.flutter.plugins.firebase.firestore.streamhandler;
+
+import static io.flutter.plugins.firebase.firestore.FlutterFirebaseFirestorePlugin.DEFAULT_ERROR_CODE;
+
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.ListenerRegistration;
+import com.google.firebase.firestore.MetadataChanges;
+import com.google.firebase.firestore.Query;
+import com.google.firebase.firestore.QuerySnapshot;
+import io.flutter.plugin.common.EventChannel.EventSink;
+import io.flutter.plugin.common.EventChannel.StreamHandler;
+import io.flutter.plugins.firebase.firestore.FlutterFirebaseFirestorePlugin;
+import io.flutter.plugins.firebase.firestore.utils.ExceptionConverter;
+import io.flutter.plugins.firebase.firestore.utils.ServerTimestampBehaviorConverter;
+import java.util.Map;
+import java.util.Objects;
+import android.util.Log;
+
+public class QuerySnapshotChangesStreamHandler implements StreamHandler {
+
+  ListenerRegistration listenerRegistration;
+
+  @Override
+  public void onListen(Object arguments, EventSink events) {
+    @SuppressWarnings("unchecked")
+    Map<String, Object> argumentsMap = (Map<String, Object>) arguments;
+
+    MetadataChanges metadataChanges =
+      (Boolean) Objects.requireNonNull(argumentsMap.get("includeMetadataChanges"))
+        ? MetadataChanges.INCLUDE
+        : MetadataChanges.EXCLUDE;
+
+    Query query = (Query) argumentsMap.get("query");
+    String serverTimestampBehaviorString = (String) argumentsMap.get("serverTimestampBehavior");
+    DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior =
+      ServerTimestampBehaviorConverter.toServerTimestampBehavior(serverTimestampBehaviorString);
+
+    if (query == null) {
+      throw new IllegalArgumentException(
+        "An error occurred while parsing query arguments, see native logs for more information. Please report this issue.");
+    }
+
+    listenerRegistration =
+      query.addSnapshotListener(
+        metadataChanges,
+        (querySnapshot, exception) -> {
+          if (exception != null) {
+            Map<String, String> exceptionDetails = ExceptionConverter.createDetails(exception);
+            events.error(DEFAULT_ERROR_CODE, exception.getMessage(), exceptionDetails);
+            events.endOfStream();
+
+            Log.e(
+              "QuerySnapshotChangesStreamHandler",
+              "OnListen exception: " + exception.getMessage());
+
+            onCancel(null);
+          } else {
+            if (querySnapshot != null) {
+              FlutterFirebaseFirestorePlugin.serverTimestampBehaviorHashMap.put(
+                querySnapshot.hashCode(), serverTimestampBehavior);
+            }
+
+            QuerySnapshotWrapper wrappedQuerySnapshot = new QuerySnapshotWrapper(querySnapshot);
+            events.success((QuerySnapshotWrapper) wrappedQuerySnapshot);
+          }
+        });
+  }
+
+  @Override
+  public void onCancel(Object arguments) {
+    if (listenerRegistration != null) {
+      listenerRegistration.remove();
+      listenerRegistration = null;
+    }
+  }
+}

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/QuerySnapshotWrapper.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/QuerySnapshotWrapper.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ */
+
+// Wrapper for com.google.firebase.firestore.QuerySnapshot, since it does
+// not have a public constructor at this time.
+
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.flutter.plugins.firebase.firestore.streamhandler;
+
+import com.google.firebase.firestore.QuerySnapshot;
+import static com.google.firebase.firestore.util.Preconditions.checkNotNull;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.firebase.firestore.DocumentChange;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.MetadataChanges;
+import com.google.firebase.firestore.Query;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.firebase.firestore.SnapshotMetadata;
+import com.google.firebase.firestore.core.ViewSnapshot;
+import com.google.firebase.firestore.model.Document;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class QuerySnapshotWrapper {
+  private final QuerySnapshot querySnapshot;
+
+  public QuerySnapshotWrapper(QuerySnapshot querySnapshot) {
+    this.querySnapshot = checkNotNull(querySnapshot);
+  }
+
+  @NonNull
+  public Query getQuery() {
+    return querySnapshot.getQuery();
+  }
+
+  /** @return The metadata for this query snapshot. */
+  @NonNull
+  public SnapshotMetadata getMetadata() {
+    return querySnapshot.getMetadata();
+  }
+
+  /**
+   * Returns the list of documents that changed since the last snapshot. If it's the first snapshot
+   * all documents will be in the list as added changes.
+   *
+   * <p>Documents with changes only to their metadata will not be included.
+   *
+   * @return The list of document changes since the last snapshot.
+   */
+  @NonNull
+  public List<DocumentChange> getDocumentChanges() {
+    return querySnapshot.getDocumentChanges();
+  }
+
+  /**
+   * Returns the list of documents that changed since the last snapshot. If it's the first snapshot
+   * all documents will be in the list as added changes.
+   *
+   * @param metadataChanges Indicates whether metadata-only changes (i.e. only {@code
+   *     DocumentSnapshot.getMetadata()} changed) should be included.
+   * @return The list of document changes since the last snapshot.
+   */
+  @NonNull
+  public List<DocumentChange> getDocumentChanges(@NonNull MetadataChanges metadataChanges) {
+
+    return querySnapshot.getDocumentChanges(metadataChanges);
+  }
+
+  /**
+   * Returns the documents in this {@code QuerySnapshot} as a List in order of the query.
+   *
+   * @return The list of documents.
+   */
+  @NonNull
+  public List<DocumentSnapshot> getDocuments() {
+
+    return querySnapshot.getDocuments();
+  }
+
+  /** Returns true if there are no documents in the {@code QuerySnapshot}. */
+  public boolean isEmpty() {
+    return querySnapshot.isEmpty();
+  }
+
+  /** Returns the number of documents in the {@code QuerySnapshot}. */
+  public int size() {
+    return querySnapshot.size();
+  }
+
+  @NonNull
+  public Iterator<QueryDocumentSnapshot> iterator() {
+    return querySnapshot.iterator();
+  }
+
+  /**
+   * Returns the contents of the documents in the {@code QuerySnapshot}, converted to the provided
+   * class, as a list.
+   *
+   * @param clazz The POJO type used to convert the documents in the list.
+   */
+  @NonNull
+  public <T> List<T> toObjects(@NonNull Class<T> clazz) {
+    return querySnapshot.toObjects(clazz);
+  }
+
+  /**
+   * Returns the contents of the documents in the {@code QuerySnapshot}, converted to the provided
+   * class, as a list.
+   *
+   * @param clazz The POJO type used to convert the documents in the list.
+   * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet
+   *     been set to their final value.
+   */
+  @NonNull
+  public <T> List<T> toObjects(
+    @NonNull Class<T> clazz,
+    @NonNull DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior) {
+
+    return querySnapshot.toObjects(clazz, serverTimestampBehavior);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    return querySnapshot.equals(obj);
+  }
+
+  @Override
+  public int hashCode() {
+    return querySnapshot.hashCode();
+  }
+
+}

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/QuerySnapshotWrapper.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/QuerySnapshotWrapper.java
@@ -23,7 +23,6 @@
 
 package io.flutter.plugins.firebase.firestore.streamhandler;
 
-import com.google.firebase.firestore.QuerySnapshot;
 import static com.google.firebase.firestore.util.Preconditions.checkNotNull;
 
 import androidx.annotation.NonNull;
@@ -33,10 +32,8 @@ import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.MetadataChanges;
 import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.firebase.firestore.QuerySnapshot;
 import com.google.firebase.firestore.SnapshotMetadata;
-import com.google.firebase.firestore.core.ViewSnapshot;
-import com.google.firebase.firestore.model.Document;
-
 import java.util.Iterator;
 import java.util.List;
 
@@ -132,8 +129,8 @@ public class QuerySnapshotWrapper {
    */
   @NonNull
   public <T> List<T> toObjects(
-    @NonNull Class<T> clazz,
-    @NonNull DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior) {
+      @NonNull Class<T> clazz,
+      @NonNull DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior) {
 
     return querySnapshot.toObjects(clazz, serverTimestampBehavior);
   }
@@ -147,5 +144,4 @@ public class QuerySnapshotWrapper {
   public int hashCode() {
     return querySnapshot.hashCode();
   }
-
 }

--- a/packages/cloud_firestore/cloud_firestore/lib/cloud_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/cloud_firestore.dart
@@ -55,6 +55,7 @@ part 'src/load_bundle_task_snapshot.dart';
 part 'src/query.dart';
 part 'src/query_document_snapshot.dart';
 part 'src/query_snapshot.dart';
+part 'src/query_snapshot_changes.dart';
 part 'src/snapshot_metadata.dart';
 part 'src/transaction.dart';
 part 'src/utils/codec_utility.dart';

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -86,6 +86,11 @@ abstract class Query<T extends Object?> {
   /// Notifies of query results at this location.
   Stream<QuerySnapshot<T>> snapshots({bool includeMetadataChanges = false});
 
+  /// Notifies of query change results at this location.
+  Stream<QuerySnapshotChanges<T>> snapshotChanges({
+    bool includeMetadataChanges = false,
+  });
+
   /// Creates and returns a new [Query] that's additionally sorted by the specified
   /// [field].
   /// The field may be a [String] representing a single field name or a [FieldPath].
@@ -429,6 +434,16 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
     return _delegate
         .snapshots(includeMetadataChanges: includeMetadataChanges)
         .map((item) => _JsonQuerySnapshot(firestore, item));
+  }
+
+  /// Notifies of query change results at this location.
+  @override
+  Stream<QuerySnapshotChanges<Map<String, dynamic>>> snapshotChanges({
+    bool includeMetadataChanges = false,
+  }) {
+    return _delegate
+        .snapshotChanges(includeMetadataChanges: includeMetadataChanges)
+        .map((item) => _JsonQuerySnapshotChanges(firestore, item));
   }
 
   /// Creates and returns a new [Query] that's additionally sorted by the specified
@@ -887,6 +902,21 @@ class _WithConverterQuery<T extends Object?> implements Query<T> {
         .snapshots(includeMetadataChanges: includeMetadataChanges)
         .map(
           (snapshot) => _WithConverterQuerySnapshot<T>(
+            snapshot,
+            _fromFirestore,
+            _toFirestore,
+          ),
+        );
+  }
+
+  @override
+  Stream<QuerySnapshotChanges<T>> snapshotChanges({
+    bool includeMetadataChanges = false,
+  }) {
+    return _originalQuery
+        .snapshotChanges(includeMetadataChanges: includeMetadataChanges)
+        .map(
+          (snapshot) => _WithConverterQuerySnapshotChanges<T>(
             snapshot,
             _fromFirestore,
             _toFirestore,

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query_snapshot_changes.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query_snapshot_changes.dart
@@ -1,0 +1,78 @@
+// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of cloud_firestore;
+
+/// Contains the results of a query.
+/// It can contain zero or more [DocumentSnapshot] objects.
+abstract class QuerySnapshotChanges<T extends Object?> {
+  /// An array of the documents that changed since the last snapshot. If this
+  /// is the first snapshot, all documents will be in the list as Added changes.
+  List<DocumentChange<T>> get docChanges;
+
+  /// Returns the [SnapshotMetadata] for this snapshot.
+  SnapshotMetadata get metadata;
+
+  /// Returns the size (number of documents) of this snapshot.
+  int get size;
+}
+
+/// Contains the results of a query.
+/// It can contain zero or more [DocumentSnapshot] objects.
+class _JsonQuerySnapshotChanges
+    implements QuerySnapshotChanges<Map<String, dynamic>> {
+  _JsonQuerySnapshotChanges(this._firestore, this._delegate) {
+    QuerySnapshotChangesPlatform.verify(_delegate);
+  }
+
+  final FirebaseFirestore _firestore;
+  final QuerySnapshotChangesPlatform _delegate;
+
+  @override
+  List<DocumentChange<Map<String, dynamic>>> get docChanges {
+    return _delegate.docChanges.map((documentDelegate) {
+      return _JsonDocumentChange(_firestore, documentDelegate);
+    }).toList();
+  }
+
+  @override
+  SnapshotMetadata get metadata => SnapshotMetadata._(_delegate.metadata);
+
+  @override
+  int get size => _delegate.size;
+}
+
+/// Contains the results of a query.
+/// It can contain zero or more [DocumentSnapshot] objects.
+class _WithConverterQuerySnapshotChanges<T extends Object?>
+    implements QuerySnapshotChanges<T> {
+  _WithConverterQuerySnapshotChanges(
+    this._originalQuerySnapshotChanges,
+    this._fromFirestore,
+    this._toFirestore,
+  );
+
+  final QuerySnapshotChanges<Map<String, dynamic>>
+      _originalQuerySnapshotChanges;
+  final FromFirestore<T> _fromFirestore;
+  final ToFirestore<T> _toFirestore;
+
+  @override
+  List<DocumentChange<T>> get docChanges {
+    return [
+      for (final change in _originalQuerySnapshotChanges.docChanges)
+        _WithConverterDocumentChange<T>(
+          change,
+          _fromFirestore,
+          _toFirestore,
+        ),
+    ];
+  }
+
+  @override
+  SnapshotMetadata get metadata => _originalQuerySnapshotChanges.metadata;
+
+  @override
+  int get size => _originalQuerySnapshotChanges.size;
+}

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/cloud_firestore_platform_interface.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/cloud_firestore_platform_interface.dart
@@ -31,6 +31,7 @@ export 'src/platform_interface/platform_interface_load_bundle_task.dart';
 export 'src/platform_interface/platform_interface_load_bundle_task_snapshot.dart';
 export 'src/platform_interface/platform_interface_query.dart';
 export 'src/platform_interface/platform_interface_query_snapshot.dart';
+export 'src/platform_interface/platform_interface_query_snapshot_changes.dart';
 export 'src/platform_interface/platform_interface_transaction.dart';
 export 'src/platform_interface/platform_interface_write_batch.dart';
 export 'src/platform_interface/utils/load_bundle_task_state.dart';

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query.dart
@@ -186,7 +186,7 @@ class MethodChannelQuery extends QueryPlatform {
     // It's fine to let the StreamController be garbage collected once all the
     // subscribers have cancelled; this analyzer warning is safe to ignore.
     late StreamController<QuerySnapshotChangesPlatform>
-    controller; // ignore: close_sinks
+        controller; // ignore: close_sinks
 
     StreamSubscription<dynamic>? snapshotChangesStreamSubscription;
 
@@ -198,21 +198,21 @@ class MethodChannelQuery extends QueryPlatform {
         snapshotChangesStreamSubscription =
             MethodChannelFirebaseFirestore.querySnapshotChannel(observerId!)
                 .receiveGuardedBroadcastStream(
-              arguments: <String, dynamic>{
-                'query': this,
-                'includeMetadataChanges': includeMetadataChanges,
-                'serverTimestampBehavior': getServerTimestampBehaviorString(
-                  serverTimestampBehavior,
-                ),
-              },
-              onError: convertPlatformException,
-            ).listen(
-                  (snapshotChanges) {
-                controller.add(
-                    MethodChannelQuerySnapshotChanges(firestore, snapshotChanges));
-              },
-              onError: controller.addError,
-            );
+          arguments: <String, dynamic>{
+            'query': this,
+            'includeMetadataChanges': includeMetadataChanges,
+            'serverTimestampBehavior': getServerTimestampBehaviorString(
+              serverTimestampBehavior,
+            ),
+          },
+          onError: convertPlatformException,
+        ).listen(
+          (snapshotChanges) {
+            controller.add(
+                MethodChannelQuerySnapshotChanges(firestore, snapshotChanges));
+          },
+          onError: controller.addError,
+        );
       },
       onCancel: () {
         snapshotChangesStreamSubscription?.cancel();

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query_snapshot_changes.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query_snapshot_changes.dart
@@ -1,0 +1,28 @@
+// ignore_for_file: require_trailing_commas
+// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+
+import 'method_channel_document_change.dart';
+
+/// An implementation of [QuerySnapshotChangesPlatform] that uses [MethodChannel] to
+/// communicate with Firebase plugins.
+class MethodChannelQuerySnapshotChanges extends QuerySnapshotChangesPlatform {
+  /// Creates a [MethodChannelQuerySnapshotChanges] from the given [data]
+  MethodChannelQuerySnapshotChanges(
+      FirebaseFirestorePlatform firestore, Map<dynamic, dynamic> data)
+      : super(
+            List<DocumentChangePlatform>.generate(
+                data['documentChanges'].length, (int index) {
+              return MethodChannelDocumentChange(
+                firestore,
+                Map<String, dynamic>.from(data['documentChanges'][index]),
+              );
+            }),
+            SnapshotMetadataPlatform(
+              data['metadata']['hasPendingWrites'],
+              data['metadata']['isFromCache'],
+            ));
+}

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_query.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_query.dart
@@ -139,6 +139,13 @@ abstract class QueryPlatform extends PlatformInterface {
     throw UnimplementedError('snapshots() is not implemented');
   }
 
+  /// Notifies of query change results at this location
+  Stream<QuerySnapshotChangesPlatform> snapshotChanges({
+    bool includeMetadataChanges = false,
+  }) {
+    throw UnimplementedError('snapshotChanges() is not implemented');
+  }
+
   /// Creates and returns a new [QueryPlatform] that's additionally sorted by the specified
   /// [field].
   /// The field may be a [String] representing a single field name or a [FieldPath].

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_query_snapshot_changes.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_query_snapshot_changes.dart
@@ -1,0 +1,42 @@
+// ignore_for_file: require_trailing_commas
+// Copyright 2023, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+/// A interface that contains zero or more [DocumentSnapshotChangesPlatform] objects
+/// representing the results of a query.
+///
+/// The document changes can be accessed as a list by calling [docChanges()]
+/// and the number of documents with changes can be determined by calling [size()].
+class QuerySnapshotChangesPlatform extends PlatformInterface {
+  /// Create a [QuerySnapshotChangesPlatform]
+  QuerySnapshotChangesPlatform(
+    this.docChanges,
+    this.metadata,
+  ) : super(token: _token);
+
+  static final Object _token = Object();
+
+  /// Throws an [AssertionError] if [instance] does not extend
+  /// [QuerySnapshotChangesPlatform].
+  ///
+  /// This is used by the app-facing [QuerySnapshotChanges] to ensure that
+  /// the object in which it's going to delegate calls has been
+  /// constructed properly.
+  static void verify(QuerySnapshotChangesPlatform instance) {
+    PlatformInterface.verify(instance, _token);
+  }
+
+  /// An array of the documents that changed since the last snapshot. If this
+  /// is the first snapshot, all documents will be in the list as Added changes.
+  final List<DocumentChangePlatform> docChanges;
+
+  /// Metadata for the document
+  final SnapshotMetadataPlatform metadata;
+
+  /// The number of documents with changes in this [QuerySnapshotChangesPlatform].
+  int get size => docChanges.length;
+}


### PR DESCRIPTION
## Description

The current querySnapsot returns the list of all documents that match the query every time that a change occurs. For streams that return a large number of documents this an be an issue, as well as inefficient. 

For instance, our use case requires us to keep a local cache of all documents returned by a query. When a single document is updated, querySnapshot will send a list all documents matching the query along with a list of the documents that were changed. All we need is that list of changes to update our local cache. 

Since we have such a large number of documents in our streams, the querySnapshot was leading to issues with the method channels. We were getting ANR, and crashes while trying to pass data from the java to dart. This change has completely fixed these issues for us.

Changes were based on existing querySnapshot, to be backward compatible a new querySnapshotChanges was created that just removed the "docs".

I did not add any tests at this time. I can't seem to get the tests to run, even on a clean master branch. "melos run test:e2e:cloud_firestore" says, "Running", then "Installing" but then gets stuck on next step for 12 minutes and times out.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
