### PR TITLE
feat(app-check, web)!: support for `ReCaptchaEnterpriseProvider`. User facing API updated.

### DIFF
--- a/docs/app-check/default-providers.md
+++ b/docs/app-check/default-providers.md
@@ -78,7 +78,8 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
   await FirebaseAppCheck.instance.activate(
-    webRecaptchaSiteKey: 'recaptcha-v3-site-key',
+    // You may also use a `ReCaptchaEnterpriseProvider` provider instance as an argument for `webProvider`
+    webProvider: ReCaptchaV3Provider('recaptcha-v3-site-key'),
     // Default provider for Android is the Play Integrity provider. You can use the "AndroidProvider" enum to choose
     // your preferred provider. Choose from:
     // 1. Debug provider

--- a/packages/firebase_app_check/firebase_app_check/example/lib/main.dart
+++ b/packages/firebase_app_check/firebase_app_check/example/lib/main.dart
@@ -25,7 +25,7 @@ Future<void> main() async {
       .activate(
     androidProvider: AndroidProvider.debug,
     appleProvider: AppleProvider.debug,
-    webRecaptchaSiteKey: kWebRecaptchaSiteKey,
+    webProvider: ReCaptchaV3Provider(kWebRecaptchaSiteKey),
   );
 
   runApp(MyApp());
@@ -115,7 +115,7 @@ class _FirebaseAppCheck extends State<FirebaseAppCheckExample> {
                   );
                 }
                 await appCheck.activate(
-                  webRecaptchaSiteKey: kWebRecaptchaSiteKey,
+                  webProvider: ReCaptchaV3Provider(kWebRecaptchaSiteKey),
                 );
                 setMessage('activated!!');
               },

--- a/packages/firebase_app_check/firebase_app_check/lib/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/firebase_app_check.dart
@@ -10,7 +10,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
 
 export 'package:firebase_app_check_platform_interface/firebase_app_check_platform_interface.dart'
-    show AndroidProvider, AppleProvider;
+    show AndroidProvider, AppleProvider, ReCaptchaEnterpriseProvider, ReCaptchaV3Provider;
 export 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
     show FirebaseException;
 

--- a/packages/firebase_app_check/firebase_app_check/lib/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/firebase_app_check.dart
@@ -10,7 +10,11 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
 
 export 'package:firebase_app_check_platform_interface/firebase_app_check_platform_interface.dart'
-    show AndroidProvider, AppleProvider, ReCaptchaEnterpriseProvider, ReCaptchaV3Provider;
+    show
+        AndroidProvider,
+        AppleProvider,
+        ReCaptchaEnterpriseProvider,
+        ReCaptchaV3Provider;
 export 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
     show FirebaseException;
 

