### PR TITLE
fix(auth): ensure `PigeonAuthCredential` is passed back to Dart side within try/catch

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/Classes/Private/PigeonParser.h
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/Private/PigeonParser.h
@@ -19,7 +19,8 @@
 + (FIRActionCodeSettings *_Nullable)parseActionCodeSettings:
     (nullable PigeonActionCodeSettings *)settings;
 + (PigeonUserCredential *_Nullable)getPigeonUserCredentialFromFIRUser:(nonnull FIRUser *)user;
-+ (PigeonIdTokenResult *)parseIdTokenResult:(FIRAuthTokenResult *)tokenResult;
++ (PigeonIdTokenResult *_Nonnull)parseIdTokenResult:(nonnull FIRAuthTokenResult *)tokenResult;
 + (PigeonTotpSecret *_Nonnull)getPigeonTotpSecret:(nonnull FIRTOTPSecret *)secret;
-
++ (PigeonAuthCredential *_Nullable)getPigeonAuthCredential:
+    (FIRAuthCredential *_Nullable)authCredential;
 @end

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/utils/exception.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/utils/exception.dart
@@ -58,9 +58,26 @@ FirebaseException platformExceptionToFirebaseAuthException(
       }
     }
 
+    AuthCredential? credential;
+
+    if (platformException.details != null &&
+        platformException.details['authCredential'] != null &&
+        platformException.details['authCredential'] is PigeonAuthCredential) {
+      PigeonAuthCredential pigeonAuthCredential =
+          platformException.details['authCredential'];
+
+      credential = AuthCredential(
+        providerId: pigeonAuthCredential.providerId,
+        signInMethod: pigeonAuthCredential.signInMethod,
+        token: pigeonAuthCredential.nativeId,
+        accessToken: pigeonAuthCredential.accessToken,
+      );
+    }
+
     return FirebaseAuthException(
       code: code,
       message: platformException.message?.split(': ').last,
+      credential: credential,
     );
   }
 


### PR DESCRIPTION
## Description

Whilst testing this code, I observed a few issues:
```dart
TwitterAuthProvider twitterProvider =
    TwitterAuthProvider();
try {
  await FirebaseAuth.instance.currentUser!
      .linkWithProvider(twitterProvider);
} on FirebaseAuthException catch (e) {
  if (e.code == 'credential-already-in-use') {
    print(
        'The account already exists for that email. - ${e.credential}');
    await FirebaseAuth.instance.signOut();
    final cred = await FirebaseAuth.instance
        .signInWithCredential(e.credential!);
  }
}
```

1. We were not passing back the `AuthCredential` when present on the exception which was an issue for both andriod and iOS. [Fixed here](https://github.com/firebase/flutterfire/pull/11683/files#diff-a2a0fb36528efebd6ce2a82ec76ffb25fde2eef6ccd166e3b4c68c38dc887906R61-R80).
2. We were passing back a dictionary of `AuthCredential` on iOS side, we needed to pass back the `PigeonAuthCredential`. [Fixed here](https://github.com/firebase/flutterfire/pull/11683/files#diff-926b26fe3f9119fb3548066f1b05028306ff8766f9a04abba0fefdb5dac5c0b2R190).
3. We were passing a generic "sign-in-failed" exception and not using the code from the error. [Fixed here](https://github.com/firebase/flutterfire/pull/11683/files#diff-926b26fe3f9119fb3548066f1b05028306ff8766f9a04abba0fefdb5dac5c0b2R578).
4. Upon using `signInWithCredential` after `linkWithProvider` failed with this exception code `credential-already-in-use`, we were receiving an exception code for `signInWithCredential` that was network error code (i.e. the number "400"), I have updated to check if the error code is a number and responded with the underlying error code. [Fixed here](https://github.com/firebase/flutterfire/pull/11683/files#diff-926b26fe3f9119fb3548066f1b05028306ff8766f9a04abba0fefdb5dac5c0b2R1227-R1233).


## Related Issues

fixes https://github.com/firebase/flutterfire/issues/11164
fixes https://github.com/firebase/flutterfire/issues/11686

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
