### PR TITLE
fix(auth, android): fixing an issue that could cause `getEnrolledFactors` to return an empty list if signing out in the same app session

### DIFF
--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -444,7 +444,8 @@ public class FlutterFirebaseAuthPlugin
     try {
       FirebaseAuth firebaseAuth = getAuthFromPigeon(app);
       if (firebaseAuth.getCurrentUser() != null) {
-        final Map<String, MultiFactor> appMultiFactorUser = multiFactorUserMap.get(app.getAppName());
+        final Map<String, MultiFactor> appMultiFactorUser =
+            multiFactorUserMap.get(app.getAppName());
         if (appMultiFactorUser != null) {
           appMultiFactorUser.remove(firebaseAuth.getCurrentUser().getUid());
         }

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -4,6 +4,7 @@
 
 package io.flutter.plugins.firebase.auth;
 
+import static io.flutter.plugins.firebase.auth.FlutterFirebaseMultiFactor.multiFactorUserMap;
 import static io.flutter.plugins.firebase.core.FlutterFirebasePluginRegistry.registerPlugin;
 
 import android.app.Activity;
@@ -17,6 +18,7 @@ import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
+import com.google.firebase.auth.MultiFactor;
 import com.google.firebase.auth.MultiFactorInfo;
 import com.google.firebase.auth.MultiFactorSession;
 import com.google.firebase.auth.OAuthProvider;
@@ -441,6 +443,12 @@ public class FlutterFirebaseAuthPlugin
       @NonNull GeneratedAndroidFirebaseAuth.Result<Void> result) {
     try {
       FirebaseAuth firebaseAuth = getAuthFromPigeon(app);
+      if (firebaseAuth.getCurrentUser() != null) {
+        final Map<String, MultiFactor> appMultiFactorUser = multiFactorUserMap.get(app.getAppName());
+        if (appMultiFactorUser != null) {
+          appMultiFactorUser.remove(firebaseAuth.getCurrentUser().getUid());
+        }
+      }
       firebaseAuth.signOut();
       result.success(null);
     } catch (Exception e) {

--- a/tests/integration_test/firebase_auth/firebase_auth_multi_factor_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_multi_factor_e2e_test.dart
@@ -171,6 +171,121 @@ void main() {
         );
 
         test(
+          'should enroll and unenroll factor with signing out in the middle',
+          () async {
+            String testPhoneNumber = '+441444555666';
+            User? user;
+            UserCredential userCredential;
+
+            userCredential =
+                await FirebaseAuth.instance.createUserWithEmailAndPassword(
+              email: email,
+              password: testPassword,
+            );
+            user = userCredential.user;
+
+            await user!.sendEmailVerification();
+            final oobCode = (await emulatorOutOfBandCode(
+              email,
+              EmulatorOobCodeType.verifyEmail,
+            ))!;
+
+            await emulatorVerifyEmail(
+              oobCode.oobCode!,
+            );
+
+            await FirebaseAuth.instance.signOut();
+
+            await FirebaseAuth.instance.signInWithEmailAndPassword(
+              email: email,
+              password: testPassword,
+            );
+
+            final multiFactor = user.multiFactor;
+            final session = await multiFactor.getSession();
+
+            Future<String> getCredential() async {
+              Completer completer = Completer<String>();
+
+              unawaited(
+                FirebaseAuth.instance.verifyPhoneNumber(
+                  phoneNumber: testPhoneNumber,
+                  multiFactorSession: session,
+                  verificationCompleted: (PhoneAuthCredential credential) {
+                    if (!completer.isCompleted) {
+                      return completer.completeError(
+                        Exception(
+                          'verificationCompleted should not have been called',
+                        ),
+                      );
+                    }
+                  },
+                  verificationFailed: (FirebaseException e) {
+                    if (!completer.isCompleted) {
+                      return completer.completeError(
+                        Exception(
+                          'verificationFailed should not have been called',
+                        ),
+                      );
+                    }
+                  },
+                  codeSent: (String verificationId, int? resetToken) {
+                    completer.complete(verificationId);
+                  },
+                  codeAutoRetrievalTimeout: (String foo) {
+                    if (!completer.isCompleted) {
+                      return completer.completeError(
+                        Exception(
+                          'codeAutoRetrievalTimeout should not have been called',
+                        ),
+                      );
+                    }
+                  },
+                ),
+              );
+
+              return completer.future as FutureOr<String>;
+            }
+
+            final verificationId = await getCredential();
+
+            final smsCode = await emulatorPhoneVerificationCode(
+              testPhoneNumber,
+            );
+
+            final credential = PhoneAuthProvider.credential(
+              verificationId: verificationId,
+              smsCode: smsCode!,
+            );
+
+            expect(credential, isA<PhoneAuthCredential>());
+
+            await user.multiFactor.enroll(
+              PhoneMultiFactorGenerator.getAssertion(
+                credential,
+              ),
+              displayName: 'My phone number',
+            );
+
+            final enrolledFactors = await multiFactor.getEnrolledFactors();
+
+            // Assertions
+            expect(enrolledFactors.length, 1);
+            expect(enrolledFactors.first.displayName, 'My phone number');
+
+            await user.multiFactor.unenroll(
+              multiFactorInfo: enrolledFactors.first,
+            );
+
+            final enrolledFactorsAfter = await multiFactor.getEnrolledFactors();
+
+            // Assertions
+            expect(enrolledFactorsAfter.length, 0);
+          },
+          skip: kIsWeb || defaultTargetPlatform != TargetPlatform.android,
+        );
+
+        test(
           'should enroll and throw if trying to unenroll an unknown factor',
           () async {
             final email = generateRandomEmail();

--- a/tests/integration_test/firebase_auth/firebase_auth_multi_factor_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_multi_factor_e2e_test.dart
@@ -173,7 +173,9 @@ void main() {
         test(
           'should enroll and unenroll factor with signing out in the middle',
           () async {
-            String testPhoneNumber = '+441444555666';
+            String email = generateRandomEmail();
+
+            String testPhoneNumber = '+441444555626';
             User? user;
             UserCredential userCredential;
 


### PR DESCRIPTION
## Description

When signing out we weren't removing the old multifactor objects.

## Related Issues

closes #12486 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
