### PR TITLE
ci: remove query test combining `arrayContainsAny` and `notEqualTo` that is now valid.

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/second_database.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/second_database.dart
@@ -1776,59 +1776,6 @@ void runSecondDatabaseTests() {
 
       group('Query.where() with Filter class', () {
         testWidgets(
-          'Exception thrown when combining `arrayContainsAny` & `isNotEqualTo` in multiple conjunctive queries',
-          (_) async {
-            CollectionReference<Map<String, dynamic>> collection =
-                await initializeTest('multiple-conjunctive-queries');
-
-            await expectLater(
-              collection
-                  .where(
-                    Filter.and(
-                      Filter('rating1', isEqualTo: 3.8),
-                      Filter('year1', isEqualTo: 1970),
-                      Filter('runtime1', isEqualTo: 90),
-                      Filter('director1', isEqualTo: 'Director2'),
-                      Filter('producer1', isEqualTo: 'Producer2'),
-                      Filter('budget1', isEqualTo: 20000000),
-                      Filter('boxOffice1', isEqualTo: 50000000),
-                      Filter('actor1', isEqualTo: 'Actor2'),
-                      Filter('language1', isEqualTo: 'English'),
-                      Filter('award1', isEqualTo: 'Award2'),
-                      Filter('genre1', arrayContainsAny: ['sci-fi']),
-                      Filter('country1', isEqualTo: 'USA'),
-                      Filter('released1', isEqualTo: true),
-                      Filter('screenplay1', isEqualTo: 'Screenplay2'),
-                      Filter('cinematography1', isEqualTo: 'Cinematography2'),
-                      Filter('music1', isEqualTo: 'Music2'),
-                      Filter('rating2', isEqualTo: 4.2),
-                      Filter('year2', isEqualTo: 1982),
-                      Filter('runtime2', isEqualTo: 60),
-                      Filter('director2', isEqualTo: 'Director3'),
-                      Filter('producer2', isEqualTo: 'Producer3'),
-                      Filter('budget2', isEqualTo: 30000000),
-                      Filter('boxOffice2', isEqualTo: 60000000),
-                      Filter('actor2', isEqualTo: 'Actor3'),
-                      Filter('language2', isEqualTo: 'Korean'),
-                      Filter('award2', isEqualTo: 'Award3'),
-                      Filter('genre2', isEqualTo: ['sci-fi', 'action']),
-                      Filter('country2', isEqualTo: 'South Korea'),
-                      Filter('released2', isEqualTo: false),
-                      // Fails because this is not allowed when arrayContainsAny is included in the Query
-                      Filter('screenplay2', isNotEqualTo: 'blah'),
-                    ),
-                  )
-                  .orderBy('rating1', descending: true)
-                  .get(),
-              throwsA(
-                isA<FirebaseException>()
-                    .having((e) => e.code, 'code', 'invalid-argument'),
-              ),
-            );
-          },
-        );
-
-        testWidgets(
           'Exception thrown when combining `arrayContainsAny` & `isNotEqualTo` in multiple disjunctive queries',
           (_) async {
             CollectionReference<Map<String, dynamic>> collection =


### PR DESCRIPTION
## Description

See failing e2e tests because it now provides a link for an index rather than throwing an exception

https://github.com/firebase/flutterfire/actions/runs/8371322167/job/22930126154?pr=12218#step:14:464

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
