### PR TITLE
feat(auth, windows): add support for oAuth with credentials on Windows

### DIFF
--- a/packages/firebase_auth/firebase_auth/windows/firebase_auth_plugin.cpp
+++ b/packages/firebase_auth/firebase_auth/windows/firebase_auth_plugin.cpp
@@ -638,11 +638,8 @@ firebase::auth::Credential getCredentialFromArguments(
   if (signInMethod == kSignInMethodOAuth) {
     std::string providerId =
         std::get<std::string>(arguments[kArgumentProviderId]);
-    // As of my knowledge cutoff in September 2021, Firebase C++ SDK doesn't
-    // support creating OAuthProvider credentials directly
-    std::cout << "Creating OAuthProvider credentials directly is not supported "
-                 "in Firebase C++ SDK as of September 2021.\n";
-    return firebase::auth::Credential();
+    return firebase::auth::OAuthProvider::GetCredential(
+        providerId.c_str(), idToken.c_str(), accessToken.c_str());
   }
 
   // If no known auth method matched


### PR DESCRIPTION
## Description

Fix crash caused when trying to use firebase auth `signInWithCredential` on windows 

###  To Reproduce Crash On Windows

```dart
await FirebaseAuth.instance.signInWithCredential(
  OAuthProvider('oidc.provider').credential(
    idToken: idToken,
    accessToken: accessToken,
  )
);
```

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
