### PR TITLE
fix(auth, ios): Initialise static dictionary for custom auth domains

### DIFF
--- a/packages/firebase_core/firebase_core/ios/Classes/FLTFirebaseCorePlugin.m
+++ b/packages/firebase_core/firebase_core/ios/Classes/FLTFirebaseCorePlugin.m
@@ -53,6 +53,14 @@
 
 static NSMutableDictionary<NSString *, NSString *> *customAuthDomains;
 
+// Initialize static properties
+
++ (void)initialize {
+  if (self == [FLTFirebaseCorePlugin self]) {
+    customAuthDomains = [[NSMutableDictionary alloc] init];
+  }
+}
+
 + (NSString *)getCustomDomain:(NSString *)appName {
   return customAuthDomains[appName];
 }


### PR DESCRIPTION
## Description

PR #11925 added support for custom auth domains on mobile.  

Custom auto domains are stored in a static `NSMutableDictionary`  called `customAuthDomains` in the `FLTFirebaseCorePlugin` class, keyed by the app name.

Unfortunately, this static dictionary is never initialized, so custom domains do not take effect.

This PR adds a static initializer to the `FLTFirebaseCorePlugin` class to initialize this dictionary

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
