### PR TITLE
fix(auth, web): `signInWithEmailAndPassword()` throwing with incorrect exception code

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
@@ -20,8 +20,8 @@ bool _hasFirebaseAuthErrorCodeAndMessage(JSError e) {
   if (e.name?.toDart == 'FirebaseError') {
     String code = e.code?.toDart ?? '';
     String message = e.message?.toDart ?? '';
-    if (code.startsWith('auth/')) return false;
-    if (message.contains('Firebase')) return false;
+    if (!code.startsWith('auth/')) return false;
+    if (!message.contains('Firebase')) return false;
     return true;
   } else {
     return false;

--- a/tests/integration_test/firebase_auth/firebase_auth_user_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_user_e2e_test.dart
@@ -421,6 +421,26 @@ void main() {
 
           fail('should have thrown an error');
         });
+
+        test('should throw wrong-password ', () async {
+          // Setup
+          final email = generateRandomEmail();
+          await FirebaseAuth.instance.createUserWithEmailAndPassword(
+            email: email,
+            password: testPassword,
+          );
+
+          await FirebaseAuth.instance.signOut();
+
+          await expectLater(
+            FirebaseAuth.instance.signInWithEmailAndPassword(email: email, password: 'wrong password'),
+            throwsA(
+              isA<FirebaseAuthException>().having((e) => e.code, 'code', equals('wrong-password'))
+                  .having((e) => e.message, 'message', equals('The password is invalid or the user does not have a password.')),
+            ),
+          );
+        });
+
       }, skip: !kIsWeb && defaultTargetPlatform == TargetPlatform.windows,);
 
       group('reload()', () {


### PR DESCRIPTION
## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/12309

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
