### PR TITLE
feat(app_check): Use Android dependencies from Firebase BOM

### DIFF
--- a/packages/firebase_app_check/firebase_app_check/android/build.gradle
+++ b/packages/firebase_app_check/firebase_app_check/android/build.gradle
@@ -55,10 +55,9 @@ android {
   dependencies {
     api firebaseCoreProject
     implementation platform("com.google.firebase:firebase-bom:${getRootProjectExtOrCoreProperty("FirebaseSDKVersion", firebaseCoreProject)}")
-    // TODO: Since App Check is a beta SDK it's not available in the Firebase Android BoM so we need to specify an exact version here.
-    implementation 'com.google.firebase:firebase-appcheck-safetynet:16.1.0'
-    implementation 'com.google.firebase:firebase-appcheck-debug:16.1.0'
+    implementation 'com.google.firebase:firebase-appcheck-debug'
     implementation 'com.google.firebase:firebase-appcheck-playintegrity'
+    implementation 'com.google.firebase:firebase-appcheck-safetynet'
     implementation 'androidx.annotation:annotation:1.5.0'
   }
 }

--- a/packages/firebase_app_check/firebase_app_check/android/build.gradle
+++ b/packages/firebase_app_check/firebase_app_check/android/build.gradle
@@ -57,7 +57,8 @@ android {
     implementation platform("com.google.firebase:firebase-bom:${getRootProjectExtOrCoreProperty("FirebaseSDKVersion", firebaseCoreProject)}")
     implementation 'com.google.firebase:firebase-appcheck-debug'
     implementation 'com.google.firebase:firebase-appcheck-playintegrity'
-    implementation 'com.google.firebase:firebase-appcheck-safetynet'
+    // SafetyNet is deprecated and not part of Firebase BOM
+    implementation 'com.google.firebase:firebase-appcheck-safetynet:16.1.2'
     implementation 'androidx.annotation:annotation:1.5.0'
   }
 }


### PR DESCRIPTION
## Description

App Check dependencies are available in Firebase BOM for some time already, so it makes sense to keep versions of App Check artifacts aligned with what BOM provides. Moreover, seems like current version of App Check for Flutter had quite old corresponding Android dependencies, so this change will also bump version of App Check Android.

## Related Issues

-

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
