### PR TITLE
fix(core, apple): remove usage of deprecated options trackingID and androidClientID

### DIFF
--- a/packages/firebase_core/firebase_core/example/android/build.gradle
+++ b/packages/firebase_core/firebase_core/example/android/build.gradle
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/packages/firebase_core/firebase_core/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/firebase_core/firebase_core/example/ios/Runner.xcodeproj/project.pbxproj
@@ -166,7 +166,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/packages/firebase_core/firebase_core/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/firebase_core/firebase_core/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/firebase_core/firebase_core/example/ios/Runner/Info.plist
+++ b/packages/firebase_core/firebase_core/example/ios/Runner/Info.plist
@@ -43,5 +43,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/packages/firebase_core/firebase_core/ios/Classes/FLTFirebaseCorePlugin.m
+++ b/packages/firebase_core/firebase_core/ios/Classes/FLTFirebaseCorePlugin.m
@@ -61,9 +61,7 @@
   pigeonOptions.projectId = (id)options.projectID ?: [NSNull null];
   pigeonOptions.databaseURL = (id)options.databaseURL ?: [NSNull null];
   pigeonOptions.storageBucket = (id)options.storageBucket ?: [NSNull null];
-  pigeonOptions.trackingId = (id)options.trackingID ?: [NSNull null];
   pigeonOptions.deepLinkURLScheme = (id)options.deepLinkURLScheme ?: [NSNull null];
-  pigeonOptions.androidClientId = (id)options.androidClientID ?: [NSNull null];
   pigeonOptions.iosBundleId = (id)options.bundleID ?: [NSNull null];
   pigeonOptions.iosClientId = (id)options.clientID ?: [NSNull null];
   pigeonOptions.appGroupId = (id)options.appGroupID ?: [NSNull null];
@@ -137,19 +135,10 @@
     options.storageBucket = initializeAppRequest.storageBucket;
   }
 
-  // kFirebaseOptionsTrackingId
-  if (![initializeAppRequest.trackingId isEqual:[NSNull null]]) {
-    options.trackingID = initializeAppRequest.trackingId;
-  }
 
   // kFirebaseOptionsDeepLinkURLScheme
   if (![initializeAppRequest.deepLinkURLScheme isEqual:[NSNull null]]) {
     options.deepLinkURLScheme = initializeAppRequest.deepLinkURLScheme;
-  }
-
-  // kFirebaseOptionsAndroidClientId
-  if (![initializeAppRequest.androidClientId isEqual:[NSNull null]]) {
-    options.androidClientID = initializeAppRequest.androidClientId;
   }
 
   // kFirebaseOptionsIosBundleId

--- a/packages/firebase_core/firebase_core/ios/Classes/FLTFirebaseCorePlugin.m
+++ b/packages/firebase_core/firebase_core/ios/Classes/FLTFirebaseCorePlugin.m
@@ -135,7 +135,6 @@
     options.storageBucket = initializeAppRequest.storageBucket;
   }
 
-
   // kFirebaseOptionsDeepLinkURLScheme
   if (![initializeAppRequest.deepLinkURLScheme isEqual:[NSNull null]]) {
     options.deepLinkURLScheme = initializeAppRequest.deepLinkURLScheme;

--- a/tests/lib/firebase_options.dart
+++ b/tests/lib/firebase_options.dart
@@ -82,8 +82,6 @@ class DefaultFirebaseOptions {
     databaseURL:
         'https://flutterfire-e2e-tests-default-rtdb.europe-west1.firebasedatabase.app',
     storageBucket: 'flutterfire-e2e-tests.appspot.com',
-    androidClientId:
-        '406099696497-tvtvuiqogct1gs1s6lh114jeps7hpjm5.apps.googleusercontent.com',
     iosClientId:
         '406099696497-taeapvle10rf355ljcvq5dt134mkghmp.apps.googleusercontent.com',
     iosBundleId: 'io.flutter.plugins.firebase.tests',

--- a/tests/lib/firebase_options.dart
+++ b/tests/lib/firebase_options.dart
@@ -69,8 +69,6 @@ class DefaultFirebaseOptions {
     databaseURL:
         'https://flutterfire-e2e-tests-default-rtdb.europe-west1.firebasedatabase.app',
     storageBucket: 'flutterfire-e2e-tests.appspot.com',
-    androidClientId:
-        '406099696497-tvtvuiqogct1gs1s6lh114jeps7hpjm5.apps.googleusercontent.com',
     iosClientId:
         '406099696497-taeapvle10rf355ljcvq5dt134mkghmp.apps.googleusercontent.com',
     iosBundleId: 'io.flutter.plugins.firebase.tests',


### PR DESCRIPTION

## Description

As mentioned in the reference docs, those parameters are unused by the SDK:
https://firebase.google.com/docs/reference/ios/firebasecore/api/reference/Classes/FIROptions#trackingid

## Related Issues

closes #11751 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
