### PR TITLE
fix(database, web): fix `DatabaseReference` path producing "undefined" on profile and release builds.

### DIFF
--- a/packages/firebase_database/firebase_database_web/lib/src/query_web.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/query_web.dart
@@ -66,8 +66,19 @@ class QueryWeb extends QueryPlatform {
 
   @override
   String get path {
-    final refPath = Uri.parse(_queryDelegate.ref.toString()).path;
-    return refPath.isEmpty ? '/' : refPath;
+    // A bug on Flutter web causes this to throw an exception on "profile" & "release" mode and leaves the path as "undefined"
+    // See: https://github.com/firebase/flutterfire/issues/11670
+    String? path;
+    try {
+      path = Uri.parse(_queryDelegate.ref.toString()).path;
+    } catch (e) {
+      if (path == null) {
+        // testing shows "path" contains correct string even when it throws an exception on "profile" and "release" mode
+        rethrow;
+      }
+    }
+
+    return path.isEmpty ? '/' : path;
   }
 
   @override


### PR DESCRIPTION

## Description

Fairly bizarre Flutter web bug, the path variable evaluates correctly but throws an exception once variable inside try/catch has been set. Only occurs on profile and release builds.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/11670

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
