### PR TITLE
fix(core, windows): remove unused map of string that was causing a crash

### DIFF
--- a/packages/firebase_core/firebase_core/windows/firebase_core_plugin.cpp
+++ b/packages/firebase_core/firebase_core/windows/firebase_core_plugin.cpp
@@ -40,8 +40,6 @@ void FirebaseCorePlugin::RegisterWithRegistrar(
   registrar->AddPlugin(std::move(plugin));
 }
 
-std::map<std::string, std::vector<std::string>> apps;
-
 FirebaseCorePlugin::FirebaseCorePlugin() {}
 
 FirebaseCorePlugin::~FirebaseCorePlugin() = default;
@@ -102,20 +100,6 @@ void FirebaseCorePlugin::InitializeApp(
   App *app =
       App::Create(PigeonFirebaseOptionsToAppOptions(initialize_app_request),
                   app_name.c_str());
-
-  auto app_it = apps.find(app_name);
-
-  // If the app is already in the map, return the stored shared_ptr
-  if (app_it == apps.end()) {
-    std::vector<std::string> app_vector;
-    app_vector.push_back(app_name);
-    app_vector.push_back(initialize_app_request.api_key());
-    app_vector.push_back(initialize_app_request.app_id());
-    app_vector.push_back(*initialize_app_request.database_u_r_l());
-    app_vector.push_back(initialize_app_request.project_id());
-
-    apps[app_name] = app_vector;
-  }
 
   // Send back the result to Flutter
   result(AppToPigeonInitializeResponse(*app));

--- a/packages/firebase_core/firebase_core/windows/firebase_core_plugin.h
+++ b/packages/firebase_core/firebase_core/windows/firebase_core_plugin.h
@@ -57,7 +57,6 @@ class FirebaseCorePlugin : public flutter::Plugin,
 
  private:
   bool coreInitialized = false;
-  static std::map<std::string, std::vector<std::string>> firebase_apps;
 };
 
 }  // namespace firebase_core_windows


### PR DESCRIPTION
## Description
Before we used a STATIC compilation of the different Windows plugins, we needed to recreate the Firebase App in each plugin. I've removed this stale code that we don't use anymore. 

## Related Issues

closes #11684 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
