### PR TITLE
ci(macos): reinsert tests that were failing due to keysharing

### DIFF
--- a/tests/integration_test/firebase_app_installations/firebase_app_installations_e2e_test.dart
+++ b/tests/integration_test/firebase_app_installations/firebase_app_installations_e2e_test.dart
@@ -26,9 +26,7 @@ void main() {
         () async {
           final id = await FirebaseInstallations.instance.getId();
           expect(id, isNotEmpty);
-          // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
         },
-        skip: defaultTargetPlatform == TargetPlatform.macOS,
       );
 
       test(
@@ -46,9 +44,7 @@ void main() {
 
           final newId = await FirebaseInstallations.instance.getId();
           expect(newId, isNot(equals(id)));
-          // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
         },
-        skip: defaultTargetPlatform == TargetPlatform.macOS,
       );
 
       test(
@@ -56,9 +52,7 @@ void main() {
         () async {
           final token = await FirebaseInstallations.instance.getToken();
           expect(token, isNotEmpty);
-          // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
         },
-        skip: defaultTargetPlatform == TargetPlatform.macOS,
       );
     },
   );

--- a/tests/integration_test/firebase_auth/firebase_auth_instance_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_instance_e2e_test.dart
@@ -881,7 +881,5 @@ void main() {
         skip: true,
       );
     },
-    // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
-    skip: defaultTargetPlatform == TargetPlatform.macOS,
   );
 }

--- a/tests/integration_test/firebase_auth/firebase_auth_user_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_user_e2e_test.dart
@@ -492,8 +492,6 @@ void main() {
             }
             expect(FirebaseAuth.instance.currentUser, isNotNull);
           },
-          // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
-          skip: kIsWeb || defaultTargetPlatform == TargetPlatform.macOS,
         );
       }, skip: !kIsWeb && defaultTargetPlatform == TargetPlatform.windows,);
 
@@ -658,9 +656,7 @@ void main() {
           },
           // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
           // iOS supports it
-          skip: kIsWeb ||
-              defaultTargetPlatform == TargetPlatform.macOS ||
-              defaultTargetPlatform == TargetPlatform.iOS,
+          skip: kIsWeb,
         );
 
         test(
@@ -849,8 +845,7 @@ void main() {
             );
           },
           // setting `photoURL` on web throws an error
-          // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
-          skip: kIsWeb || defaultTargetPlatform == TargetPlatform.macOS  || defaultTargetPlatform == TargetPlatform.windows,
+          skip: kIsWeb || defaultTargetPlatform == TargetPlatform.windows,
         );
       },);
 
@@ -1036,7 +1031,5 @@ void main() {
         });
       }, skip: !kIsWeb && defaultTargetPlatform == TargetPlatform.windows,);
     },
-    // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
-    skip: defaultTargetPlatform == TargetPlatform.macOS,
   );
 }

--- a/tests/integration_test/firebase_messaging/firebase_messaging_e2e_test.dart
+++ b/tests/integration_test/firebase_messaging/firebase_messaging_e2e_test.dart
@@ -174,9 +174,8 @@ void main() {
             const topic = 'test-topic';
             await messaging.subscribeToTopic(topic);
           },
-          // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
           // android skipped due to consistently failing, works locally: https://github.com/firebase/flutterfire/pull/11260
-          skip: kIsWeb || defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.android,
+          skip: kIsWeb || defaultTargetPlatform == TargetPlatform.android,
         );
       });
 
@@ -187,9 +186,8 @@ void main() {
             const topic = 'test-topic';
             await messaging.unsubscribeFromTopic(topic);
           },
-          // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
           // android skipped due to consistently failing, works locally: https://github.com/firebase/flutterfire/pull/11260
-          skip: kIsWeb || defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.android,
+          skip: kIsWeb || defaultTargetPlatform == TargetPlatform.android,
         );
       });
 

--- a/tests/integration_test/firebase_remote_config/firebase_remote_config_e2e_test.dart
+++ b/tests/integration_test/firebase_remote_config/firebase_remote_config_e2e_test.dart
@@ -79,9 +79,7 @@ void main() {
           );
         },
         // iOS v9.2.0 hangs on ci if `fetchAndActivate()` is used, but works locally.
-        // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
-        skip: defaultTargetPlatform == TargetPlatform.iOS ||
-            defaultTargetPlatform == TargetPlatform.macOS,
+        skip: defaultTargetPlatform == TargetPlatform.iOS,
       );
 
       test('settings', () async {


### PR DESCRIPTION
## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

closes https://github.com/firebase/flutterfire/issues/9538

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
