### PR TITLE
feat: Allow using localhost for emulators on Android

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -143,7 +143,7 @@ class FirebaseFirestore extends FirebasePluginPlatform {
         if (mappedHost == 'localhost' || mappedHost == '127.0.0.1') {
           // ignore: avoid_print
           print(
-              'You are using the Firestore Emulator on "$mappedHost". This host might not be accessible on Android.');
+              'You are using the Firestore Emulator on "$mappedHost". This host might not be accessible on Android.',);
         }
       }
 

--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -138,12 +138,12 @@ class FirebaseFirestore extends FirebasePluginPlatform {
       }
     } else {
       String mappedHost = host;
-      // Android considers localhost as 10.0.2.2 - automatically handle this for users.
+      // Android considers localhost as 10.0.2.2 - display a warning if localhost is used.
       if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
         if (mappedHost == 'localhost' || mappedHost == '127.0.0.1') {
           // ignore: avoid_print
-          print('Mapping Firestore Emulator host "$mappedHost" to "10.0.2.2".');
-          mappedHost = '10.0.2.2';
+          print(
+              'You are using the Firestore Emulator on "$mappedHost". This host might not be accessible on Android.');
         }
       }
 

--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -143,7 +143,8 @@ class FirebaseFirestore extends FirebasePluginPlatform {
         if (mappedHost == 'localhost' || mappedHost == '127.0.0.1') {
           // ignore: avoid_print
           print(
-              'You are using the Firestore Emulator on "$mappedHost". This host might not be accessible on Android.',);
+            'You are using the Firestore Emulator on "$mappedHost". This host might not be accessible on Android.',
+          );
         }
       }
 

--- a/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
+++ b/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
@@ -106,8 +106,8 @@ class FirebaseFunctions extends FirebasePluginPlatform {
     if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
       if (mappedHost == 'localhost' || mappedHost == '127.0.0.1') {
         // ignore: avoid_print
-        print('Mapping Functions Emulator host "$mappedHost" to "10.0.2.2".');
-        mappedHost = '10.0.2.2';
+        print(
+            'You are using the Functions Emulator on "$mappedHost". This host might not be accessible on Android.');
       }
     }
 

--- a/packages/cloud_functions/cloud_functions/test/firebase_functions_test.dart
+++ b/packages/cloud_functions/cloud_functions/test/firebase_functions_test.dart
@@ -6,7 +6,6 @@
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:cloud_functions_platform_interface/cloud_functions_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'mock.dart';
@@ -118,32 +117,6 @@ void main() {
                 .delegate
                 .origin,
             isNull);
-      });
-
-      test('handles "localhost" and "127.0.0.1" origin only for Android', () {
-        const testLocalhostOrigins = [
-          '127.0.0.1',
-          'localhost',
-        ];
-
-        for (final platform in TargetPlatform.values) {
-          debugDefaultTargetPlatformOverride = platform;
-
-          for (final testOrigin in testLocalhostOrigins) {
-            final expectedOrigin = platform == TargetPlatform.android
-                ? 'http://10.0.2.2:5000'
-                : 'http://$testOrigin:5000';
-
-            FirebaseFunctions.instance.useFunctionsEmulator(testOrigin, 5000);
-            // Origin on the default FirebaseFunctions instance should be set.
-            expect(
-                FirebaseFunctions.instance
-                    .httpsCallable('test')
-                    .delegate
-                    .origin,
-                equals(expectedOrigin));
-          }
-        }
       });
     });
 

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -132,8 +132,8 @@ class FirebaseAuth extends FirebasePluginPlatform {
     if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
       if (mappedHost == 'localhost' || mappedHost == '127.0.0.1') {
         // ignore: avoid_print
-        print('Mapping Auth Emulator host "$mappedHost" to "10.0.2.2".');
-        mappedHost = '10.0.2.2';
+        print(
+            'You are using the Auth Emulator on "$mappedHost". This host might not be accessible on Android.');
       }
     }
 

