### PR TITLE
fix(firestore): Correct static property getter `serverTimestampMap`

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestorePlugin.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestorePlugin.m
@@ -71,7 +71,7 @@ static NSCache<NSNumber *, NSString *> *_serverTimestampMap;
 
 FlutterStandardMethodCodec *_codec;
 
-+ (NSMutableDictionary<NSNumber *, NSString *> *)serverTimestampMap {
++ (NSCache<NSNumber *, NSString *> *)serverTimestampMap {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     _serverTimestampMap = [NSCache<NSNumber *, NSString *> new];


### PR DESCRIPTION
## Description

Correct an error in the definition of `serverTimestampMap`.
It was not changed from `NSMutableDictionary` to `NSCache` as part of #11501

## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
