### PR TITLE
fix(firebase_messaging, web): Define scope for 'firebase-messaging-sw.js' on registration

### DIFF
--- a/docs/cloud-messaging/receive.md
+++ b/docs/cloud-messaging/receive.md
@@ -208,7 +208,9 @@ Next, the worker must be registered. Within the entry file, **after** the `main.
         // Service workers are supported. Use them.
         window.addEventListener('load', function () {
           // Register Firebase Messaging service worker.
-          navigator.serviceWorker.register('firebase-messaging-sw.js');
+          navigator.serviceWorker.register('firebase-messaging-sw.js', {
+            scope: '/firebase-cloud-messaging-push-scope',
+          });
 
           // Wait for registration to finish before dropping the <script> tag.
           // Otherwise, the browser will load the script multiple times,

--- a/packages/firebase_messaging/firebase_messaging/example/web/index.html
+++ b/packages/firebase_messaging/firebase_messaging/example/web/index.html
@@ -23,7 +23,9 @@
         // Service workers are supported. Use them.
         window.addEventListener('load', function () {
           // Register Firebase Messaging service worker.
-          navigator.serviceWorker.register('firebase-messaging-sw.js');
+          navigator.serviceWorker.register('firebase-messaging-sw.js', {
+            scope: '/firebase-cloud-messaging-push-scope',
+          });
 
           // Wait for registration to finish before dropping the <script> tag.
           // Otherwise, the browser will load the script multiple times,

--- a/tests/web/index.html
+++ b/tests/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <!--
+<head>
+  <!--
     If you are serving your web app in a path other than the root, change the
     href value below to reflect the base path you are serving from.
 
@@ -31,9 +31,9 @@
 
   <title>tests</title>
   <link rel="manifest" href="manifest.json">
-  </head>
-  <body>
-    <script>
+</head>
+<body>
+<script>
       var serviceWorkerVersion = null;
       var scriptLoaded = false;
       function loadMainDartJs() {
@@ -102,6 +102,6 @@
         // Service workers not supported. Just drop the <script> tag.
         loadMainDartJs();
       }
-    </script>
-  </body>
+  </script>
+</body>
 </html>

--- a/tests/web/index.html
+++ b/tests/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <!--
+  <head>
+    <!--
     If you are serving your web app in a path other than the root, change the
     href value below to reflect the base path you are serving from.
 
@@ -31,9 +31,9 @@
 
   <title>tests</title>
   <link rel="manifest" href="manifest.json">
-</head>
-<body>
-<script>
+  </head>
+  <body>
+    <script>
       var serviceWorkerVersion = null;
       var scriptLoaded = false;
       function loadMainDartJs() {
@@ -51,7 +51,9 @@
         // Service workers are supported. Use them.
         window.addEventListener('load', function () {
           // Register Firebase Messaging service worker.
-          navigator.serviceWorker.register('firebase-messaging-sw.js');
+          navigator.serviceWorker.register('firebase-messaging-sw.js', {
+            scope: '/firebase-cloud-messaging-push-scope',
+          });
 
           // Wait for registration to finish before dropping the <script> tag.
           // Otherwise, the browser will load the script multiple times,
@@ -100,6 +102,6 @@
         // Service workers not supported. Just drop the <script> tag.
         loadMainDartJs();
       }
-  </script>
-</body>
+    </script>
+  </body>
 </html>


### PR DESCRIPTION

## Description

> fixes: #12638


Add scope for '**firebase-messaging-sw.js**' on registration itself. The scope remains unchanged from the existing scope of the Firebase messaging service worker, only the definition is now at registration as compared to earlier behaviour which happens after initialization.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
