### PR TITLE
fix(storage, apple): call platform channels from the main thread

### DIFF
--- a/packages/firebase_storage/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.m
+++ b/packages/firebase_storage/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.m
@@ -594,7 +594,7 @@ typedef NS_ENUM(NSUInteger, FLTFirebaseStorageStringType) {
     // upload paused
     [task observeStatus:FIRStorageTaskStatusPause
                 handler:^(FIRStorageTaskSnapshot *snapshot) {
-                  dispatch_async(self->_callbackQueue, ^() {
+                  dispatch_async(dispatch_get_main_queue(), ^{
                     [weakSelf.channel invokeMethod:@"Task#onPaused"
                                          arguments:[weakSelf NSDictionaryFromHandle:handle
                                                           andFIRStorageTaskSnapshot:snapshot]];
@@ -604,7 +604,7 @@ typedef NS_ENUM(NSUInteger, FLTFirebaseStorageStringType) {
     // upload reported progress
     [task observeStatus:FIRStorageTaskStatusProgress
                 handler:^(FIRStorageTaskSnapshot *snapshot) {
-                  dispatch_async(self->_callbackQueue, ^() {
+                  dispatch_async(dispatch_get_main_queue(), ^{
                     [weakSelf.channel invokeMethod:@"Task#onProgress"
                                          arguments:[weakSelf NSDictionaryFromHandle:handle
                                                           andFIRStorageTaskSnapshot:snapshot]];
@@ -614,7 +614,7 @@ typedef NS_ENUM(NSUInteger, FLTFirebaseStorageStringType) {
     // upload completed successfully
     [task observeStatus:FIRStorageTaskStatusSuccess
                 handler:^(FIRStorageTaskSnapshot *snapshot) {
-                  dispatch_async(self->_callbackQueue, ^() {
+                  dispatch_async(dispatch_get_main_queue(), ^{
                     @synchronized(self->_tasks) {
                       [self->_tasks removeObjectForKey:handle];
                     }
@@ -626,7 +626,7 @@ typedef NS_ENUM(NSUInteger, FLTFirebaseStorageStringType) {
 
     [task observeStatus:FIRStorageTaskStatusFailure
                 handler:^(FIRStorageTaskSnapshot *snapshot) {
-                  dispatch_async(self->_callbackQueue, ^() {
+                  dispatch_async(dispatch_get_main_queue(), ^{
                     @synchronized(self->_tasks) {
                       [self->_tasks removeObjectForKey:handle];
                     }


### PR DESCRIPTION
## Description

As mentioned in this PR: https://github.com/firebase/flutterfire/pull/11650, platform channel calls are required to be run on main thread.

See documentation about executing platform channel requests on the main thread: https://docs.flutter.dev/platform-integration/platform-channels?tab=type-mappings-obj-c-tab#channels-and-platform-threading

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/11667

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
