### PR TITLE
fix(firestore): cannot use `not-in` & `in` filters in the same query

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -804,10 +804,19 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
           !hasNotEqualTo,
           "You cannot use 'not-in' filters with '!=' filters.",
         );
+        assert(
+          !hasIn,
+          "You cannot use 'not-in' filters with 'in' filters.",
+        );
+        hasNotIn = true;
       }
 
       if (operator == 'in') {
         assert(!hasIn, "You cannot use 'whereIn' filters more than once.");
+        assert(
+          !hasNotIn,
+          "You cannot use 'in' filters with 'not-in' filters.",
+        );
         hasIn = true;
       }
 

--- a/packages/cloud_firestore/cloud_firestore/test/query_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/query_test.dart
@@ -61,6 +61,26 @@ void main() {
             .where('foo.bar', isGreaterThan: 1234);
       });
 
+      test('throw an exception when making query combining `in` & `not-in`',
+          () {
+        expect(
+          () => query!.where('number', whereIn: [1, 2], whereNotIn: [3, 4]),
+          throwsAssertionError,
+        );
+
+        expect(
+          () => query!.where('number', whereIn: [1, 2]).where('number',
+              whereNotIn: [3, 4]),
+          throwsAssertionError,
+        );
+
+        expect(
+          () => query!.where('number', whereNotIn: [3, 4]).where('number',
+              whereIn: [1, 2]),
+          throwsAssertionError,
+        );
+      });
+
       test('throws if inequality is different to first orderBy', () {
         expect(
           () => query!.where('foo', isGreaterThan: 123).orderBy('bar'),

--- a/packages/cloud_firestore/cloud_firestore/test/query_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/query_test.dart
@@ -69,14 +69,18 @@ void main() {
         );
 
         expect(
-          () => query!.where('number', whereIn: [1, 2]).where('number',
-              whereNotIn: [3, 4]),
+          () => query!.where('number', whereIn: [1, 2]).where(
+            'number',
+            whereNotIn: [3, 4],
+          ),
           throwsAssertionError,
         );
 
         expect(
-          () => query!.where('number', whereNotIn: [3, 4]).where('number',
-              whereIn: [1, 2]),
+          () => query!.where('number', whereNotIn: [3, 4]).where(
+            'number',
+            whereIn: [1, 2],
+          ),
           throwsAssertionError,
         );
       });


### PR DESCRIPTION
## Description

Stop incorrect filters from reaching underlying Firebase SDKs.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/12211

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
