### PR TITLE
fix(firebase_app_check_web): Activate web app check on startup if it was previously activated

### DIFF
--- a/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
@@ -32,13 +32,12 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
 
   /// Called by PluginRegistry to register this plugin for Flutter Web
   static void registerWith(Registrar registrar) {
-    final instance =
-        FirebaseAppCheckPlatform.instance = FirebaseAppCheckWeb.instance;
-
     FirebaseCoreWeb.registerService(
       'app-check',
       productNameOverride: 'app_check',
       ensurePluginInitialized: (firebaseApp) async {
+        final instance =
+            FirebaseAppCheckWeb(app: Firebase.app(firebaseApp.name));
         final recaptchaType =
             window.sessionStorage[_sessionKeyRecaptchaType(firebaseApp.name)];
         final recaptchaSiteKey = window
@@ -56,6 +55,8 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
         }
       },
     );
+
+    FirebaseAppCheckPlatform.instance = FirebaseAppCheckWeb.instance;
   }
 
   /// Initializes a stub instance to allow the class to be registered.

--- a/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
@@ -16,6 +16,9 @@ import 'src/internals.dart';
 import 'src/interop/app_check.dart' as app_check_interop;
 
 class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
+  static const recaptchaTypeV3 = 'recaptcha-v3';
+  static const recaptchaTypeEnterprise = 'enterprise';
+
   static Map<String, StreamController<String?>> _tokenChangesListeners = {};
 
   /// Stub initializer to allow the [registerWith] to create an instance without
@@ -37,14 +40,14 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
       productNameOverride: 'app_check',
       ensurePluginInitialized: (firebaseApp) async {
         final recaptchaType =
-            window.sessionStorage['${firebaseApp.name}-recaptchaType'];
-        final recaptchaSiteKey =
-            window.sessionStorage['${firebaseApp.name}-recaptchaSiteKey'];
+            window.sessionStorage[_sessionKeyRecaptchaType(firebaseApp.name)];
+        final recaptchaSiteKey = window
+            .sessionStorage[_sessionKeyRecaptchaSiteKey(firebaseApp.name)];
         if (recaptchaType != null && recaptchaSiteKey != null) {
           final WebProvider provider;
-          if (recaptchaType == 'recaptcha-v3') {
+          if (recaptchaType == recaptchaTypeV3) {
             provider = ReCaptchaV3Provider(recaptchaSiteKey);
-          } else if (recaptchaType == 'enterprise') {
+          } else if (recaptchaType == recaptchaTypeEnterprise) {
             provider = ReCaptchaEnterpriseProvider(recaptchaSiteKey);
           } else {
             throw Exception('Invalid recaptcha type: $recaptchaType');
@@ -58,6 +61,14 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
   /// Initializes a stub instance to allow the class to be registered.
   static FirebaseAppCheckWeb get instance {
     return FirebaseAppCheckWeb._();
+  }
+
+  static String _sessionKeyRecaptchaType(String appName) {
+    return 'FlutterFire-$appName-recaptchaType';
+  }
+
+  static String _sessionKeyRecaptchaSiteKey(String appName) {
+    return 'FlutterFire-$appName-recaptchaSiteKey';
   }
 
   /// instance of AppCheck from the web plugin
@@ -92,14 +103,14 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
     if (webProvider != null) {
       final String recaptchaType;
       if (webProvider is ReCaptchaV3Provider) {
-        recaptchaType = 'recaptcha-v3';
+        recaptchaType = recaptchaTypeV3;
       } else if (webProvider is ReCaptchaEnterpriseProvider) {
-        recaptchaType = 'enterprise';
+        recaptchaType = recaptchaTypeEnterprise;
       } else {
         throw Exception('Invalid web provider: $webProvider');
       }
-      window.sessionStorage['${app.name}-recaptchaType'] = recaptchaType;
-      window.sessionStorage['${app.name}-recaptchaSiteKey'] =
+      window.sessionStorage[_sessionKeyRecaptchaType(app.name)] = recaptchaType;
+      window.sessionStorage[_sessionKeyRecaptchaSiteKey(app.name)] =
           webProvider.siteKey;
     }
 

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -299,6 +299,12 @@ class FirebaseCoreWeb extends FirebasePlatform {
       }
     }
 
+    final appCheck = _services.remove('app-check');
+    if (appCheck != null) {
+      // Activate app check first
+      await appCheck.ensurePluginInitialized!(app!);
+    }
+
     await Future.wait(
       _services.values.map((service) {
         final ensureInitializedFunction = service.ensurePluginInitialized;


### PR DESCRIPTION
## Description

Right now on web, auth gets initialized before developers get a chance to activate app check. This means that the startup auth check fails when app check is enforced and the app is logged out on every start.

## Related Issues

Closes #11334

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
