### PR TITLE
fix(database): sorting was not applied when database child changed.

### DIFF
--- a/packages/firebase_database/firebase_database/lib/ui/firebase_sorted_list.dart
+++ b/packages/firebase_database/firebase_database/lib/ui/firebase_sorted_list.dart
@@ -111,6 +111,7 @@ class FirebaseSortedList extends ListBase<DataSnapshot>
     });
     final int index = _snapshots.indexOf(snapshot);
     _snapshots[index] = event.snapshot;
+    _snapshots.sort(comparator);
     onChildChanged!(index, event.snapshot);
   }
 


### PR DESCRIPTION
## Description

Quick fix because when giving a sort/compare to FirebaseAnimatedList(), the sort/compare don't apply when editing a Database child. It used to only apply on build. So I've added the missing `_snapshots.sort(comparator);` method to the `_onChildChanged()` function.

## Related Issues

closes https://github.com/firebase/flutterfire/issues/12657

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
