### PR TITLE
fix(firestore, android): `cacheSizeBytes` value cannot be null when setting `persistenceEnabled`

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -282,10 +282,8 @@ public class FlutterFirebaseFirestorePlugin
         Long receivedCacheSizeBytes = pigeonApp.getSettings().getCacheSizeBytes();
         // This is the maximum amount of cache allowed.
         Long cacheSizeBytes = 104857600L;
-        if (receivedCacheSizeBytes != null) {
-          if (receivedCacheSizeBytes != -1) {
-            cacheSizeBytes = receivedCacheSizeBytes;
-          }
+        if (receivedCacheSizeBytes != null && receivedCacheSizeBytes != -1) {
+          cacheSizeBytes = receivedCacheSizeBytes;
         }
         builder.setLocalCacheSettings(
             PersistentCacheSettings.newBuilder().setSizeBytes(cacheSizeBytes).build());

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -279,10 +279,16 @@ public class FlutterFirebaseFirestorePlugin
     }
     if (pigeonApp.getSettings().getPersistenceEnabled() != null) {
       if (pigeonApp.getSettings().getPersistenceEnabled()) {
+        Long receivedCacheSizeBytes = pigeonApp.getSettings().getCacheSizeBytes();
+        // This is the maximum amount of cache allowed.
+        Long cacheSizeBytes = 104857600L;
+        if (receivedCacheSizeBytes != null) {
+          if (receivedCacheSizeBytes != -1) {
+            cacheSizeBytes = receivedCacheSizeBytes;
+          }
+        }
         builder.setLocalCacheSettings(
-            PersistentCacheSettings.newBuilder()
-                .setSizeBytes(pigeonApp.getSettings().getCacheSizeBytes())
-                .build());
+            PersistentCacheSettings.newBuilder().setSizeBytes(cacheSizeBytes).build());
       } else {
         builder.setLocalCacheSettings(MemoryCacheSettings.newBuilder().build());
       }

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -280,7 +280,8 @@ public class FlutterFirebaseFirestorePlugin
     if (pigeonApp.getSettings().getPersistenceEnabled() != null) {
       if (pigeonApp.getSettings().getPersistenceEnabled()) {
         Long receivedCacheSizeBytes = pigeonApp.getSettings().getCacheSizeBytes();
-        // This is the maximum amount of cache allowed.
+        // This is the maximum amount of cache allowed:
+        // https://firebase.google.com/docs/firestore/manage-data/enable-offline#configure_cache_size
         Long cacheSizeBytes = 104857600L;
         if (receivedCacheSizeBytes != null && receivedCacheSizeBytes != -1) {
           cacheSizeBytes = receivedCacheSizeBytes;

--- a/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
@@ -15,7 +15,9 @@ bool shouldUseFirestoreEmulator = false;
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
-
+  FirebaseFirestore.instance.settings = const Settings(
+    persistenceEnabled: true,
+  );
   if (shouldUseFirestoreEmulator) {
     FirebaseFirestore.instance.useFirestoreEmulator('localhost', 8080);
   }


### PR DESCRIPTION
## Description

Throwing exception when setting the following:
```dart
  FirebaseFirestore.instance.settings = const Settings(
    persistenceEnabled: true,
  );
```
without `cacheSizeBytes` also set. 

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/11738

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
