### PR TITLE
fix(firestore, android): lint warnings and deprecated API

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreMessageCodec.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreMessageCodec.java
@@ -430,7 +430,8 @@ class FlutterFirebaseFirestoreMessageCodec extends StandardMessageCodec {
       boolean isFilterQuery = parameters.containsKey("filters");
       if (isFilterQuery) {
         @SuppressWarnings("unchecked")
-        Filter filter = filterFromJson((Map<String, Object>) Objects.requireNonNull(parameters.get("filters")));
+        Filter filter =
+            filterFromJson((Map<String, Object>) Objects.requireNonNull(parameters.get("filters")));
         query = query.where(filter);
       }
 

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreMessageCodec.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreMessageCodec.java
@@ -388,6 +388,7 @@ class FlutterFirebaseFirestoreMessageCodec extends StandardMessageCodec {
     }
     // Deserialize a FilterOperator
     String op = (String) map.get("op");
+    @SuppressWarnings("unchecked")
     List<Map<String, Object>> queries = (List<Map<String, Object>>) map.get("queries");
 
     // Map queries recursively
@@ -428,7 +429,8 @@ class FlutterFirebaseFirestoreMessageCodec extends StandardMessageCodec {
 
       boolean isFilterQuery = parameters.containsKey("filters");
       if (isFilterQuery) {
-        Filter filter = filterFromJson((Map<String, Object>) parameters.get("filters"));
+        @SuppressWarnings("unchecked")
+        Filter filter = filterFromJson((Map<String, Object>) Objects.requireNonNull(parameters.get("filters")));
         query = query.where(filter);
       }
 

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -262,14 +262,14 @@ public class FlutterFirebaseFirestorePlugin
   private void removeEventListeners() {
     synchronized (eventChannels) {
       for (String identifier : eventChannels.keySet()) {
-        eventChannels.get(identifier).setStreamHandler(null);
+        Objects.requireNonNull(eventChannels.get(identifier)).setStreamHandler(null);
       }
       eventChannels.clear();
     }
 
     synchronized (streamHandlers) {
       for (String identifier : streamHandlers.keySet()) {
-        streamHandlers.get(identifier).onCancel(null);
+        Objects.requireNonNull(streamHandlers.get(identifier)).onCancel(null);
       }
       streamHandlers.clear();
     }
@@ -291,7 +291,7 @@ public class FlutterFirebaseFirestorePlugin
         Long receivedCacheSizeBytes = pigeonApp.getSettings().getCacheSizeBytes();
         // This is the maximum amount of cache allowed:
         // https://firebase.google.com/docs/firestore/manage-data/enable-offline#configure_cache_size
-        Long cacheSizeBytes = 104857600L;
+        long cacheSizeBytes = 104857600L;
         if (receivedCacheSizeBytes != null && receivedCacheSizeBytes != -1) {
           cacheSizeBytes = receivedCacheSizeBytes;
         }
@@ -454,6 +454,7 @@ public class FlutterFirebaseFirestorePlugin
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public void setIndexConfiguration(
       @NonNull GeneratedAndroidFirebaseFirestore.FirestorePigeonFirebaseApp app,
       @NonNull String indexConfiguration,

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -454,6 +454,7 @@ public class FlutterFirebaseFirestorePlugin
   }
 
   @Override
+  // Suppressed because we have already annotated the user facing Dart API as deprecated.
   @SuppressWarnings("deprecation")
   public void setIndexConfiguration(
       @NonNull GeneratedAndroidFirebaseFirestore.FirestorePigeonFirebaseApp app,

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/utils/PigeonParser.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/utils/PigeonParser.java
@@ -292,6 +292,7 @@ public class PigeonParser {
     }
     // Deserialize a FilterOperator
     String op = (String) map.get("op");
+    @SuppressWarnings("unchecked")
     List<Map<String, Object>> queries = (List<Map<String, Object>>) map.get("queries");
 
     // Map queries recursively

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
@@ -226,7 +226,7 @@ void runInstanceTests() {
             ],
             collectionGroup: 'collectiongroup',
           );
-
+          // ignore_for_file: deprecated_member_use
           await firestore.setIndexConfiguration(
             indexes: [index1, index2],
             fieldOverrides: [fieldOverride1, fieldOverride2],

--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -334,8 +334,8 @@ class FirebaseFirestore extends FirebasePluginPlatform {
   /// require indexing even if the indices are not yet available. Query execution will automatically
   /// start using the index once the index entries have been written.
   ///
-  /// This API is in preview mode and is subject to change.
-  @experimental
+  /// This API is now deprecated
+  @Deprecated('setIndexConfiguration() has been deprecated.')
   Future<void> setIndexConfiguration({
     required List<Index> indexes,
     List<FieldOverrides>? fieldOverrides,


### PR DESCRIPTION
## Description

- Suppressed deprecated API on android and annotated on user facing Dart API.
- Suppressed unchecked cast warnings on safe casts.

## Related Issues

part of: https://github.com/firebase/flutterfire/issues/8073

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
