### PR TITLE
fix(remote-config, web): getAll() API throwing runtime exception with incorrect cast to `List<String>`

### DIFF
--- a/packages/firebase_remote_config/firebase_remote_config_web/lib/src/interop/firebase_remote_config.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_web/lib/src/interop/firebase_remote_config.dart
@@ -106,9 +106,12 @@ class RemoteConfig
 
   /// Returns all config values.
   Map<String, RemoteConfigValue> getAll() {
-    final keys =
-        remote_config_interop.getAll(jsObject).dartify()! as List<String>;
-    final entries = keys.map<MapEntry<String, RemoteConfigValue>>(
+    // Return type is Map<Object?, Object?>
+    final map = remote_config_interop.getAll(jsObject).dartify()!
+        as Map<Object?, Object?>;
+    // Cast the map to <String, Object?> to mirror expected return type: Record<string, Value>;
+    final castMap = map.cast<String, Object?>();
+    final entries = castMap.keys.map<MapEntry<String, RemoteConfigValue>>(
       (dynamic k) => MapEntry<String, RemoteConfigValue>(k, getValue(k)),
     );
     return Map<String, RemoteConfigValue>.fromEntries(entries);

--- a/tests/integration_test/firebase_remote_config/firebase_remote_config_e2e_test.dart
+++ b/tests/integration_test/firebase_remote_config/firebase_remote_config_e2e_test.dart
@@ -77,6 +77,11 @@ void main() {
             FirebaseRemoteConfig.instance.getValue('nonexisting').source,
             ValueSource.valueStatic,
           );
+
+          expect(
+            FirebaseRemoteConfig.instance.getAll(),
+            isA<Map<String, RemoteConfigValue>>(),
+          );
         },
         // iOS v9.2.0 hangs on ci if `fetchAndActivate()` is used, but works locally.
         // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538


### PR DESCRIPTION
## Description

See title.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/12598

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
