### PR TITLE
fix(app_check, web): fix typing inference for `getToken` on web

### DIFF
--- a/packages/firebase_app_check/firebase_app_check_web/lib/src/interop/app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/src/interop/app_check.dart
@@ -58,12 +58,14 @@ class AppCheck extends JsObjectWrapper<app_check_interop.AppCheckJsImpl> {
       );
 
   Future<app_check_interop.AppCheckTokenResult> getToken(bool? forceRefresh) =>
-      app_check_interop.getToken(jsObject, forceRefresh?.toJS).toDart
-          as Future<app_check_interop.AppCheckTokenResult>;
+      app_check_interop.getToken(jsObject, forceRefresh?.toJS).toDart.then(
+            (value) => value! as app_check_interop.AppCheckTokenResult,
+          );
 
   Future<app_check_interop.AppCheckTokenResult> getLimitedUseToken() =>
-      app_check_interop.getLimitedUseToken(jsObject).toDart
-          as Future<app_check_interop.AppCheckTokenResult>;
+      app_check_interop.getLimitedUseToken(jsObject).toDart.then(
+            (value) => value! as app_check_interop.AppCheckTokenResult,
+          );
 
   JSFunction? _idTokenChangedUnsubscribe;
 


### PR DESCRIPTION
## Description

`getToken` test is currently being skipped on Web and doesn't test success in e2e test.

## Related Issues

closes #12500 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
