### PR TITLE
docs(cloud_firestore_odm_generator): ODM now need create_per_field_to_json: true

### DIFF
--- a/packages/cloud_firestore_odm/README.md
+++ b/packages/cloud_firestore_odm/README.md
@@ -74,10 +74,10 @@ flutter pub add --dev cloud_firestore_odm_generator
 flutter pub add --dev json_serializable
 ```
 
-## 5. Enable `create_field_map` of `json_serializable`
+## 5. Enable `create_field_map` and `create_per_field_to_json` of `json_serializable`
 
 
-For the ODM to work, it is necessary to enable the `create_field_map` of `json_serializable`.  
+For the ODM to work, it is necessary to enable the `create_field_map` and `create_per_field_to_json` of `json_serializable`.  
 This can be done by creating a `build.yaml` file next to your `pubspec.yaml` and
 paste the following:
 
@@ -88,15 +88,16 @@ targets:
       json_serializable:
         options:
           create_field_map: true
+          create_per_field_to_json: true
 ```
 
 
-This will enable `create_field_map` for the entire project.
+This will enable `create_field_map` and `create_per_field_to_json` for the entire project.
 
 Alternatively, you can enable the option on a per-model basis using `json_annotation`'s `@JsonSerializable` object:
 
 ```dart
-@JsonSerializable(createFieldMap: true)
+@JsonSerializable(createFieldMap: true, createPerFieldToJson: true)
 @Collection<Model>(...)
 class MyModel {...}
 ```


### PR DESCRIPTION
## Description

Following https://github.com/firebase/flutterfire/commit/f4c21f834569bb363c80af583b53164f7cbd5ada merge, ODM fail to generate models if create_per_field_to_json is not enabled for json_serializable. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
