### PR TITLE
fix(firestore, android): fix a race condition that could cause a crash when adding event channels while closing the app

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -255,15 +255,19 @@ public class FlutterFirebaseFirestorePlugin
   }
 
   private void removeEventListeners() {
-    for (String identifier : eventChannels.keySet()) {
-      eventChannels.get(identifier).setStreamHandler(null);
+    synchronized (eventChannels) {
+      for (String identifier : eventChannels.keySet()) {
+        eventChannels.get(identifier).setStreamHandler(null);
+      }
+      eventChannels.clear();
     }
-    eventChannels.clear();
 
-    for (String identifier : streamHandlers.keySet()) {
-      streamHandlers.get(identifier).onCancel(null);
+    synchronized (streamHandlers) {
+      for (String identifier : streamHandlers.keySet()) {
+        streamHandlers.get(identifier).onCancel(null);
+      }
+      streamHandlers.clear();
     }
-    streamHandlers.clear();
 
     transactionHandlers.clear();
   }


### PR DESCRIPTION
## Description

Hard to reproduce but `synchronized` should be helping

## Related Issues

Closes #11875 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