--- a/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
@@ -59,12 +59,12 @@ class FirebaseAppCheck extends FirebasePluginPlatform {
   ///
   /// For more information, see [the Firebase Documentation](https://firebase.google.com/docs/app-check)
   Future<void> activate({
-    String? webRecaptchaSiteKey,
+    WebProvider? webProvider,
     AndroidProvider androidProvider = AndroidProvider.playIntegrity,
     AppleProvider appleProvider = AppleProvider.deviceCheck,
   }) {
     return _delegate.activate(
-      webRecaptchaSiteKey: webRecaptchaSiteKey,
+      webProvider: webProvider,
       androidProvider: androidProvider,
       appleProvider: appleProvider,
     );

--- a/packages/firebase_app_check/firebase_app_check/test/firebase_app_check_test.dart
+++ b/packages/firebase_app_check/firebase_app_check/test/firebase_app_check_test.dart
@@ -56,7 +56,7 @@ void main() {
     group('activate', () {
       test('successful call', () async {
         await appCheck.activate(
-          webRecaptchaSiteKey: 'key',
+          webProvider: ReCaptchaV3Provider('key'),
         );
 
         expect(

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/firebase_app_check_platform_interface.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/firebase_app_check_platform_interface.dart
@@ -9,3 +9,4 @@ export 'src/method_channel/method_channel_firebase_app_check.dart';
 export 'src/platform_interface/platform_interface_firebase_app_check.dart';
 export 'src/android_provider.dart';
 export 'src/apple_provider.dart';
+export 'src/web_providers.dart';

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
@@ -76,7 +76,7 @@ class MethodChannelFirebaseAppCheck extends FirebaseAppCheckPlatform {
 
   @override
   Future<void> activate({
-    String? webRecaptchaSiteKey,
+    WebProvider? webProvider,
     AndroidProvider? androidProvider,
     AppleProvider? appleProvider,
   }) async {

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/platform_interface/platform_interface_firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/platform_interface/platform_interface_firebase_app_check.dart
@@ -63,7 +63,7 @@ abstract class FirebaseAppCheckPlatform extends PlatformInterface {
   ///
   /// For more information, see [the Firebase Documentation](https://firebase.google.com/docs/app-check)
   Future<void> activate({
-    String? webRecaptchaSiteKey,
+    WebProvider? webProvider,
     AndroidProvider? androidProvider,
     AppleProvider? appleProvider,
   }) {

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/web_providers.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/web_providers.dart
@@ -1,0 +1,17 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+abstract class WebProvider {
+  final String siteKey;
+
+  WebProvider(this.siteKey);
+}
+
+class ReCaptchaV3Provider extends WebProvider {
+  ReCaptchaV3Provider(String siteKey) : super(siteKey);
+}
+
+class ReCaptchaEnterpriseProvider extends WebProvider {
+  ReCaptchaEnterpriseProvider(String siteKey) : super(siteKey);
+}

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/test/method_channel_tests/method_channel_firebase_app_check_test.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/test/method_channel_tests/method_channel_firebase_app_check_test.dart
@@ -68,7 +68,7 @@ void main() {
 
     test('activate', () async {
       await appCheck.activate(
-        webRecaptchaSiteKey: 'test-key',
+        webProvider: ReCaptchaV3Provider('test-key'),
       );
       expect(
         methodCallLogger,

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/test/platform_interface_tests/platform_interface_app_check_test.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/test/platform_interface_tests/platform_interface_app_check_test.dart
@@ -78,8 +78,9 @@ void main() {
 
     test('throws if .activate() not implemented', () async {
       await expectLater(
-        () =>
-            firebaseAppCheckPlatform.activate(webRecaptchaSiteKey: 'test key'),
+        () => firebaseAppCheckPlatform.activate(
+          webProvider: ReCaptchaV3Provider('test key'),
+        ),
         throwsA(
           isA<UnimplementedError>().having(
             (e) => e.message,

--- a/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
@@ -64,14 +64,14 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
 
   @override
   Future<void> activate({
-    String? webRecaptchaSiteKey,
+    WebProvider? webProvider,
     AndroidProvider? androidProvider,
     AppleProvider? appleProvider,
   }) async {
     // activate API no longer exists, recaptcha key has to be passed on initialization of app-check instance.
     return convertWebExceptions<Future<void>>(() async {
       _webAppCheck ??= app_check_interop.getAppCheckInstance(
-          core_interop.app(app.name), webRecaptchaSiteKey);
+          core_interop.app(app.name), webProvider);
       if (_tokenChangesListeners[app.name] == null) {
         _tokenChangesListeners[app.name] =
             StreamController<String?>.broadcast();

--- a/packages/firebase_app_check/firebase_app_check_web/lib/src/interop/app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/src/interop/app_check.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:js';
 
+import 'package:firebase_app_check_platform_interface/firebase_app_check_platform_interface.dart';
 import 'package:firebase_core_web/firebase_core_web_interop.dart';
 
 import 'app_check_interop.dart' as app_check_interop;
@@ -12,9 +13,21 @@ import 'app_check_interop.dart' as app_check_interop;
 export 'app_check_interop.dart';
 
 /// Given an AppJSImp, return the AppCheck instance.
-AppCheck? getAppCheckInstance([App? app, String? recaptchaKey]) {
-  final provider = app_check_interop.ReCaptchaV3Provider(recaptchaKey);
-  final options = app_check_interop.AppCheckOptions(provider: provider);
+AppCheck? getAppCheckInstance([App? app, WebProvider? provider]) {
+  late app_check_interop.ReCaptchaProvider jsProvider;
+
+  if (provider is ReCaptchaV3Provider) {
+    jsProvider = app_check_interop.ReCaptchaV3Provider(provider.siteKey);
+  } else if (provider is ReCaptchaEnterpriseProvider) {
+    jsProvider =
+        app_check_interop.ReCaptchaEnterpriseProvider(provider.siteKey);
+  } else {
+    throw ArgumentError(
+      'A `WebProvider` is required for `activate()` to initialise App Check on the web platform',
+    );
+  }
+
+  final options = app_check_interop.AppCheckOptions(provider: jsProvider);
 
   return AppCheck.getInstance(
     app != null

--- a/packages/firebase_app_check/firebase_app_check_web/lib/src/interop/app_check_interop.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/src/interop/app_check_interop.dart
@@ -35,8 +35,16 @@ external void setTokenAutoRefreshEnabled(
 );
 
 @JS()
-class ReCaptchaV3Provider {
+abstract class ReCaptchaProvider {}
+
+@JS()
+class ReCaptchaV3Provider implements ReCaptchaProvider {
   external factory ReCaptchaV3Provider(recaptchaKey);
+}
+
+@JS()
+class ReCaptchaEnterpriseProvider implements ReCaptchaProvider {
+  external factory ReCaptchaEnterpriseProvider(recaptchaKey);
 }
 
 @JS()
@@ -48,10 +56,12 @@ abstract class AppCheckTokenResult {
 @JS()
 class AppCheckOptions {
   external bool? get isTokenAutoRefreshEnabled;
-  external ReCaptchaV3Provider get provider;
+
+  external ReCaptchaProvider get provider;
+
   external factory AppCheckOptions({
     bool? isTokenAutoRefreshEnabled,
-    ReCaptchaV3Provider provider,
+    ReCaptchaProvider provider,
   });
 }
 

--- a/packages/firebase_app_check/firebase_app_check_web/test/firebase_app_check_web_test.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/test/firebase_app_check_web_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 @TestOn('chrome')
-
+import 'package:firebase_app_check_platform_interface/firebase_app_check_platform_interface.dart';
 import 'package:firebase_app_check_web/firebase_app_check_web.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -32,11 +32,27 @@ void main() {
       verifyNoMoreInteractions(appCheck);
     });
 
-    test('activate', () async {
+    test('activate with ReCaptchaV3Provider', () async {
       await appCheck.activate(
-        webRecaptchaSiteKey: 'key',
+        webProvider: ReCaptchaV3Provider('key'),
       );
-      verify(appCheck.activate(webRecaptchaSiteKey: 'key'));
+      verify(
+        appCheck.activate(
+          webProvider: ReCaptchaV3Provider('key'),
+        ),
+      );
+      verifyNoMoreInteractions(appCheck);
+    });
+
+    test('activate with ReCaptchaEnterpriseProvider', () async {
+      await appCheck.activate(
+        webProvider: ReCaptchaEnterpriseProvider('key'),
+      );
+      verify(
+        appCheck.activate(
+          webProvider: ReCaptchaEnterpriseProvider('key'),
+        ),
+      );
       verifyNoMoreInteractions(appCheck);
     });
 

--- a/packages/firebase_app_check/firebase_app_check_web/test/firebase_app_check_web_test.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/test/firebase_app_check_web_test.dart
@@ -33,24 +33,26 @@ void main() {
     });
 
     test('activate with ReCaptchaV3Provider', () async {
+      final provider = ReCaptchaV3Provider('key');
       await appCheck.activate(
-        webProvider: ReCaptchaV3Provider('key'),
+        webProvider: provider,
       );
       verify(
         appCheck.activate(
-          webProvider: ReCaptchaV3Provider('key'),
+          webProvider: provider,
         ),
       );
       verifyNoMoreInteractions(appCheck);
     });
 
     test('activate with ReCaptchaEnterpriseProvider', () async {
+      final provider = ReCaptchaEnterpriseProvider('key');
       await appCheck.activate(
-        webProvider: ReCaptchaEnterpriseProvider('key'),
+        webProvider: provider,
       );
       verify(
         appCheck.activate(
-          webProvider: ReCaptchaEnterpriseProvider('key'),
+          webProvider: provider,
         ),
       );
       verifyNoMoreInteractions(appCheck);

--- a/packages/firebase_app_check/firebase_app_check_web/test/firebase_app_check_web_test.mocks.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/test/firebase_app_check_web_test.mocks.dart
@@ -128,7 +128,7 @@ class MockFirebaseAppCheckWeb extends _i1.Mock
       ) as _i4.FirebaseAppCheckWeb);
   @override
   _i5.Future<void> activate({
-    String? webRecaptchaSiteKey,
+    _i3.WebProvider? webProvider,
     _i3.AndroidProvider? androidProvider,
     _i3.AppleProvider? appleProvider,
   }) =>
@@ -137,7 +137,7 @@ class MockFirebaseAppCheckWeb extends _i1.Mock
           #activate,
           [],
           {
-            #webRecaptchaSiteKey: webRecaptchaSiteKey,
+            #webProvider: webProvider,
             #androidProvider: androidProvider,
             #appleProvider: appleProvider,
           },

--- a/tests/integration_test/firebase_app_check/firebase_app_check_e2e_test.dart
+++ b/tests/integration_test/firebase_app_check/firebase_app_check_e2e_test.dart
@@ -24,7 +24,7 @@ void main() {
       test('activate', () async {
         await expectLater(
           FirebaseAppCheck.instance.activate(
-            webRecaptchaSiteKey: '6Lemcn0dAAAAABLkf6aiiHvpGD6x-zF3nOSDU2M8',
+            webProvider: ReCaptchaV3Provider('6Lemcn0dAAAAABLkf6aiiHvpGD6x-zF3nOSDU2M8'),
           ),
           completes,
         );


### PR DESCRIPTION
## Description

**Breaking change**

Updates user facing API `activate()` which now accepts `ReCaptchaEnterpriseProvider(siteKey)` or `ReCaptchaV3Provider(siteKey)` as an argument for `webProvider`.

We've also implemented an exception if `webProvider` argument is not provided when running on web as it is a requirement when initialising App Check via `initializeAppCheck()` https://firebase.google.com/docs/reference/js/app-check.md#initializeappcheck.

If a provider is not passed on web:
```js
const options = {
  provider: {},
};
const appCheck = initializeAppCheck(undefined, options);
```
The following exception occurs:
<img width="526" alt="Screenshot 2023-09-12 at 12 59 45" src="https://github.com/firebase/flutterfire/assets/16018629/1d4a8d0e-3a60-45d9-9955-fac461d731e1">



## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [X] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
