### PR TITLE
chore: update publishing steps due to rate limit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,12 +301,12 @@ Some things to keep in mind before publishing the release:
 2. Run `git pull origin master`.
 3. Run `git pull --tags` to make sure all tags are fetched.
 4. Create new branch with the signature "release/[year]-[month]-[day]".
-5. Run `melos version --no-git-tag-version` to automatically version packages and update Changelogs.
+5. Run `melos version --git-tag-version` to automatically version packages and update Changelogs.
 6. Run `melos publish` to dry run and confirm all packages are publishable.
 7. After successful dry run, commit all changes with the signature "chore(release): prepare for release".
 8. Run `git push origin [RELEASE BRANCH NAME]` & open pull request for review on GitHub.
 9. After successful review and merge of the pull request, switch to `master` branch locally, & run `git pull origin master`.
-10. Run `melos publish --no-dry-run --git-tag-version` to now publish to Pub.dev.
+10. Run `melos publish --no-dry-run --no-git-tag-version` to now publish to Pub.dev.
 11. Run `git push --tags` to push tags to repository.
 12. Ping @kevinthecheung to get the changelog in Firebase releases.
 


### PR DESCRIPTION
## Description

With pub.dev rate limit (set to 10), we've updated the publishing steps to tag the packages first. This allows packages to be tagged, once you try to publish (i.e. `melos publish --no-dry-run --no-git-tag-version`), it will fail when limit hits 10. But you can keep running that command until all packages are published safe in the knowledge all packages have already been tagged (which wouldn't happen if you tried to tag during `melos publish`).

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
