### PR TITLE
Add `isUtc` to the `Timestamp.toDate`

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/timestamp.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/timestamp.dart
@@ -78,8 +78,13 @@ class Timestamp implements Comparable<Timestamp> {
       seconds * _kMillion + nanoseconds ~/ _kThousand;
 
   /// Converts [Timestamp] to [DateTime]
-  DateTime toDate() {
-    return DateTime.fromMicrosecondsSinceEpoch(microsecondsSinceEpoch);
+  ///
+  /// Use [isUtc] to determine whether a returned `DateTime` object is based in UTC.
+  DateTime toDate({bool isUtc = false}) {
+    return DateTime.fromMicrosecondsSinceEpoch(
+      microsecondsSinceEpoch,
+      isUtc: isUtc,
+    );
   }
 
   @override

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/timestamp_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/timestamp_test.dart
@@ -80,5 +80,28 @@ void main() {
 
       expect(epoch, equals(-9999999999));
     });
+
+    test('isUtc: false return local DateTime', () {
+      Timestamp t = Timestamp.now();
+      DateTime fromT = t.toDate();
+
+      expect(fromT.isUtc, false);
+    });
+
+    test('isUtc: true return utc DateTime', () {
+      Timestamp t = Timestamp.now();
+      DateTime fromT = t.toDate(isUtc: true);
+
+      expect(fromT.isUtc, true);
+    });
+
+    test('isUtc: true return correct uts DateTime', () {
+      DateTime datetime = DateTime.utc(2024, 01, 23, 02, 27, 12, 345, 678);
+      Timestamp t =
+          Timestamp.fromMicrosecondsSinceEpoch(datetime.microsecondsSinceEpoch);
+      DateTime fromT = t.toDate(isUtc: true);
+
+      expect(fromT.microsecondsSinceEpoch, datetime.microsecondsSinceEpoch);
+    });
   });
 }


### PR DESCRIPTION
## Description

Ability to convert `Timestamp` objects to the UTC `DateTime` object.

In case, when we save UTC timestamps to the firestore, we need to restore them in that state.
Currently, we need to create `DateTime` someway like this:
```dart
          final Timestamp timestamp = // get timestamp object
          final datetime = DateTime.fromMicrosecondsSinceEpoch(
            timestamp.microsecondsSinceEpoch,
            isUtc: true,
          );
```
With this changes we will just use build-in methods.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
