### PR TITLE
feat(firebase_storage): Add complete path getter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -62,3 +62,4 @@ Markus Köhne <markus@koehne.dev>
 Max Steffen <git@max-steffen.dev>
 Mohd Faheem Ansari <codefaheem@gmail.com>
 Om Phatak <everythingoutdated@gmail.com>
+Wilhelm Perdahl <wilhelm.perdahl@gmail.com>

--- a/packages/firebase_storage/firebase_storage/lib/src/reference.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/reference.dart
@@ -23,6 +23,9 @@ class Reference {
   /// The full path of this object.
   String get fullPath => _delegate.fullPath;
 
+  /// The complete path of this object, including bucket and protocol.
+  String get completePath => "gs://$bucket/$fullPath";
+
   /// The short name of this object, which is the last component of the full path.
   ///
   /// For example, if fullPath is 'full/path/image.png', name is 'image.png'.

--- a/packages/firebase_storage/firebase_storage/lib/src/reference.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/reference.dart
@@ -24,7 +24,7 @@ class Reference {
   String get fullPath => _delegate.fullPath;
 
   /// The complete path of this object, including bucket and protocol.
-  String get completePath => "gs://$bucket/$fullPath";
+  String get completePath => 'gs://$bucket/$fullPath';
 
   /// The short name of this object, which is the last component of the full path.
   ///

--- a/packages/firebase_storage/firebase_storage/test/firebase_storage_test.dart
+++ b/packages/firebase_storage/firebase_storage/test/firebase_storage_test.dart
@@ -105,6 +105,14 @@ void main() {
         expect(reference, isA<Reference>());
         verify(kMockStoragePlatform.ref(testPath));
       });
+
+      test('gets a correct complete path', () {
+        const String testPath = 'foo/bar';
+        const String testCompletePath = 'gs://$testBucket/$testPath';
+        final reference = storage.ref(testPath);
+
+        expect(reference.completePath, testCompletePath);
+      });
     });
 
     group('.refFromURL()', () {


### PR DESCRIPTION
## Description

This PR adds a convenience method to getting the complete path of the object. 
``` dart
    // output: gs://test-bucket/foo/ba
   ref.completePath
 ```
This is useful when using other Google Cloud services such as Vertex AI where a complete reference is needed for adding training data.

## Related Issues



## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
