### PR TITLE
chore(auth): Removed redundant `languageCode` null-check.

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -71,11 +71,7 @@ class FirebaseAuth extends FirebasePluginPlatform {
   ///
   /// See [setLanguageCode] to update the language code.
   String? get languageCode {
-    if (_delegate.languageCode != null) {
-      return _delegate.languageCode;
-    }
-
-    return null;
+    return _delegate.languageCode;
   }
 
   /// Changes this instance to point to an Auth emulator running locally.


### PR DESCRIPTION
## Description

` String? get languageCode {
    if (_delegate.languageCode != null) {
      return _delegate.languageCode;
    }

    return null;
  }`
  
  This code has a redundant check. Getter languageCode will always return String? for _delegate.languageCode. It is more easier to understand the simple and straight logic if is done as:
  
  `String? get languageCode {
    return _delegate.languageCode;
  }`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x ] No, this is *not* a breaking change.
