### PR TITLE
fix(auth, web): use the device language when using setLanguageCode with null

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -362,8 +362,7 @@ class FirebaseAuth extends FirebasePluginPlatform {
     await _delegate.sendSignInLinkToEmail(email, actionCodeSettings);
   }
 
-  /// When set to null, the default Firebase Console language setting is
-  /// applied.
+  /// When set to null, sets the user-facing language code to be the default app language.
   ///
   /// The language code will propagate to email action templates (password
   /// reset, email verification and email change revocation), SMS templates for

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -369,10 +369,6 @@ class FirebaseAuth extends FirebasePluginPlatform {
   /// phone authentication, reCAPTCHA verifier and OAuth popup/redirect
   /// operations provided the specified providers support localization with the
   /// language code specified.
-  ///
-  /// On web platforms, if `null` is provided as the [languageCode] the Firebase
-  /// project default language will be used. On native platforms, the device
-  /// language will be used.
   Future<void> setLanguageCode(String? languageCode) {
     return _delegate.setLanguageCode(languageCode);
   }

--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -311,7 +311,11 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
 
   @override
   Future<void> setLanguageCode(String? languageCode) async {
-    delegate.languageCode = languageCode;
+    if (languageCode == null) {
+      delegate.useDeviceLanguage();
+    } else {
+      delegate.languageCode = languageCode;
+    }
   }
 
   @override

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -687,7 +687,7 @@ class Auth extends JsObjectWrapper<auth_interop.AuthJsImpl> {
       auth_interop.connectAuthEmulator(jsObject, origin);
 
   /// Sets the current language to the default device/browser preference.
-  void useDeviceLanguage() => jsObject.useDeviceLanguage();
+  void useDeviceLanguage() => auth_interop.useDeviceLanguage(jsObject);
 
   /// Verifies a password reset [code] sent to the user by email
   /// or other out-of-band mechanism.

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
@@ -236,6 +236,9 @@ external PromiseJsImpl<void> updateProfile(
   UserProfile profile,
 );
 
+@JS()
+external void useDeviceLanguage(AuthJsImpl auth);
+
 /// https://firebase.google.com/docs/reference/js/auth.md#multifactor
 @JS()
 external MultiFactorUserJsImpl multiFactor(
@@ -269,7 +272,6 @@ abstract class AuthJsImpl {
     Func0? opt_completed,
   ]);
   external PromiseJsImpl<void> signOut();
-  external void useDeviceLanguage();
 }
 
 @anonymous


### PR DESCRIPTION
## Description

The inline documentation was currently wrong:
Android
```java
  @Override
  public void setLanguageCode(
      @NonNull GeneratedAndroidFirebaseAuth.AuthPigeonFirebaseApp app,
      @Nullable String languageCode,
      @NonNull GeneratedAndroidFirebaseAuth.Result<String> result) {
    try {
      FirebaseAuth firebaseAuth = getAuthFromPigeon(app);

      if (languageCode == null) {
        firebaseAuth.useAppLanguage();
      } else {
        firebaseAuth.setLanguageCode(languageCode);
      }

      result.success(firebaseAuth.getLanguageCode());
    } catch (Exception e) {
      result.error(e);
    }
  }
```

iOS
```ObjC
- (void)setLanguageCodeApp:(nonnull AuthPigeonFirebaseApp *)app
              languageCode:(nullable NSString *)languageCode
                completion:
                    (nonnull void (^)(NSString *_Nullable, FlutterError *_Nullable))completion {
  FIRAuth *auth = [self getFIRAuthFromAppNameFromPigeon:app];

  if (languageCode != nil && ![languageCode isEqual:[NSNull null]]) {
    auth.languageCode = languageCode;
  } else {
    [auth useAppLanguage];
  }

  completion(auth.languageCode, nil);
}
```

The modifications in this PR align the behavior of web with Android and iOS.

## Related Issues

closes #9458 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
