### PR TITLE
chore: Bump Melos to ^5.3.0

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           melos-version: '3.0.1'
       - name: 'Run Analyze'
-        run: melos run analyze
+        run: melos analyze-ci
 
   # Separated from "analyse" action as pubspec_override file is not being taken into account when running `flutter pub publish --dry-run`
   # This will fail on CI until this is fixed: https://github.com/invertase/melos/issues/467

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,10 +198,10 @@ commands can be run locally to highlight any issues before committing your code:
 
 ```bash
 # Run the analyze check
-melos run analyze
+melos analyze-ci
 
 # Format code
-melos run format
+melos format-ci
 ```
 
 Assuming all is successful, commit and push your code:

--- a/melos.yaml
+++ b/melos.yaml
@@ -25,10 +25,10 @@ command:
 
 scripts:
   lint:all:
-    run: melos run analyze && melos run format
+    run: melos run analyze-ci && melos run format-ci
     description: Run all static analysis checks.
 
-  analyze:
+  analyze-ci:
     # We are setting the concurrency to 1 because a higher concurrency can crash
     # the analysis server on low performance machines (like GitHub Actions).
     run: |
@@ -46,7 +46,7 @@ scripts:
       integration testing.
        - Requires Node.js and NPM installed.
 
-  format:
+  format-ci:
     run: |
       dart pub global run flutter_plugin_tools format && \
       swiftformat .

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,4 +4,4 @@ environment:
   sdk: '>=2.18.0 <4.0.0'
 
 dev_dependencies:
-  melos: ^3.0.1
+  melos: ^5.3.0


### PR DESCRIPTION
## Description

This bumps the version of Melos used to be at least 5.3.0

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
