### PR TITLE
feat(messaging, ios): Support get notification raw data

### DIFF
--- a/packages/firebase_messaging/firebase_messaging_platform_interface/CHANGELOG.md
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.5.25
+
+ - **FEAT**: Support get notification raw data
+
 ## 4.5.24
 
  - Update a dependency to the latest release.

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_message.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_message.dart
@@ -8,20 +8,22 @@ import 'package:firebase_messaging_platform_interface/firebase_messaging_platfor
 /// A class representing a message sent from Firebase Cloud Messaging.
 class RemoteMessage {
   // ignore: public_member_api_docs
-  const RemoteMessage(
-      {this.senderId,
-      this.category,
-      this.collapseKey,
-      this.contentAvailable = false,
-      this.data = const <String, dynamic>{},
-      this.from,
-      this.messageId,
-      this.messageType,
-      this.mutableContent = false,
-      this.notification,
-      this.sentTime,
-      this.threadId,
-      this.ttl});
+  const RemoteMessage({
+    this.senderId,
+    this.category,
+    this.collapseKey,
+    this.contentAvailable = false,
+    this.data = const <String, dynamic>{},
+    this.from,
+    this.messageId,
+    this.messageType,
+    this.mutableContent = false,
+    this.notification,
+    this.sentTime,
+    this.threadId,
+    this.ttl,
+    this.notificationRawData,
+  });
 
   /// Constructs a [RemoteMessage] from a raw Map.
   factory RemoteMessage.fromMap(Map<String, dynamic> map) {
@@ -49,6 +51,9 @@ class RemoteMessage {
               int.parse(map['sentTime'].toString())),
       threadId: map['threadId'],
       ttl: map['ttl'],
+      notificationRawData: map['notification'] == null
+          ? null
+          : Map<String, dynamic>.from(map['notification']),
     );
   }
 
@@ -110,4 +115,7 @@ class RemoteMessage {
 
   /// The time to live for the message in seconds.
   final int? ttl;
+
+  /// Any additional notification raw data.
+  final Map<String, dynamic>? notificationRawData;
 }

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_messaging_platform_interface
 description: A common platform interface for the firebase_messaging plugin.
-version: 4.5.24
+version: 4.5.25
 homepage: https://github.com/firebase/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging_platform_interface
 

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/test/remote_message_test.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/test/remote_message_test.dart
@@ -29,6 +29,7 @@ void main() {
         'notification': {
           'title': 'Hello FlutterFire!',
           'body': 'This notification was created from unit tests!',
+          'click_action': 'HANDLE_BREAKING_NEWS',
         },
         'sentTime': DateTime.now().millisecondsSinceEpoch,
         'threadId': 'threadId',
@@ -76,6 +77,11 @@ void main() {
       expect(message.sentTime, isA<DateTime>());
       expect(message.threadId, mockMessageMap!['threadId']);
       expect(message.ttl, mockMessageMap!['ttl']);
+      expect(message.notificationRawData, mockMessageMap!['notification']);
+      expect(
+        'HANDLE_BREAKING_NEWS',
+        mockMessageMap!['notification']['click_action'],
+      );
     });
 
     test(
@@ -96,6 +102,8 @@ void main() {
       expect(message.sentTime, null);
       expect(message.threadId, mockNullableMessageMap['threadId']);
       expect(message.ttl, mockNullableMessageMap['ttl']);
+      expect(
+          message.notificationRawData, mockNullableMessageMap['notification']);
     });
 
     test('Use RemoteMessage constructor to create every available property',
@@ -116,6 +124,7 @@ void main() {
         sentTime: date,
         threadId: mockMessageMap!['threadId'],
         ttl: mockMessageMap!['ttl'],
+        notificationRawData: mockMessageMap!['notification'],
       );
 
       expect(message.senderId, mockMessageMap!['senderId']);
@@ -133,6 +142,7 @@ void main() {
       expect(message.sentTime, date);
       expect(message.threadId, mockMessageMap!['threadId']);
       expect(message.ttl, mockMessageMap!['ttl']);
+      expect(message.notificationRawData, mockMessageMap!['notification']);
     });
 
     test(
@@ -167,9 +177,15 @@ void main() {
       expect(message.sentTime, null);
       expect(message.threadId, mockNullableMessageMap['threadId']);
       expect(message.ttl, mockNullableMessageMap['ttl']);
+      expect(
+          message.notificationRawData, mockNullableMessageMap['notification']);
     });
 
     test('"RemoteMessage.toMap" returns "RemoteMessage" as Map', () {
+      const remoteNotification = RemoteNotification(
+        title: 'notification_title',
+        body: 'notification_body',
+      );
       final RemoteMessage remoteMessage = RemoteMessage(
         senderId: 'senderId',
         category: 'category',
@@ -180,13 +196,11 @@ void main() {
         messageId: 'messageId',
         messageType: 'messageType',
         mutableContent: true,
-        notification: const RemoteNotification(
-          title: 'notification_title',
-          body: 'notification_body',
-        ),
+        notification: remoteNotification,
         sentTime: DateTime.now(),
         threadId: 'threadId',
         ttl: 30000,
+        notificationRawData: remoteNotification.toMap(),
       );
 
       final Map<String, dynamic> map = remoteMessage.toMap();
@@ -211,6 +225,7 @@ void main() {
       expect(map['sentTime'], remoteMessage.sentTime!.millisecondsSinceEpoch);
       expect(map['threadId'], remoteMessage.threadId);
       expect(map['ttl'], remoteMessage.ttl);
+      expect(map['notification'], remoteMessage.notificationRawData);
     });
   });
 }


### PR DESCRIPTION
## Description
Support to get the messaging notification raw data to support apple push, but now it was  `RemoteNotification` object.
```dart
  /// Constructs a [RemoteMessage] from a raw Map.
  factory RemoteMessage.fromMap(Map<String, dynamic> map) {
    return RemoteMessage(
      senderId: map['senderId'],
      category: map['category'],
      collapseKey: map['collapseKey'],
      contentAvailable: map['contentAvailable'] ?? false,
      data: map['data'] == null
          ? <String, dynamic>{}
          : Map<String, dynamic>.from(map['data']),
      from: map['from'],
      // Note: using toString on messageId as it can be an int or string when being sent from native.
      messageId: map['messageId']?.toString(),
      messageType: map['messageType'],
      mutableContent: map['mutableContent'] ?? false,
      notification: map['notification'] == null
          ? null
          : RemoteNotification.fromMap(
              Map<String, dynamic>.from(map['notification'])),
      // Note: using toString on sentTime as it can be an int or string when being sent from native.
      sentTime: map['sentTime'] == null
          ? null
          : DateTime.fromMillisecondsSinceEpoch(
              int.parse(map['sentTime'].toString())),
      threadId: map['threadId'],
      ttl: map['ttl'],
    );
  }
```

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
