### PR TITLE
fix(auth): deprecate `updateEmail()` & `fetchSignInMethodsForEmail()`

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -484,6 +484,7 @@ class FirebaseAuth extends FirebasePluginPlatform {
   /// - **account-exists-with-different-credential**:
   ///  - Thrown if there already exists an account with the email address
   ///    asserted by the credential.
+  // ignore: deprecated_member_use_from_same_package
   ///    Resolve this by calling [fetchSignInMethodsForEmail] and then asking
   ///    the user to sign in using one of the returned providers.
   ///    Once the user is signed in, the original credential can be linked to

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -258,6 +258,9 @@ class FirebaseAuth extends FirebasePluginPlatform {
   /// A [FirebaseAuthException] maybe thrown with the following error code:
   /// - **invalid-email**:
   ///  - Thrown if the email address is not valid.
+  @Deprecated('fetchSignInMethodsForEmail() has been deprecated. '
+      'Migrating off of this method is recommended as a security best-practice. Learn more in the Identity Platform documentation for'
+      ' more information, please read: https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection.')
   Future<List<String>> fetchSignInMethodsForEmail(String email) {
     return _delegate.fetchSignInMethodsForEmail(email);
   }

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -259,8 +259,8 @@ class FirebaseAuth extends FirebasePluginPlatform {
   /// - **invalid-email**:
   ///  - Thrown if the email address is not valid.
   @Deprecated('fetchSignInMethodsForEmail() has been deprecated. '
-      'Migrating off of this method is recommended as a security best-practice. Learn more in the Identity Platform documentation for'
-      ' more information, please read: https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection.')
+      'Migrating off of this method is recommended as a security best-practice. Learn more in the Identity Platform documentation: '
+      ' https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection.')
   Future<List<String>> fetchSignInMethodsForEmail(String email) {
     return _delegate.fetchSignInMethodsForEmail(email);
   }

--- a/packages/firebase_auth/firebase_auth/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/user.dart
@@ -593,6 +593,8 @@ class User {
   ///  - Thrown if the user's last sign-in time does not meet the security
   ///    threshold. Use [User.reauthenticateWithCredential] to resolve. This
   ///    does not apply if the user is anonymous.
+  @Deprecated(
+      'updateEmail() has been deprecated. Please use verifyBeforeUpdateEmail() instead.')
   Future<void> updateEmail(String newEmail) async {
     await _delegate.updateEmail(newEmail);
   }

--- a/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
@@ -298,7 +298,7 @@ void main() {
         // Necessary as we otherwise get a "null is not a Future<void>" error
         when(mockAuthPlatform.fetchSignInMethodsForEmail(any))
             .thenAnswer((i) async => []);
-
+        // ignore: deprecated_member_use_from_same_package
         await auth.fetchSignInMethodsForEmail(kMockEmail);
         verify(mockAuthPlatform.fetchSignInMethodsForEmail(kMockEmail));
       });

--- a/packages/firebase_auth/firebase_auth/test/user_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/user_test.dart
@@ -253,7 +253,7 @@ void main() {
         when(mockUserPlatform.updateEmail(any)).thenAnswer((i) async {});
 
         const String newEmail = 'newEmail';
-
+        // ignore: deprecated_member_use_from_same_package
         await auth.currentUser!.updateEmail(newEmail);
 
         verify(mockUserPlatform.updateEmail(newEmail));

--- a/tests/integration_test/firebase_auth/firebase_auth_instance_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_instance_e2e_test.dart
@@ -327,6 +327,7 @@ void main() {
       group('fetchSignInMethodsForEmail()', () {
         test('should return password provider for an email address', () async {
           var providers =
+          // ignore: deprecated_member_use
               await FirebaseAuth.instance.fetchSignInMethodsForEmail(testEmail);
           expect(providers, isList);
           expect(providers.contains('password'), isTrue);
@@ -334,6 +335,7 @@ void main() {
 
         test('should return empty array for a not found email', () async {
           var providers = await FirebaseAuth.instance
+          // ignore: deprecated_member_use
               .fetchSignInMethodsForEmail(generateRandomEmail());
 
           expect(providers, isList);
@@ -342,6 +344,7 @@ void main() {
 
         test('throws for a bad email address', () async {
           try {
+            // ignore: deprecated_member_use
             await FirebaseAuth.instance.fetchSignInMethodsForEmail('foobar');
             fail('Should have thrown');
           } on FirebaseAuthException catch (e) {

--- a/tests/integration_test/firebase_auth/firebase_auth_user_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_user_e2e_test.dart
@@ -570,6 +570,7 @@ void main() {
           expect(FirebaseAuth.instance.currentUser!.email, equals(emailBefore));
 
           // Update user email
+          // ignore: deprecated_member_use
           await FirebaseAuth.instance.currentUser!.updateEmail(email);
           expect(FirebaseAuth.instance.currentUser!.email, equals(email));
         });


### PR DESCRIPTION
## Description

iOS, android and web have updated to deprecate `updateEmail()` & `fetchSignInMethodsForEmail()` API.

Web: https://firebase.google.com/docs/reference/js/auth.md#fetchsigninmethodsforemail
android: https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseAuth#fetchSignInMethodsForEmail(java.lang.String)

iOS: https://firebase.google.com/support/release-notes/ios#version_10190_-_dec_5_2023 

## Related Issues

closes https://github.com/firebase/flutterfire/issues/12121

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
