### PR TITLE
fix(firestore, web): fix being able to use DocumentSnapshot for `startAfter` on web

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
@@ -1012,7 +1012,8 @@ void runQueryTests() {
         expect(snapshot.docs[1].id, equals('doc4'));
       });
 
-      testWidgets('startAfterDocument() starts after a document', (_) async {
+      testWidgets('startAfterDocument() starts after a document using snapshot',
+          (_) async {
         CollectionReference<Map<String, dynamic>> collection =
             await initializeTest('startAfter-document');
         await Future.wait([
@@ -1032,8 +1033,9 @@ void runQueryTests() {
 
         DocumentSnapshot startAtSnapshot = await collection.doc('doc2').get();
 
-        QuerySnapshot<Map<String, dynamic>> snapshot =
-            await collection.startAfter([startAtSnapshot]).get();
+        QuerySnapshot<Map<String, dynamic>> snapshot = await collection
+            .orderBy('bar.value')
+            .startAfter([startAtSnapshot]).get();
 
         expect(snapshot.docs.length, equals(2));
         expect(snapshot.docs[0].id, equals('doc3'));

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
@@ -1011,6 +1011,34 @@ void runQueryTests() {
         expect(snapshot.docs[0].id, equals('doc3'));
         expect(snapshot.docs[1].id, equals('doc4'));
       });
+
+      testWidgets('startAfterDocument() starts after a document', (_) async {
+        CollectionReference<Map<String, dynamic>> collection =
+            await initializeTest('startAfter-document');
+        await Future.wait([
+          collection.doc('doc1').set({
+            'bar': {'value': 1},
+          }),
+          collection.doc('doc2').set({
+            'bar': {'value': 2},
+          }),
+          collection.doc('doc3').set({
+            'bar': {'value': 3},
+          }),
+          collection.doc('doc4').set({
+            'bar': {'value': 4},
+          }),
+        ]);
+
+        DocumentSnapshot startAtSnapshot = await collection.doc('doc2').get();
+
+        QuerySnapshot<Map<String, dynamic>> snapshot =
+            await collection.startAfter([startAtSnapshot]).get();
+
+        expect(snapshot.docs.length, equals(2));
+        expect(snapshot.docs[0].id, equals('doc3'));
+        expect(snapshot.docs[1].id, equals('doc4'));
+      });
     });
 
     /**

--- a/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
@@ -194,23 +194,11 @@ class _FilmListState extends State<FilmList> {
   }
 
   Future<void> _resetLikes() async {
-    final collection =
-        FirebaseFirestore.instance.collection('firestore-example-app');
-
-    final movies = await collection.orderBy('title').get(
+    final movies = await moviesRef.orderBy('title').get(
           const GetOptions(
             serverTimestampBehavior: ServerTimestampBehavior.previous,
           ),
         );
-    print(movies.docs.map((e) => e.data()['title']).toList());
-
-    final movies2 =
-        await collection.orderBy('title').startAfter([movies.docs[0]]).get(
-      const GetOptions(
-        serverTimestampBehavior: ServerTimestampBehavior.previous,
-      ),
-    );
-    print(movies2.docs.map((e) => e.data()['title']).toList());
 
     WriteBatch batch = FirebaseFirestore.instance.batch();
 

--- a/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
@@ -194,11 +194,23 @@ class _FilmListState extends State<FilmList> {
   }
 
   Future<void> _resetLikes() async {
-    final movies = await moviesRef.get(
+    final collection =
+        FirebaseFirestore.instance.collection('firestore-example-app');
+
+    final movies = await collection.orderBy('title').get(
+          const GetOptions(
+            serverTimestampBehavior: ServerTimestampBehavior.previous,
+          ),
+        );
+    print(movies.docs.map((e) => e.data()['title']).toList());
+
+    final movies2 =
+        await collection.orderBy('title').startAfter([movies.docs[0]]).get(
       const GetOptions(
         serverTimestampBehavior: ServerTimestampBehavior.previous,
       ),
     );
+    print(movies2.docs.map((e) => e.data()['title']).toList());
 
     WriteBatch batch = FirebaseFirestore.instance.batch();
 

--- a/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
@@ -194,11 +194,11 @@ class _FilmListState extends State<FilmList> {
   }
 
   Future<void> _resetLikes() async {
-    final movies = await moviesRef.orderBy('title').get(
-          const GetOptions(
-            serverTimestampBehavior: ServerTimestampBehavior.previous,
-          ),
-        );
+    final movies = await moviesRef.get(
+      const GetOptions(
+        serverTimestampBehavior: ServerTimestampBehavior.previous,
+      ),
+    );
 
     WriteBatch batch = FirebaseFirestore.instance.batch();
 

--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_snapshot.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_snapshot.dart
@@ -144,4 +144,8 @@ class _WithConverterDocumentSnapshot<T> implements DocumentSnapshot<T> {
 
   @override
   dynamic operator [](Object field) => _originalDocumentSnapshot[field];
+
+  /// Used to get the underlying platform representation of the snapshot.
+  DocumentSnapshotPlatform get delegate =>
+      (_originalDocumentSnapshot as _JsonDocumentSnapshot).delegate;
 }

--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_snapshot.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_snapshot.dart
@@ -27,7 +27,8 @@ class SnapshotOptions {}
 /// The data can be extracted with the data property or by using subscript
 /// syntax to access a specific field.
 @sealed
-abstract class DocumentSnapshot<T extends Object?> {
+abstract class DocumentSnapshot<T extends Object?>
+    extends DocumentSnapshotObject {
   /// This document's given ID for this snapshot.
   String get id;
 
@@ -64,6 +65,9 @@ class _JsonDocumentSnapshot implements DocumentSnapshot<Map<String, dynamic>> {
 
   final FirebaseFirestore _firestore;
   final DocumentSnapshotPlatform _delegate;
+
+  /// Used to get the underlying platform representation of the snapshot.
+  DocumentSnapshotPlatform get delegate => _delegate;
 
   @override
   String get id => _delegate.id;

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_document_change.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_document_change.dart
@@ -20,5 +20,6 @@ class MethodChannelDocumentChange extends DocumentChangePlatform {
               documentChange.document.path,
               documentChange.document.data,
               documentChange.document.metadata,
+              null,
             ));
 }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_document_reference.dart
@@ -84,6 +84,7 @@ class MethodChannelDocumentReference extends DocumentReferencePlatform {
         _pointer.path,
         result.data,
         result.metadata,
+        null,
       );
     } catch (e, stack) {
       convertPlatformException(e, stack);
@@ -142,6 +143,7 @@ class MethodChannelDocumentReference extends DocumentReferencePlatform {
                 result.path,
                 result.data,
                 result.metadata,
+                null,
               ),
             );
           },

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query_snapshot.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query_snapshot.dart
@@ -25,6 +25,7 @@ class MethodChannelQuerySnapshot extends QuerySnapshotPlatform {
                     document.path,
                     document.data,
                     document.metadata,
+                    null,
                   );
                 })
                 .whereNotNull()

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_transaction.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_transaction.dart
@@ -54,6 +54,7 @@ class MethodChannelTransaction extends TransactionPlatform {
       documentPath,
       result.data,
       result.metadata,
+      null,
     );
   }
 

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_document_snapshot.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_document_snapshot.dart
@@ -7,6 +7,9 @@ import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_inte
 import 'package:cloud_firestore_platform_interface/src/internal/pointer.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+/// Dummy class used to represent a [DocumentSnapshotPlatform] in the web
+class DocumentSnapshotObject {}
+
 /// Contains data read from a document in your Firestore
 /// database.
 ///
@@ -15,7 +18,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 class DocumentSnapshotPlatform extends PlatformInterface {
   /// Constructs a [DocumentSnapshotPlatform] using the provided [FirebaseFirestorePlatform].
   DocumentSnapshotPlatform(
-      this._firestore, String path, this._data, this._metadata)
+      this._firestore, String path, this._data, this._metadata, this.delegate)
       : _pointer = Pointer(path),
         super(token: _token);
 
@@ -39,6 +42,9 @@ class DocumentSnapshotPlatform extends PlatformInterface {
   final Map<String?, Object?>? _data;
 
   final PigeonSnapshotMetadata _metadata;
+
+  /// The delegate used to handle calls to this [DocumentSnapshotPlatform] on the native platform.
+  final dynamic delegate;
 
   /// The database ID of the snapshot's document.
   String get id => _pointer.id;

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/encode_utility.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/encode_utility.dart
@@ -132,6 +132,12 @@ class EncodeUtility {
       return encodeArrayData(value);
     } else if (value is Iterable<dynamic>) {
       return encodeArrayData(value.toList());
+    } else if (value is DocumentSnapshotObject) {
+      // We are using dynamic here to upcast DocumentSnapshotObject to DocumentSnapshot to avoid a circular dependency
+      DocumentSnapshotPlatform reference = (value as dynamic).delegate;
+      firestore_interop.DocumentSnapshot delegate = reference.delegate;
+
+      return delegate.jsObject;
     }
     return value;
   }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/web_utils.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/web_utils.dart
@@ -72,6 +72,7 @@ DocumentSnapshotPlatform convertWebDocumentSnapshot(
       hasPendingWrites: webSnapshot.metadata.hasPendingWrites,
       isFromCache: webSnapshot.metadata.fromCache,
     ),
+    webSnapshot,
   );
 }
 


### PR DESCRIPTION
## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

closes #11817 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
