### PR TITLE
fix(auth, web): fix null safety issue in typing JS Interop for OAuthCredential

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
@@ -388,15 +388,15 @@ abstract class OAuthCredential extends AuthCredential {}
 extension OAuthCredentialExtension on OAuthCredential {
   /// The OAuth access token associated with the credential if it belongs to
   /// an OAuth provider, such as facebook.com, twitter.com, etc.
-  external JSString get accessToken;
+  external JSString? get accessToken;
 
   /// The OAuth ID token associated with the credential if it belongs to an
   /// OIDC provider, such as google.com.
-  external JSString get idToken;
+  external JSString? get idToken;
 
   /// The OAuth access token secret associated with the credential if it
   /// belongs to an OAuth 1.0 provider, such as twitter.com.
-  external JSString get secret;
+  external JSString? get secret;
 }
 
 /// Defines the options for initializing an firebase.auth.OAuthCredential.

--- a/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
@@ -331,9 +331,9 @@ AuthCredential? convertWebOAuthCredential(
 
   return OAuthProvider(authCredential.providerId.toDart).credential(
     signInMethod: authCredential.signInMethod.toDart,
-    accessToken: authCredential.accessToken.toDart,
-    secret: authCredential.secret.toDart,
-    idToken: authCredential.idToken.toDart,
+    accessToken: authCredential.accessToken?.toDart,
+    secret: authCredential.secret?.toDart,
+    idToken: authCredential.idToken?.toDart,
   );
 }
 


### PR DESCRIPTION
## Description

API Reference: https://firebase.google.com/docs/reference/js/auth.oauthcredential

## Related Issues

closes #12252 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
