### PR TITLE
fix(auth, web): lower SDK minimum version constraint to "3.2.0"

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -33,7 +33,7 @@ Auth getAuthInstance(App app) {
       app.jsObject,
       auth_interop.AuthOptions(
         errorMap: auth_interop.debugErrorMap,
-        persistence: persistences.toJS,
+        persistence: customJSList(persistences),
         popupRedirectResolver: auth_interop.browserPopupRedirectResolver,
       ),
     ),

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
@@ -20,15 +20,15 @@ external AuthJsImpl getAuth([AppJsImpl? app]);
 @JS()
 external AuthJsImpl initializeAuth(AppJsImpl app, AuthOptions authOptions);
 
-extension type AuthOptions._(JSObject o) implements JSObject {
-  external AuthOptions({
-    JSObject errorMap,
+@anonymous
+@JS()
+@staticInterop
+abstract class AuthOptions {
+  external factory AuthOptions({
+    JSObject? errorMap,
     JSArray? persistence,
     JSObject? popupRedirectResolver,
   });
-  external JSObject? get errorMap;
-  external JSArray? get persistence;
-  external JSObject? get popupRedirectResolver;
 }
 
 @JS('debugErrorMap')
@@ -359,7 +359,10 @@ extension UserJsImplExtension on UserJsImpl {
 ///
 /// See: <https://firebase.google.com/docs/reference/js/firebase.auth.Auth#.Persistence>
 @JS('Persistence')
-extension type Persistence._(JSObject _) implements JSObject {
+@staticInterop
+class Persistence {}
+
+extension PersistenceExtension on Persistence {
   external JSString get type;
 }
 

--- a/packages/firebase_auth/firebase_auth_web/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_web/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/firebase/flutterfire/tree/master/packages/firebas
 version: 5.9.5
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.2.0 <4.0.0'
   flutter: '>=3.3.0'
 
 dependencies:

--- a/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
@@ -62,6 +62,11 @@ dynamic jsifyList(
   return js.toJSArray(list.map((item) => jsify(item, customJsify)).toList());
 }
 
+/// Converts a List into a JS Array without converting the items.
+dynamic customJSList(List list) {
+  return js.toJSArray(list.toList());
+}
+
 /// Returns the JS implementation from Dart Object.
 ///
 /// The optional [customJsify] function may return `null` to indicate,


### PR DESCRIPTION
## Description

Revert changes to auth web SDK minimum constraint back to "3.2.0" from this PR: https://github.com/firebase/flutterfire/pull/12338/files

## Related Issues

fixes: https://github.com/firebase/flutterfire/issues/12354

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
