### PR TITLE
doc(crashlytics): improve documentation for setCrashlyticsCollectionEnabled

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -181,6 +181,8 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
   /// Android Manifest, iOS Plist settings, as well as any Firebase-wide automatic
   /// data collection settings.
   ///
+  /// When you set a value for this method, it persists across runs of the app.
+  ///
   /// If automatic data collection is disabled for Crashlytics, crash reports are
   /// stored on the device. To check for reports, use the [checkForUnsentReports]
   /// method. Use [sendUnsentReports] to upload existing reports even when automatic


### PR DESCRIPTION

## Description

I've taken the sentence from the official iOS SDK: https://firebase.google.com/docs/reference/swift/firebasecrashlytics/api/reference/Classes/Crashlytics#setcrashlyticscollectionenabled_:

## Related Issues

closes #11971 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
