### PR TITLE
refactor(firebase_app_check): Disable Jetifier

### DIFF
--- a/packages/firebase_app_check/firebase_app_check/android/gradle.properties
+++ b/packages/firebase_app_check/firebase_app_check/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true

--- a/packages/firebase_app_check/firebase_app_check/example/android/gradle.properties
+++ b/packages/firebase_app_check/firebase_app_check/example/android/gradle.properties
@@ -1,6 +1,5 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
## Description

Jetifier is needed to provide compatibility between old `support` packages and modern `androidx` ones: https://developer.android.com/tools/jetifier
If project has no `support` libraries in its dependencies it makes no sense to have Jetifier enabled as it influences the build speed:
https://adambennett.dev/2020/08/disabling-jetifier/
https://developer.android.com/build/optimize-your-build#disable-the-jetifier-flag

Thus, dropping Jetifier. Will open a series of PRs on this topic to not change all packages at once.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
