### PR TITLE
feat(core, windows) Change the windows plugin compiling way

### DIFF
--- a/packages/firebase_auth/firebase_auth/example/windows/flutter/CMakeLists.txt
+++ b/packages/firebase_auth/firebase_auth/example/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/packages/firebase_auth/firebase_auth/windows/CMakeLists.txt
+++ b/packages/firebase_auth/firebase_auth/windows/CMakeLists.txt
@@ -22,7 +22,7 @@ list(APPEND PLUGIN_SOURCES
 
 # Define the plugin library target. Its name must not be changed (see comment
 # on PLUGIN_NAME above).
-add_library(${PLUGIN_NAME} SHARED
+add_library(${PLUGIN_NAME} STATIC
   "include/firebase_auth/firebase_auth_plugin_c_api.h"
   "firebase_auth_plugin_c_api.cpp"
   ${PLUGIN_SOURCES}
@@ -38,14 +38,13 @@ apply_standard_settings(${PLUGIN_NAME})
 # exported should be explicitly exported with the FLUTTER_PLUGIN_EXPORT macro.
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
-target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+target_compile_definitions(${PLUGIN_NAME} PUBLIC FLUTTER_PLUGIN_IMPL)
 
 # Source include directories and library dependencies. Add any plugin-specific
 # dependencies here.
 set(MSVC_RUNTIME_MODE MD)
-set(firebase_libs firebase_core_plugin firebase_auth firebase_app)
-set(ADDITIONAL_LIBS advapi32 ws2_32 crypt32)
-target_link_libraries(${PLUGIN_NAME} PRIVATE "${firebase_libs}" "${ADDITIONAL_LIBS}")
+set(firebase_libs firebase_core_plugin firebase_auth)
+target_link_libraries(${PLUGIN_NAME} PRIVATE "${firebase_libs}")
 
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")

--- a/packages/firebase_auth/firebase_auth/windows/firebase_auth_plugin.cpp
+++ b/packages/firebase_auth/firebase_auth/windows/firebase_auth_plugin.cpp
@@ -61,15 +61,7 @@ FirebaseAuthPlugin::FirebaseAuthPlugin() {
 FirebaseAuthPlugin::~FirebaseAuthPlugin() = default;
 
 Auth* GetAuthFromPigeon(const PigeonFirebaseApp& pigeonApp) {
-  std::vector<std::string> app_vector = GetFirebaseApp(pigeonApp.app_name());
-  firebase::AppOptions options;
-
-  options.set_api_key(app_vector[1].c_str());
-  options.set_app_id(app_vector[2].c_str());
-  options.set_database_url(app_vector[3].c_str());
-  options.set_project_id(app_vector[4].c_str());
-
-  App* app = App::Create(options, pigeonApp.app_name().c_str());
+  App* app = App::GetInstance(pigeonApp.app_name().c_str());
 
   Auth* auth = Auth::GetAuth(app);
 

--- a/packages/firebase_core/firebase_core/windows/CMakeLists.txt
+++ b/packages/firebase_core/firebase_core/windows/CMakeLists.txt
@@ -65,7 +65,7 @@ list(APPEND PLUGIN_SOURCES
 
 # Define the plugin library target. Its name must not be changed (see comment
 # on PLUGIN_NAME above).
-add_library(${PLUGIN_NAME} SHARED
+add_library(${PLUGIN_NAME} STATIC
   "include/firebase_core/firebase_core_plugin_c_api.h"
   "firebase_core_plugin_c_api.cpp"
   ${PLUGIN_SOURCES}
@@ -82,7 +82,7 @@ apply_standard_settings(${PLUGIN_NAME})
 # exported should be explicitly exported with the FLUTTER_PLUGIN_EXPORT macro.
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
-target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+target_compile_definitions(${PLUGIN_NAME} PUBLIC FLUTTER_PLUGIN_IMPL)
 
 # Source include directories and library dependencies. Add any plugin-specific
 # dependencies here.
@@ -90,7 +90,7 @@ set(MSVC_RUNTIME_MODE MD)
 add_subdirectory(${FIREBASE_CPP_SDK_DIR} bin/ EXCLUDE_FROM_ALL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${FIREBASE_CPP_SDK_DIR}/include")
-set(FIREBASE_LIBS firebase_app firebase_auth firebase_remote_config)
+set(FIREBASE_LIBS firebase_app)
 foreach(firebase_lib IN ITEMS ${FIREBASE_LIBS})
     get_target_property(firebase_lib_path ${firebase_lib} IMPORTED_LOCATION)
     string(REPLACE "Debug" "Release" firebase_lib_release_path ${firebase_lib_path})

--- a/packages/firebase_core/firebase_core/windows/firebase_core_plugin.cpp
+++ b/packages/firebase_core/firebase_core/windows/firebase_core_plugin.cpp
@@ -8,8 +8,6 @@
 #include <windows.h>
 
 #include "firebase/app.h"
-#include "firebase/auth.h"
-#include "firebase/remote_config.h"
 #include "messages.g.h"
 
 // For getPlatformVersion; remove unless needed for your plugin implementation.
@@ -28,8 +26,6 @@
 #include <vector>
 
 using ::firebase::App;
-using ::firebase::auth::Auth;
-using ::firebase::remote_config::RemoteConfig;
 
 namespace firebase_core_windows {
 
@@ -45,35 +41,6 @@ void FirebaseCorePlugin::RegisterWithRegistrar(
 }
 
 std::map<std::string, std::vector<std::string>> apps;
-
-std::vector<std::string> FirebaseCorePlugin::GetFirebaseApp(
-    std::string appName) {
-  auto app_it = apps.find(appName);
-
-  // If the app is already in the map, return the stored shared_ptr
-  if (app_it != apps.end()) {
-    return app_it->second;
-  }
-
-  std::vector<std::string> app_vector;
-  return app_vector;
-}
-
-void *FirebaseCorePlugin::GetFirebaseAuth(std::string appName) {
-  App *app = App::GetInstance(appName.c_str());
-  if (app == nullptr) {
-    return nullptr;
-  }
-  return Auth::GetAuth(app);
-}
-
-void *FirebaseCorePlugin::GetFirebaseRemoteConfig(std::string appName) {
-  App *app = App::GetInstance(appName.c_str());
-  if (app == nullptr) {
-    return nullptr;
-  }
-  return RemoteConfig::GetInstance(app);
-}
 
 FirebaseCorePlugin::FirebaseCorePlugin() {}
 

--- a/packages/firebase_core/firebase_core/windows/firebase_core_plugin.h
+++ b/packages/firebase_core/firebase_core/windows/firebase_core_plugin.h
@@ -22,9 +22,6 @@ class FirebaseCorePlugin : public flutter::Plugin,
                            public FirebaseAppHostApi {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
-  static std::vector<std::string> GetFirebaseApp(std::string appName);
-  static void *GetFirebaseAuth(std::string appName);
-  static void *GetFirebaseRemoteConfig(std::string appName);
 
   FirebaseCorePlugin();
 

--- a/packages/firebase_core/firebase_core/windows/firebase_core_plugin_c_api.cpp
+++ b/packages/firebase_core/firebase_core/windows/firebase_core_plugin_c_api.cpp
@@ -17,16 +17,3 @@ void FirebaseCorePluginCApiRegisterWithRegistrar(
       flutter::PluginRegistrarManager::GetInstance()
           ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
 }
-
-std::vector<std::string> GetFirebaseApp(std::string appName) {
-  return firebase_core_windows::FirebaseCorePlugin::GetFirebaseApp(appName);
-}
-
-void* GetFirebaseAuth(std::string appName) {
-  return firebase_core_windows::FirebaseCorePlugin::GetFirebaseAuth(appName);
-}
-
-void* GetFirebaseRemoteConfig(std::string appName) {
-  return firebase_core_windows::FirebaseCorePlugin::GetFirebaseRemoteConfig(
-      appName);
-}

--- a/packages/firebase_core/firebase_core/windows/include/firebase_core/firebase_core_plugin_c_api.h
+++ b/packages/firebase_core/firebase_core/windows/include/firebase_core/firebase_core_plugin_c_api.h
@@ -21,11 +21,4 @@
 FLUTTER_PLUGIN_EXPORT void FirebaseCorePluginCApiRegisterWithRegistrar(
     FlutterDesktopPluginRegistrarRef registrar);
 
-FLUTTER_PLUGIN_EXPORT std::vector<std::string> GetFirebaseApp(
-    std::string appName);
-
-FLUTTER_PLUGIN_EXPORT void* GetFirebaseAuth(std::string appName);
-
-FLUTTER_PLUGIN_EXPORT void* GetFirebaseRemoteConfig(std::string appName);
-
 #endif  // FLUTTER_PLUGIN_FIREBASE_CORE_PLUGIN_C_API_H_


### PR DESCRIPTION
## Description

To make different sdk plugins can refer to the same c++ sdk instances, which would give the ability to support the firestore->auth dependency.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
