### PR TITLE
chore(auth): fix typo in documentation

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/user.dart
@@ -173,7 +173,7 @@ class User {
   /// - **invalid-email**:
   ///  - Thrown if the email used in a [EmailAuthProvider.credential] is
   ///    invalid.
-  /// - **invalid-email**:
+  /// - **invalid-password**:
   ///  - Thrown if the password used in a [EmailAuthProvider.credential] is not
   ///    correct or when the user associated with the email does not have a
   ///    password.


### PR DESCRIPTION
## Description
  In description of Future<UserCredential> linkWithCredential there is a misprint
  /// - **invalid-email**:
  ///  - Thrown if the email used in a [EmailAuthProvider.credential] is
  ///    invalid.
  /// - **invalid-email**:
  ///  - Thrown if the password used in a [EmailAuthProvider.credential] is not
  ///    correct or when the user associated with the email does not have a
  ///    password.

The secon occurrence of **invalid-email** should be changed to **invalid-password**.


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
