### PR TITLE
fix(firebase_auth): use nullable on getRedirectResult to avoid stop widget building on web

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -267,8 +267,12 @@ class FirebaseAuth extends FirebasePluginPlatform {
   /// returns a [UserCredential] with a null User.
   ///
   /// This method is only support on web platforms.
-  Future<UserCredential> getRedirectResult() async {
-    return UserCredential._(this, await _delegate.getRedirectResult());
+  Future<UserCredential?> getRedirectResult() async {
+    final userCredential = await _delegate.getRedirectResult();
+
+    return userCredential != null
+        ? UserCredential._(this, userCredential)
+        : null;
   }
 
   /// Checks if an incoming link is a sign-in with email link.

--- a/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
@@ -859,7 +859,7 @@ class MockFirebaseAuth extends Mock
   }
 
   @override
-  Future<UserCredentialPlatform> getRedirectResult() {
+  Future<UserCredentialPlatform?> getRedirectResult() {
     return super.noSuchMethod(
       Invocation.method(#getRedirectResult, []),
       returnValue: neverEndingFuture<UserCredentialPlatform>(),

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_firebase_auth.dart
@@ -249,7 +249,7 @@ abstract class FirebaseAuthPlatform extends PlatformInterface {
   /// returns a [UserCredential] with a null User.
   ///
   /// This method is only support on web platforms.
-  Future<UserCredentialPlatform> getRedirectResult() {
+  Future<UserCredentialPlatform?> getRedirectResult() {
     throw UnimplementedError('getRedirectResult() is not implemented');
   }
 

--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -245,13 +245,17 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   }
 
   @override
-  Future<UserCredentialPlatform> getRedirectResult() async {
+  Future<UserCredentialPlatform?> getRedirectResult() async {
     try {
-      return UserCredentialWeb(
-        this,
-        await delegate.getRedirectResult(),
-        _webAuth,
-      );
+      final userCredential = await delegate.getRedirectResult();
+
+      return userCredential != null
+          ? UserCredentialWeb(
+              this,
+              userCredential,
+              _webAuth,
+            )
+          : null;
     } catch (e) {
       throw getFirebaseAuthException(e);
     }

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -507,9 +507,10 @@ class Auth extends JsObjectWrapper<auth_interop.AuthJsImpl> {
   /// if sign is unsuccessful.
   /// The [UserCredential] with a null [User] is returned if no redirect
   /// operation was called.
-  Future<UserCredential> getRedirectResult() =>
-      handleThenable(auth_interop.getRedirectResult(jsObject))
-          .then(UserCredential.fromJsObject);
+  Future<UserCredential?> getRedirectResult() =>
+      handleThenable(auth_interop.getRedirectResult(jsObject)).then(
+        (value) => value != null ? UserCredential.fromJsObject(value) : null,
+      );
 
   /// Sends a sign-in email link to the user with the specified email.
   ///

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
@@ -79,7 +79,8 @@ external PromiseJsImpl<List> fetchSignInMethodsForEmail(
 external bool isSignInWithEmailLink(String emailLink);
 
 @JS()
-external PromiseJsImpl<UserCredentialJsImpl> getRedirectResult(AuthJsImpl auth);
+external PromiseJsImpl<UserCredentialJsImpl?> getRedirectResult(
+    AuthJsImpl auth);
 
 @JS()
 external PromiseJsImpl<void> sendSignInLinkToEmail(


### PR DESCRIPTION
## Description
https://github.com/firebase/flutterfire/issues/12023

I converted getRedirectResult on web to be nullable so If I used sign in with redirect and no data I don't want to get js error which will stop my web app.

## Related Issues
https://github.com/firebase/flutterfire/issues/9305

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
