### PR TITLE
fix(auth, web): invocation of unsubscribe callback for dart2wasm compatibility.

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -383,7 +383,7 @@ class Auth extends JsObjectWrapper<auth_interop.AuthJsImpl> {
 
     await completer.future;
 
-    await (unsubscribe.dartify()! as Future<void> Function())();
+    await (unsubscribe.callAsFunction() as JSPromise<JSAny?>?)?.toDart;
   }
 
   JSFunction? _onAuthUnsubscribe;


### PR DESCRIPTION
In dart2wasm, JS functions and dart functions cannot be cast directly between each other. Similarly, JS promises and dart futures cannot be cast directly between each other either. Instead, we should use `callAsFunction` and use `toDart` to convert the JSPromise to a Future.