### PR TITLE
refactor(app_check, web): small refactor around initialisation of FirebaseAppCheckWeb

### DIFF
--- a/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
@@ -11,9 +11,6 @@ class FirebaseAppCheck extends FirebasePluginPlatform {
   FirebaseAppCheck._({required this.app})
       : super(app.name, 'plugins.flutter.io/firebase_app_check');
 
-  /// Cached instance of [FirebaseAppCheck];
-  static FirebaseAppCheck? _instance;
-
   /// The [FirebaseApp] for this current [FirebaseAppCheck] instance.
   FirebaseApp app;
 
@@ -36,8 +33,9 @@ class FirebaseAppCheck extends FirebasePluginPlatform {
 
   /// Returns an instance using the default [FirebaseApp].
   static FirebaseAppCheck get instance {
-    _instance ??= FirebaseAppCheck._(app: Firebase.app());
-    return _instance!;
+    FirebaseApp defaultAppInstance = Firebase.app();
+
+    return FirebaseAppCheck.instanceFor(app: defaultAppInstance);
   }
 
   /// Returns an instance using a specified [FirebaseApp].


### PR DESCRIPTION

## Description

In
```
static FirebaseAppCheck instanceFor({required FirebaseApp app}) {
    return _firebaseAppCheckInstances.putIfAbsent(app.name, () {
      return FirebaseAppCheck._(app: app);
    });
  }
```

We already cache the result. No need to have 2 different caching mechanism. This is matching what we are doing on FirebaseAuth
 
## Related Issues

#12452

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
