### PR TITLE
feat(android): Bump `compileSdk` version of Android plugins to latest stable (34)

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/build.gradle
+++ b/packages/cloud_firestore/cloud_firestore/android/build.gradle
@@ -40,7 +40,7 @@ android {
       namespace 'io.flutter.plugins.firebase.firestore'
     }
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 19

--- a/packages/cloud_functions/cloud_functions/android/build.gradle
+++ b/packages/cloud_functions/cloud_functions/android/build.gradle
@@ -40,7 +40,7 @@ android {
     namespace 'io.flutter.plugins.firebase.functions'
   }
 
-  compileSdk 33
+  compileSdk 34
 
   defaultConfig {
     minSdk 19

--- a/packages/cloud_functions/cloud_functions/example/android/app/build.gradle
+++ b/packages/cloud_functions/cloud_functions/example/android/app/build.gradle
@@ -27,7 +27,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     namespace 'io.flutter.plugins.firebase.functions.example'
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "io.flutter.plugins.firebase.functions.example"

--- a/packages/firebase_analytics/firebase_analytics/android/build.gradle
+++ b/packages/firebase_analytics/firebase_analytics/android/build.gradle
@@ -40,7 +40,7 @@ android {
         namespace 'io.flutter.plugins.firebase.analytics'
     }
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 19

--- a/packages/firebase_analytics/firebase_analytics/example/android/app/build.gradle
+++ b/packages/firebase_analytics/firebase_analytics/example/android/app/build.gradle
@@ -28,7 +28,7 @@ apply plugin: 'com.google.gms.google-services'
 android {
     namespace 'io.flutter.plugins.firebase.analytics.example'
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "io.flutter.plugins.firebase.analytics.example"

--- a/packages/firebase_app_check/firebase_app_check/android/build.gradle
+++ b/packages/firebase_app_check/firebase_app_check/android/build.gradle
@@ -40,7 +40,7 @@ android {
     namespace 'io.flutter.plugins.firebase.appcheck'
   }
 
-  compileSdk 33
+  compileSdk 34
 
   defaultConfig {
     minSdk 19

--- a/packages/firebase_app_check/firebase_app_check/example/android/app/build.gradle
+++ b/packages/firebase_app_check/firebase_app_check/example/android/app/build.gradle
@@ -30,7 +30,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     namespace "io.flutter.plugins.firebase.appcheck.example"
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "io.flutter.plugins.firebase.appcheck.example"

--- a/packages/firebase_app_installations/firebase_app_installations/android/build.gradle
+++ b/packages/firebase_app_installations/firebase_app_installations/android/build.gradle
@@ -40,7 +40,7 @@ android {
       namespace 'io.flutter.plugins.firebase.installations.firebase_app_installations'
     }
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 19

--- a/packages/firebase_app_installations/firebase_app_installations/example/android/app/build.gradle
+++ b/packages/firebase_app_installations/firebase_app_installations/example/android/app/build.gradle
@@ -29,7 +29,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     namespace 'io.flutter.plugins.firebase.installations.example'
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).

--- a/packages/firebase_auth/firebase_auth/android/build.gradle
+++ b/packages/firebase_auth/firebase_auth/android/build.gradle
@@ -40,7 +40,7 @@ android {
       namespace 'io.flutter.plugins.firebase.auth'
     }
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 19

--- a/packages/firebase_core/firebase_core/android/build.gradle
+++ b/packages/firebase_core/firebase_core/android/build.gradle
@@ -26,7 +26,7 @@ android {
       namespace 'io.flutter.plugins.firebase.core'
     }
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 19

--- a/packages/firebase_crashlytics/firebase_crashlytics/android/build.gradle
+++ b/packages/firebase_crashlytics/firebase_crashlytics/android/build.gradle
@@ -39,7 +39,7 @@ android {
     namespace 'io.flutter.plugins.firebase.crashlytics'
   }
 
-  compileSdk 33
+  compileSdk 34
 
   defaultConfig {
     minSdk 19

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/android/app/build.gradle
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/android/app/build.gradle
@@ -27,7 +27,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     namespace 'io.flutter.plugins.firebasecrashlyticsexample'
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId 'io.flutter.plugins.firebasecrashlyticsexample'

--- a/packages/firebase_database/firebase_database/android/build.gradle
+++ b/packages/firebase_database/firebase_database/android/build.gradle
@@ -40,7 +40,7 @@ android {
         namespace 'io.flutter.plugins.firebase.database'
     }
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 19

--- a/packages/firebase_database/firebase_database/example/android/app/build.gradle
+++ b/packages/firebase_database/firebase_database/example/android/app/build.gradle
@@ -27,7 +27,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
   namespace 'io.flutter.plugins.firebase.database.example'
 
-  compileSdk 33
+  compileSdk 34
 
   defaultConfig {
     applicationId 'io.flutter.plugins.firebase.database.example'

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/build.gradle
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/build.gradle
@@ -40,7 +40,7 @@ android {
     namespace 'io.flutter.plugins.firebase.dynamiclinks'
   }
 
-  compileSdk 33
+  compileSdk 34
 
   defaultConfig {
       minSdk 19

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/example/android/app/build.gradle
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/example/android/app/build.gradle
@@ -27,7 +27,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
   namespace 'io.flutter.plugins.firebase.dynamiclinksexample'
 
-  compileSdk 33
+  compileSdk 34
 
   defaultConfig {
     applicationId "io.flutter.plugins.firebase.dynamiclinksexample"

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/android/build.gradle
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/android/build.gradle
@@ -40,7 +40,7 @@ android {
       namespace 'io.flutter.plugins.firebase.inappmessaging'
     }
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
       minSdk 19

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/example/android/app/build.gradle
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/example/android/app/build.gradle
@@ -27,7 +27,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     namespace 'io.flutter.plugins.firebase.tests'
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "io.flutter.plugins.firebase.tests"

--- a/packages/firebase_messaging/firebase_messaging/android/build.gradle
+++ b/packages/firebase_messaging/firebase_messaging/android/build.gradle
@@ -40,7 +40,7 @@ android {
     namespace 'io.flutter.plugins.firebase.messaging'
   }
 
-  compileSdk 33
+  compileSdk 34
 
   defaultConfig {
     minSdk 19

--- a/packages/firebase_messaging/firebase_messaging/example/android/app/build.gradle
+++ b/packages/firebase_messaging/firebase_messaging/example/android/app/build.gradle
@@ -27,7 +27,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     namespace 'io.flutter.plugins.firebase.messaging.example'
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "io.flutter.plugins.firebase.messaging.example"

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/android/build.gradle
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/android/build.gradle
@@ -40,7 +40,7 @@ android {
     namespace 'io.flutter.plugins.firebase.firebase_ml_model_downloader'
   }
 
-  compileSdk 33
+  compileSdk 34
 
   defaultConfig {
     minSdk 19

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/example/android/app/build.gradle
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/example/android/app/build.gradle
@@ -30,7 +30,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     namespace 'io.flutter.plugins.firebase.tests'
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "io.flutter.plugins.firebase.tests"

--- a/packages/firebase_performance/firebase_performance/android/build.gradle
+++ b/packages/firebase_performance/firebase_performance/android/build.gradle
@@ -40,7 +40,7 @@ android {
       namespace 'io.flutter.plugins.firebase.performance'
     }
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 19

--- a/packages/firebase_performance/firebase_performance/example/android/app/build.gradle
+++ b/packages/firebase_performance/firebase_performance/example/android/app/build.gradle
@@ -28,7 +28,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
   namespace 'io.flutter.plugins.firebase.tests'
 
-  compileSdk 33
+  compileSdk 34
 
   defaultConfig {
     applicationId "io.flutter.plugins.firebase.tests"

--- a/packages/firebase_remote_config/firebase_remote_config/android/build.gradle
+++ b/packages/firebase_remote_config/firebase_remote_config/android/build.gradle
@@ -40,7 +40,7 @@ android {
         namespace 'io.flutter.plugins.firebase.firebaseremoteconfig'
     }
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 19

--- a/packages/firebase_remote_config/firebase_remote_config/example/android/app/build.gradle
+++ b/packages/firebase_remote_config/firebase_remote_config/example/android/app/build.gradle
@@ -27,7 +27,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
   namespace 'io.flutter.plugins.firebase.remoteconfig.example'
 
-  compileSdk 33
+  compileSdk 34
 
   defaultConfig {
     applicationId "io.flutter.plugins.firebase.remoteconfig.example"

--- a/packages/firebase_storage/firebase_storage/android/build.gradle
+++ b/packages/firebase_storage/firebase_storage/android/build.gradle
@@ -48,7 +48,7 @@ android {
         namespace 'io.flutter.plugins.firebase.storage'
     }
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 19

--- a/packages/firebase_storage/firebase_storage/example/android/app/build.gradle
+++ b/packages/firebase_storage/firebase_storage/example/android/app/build.gradle
@@ -27,7 +27,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     namespace 'io.flutter.plugins.firebasestorageexample'
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId 'io.flutter.plugins.firebasestorageexample'


### PR DESCRIPTION
## Description

Compile against SDK 34 which is the current latest version (and matching the version in e2e tests 😅).

## Related Issues

closes #12555

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
