### PR TITLE
feat(auth, windows): add Windows support for Google Sign In

### DIFF
--- a/packages/firebase_auth/firebase_auth/example/lib/main.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/main.dart
@@ -38,8 +38,11 @@ Future<void> main() async {
     await auth.useAuthEmulator('localhost', 9099);
   }
 
-   if (!kIsWeb && Platform.isWindows) {
-    await GoogleSignInDart.register(clientId: "406099696497-g5o9l0blii9970bgmfcfv14pioj90djd.apps.googleusercontent.com");
+  if (!kIsWeb && Platform.isWindows) {
+    await GoogleSignInDart.register(
+      clientId:
+          '406099696497-g5o9l0blii9970bgmfcfv14pioj90djd.apps.googleusercontent.com',
+    );
   }
 
   runApp(const AuthExampleApp());

--- a/packages/firebase_auth/firebase_auth/example/lib/main.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/main.dart
@@ -2,9 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:google_sign_in_dartio/google_sign_in_dartio.dart';
 
 import 'auth.dart';
 import 'firebase_options.dart';
@@ -32,6 +36,10 @@ Future<void> main() async {
 
   if (shouldUseFirebaseEmulator) {
     await auth.useAuthEmulator('localhost', 9099);
+  }
+
+   if (!kIsWeb && Platform.isWindows) {
+    await GoogleSignInDart.register(clientId: "406099696497-g5o9l0blii9970bgmfcfv14pioj90djd.apps.googleusercontent.com");
   }
 
   runApp(const AuthExampleApp());

--- a/packages/firebase_auth/firebase_auth/example/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/example/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
   flutter_signin_button: ^2.0.0
   google_sign_in: ^6.1.0
+  google_sign_in_dartio: ^0.2.2+1 # For Windows support
 
 dev_dependencies:
   http: ^0.13.3

--- a/packages/firebase_auth/firebase_auth/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/firebase_auth/firebase_auth/example/windows/flutter/generated_plugin_registrant.cc
@@ -8,10 +8,13 @@
 
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FirebaseAuthPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/packages/firebase_auth/firebase_auth/example/windows/flutter/generated_plugins.cmake
+++ b/packages/firebase_auth/firebase_auth/example/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   firebase_auth
   firebase_core
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/packages/firebase_auth/firebase_auth/windows/firebase_auth_plugin.cpp
+++ b/packages/firebase_auth/firebase_auth/windows/firebase_auth_plugin.cpp
@@ -585,11 +585,11 @@ firebase::auth::Credential getCredentialFromArguments(
     flutter::EncodableMap arguments, const AuthPigeonFirebaseApp& app) {
   std::string signInMethod =
       std::get<std::string>(arguments[kArgumentSignInMethod]);
-  std::string secret = std::get<std::string>(arguments[kArgumentSecret]);
 
   // Password Auth
   if (signInMethod == kSignInMethodPassword) {
     std::string email = std::get<std::string>(arguments[kArgumentEmail]);
+    std::string secret = std::get<std::string>(arguments[kArgumentSecret]);
     return firebase::auth::EmailAuthProvider::GetCredential(email.c_str(),
                                                             secret.c_str());
   }
@@ -606,7 +606,6 @@ firebase::auth::Credential getCredentialFromArguments(
   std::string idToken = std::get<std::string>(arguments[kArgumentIdToken]);
   std::string accessToken =
       std::get<std::string>(arguments[kArgumentAccessToken]);
-  std::string rawNonce = std::get<std::string>(arguments[kArgumentRawNonce]);
 
   // Facebook Auth
   if (signInMethod == kSignInMethodFacebook) {
@@ -622,6 +621,7 @@ firebase::auth::Credential getCredentialFromArguments(
 
   // Twitter Auth
   if (signInMethod == kSignInMethodTwitter) {
+    std::string secret = std::get<std::string>(arguments[kArgumentSecret]);
     return firebase::auth::TwitterAuthProvider::GetCredential(idToken.c_str(),
                                                               secret.c_str());
   }


### PR DESCRIPTION
## Description

Fix Windows' parsing of Providers argument, and add in the example app how to use `google_sign_in_dartio` in order to get the correct values.

## Related Issues

closes #11752

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
