### PR TITLE
fix(auth, apple): `fetchSignInMethodsForEmail` if value is `nil`, pass empty array.

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -1049,7 +1049,11 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, PigeonFirebaseA
                           if (error != nil) {
                             completion(nil, [FLTFirebaseAuthPlugin convertToFlutterError:error]);
                           } else {
-                            completion(providers, nil);
+                            if(providers == nil) {
+                              completion(@[], nil);
+                            } else {
+                              completion(providers, nil);
+                            }
                           }
                         }];
 }

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -1049,7 +1049,7 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, PigeonFirebaseA
                           if (error != nil) {
                             completion(nil, [FLTFirebaseAuthPlugin convertToFlutterError:error]);
                           } else {
-                            if(providers == nil) {
+                            if (providers == nil) {
                               completion(@[], nil);
                             } else {
                               completion(providers, nil);


### PR DESCRIPTION
## Description

`providers` can be `nil`:https://github.com/firebase/flutterfire/blob/master/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m#L1047

This PR check ifs `nil` and passes empty array.

The other issue is that the response seems to always come back as `nil`. I checked with a user that has email/password & google providers enabled and it still responded with `nil`. Appears to be a bug on the firebase-ios-sdk.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/11293

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
