### PR TITLE
fix(auth, web): flutter `3.19.0` interop broke auth persistence setting. Updated the way we initialise JS Map inline with latest interop.

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -86,7 +86,7 @@ jobs:
       - uses: Homebrew/actions/setup-homebrew@master
       - name: 'Install Tools'
         run: |
-          brew install app-engine-python
+          brew install python3
           flutter pub global activate flutter_plugin_tools
           brew install swiftformat
           brew install clang-format

--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -86,6 +86,7 @@ jobs:
       - uses: Homebrew/actions/setup-homebrew@master
       - name: 'Install Tools'
         run: |
+          brew install app-engine-python
           flutter pub global activate flutter_plugin_tools
           brew install swiftformat
           brew install clang-format

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -270,7 +270,7 @@ jobs:
           key: firebase-emulators-v3-${{ github.run_id }}
           restore-keys: firebase-emulators-v3
       - name: Start Firebase Emulator
-        run: cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
+        run: sudo chown -R 501:20 "/Users/runner/.npm" && cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
       - name: 'E2E Tests'
         working-directory: ${{ matrix.working_directory }}
         # Web devices are not supported for the `flutter test` command yet. As a

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -21,19 +21,23 @@ export 'auth_interop.dart';
 
 /// Given an AppJSImp, return the Auth instance.
 Auth getAuthInstance(App app) {
-  return Auth.getInstance(auth_interop.initializeAuth(
+  // Default persistence can be seen here
+  // https://github.com/firebase/firebase-js-sdk/blob/master/packages/auth/src/platform_browser/index.ts#L47
+  final persistences = [
+    auth_interop.indexedDBLocalPersistence,
+    auth_interop.browserLocalPersistence,
+    auth_interop.browserSessionPersistence,
+  ];
+  return Auth.getInstance(
+    auth_interop.initializeAuth(
       app.jsObject,
-      jsify({
-        'errorMap': auth_interop.debugErrorMap,
-        // Default persistence can be seen here
-        // https://github.com/firebase/firebase-js-sdk/blob/master/packages/auth/src/platform_browser/index.ts#L47
-        'persistence': [
-          auth_interop.indexedDBLocalPersistence,
-          auth_interop.browserLocalPersistence,
-          auth_interop.browserSessionPersistence
-        ],
-        'popupRedirectResolver': auth_interop.browserPopupRedirectResolver
-      })));
+      auth_interop.AuthOptions(
+        errorMap: auth_interop.debugErrorMap,
+        persistence: persistences.toJS,
+        popupRedirectResolver: auth_interop.browserPopupRedirectResolver,
+      ),
+    ),
+  );
 }
 
 /// User profile information, visible only to the Firebase project's apps.
@@ -379,6 +383,7 @@ class Auth extends JsObjectWrapper<auth_interop.AuthJsImpl> {
   }
 
   JSFunction? _onAuthUnsubscribe;
+
   // TODO(rrousselGit): fix memory leak – the controller isn't closed even in onCancel
   // ignore: close_sinks
   StreamController<User?>? _changeController;
@@ -420,6 +425,7 @@ class Auth extends JsObjectWrapper<auth_interop.AuthJsImpl> {
   }
 
   JSFunction? _onIdTokenChangedUnsubscribe;
+
   // TODO(rrousselGit): fix memory leak – the controller isn't closed even in onCancel
   // ignore: close_sinks
   StreamController<User?>? _idTokenChangedController;

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
@@ -18,10 +18,21 @@ import 'package:firebase_core_web/firebase_core_web_interop.dart';
 external AuthJsImpl getAuth([AppJsImpl? app]);
 
 @JS()
-external AuthJsImpl initializeAuth(AppJsImpl app, JSAny debugErrorMap);
+external AuthJsImpl initializeAuth(AppJsImpl app, AuthOptions authOptions);
+
+extension type AuthOptions._(JSObject o) implements JSObject {
+  external AuthOptions({
+    JSObject errorMap,
+    JSArray? persistence,
+    JSObject? popupRedirectResolver,
+  });
+  external JSObject? get errorMap;
+  external JSArray? get persistence;
+  external JSObject? get popupRedirectResolver;
+}
 
 @JS('debugErrorMap')
-external JSAny get debugErrorMap;
+external JSObject get debugErrorMap;
 
 @JS()
 external JSPromise applyActionCode(AuthJsImpl auth, JSString oobCode);
@@ -348,10 +359,7 @@ extension UserJsImplExtension on UserJsImpl {
 ///
 /// See: <https://firebase.google.com/docs/reference/js/firebase.auth.Auth#.Persistence>
 @JS('Persistence')
-@staticInterop
-class Persistence {}
-
-extension PersistenceExtension on Persistence {
+extension type Persistence._(JSObject _) implements JSObject {
   external JSString get type;
 }
 
@@ -809,7 +817,7 @@ extension AdditionalUserInfoJsImplExtension on AdditionalUserInfoJsImpl {
 @staticInterop
 @anonymous
 class AuthSettings {
-  // external factory AuthSettings({JSBoolean appVerificationDisabledForTesting});
+// external factory AuthSettings({JSBoolean appVerificationDisabledForTesting});
 }
 
 extension AuthSettingsExtension on AuthSettings {
@@ -819,7 +827,7 @@ extension AuthSettingsExtension on AuthSettings {
 
 @JS()
 @staticInterop
-external JSAny get browserPopupRedirectResolver;
+external JSObject get browserPopupRedirectResolver;
 
 /// https://firebase.google.com/docs/reference/js/auth.multifactoruser.md#multifactoruser_interface
 @JS()

--- a/packages/firebase_auth/firebase_auth_web/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_web/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/firebase/flutterfire/tree/master/packages/firebas
 version: 5.9.4
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
   flutter: '>=3.3.0'
 
 dependencies:


### PR DESCRIPTION
## Description

Latest flutter SDK `3.19.0` broke our use of `jsify()` function here: https://github.com/firebase/flutterfire/pull/12338/files#diff-073c6ae89d1947a587a79d2020e2cd9478a0d218a4aeb8dd6bce4b37344b92e1R24-R40

Used the latest guidance to create a JS object literal: https://dart.dev/interop/js-interop/usage

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/12291

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
