### PR TITLE
docs(cloud_firestore_odm_generator): 1.0.0-dev.70 is a breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ Packages with breaking changes:
  - [`cloud_firestore_platform_interface` - `v6.0.0`](#cloud_firestore_platform_interface---v600)
  - [`firebase_auth_platform_interface` - `v7.0.0`](#firebase_auth_platform_interface---v700)
  - [`firebase_core_platform_interface` - `v5.0.0`](#firebase_core_platform_interface---v500)
+ - [`cloud_firestore_odm_generator` - `v1.0.0-dev.70`](#cloud_firestore_odm_generator---v100-dev70)
 
 Packages with other changes:
 
  - [`cloud_firestore` - `v4.10.0`](#cloud_firestore---v4100)
  - [`cloud_firestore_odm` - `v1.0.0-dev.70`](#cloud_firestore_odm---v100-dev70)
- - [`cloud_firestore_odm_generator` - `v1.0.0-dev.70`](#cloud_firestore_odm_generator---v100-dev70)
  - [`cloud_firestore_web` - `v3.8.0`](#cloud_firestore_web---v380)
  - [`cloud_functions` - `v4.5.0`](#cloud_functions---v450)
  - [`firebase_analytics` - `v10.6.0`](#firebase_analytics---v1060)
@@ -118,7 +118,7 @@ Packages with dependency updates only:
 
 #### `cloud_firestore_odm_generator` - `v1.0.0-dev.70`
 
- - **FEAT**(cloud_firestore_odm_generator): Support all serializable types ([#11365](https://github.com/firebase/flutterfire/issues/11365)). ([f4c21f83](https://github.com/firebase/flutterfire/commit/f4c21f834569bb363c80af583b53164f7cbd5ada))
+ - **BREAKING** **FEAT**(cloud_firestore_odm_generator): Support all serializable types ([#11365](https://github.com/firebase/flutterfire/issues/11365)). ([f4c21f83](https://github.com/firebase/flutterfire/commit/f4c21f834569bb363c80af583b53164f7cbd5ada))
 
 #### `cloud_firestore_web` - `v3.8.0`
 


### PR DESCRIPTION
## Description

Like stated in https://github.com/firebase/flutterfire/pull/11728, ODM generator v1.0.0-dev.70 require a config change to continue working. All ODM users are concerned, the more we communicate about this (thus preventing issue creation and blocked users) the better. Some might check the changelog, hence this PR.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
