### PR TITLE
fix(storage, apple): set the storage emulator only once to stop it from crashing on hot restart

### DIFF
--- a/packages/firebase_storage/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.m
+++ b/packages/firebase_storage/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.m
@@ -68,7 +68,7 @@ typedef NS_ENUM(NSUInteger, FLTFirebaseStorageStringType) {
 @implementation FLTFirebaseStoragePlugin {
   NSMutableDictionary<NSNumber *, FIRStorageObservableTask<FIRStorageTaskManagement> *> *_tasks;
   dispatch_queue_t _callbackQueue;
-  bool hasEmulatorBooted;
+  NSMutableDictionary<NSString *, NSNumber *> *_emulatorBooted;
   NSObject<FlutterBinaryMessenger> *_binaryMessenger;
   NSMutableDictionary<NSString *, FlutterEventChannel *> *_eventChannels;
   NSMutableDictionary<NSString *, NSObject<FlutterStreamHandler> *> *_streamHandlers;
@@ -97,7 +97,7 @@ typedef NS_ENUM(NSUInteger, FLTFirebaseStorageStringType) {
         dictionary];
     _callbackQueue =
         dispatch_queue_create("io.flutter.plugins.firebase.storage", DISPATCH_QUEUE_SERIAL);
-    hasEmulatorBooted = false;
+    _emulatorBooted = [[NSMutableDictionary alloc] init];
     _binaryMessenger = messenger;
     _eventChannels = [NSMutableDictionary dictionary];
     _streamHandlers = [NSMutableDictionary dictionary];
@@ -242,9 +242,11 @@ typedef NS_ENUM(NSUInteger, FLTFirebaseStorageStringType) {
                          port:(NSNumber *)port
                    completion:(void (^)(FlutterError *_Nullable))completion {
   FIRStorage *storage = [self getFIRStorageFromAppNameFromPigeon:app];
-  if (hasEmulatorBooted == false) {
+  NSNumber *emulatorKey = _emulatorBooted[app.bucket];
+
+  if (emulatorKey == nil) {
     [storage useEmulatorWithHost:host port:[port integerValue]];
-    hasEmulatorBooted = true;
+    [_emulatorBooted setObject:@(YES) forKey:app.bucket];
   }
   completion(nil);
 }

--- a/packages/firebase_storage/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.m
+++ b/packages/firebase_storage/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.m
@@ -242,7 +242,10 @@ typedef NS_ENUM(NSUInteger, FLTFirebaseStorageStringType) {
                          port:(NSNumber *)port
                    completion:(void (^)(FlutterError *_Nullable))completion {
   FIRStorage *storage = [self getFIRStorageFromAppNameFromPigeon:app];
-  [storage useEmulatorWithHost:host port:[port integerValue]];
+  if (hasEmulatorBooted == false) {
+    [storage useEmulatorWithHost:host port:[port integerValue]];
+    hasEmulatorBooted = true;
+  }
   completion(nil);
 }
 


### PR DESCRIPTION
## Description

see title.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/11833

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