--- a/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
@@ -194,8 +194,8 @@ class FirebaseStorage extends FirebasePluginPlatform {
     if (defaultTargetPlatform == TargetPlatform.android && !kIsWeb) {
       if (mappedHost == 'localhost' || mappedHost == '127.0.0.1') {
         // ignore: avoid_print
-        print('Mapping Storage Emulator host "$mappedHost" to "10.0.2.2".');
-        mappedHost = '10.0.2.2';
+        print(
+            'You are using the Storage Emulator on "$mappedHost". This host might not be accessible on Android.');
       }
     }
 

--- a/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
+++ b/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
@@ -29,7 +29,7 @@ void main() {
         options: DefaultFirebaseOptions.currentPlatform,
       );
       final localhostMapped =
-      kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
+          kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
       FirebaseFunctions.instance.useFunctionsEmulator(localhostMapped, 5001);
       callable =
           FirebaseFunctions.instance.httpsCallable(kTestFunctionDefaultRegion);
@@ -196,7 +196,7 @@ void main() {
       test('accepts a custom region', () async {
         final instance = FirebaseFunctions.instanceFor(region: 'europe-west1');
         final localhostMapped =
-        kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
+            kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
         instance.useFunctionsEmulator(localhostMapped, 5001);
         final customRegionCallable =
             instance.httpsCallable(kTestFunctionCustomRegion);
@@ -211,7 +211,7 @@ void main() {
         () async {
           final instance = FirebaseFunctions.instance;
           final localhostMapped =
-          kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
+              kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
           instance.useFunctionsEmulator(localhostMapped, 5001);
           final timeoutCallable = FirebaseFunctions.instance.httpsCallable(
             kTestFunctionTimeout,
@@ -239,7 +239,7 @@ void main() {
             () async {
           final instance = FirebaseFunctions.instance;
           final localhostMapped =
-          kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
+              kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
           instance.useFunctionsEmulator(localhostMapped, 5001);
           final timeoutCallable = FirebaseFunctions.instance.httpsCallable(
             kTestFunctionDefaultRegion,

--- a/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
+++ b/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
@@ -28,7 +28,9 @@ void main() {
       await Firebase.initializeApp(
         options: DefaultFirebaseOptions.currentPlatform,
       );
-      FirebaseFunctions.instance.useFunctionsEmulator('localhost', 5001);
+      final localhostMapped =
+      kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
+      FirebaseFunctions.instance.useFunctionsEmulator(localhostMapped, 5001);
       callable =
           FirebaseFunctions.instance.httpsCallable(kTestFunctionDefaultRegion);
     });
@@ -193,7 +195,9 @@ void main() {
     group('instanceFor', () {
       test('accepts a custom region', () async {
         final instance = FirebaseFunctions.instanceFor(region: 'europe-west1');
-        instance.useFunctionsEmulator('localhost', 5001);
+        final localhostMapped =
+        kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
+        instance.useFunctionsEmulator(localhostMapped, 5001);
         final customRegionCallable =
             instance.httpsCallable(kTestFunctionCustomRegion);
         final result = await customRegionCallable();
@@ -206,7 +210,9 @@ void main() {
         'times out when the provided timeout option is exceeded',
         () async {
           final instance = FirebaseFunctions.instance;
-          instance.useFunctionsEmulator('localhost', 5001);
+          final localhostMapped =
+          kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
+          instance.useFunctionsEmulator(localhostMapped, 5001);
           final timeoutCallable = FirebaseFunctions.instance.httpsCallable(
             kTestFunctionTimeout,
             options: HttpsCallableOptions(timeout: const Duration(seconds: 3)),
@@ -232,7 +238,9 @@ void main() {
         'allow passing of `limitedUseAppCheckToken` as option',
             () async {
           final instance = FirebaseFunctions.instance;
-          instance.useFunctionsEmulator('localhost', 5001);
+          final localhostMapped =
+          kIsWeb || !Platform.isAndroid ? 'localhost' : '10.0.2.2';
+          instance.useFunctionsEmulator(localhostMapped, 5001);
           final timeoutCallable = FirebaseFunctions.instance.httpsCallable(
             kTestFunctionDefaultRegion,
             options: HttpsCallableOptions(timeout: const Duration(seconds: 3), limitedUseAppCheckToken: true),


### PR DESCRIPTION
## Description

This removes the line where the host used for the emulator gets remapped to 10.0.2.2 on Android. This allows using reverse sockets on ADB to connect to the emulators. A warning is now printed to console instead.

## Related Issues
firebase/flutterfire#11907

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
