### PR TITLE
chore: small fix to template snippet sharing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -120,7 +120,13 @@ body:
       label: Flutter dependencies
       description: Seeing your dependencies can help us debug versioning issues.
       value: |
-        ```json
+         <!--- Look below for instructions on how to share your Flutter Dependencies. --->
+
+        <details>
+        <summary>Expand <code>Flutter dependencies</code> snippet</summary>
+        <br>
+
+        ```yaml
 
         Replace this line with the contents of your `flutter pub deps -- --style=compact`.
 


### PR DESCRIPTION
## Description

YAML will give better formatting for the Flutter dependencies. Also hiding it under an expand.
Based on this: https://github.com/firebase/firebase-ios-sdk/blob/main/.github/ISSUE_TEMPLATE/BUG_REPORT.yml?plain=1#L126C1-L132C1

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
