### PR TITLE
Fix more unsafe casts to `int`.

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/dartpad/lib/main.dart
+++ b/packages/cloud_firestore/cloud_firestore/dartpad/lib/main.dart
@@ -397,12 +397,12 @@ class Movie {
   Movie.fromJson(Map<String, Object?> json)
       : this(
           genre: (json['genre']! as List).cast<String>(),
-          likes: json['likes']! as int,
+          likes: (json['likes']! as num).toInt(),
           poster: json['poster']! as String,
           rated: json['rated']! as String,
           runtime: json['runtime']! as String,
           title: json['title']! as String,
-          year: json['year']! as int,
+          year: (json['year']! as num).toInt(),
         );
 
   final String poster;

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/collection_reference_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/collection_reference_e2e.dart
@@ -92,7 +92,7 @@ void runCollectionReferenceTests() {
             final foo = await initializeTest('foo');
             final fooConverter = foo.withConverter<int>(
               fromFirestore: (snapshots, _) =>
-                  snapshots.data()!['value']! as int,
+                  (snapshots.data()!['value']! as num).toInt(),
               toFirestore: (value, _) => {'value': value},
             );
 

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/document_reference_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/document_reference_e2e.dart
@@ -538,7 +538,7 @@ void runDocumentReferenceTests() {
         (_) async {
           final foo = await initializeTest('foo');
           final fooConverter = foo.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
@@ -3074,7 +3074,7 @@ void runQueryTests() {
               .where('value', isGreaterThan: 0)
               .withConverter<int>(
                 fromFirestore: (snapshots, _) =>
-                    snapshots.data()!['value']! as int,
+                    (snapshots.data()!['value']! as num).toInt(),
                 toFirestore: (value, _) => {'value': value},
               );
 
@@ -3125,7 +3125,7 @@ void runQueryTests() {
               .where(Filter('value', isGreaterThan: 0))
               .withConverter<int>(
                 fromFirestore: (snapshots, _) =>
-                    snapshots.data()!['value']! as int,
+                    (snapshots.data()!['value']! as num).toInt(),
                 toFirestore: (value, _) => {'value': value},
               );
 
@@ -3173,7 +3173,7 @@ void runQueryTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -3220,7 +3220,7 @@ void runQueryTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -3244,7 +3244,7 @@ void runQueryTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -3268,7 +3268,7 @@ void runQueryTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt() ,
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -3291,7 +3291,7 @@ void runQueryTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -3316,7 +3316,7 @@ void runQueryTests() {
         final collection = await initializeTest('foo');
 
         final converted = collection.withConverter<int>(
-          fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+          fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
           toFirestore: (value, _) => {'value': value},
         );
 
@@ -3337,7 +3337,7 @@ void runQueryTests() {
         final collection = await initializeTest('foo');
 
         final converted = collection.withConverter<int>(
-          fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+          fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
           toFirestore: (value, _) => {'value': value},
         );
 
@@ -3360,7 +3360,7 @@ void runQueryTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -3387,7 +3387,7 @@ void runQueryTests() {
         final collection = await initializeTest('foo');
 
         final converted = collection.withConverter<int>(
-          fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+          fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
           toFirestore: (value, _) => {'value': value},
         );
 
@@ -3409,7 +3409,7 @@ void runQueryTests() {
         final collection = await initializeTest('foo');
 
         final converted = collection.withConverter<int>(
-          fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+          fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
           toFirestore: (value, _) => {'value': value},
         );
 
@@ -3433,7 +3433,7 @@ void runQueryTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -3459,7 +3459,7 @@ void runQueryTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -3488,7 +3488,7 @@ void runQueryTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -3517,7 +3517,7 @@ void runQueryTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -3546,7 +3546,7 @@ void runQueryTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -3572,7 +3572,7 @@ void runQueryTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -3598,7 +3598,7 @@ void runQueryTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/second_database.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/second_database.dart
@@ -2385,7 +2385,7 @@ void runSecondDatabaseTests() {
                 .where('value', isGreaterThan: 0)
                 .withConverter<int>(
                   fromFirestore: (snapshots, _) =>
-                      snapshots.data()!['value']! as int,
+                      (snapshots.data()!['value']! as num).toInt(),
                   toFirestore: (value, _) => {'value': value},
                 );
 
@@ -2436,7 +2436,7 @@ void runSecondDatabaseTests() {
                 .where(Filter('value', isGreaterThan: 0))
                 .withConverter<int>(
                   fromFirestore: (snapshots, _) =>
-                      snapshots.data()!['value']! as int,
+                      (snapshots.data()!['value']! as num).toInt(),
                   toFirestore: (value, _) => {'value': value},
                 );
 
@@ -2485,7 +2485,7 @@ void runSecondDatabaseTests() {
 
             final converted = collection.withConverter<int>(
               fromFirestore: (snapshots, _) =>
-                  snapshots.data()!['value']! as int,
+                  (snapshots.data()!['value']! as num).toInt(),
               toFirestore: (value, _) => {'value': value},
             );
 
@@ -2533,7 +2533,7 @@ void runSecondDatabaseTests() {
 
             final converted = collection.withConverter<int>(
               fromFirestore: (snapshots, _) =>
-                  snapshots.data()!['value']! as int,
+                  (snapshots.data()!['value']! as num).toInt(),
               toFirestore: (value, _) => {'value': value},
             );
 
@@ -2561,7 +2561,7 @@ void runSecondDatabaseTests() {
 
             final converted = collection.withConverter<int>(
               fromFirestore: (snapshots, _) =>
-                  snapshots.data()!['value']! as int,
+                  (snapshots.data()!['value']! as num).toInt(),
               toFirestore: (value, _) => {'value': value},
             );
 
@@ -2588,7 +2588,7 @@ void runSecondDatabaseTests() {
 
             final converted = collection.withConverter<int>(
               fromFirestore: (snapshots, _) =>
-                  snapshots.data()!['value']! as int,
+                  (snapshots.data()!['value']! as num).toInt(),
               toFirestore: (value, _) => {'value': value},
             );
 
@@ -2617,7 +2617,7 @@ void runSecondDatabaseTests() {
 
             final converted = collection.withConverter<int>(
               fromFirestore: (snapshots, _) =>
-                  snapshots.data()!['value']! as int,
+                  (snapshots.data()!['value']! as num).toInt(),
               toFirestore: (value, _) => {'value': value},
             );
 
@@ -2643,7 +2643,7 @@ void runSecondDatabaseTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -2668,7 +2668,7 @@ void runSecondDatabaseTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -2696,7 +2696,7 @@ void runSecondDatabaseTests() {
 
             final converted = collection.withConverter<int>(
               fromFirestore: (snapshots, _) =>
-                  snapshots.data()!['value']! as int,
+                  (snapshots.data()!['value']! as num).toInt(),
               toFirestore: (value, _) => {'value': value},
             );
 
@@ -2723,7 +2723,7 @@ void runSecondDatabaseTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -2745,7 +2745,7 @@ void runSecondDatabaseTests() {
           final collection = await initializeTest('foo');
 
           final converted = collection.withConverter<int>(
-            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            fromFirestore: (snapshots, _) => (snapshots.data()!['value']! as num).toInt(),
             toFirestore: (value, _) => {'value': value},
           );
 
@@ -2770,7 +2770,7 @@ void runSecondDatabaseTests() {
 
             final converted = collection.withConverter<int>(
               fromFirestore: (snapshots, _) =>
-                  snapshots.data()!['value']! as int,
+                  (snapshots.data()!['value']! as num).toInt(),
               toFirestore: (value, _) => {'value': value},
             );
 
@@ -2797,7 +2797,7 @@ void runSecondDatabaseTests() {
 
             final converted = collection.withConverter<int>(
               fromFirestore: (snapshots, _) =>
-                  snapshots.data()!['value']! as int,
+                  (snapshots.data()!['value']! as num).toInt(),
               toFirestore: (value, _) => {'value': value},
             );
 
@@ -2827,7 +2827,7 @@ void runSecondDatabaseTests() {
 
             final converted = collection.withConverter<int>(
               fromFirestore: (snapshots, _) =>
-                  snapshots.data()!['value']! as int,
+                  (snapshots.data()!['value']! as num).toInt(),
               toFirestore: (value, _) => {'value': value},
             );
 
@@ -2857,7 +2857,7 @@ void runSecondDatabaseTests() {
 
             final converted = collection.withConverter<int>(
               fromFirestore: (snapshots, _) =>
-                  snapshots.data()!['value']! as int,
+                  (snapshots.data()!['value']! as num).toInt(),
               toFirestore: (value, _) => {'value': value},
             );
 
@@ -2887,7 +2887,7 @@ void runSecondDatabaseTests() {
 
             final converted = collection.withConverter<int>(
               fromFirestore: (snapshots, _) =>
-                  snapshots.data()!['value']! as int,
+                  (snapshots.data()!['value']! as num).toInt(),
               toFirestore: (value, _) => {'value': value},
             );
 
@@ -2914,7 +2914,7 @@ void runSecondDatabaseTests() {
 
             final converted = collection.withConverter<int>(
               fromFirestore: (snapshots, _) =>
-                  snapshots.data()!['value']! as int,
+                  (snapshots.data()!['value']! as num).toInt(),
               toFirestore: (value, _) => {'value': value},
             );
 
@@ -2941,7 +2941,7 @@ void runSecondDatabaseTests() {
 
             final converted = collection.withConverter<int>(
               fromFirestore: (snapshots, _) =>
-                  snapshots.data()!['value']! as int,
+                  (snapshots.data()!['value']! as num).toInt(),
               toFirestore: (value, _) => {'value': value},
             );
 

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/transaction_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/transaction_e2e.dart
@@ -32,7 +32,7 @@ void runTransactionTests() {
 
         DocumentReference<int> doc = rawDoc.withConverter(
           fromFirestore: (snapshot, options) {
-            return snapshot.data()!['value'] as int;
+            return (snapshot.data()!['value']! as num).toInt();
           },
           toFirestore: (value, options) => {'value': value},
         );

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/write_batch_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/write_batch_e2e.dart
@@ -35,7 +35,7 @@ void runWriteBatchTests() {
 
       DocumentReference<int> doc = collection.doc('doc1').withConverter(
             fromFirestore: (snapshot, options) {
-              return snapshot.data()!['value'] as int;
+              return (snapshot.data()!['value']! as num).toInt();
             },
             toFirestore: (value, options) => {'value': value},
           );

--- a/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
@@ -511,12 +511,12 @@ class Movie {
   Movie.fromJson(Map<String, Object?> json)
       : this(
           genre: (json['genre']! as List).cast<String>(),
-          likes: json['likes']! as int,
+          likes: (json['likes']! as num).toInt(),
           poster: json['poster']! as String,
           rated: json['rated']! as String,
           runtime: json['runtime']! as String,
           title: json['title']! as String,
-          year: json['year']! as int,
+          year: (json['year']! as num).toInt(),
         );
 
   final String poster;

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/utils/firestore_message_codec.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/utils/firestore_message_codec.dart
@@ -86,7 +86,7 @@ class FirestoreMessageCodec extends StandardMessageCodec {
       if (delegate.type == FieldValueType.incrementInteger &&
           (delegate.value > 2147483647 || delegate.value < -2147483648)) {
         buffer.putUint8(_kIncrementDouble);
-        writeValue(buffer, (delegate.value as int).toDouble());
+        writeValue(buffer, (delegate.value as num).toDouble());
       } else {
         buffer.putUint8(code);
         if (delegate.value != null) writeValue(buffer, delegate.value);

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/pigeon/messages.pigeon.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/pigeon/messages.pigeon.dart
@@ -132,7 +132,7 @@ class PigeonFirebaseSettings {
       persistenceEnabled: result[0] as bool?,
       host: result[1] as String?,
       sslEnabled: result[2] as bool?,
-      cacheSizeBytes: result[3] as int?,
+      cacheSizeBytes: (result[3] as num?)?.toInt(),
       ignoreUndefinedProperties: result[4]! as bool,
     );
   }
@@ -254,10 +254,10 @@ class PigeonDocumentChange {
   static PigeonDocumentChange decode(Object result) {
     result as List<Object?>;
     return PigeonDocumentChange(
-      type: DocumentChangeType.values[result[0]! as int],
+      type: DocumentChangeType.values[(result[0]! as num).toInt()],
       document: PigeonDocumentSnapshot.decode(result[1]! as List<Object?>),
-      oldIndex: result[2]! as int,
-      newIndex: result[3]! as int,
+      oldIndex: (result[2]! as num).toInt(),
+      newIndex: (result[3]! as num).toInt(),
     );
   }
 }
@@ -314,9 +314,9 @@ class PigeonGetOptions {
   static PigeonGetOptions decode(Object result) {
     result as List<Object?>;
     return PigeonGetOptions(
-      source: Source.values[result[0]! as int],
+      source: Source.values[(result[0]! as num).toInt()],
       serverTimestampBehavior:
-          ServerTimestampBehavior.values[result[1]! as int],
+          ServerTimestampBehavior.values[(result[1]! as num).toInt()],
     );
   }
 }
@@ -375,7 +375,7 @@ class PigeonTransactionCommand {
   static PigeonTransactionCommand decode(Object result) {
     result as List<Object?>;
     return PigeonTransactionCommand(
-      type: PigeonTransactionType.values[result[0]! as int],
+      type: PigeonTransactionType.values[(result[0]! as num).toInt()],
       path: result[1]! as String,
       data: (result[2] as Map<Object?, Object?>?)?.cast<String?, Object?>(),
       option: result[3] != null
@@ -422,9 +422,9 @@ class DocumentReferenceRequest {
       option: result[2] != null
           ? PigeonDocumentOption.decode(result[2]! as List<Object?>)
           : null,
-      source: result[3] != null ? Source.values[result[3]! as int] : null,
+      source: result[3] != null ? Source.values[(result[3]! as num).toInt()] : null,
       serverTimestampBehavior: result[4] != null
-          ? ServerTimestampBehavior.values[result[4]! as int]
+          ? ServerTimestampBehavior.values[(result[4]! as num).toInt()]
           : null,
     );
   }
@@ -480,8 +480,8 @@ class PigeonQueryParameters {
     return PigeonQueryParameters(
       where: (result[0] as List<Object?>?)?.cast<List<Object?>?>(),
       orderBy: (result[1] as List<Object?>?)?.cast<List<Object?>?>(),
-      limit: result[2] as int?,
-      limitToLast: result[3] as int?,
+      limit: (result[2] as num?)?.toInt(),
+      limitToLast: (result[3] as num?)?.toInt(),
       startAt: (result[4] as List<Object?>?)?.cast<Object?>(),
       startAfter: (result[5] as List<Object?>?)?.cast<Object?>(),
       endAt: (result[6] as List<Object?>?)?.cast<Object?>(),
@@ -511,7 +511,7 @@ class AggregateQuery {
   static AggregateQuery decode(Object result) {
     result as List<Object?>;
     return AggregateQuery(
-      type: AggregateType.values[result[0]! as int],
+      type: AggregateType.values[(result[0]! as num).toInt()],
       field: result[1] as String?,
     );
   }
@@ -541,9 +541,9 @@ class AggregateQueryResponse {
   static AggregateQueryResponse decode(Object result) {
     result as List<Object?>;
     return AggregateQueryResponse(
-      type: AggregateType.values[result[0]! as int],
+      type: AggregateType.values[(result[0]! as num).toInt()],
       field: result[1] as String?,
-      value: result[2] as double?,
+      value: (result[2] as num?)?.toDouble(),
     );
   }
 }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/pigeon/test_api.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/pigeon/test_api.dart
@@ -544,12 +544,12 @@ abstract class TestFirebaseFirestoreHostApi {
             arg_app != null,
             'Argument for dev.flutter.pigeon.cloud_firestore_platform_interface.FirebaseFirestoreHostApi.transactionCreate was null, expected non-null FirestorePigeonFirebaseApp.',
           );
-          final int? arg_timeout = (args[1] as int?);
+          final int? arg_timeout = (args[1] as num?)?.toInt();
           assert(
             arg_timeout != null,
             'Argument for dev.flutter.pigeon.cloud_firestore_platform_interface.FirebaseFirestoreHostApi.transactionCreate was null, expected non-null int.',
           );
-          final int? arg_maxAttempts = (args[2] as int?);
+          final int? arg_maxAttempts = (args[2] as num?)?.toInt();
           assert(
             arg_maxAttempts != null,
             'Argument for dev.flutter.pigeon.cloud_firestore_platform_interface.FirebaseFirestoreHostApi.transactionCreate was null, expected non-null int.',
@@ -588,7 +588,7 @@ abstract class TestFirebaseFirestoreHostApi {
           );
           final PigeonTransactionResult? arg_resultType = args[1] == null
               ? null
-              : PigeonTransactionResult.values[args[1]! as int];
+              : PigeonTransactionResult.values[(args[1]! as num).toInt()];
           assert(
             arg_resultType != null,
             'Argument for dev.flutter.pigeon.cloud_firestore_platform_interface.FirebaseFirestoreHostApi.transactionStoreResult was null, expected non-null PigeonTransactionResult.',
@@ -877,7 +877,7 @@ abstract class TestFirebaseFirestoreHostApi {
             'Argument for dev.flutter.pigeon.cloud_firestore_platform_interface.FirebaseFirestoreHostApi.aggregateQuery was null, expected non-null PigeonQueryParameters.',
           );
           final AggregateSource? arg_source =
-              args[3] == null ? null : AggregateSource.values[args[3]! as int];
+              args[3] == null ? null : AggregateSource.values[(args[3]! as num).toInt()];
           assert(
             arg_source != null,
             'Argument for dev.flutter.pigeon.cloud_firestore_platform_interface.FirebaseFirestoreHostApi.aggregateQuery was null, expected non-null AggregateSource.',
@@ -991,7 +991,7 @@ abstract class TestFirebaseFirestoreHostApi {
             'Argument for dev.flutter.pigeon.cloud_firestore_platform_interface.FirebaseFirestoreHostApi.querySnapshot was null, expected non-null bool.',
           );
           final ListenSource? arg_source =
-              args[6] == null ? null : ListenSource.values[args[6]! as int];
+              args[6] == null ? null : ListenSource.values[(args[6]! as num).toInt()];
           assert(
             arg_source != null,
             'Argument for dev.flutter.pigeon.cloud_firestore_platform_interface.FirebaseFirestoreHostApi.querySnapshot was null, expected non-null ListenSource.',
@@ -1045,7 +1045,7 @@ abstract class TestFirebaseFirestoreHostApi {
             'Argument for dev.flutter.pigeon.cloud_firestore_platform_interface.FirebaseFirestoreHostApi.documentReferenceSnapshot was null, expected non-null bool.',
           );
           final ListenSource? arg_source =
-              args[3] == null ? null : ListenSource.values[args[3]! as int];
+              args[3] == null ? null : ListenSource.values[(args[3]! as num).toInt()];
           assert(
             arg_source != null,
             'Argument for dev.flutter.pigeon.cloud_firestore_platform_interface.FirebaseFirestoreHostApi.documentReferenceSnapshot was null, expected non-null ListenSource.',

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -986,14 +986,14 @@ class AggregateQuerySnapshot
       : _data = Map.from(dartify(jsObject.data())),
         super.fromJsObject(jsObject);
 
-  int? get count => _data['count'] as int?;
+  int? get count => (_data['count'] as num?)?.toInt();
 
   double? getDataValue(platform_interface.AggregateQuery query) {
     final value = _data[AggregateQuery.name(query)];
     if (value == null) {
       return null;
     } else {
-      return value as double;
+      return (value as num).toDouble();
     }
   }
 }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/web_utils.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/web_utils.dart
@@ -85,8 +85,8 @@ DocumentChangePlatform convertWebDocumentChange(
 ) {
   return DocumentChangePlatform(
       convertWebDocumentChangeType(webDocumentChange.type),
-      webDocumentChange.oldIndex as int,
-      webDocumentChange.newIndex as int,
+      webDocumentChange.oldIndex.toInt(),
+      webDocumentChange.newIndex.toInt(),
       convertWebDocumentSnapshot(
         firestore,
         webDocumentChange.doc!,

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/pigeon/messages.pigeon.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/pigeon/messages.pigeon.dart
@@ -116,7 +116,7 @@ class PigeonMultiFactorInfo {
     result as List<Object?>;
     return PigeonMultiFactorInfo(
       displayName: result[0] as String?,
-      enrollmentTimestamp: result[1]! as double,
+      enrollmentTimestamp: (result[1]! as num).toDouble(),
       factorId: result[2] as String?,
       uid: result[3]! as String,
       phoneNumber: result[4] as String?,
@@ -201,7 +201,7 @@ class PigeonActionCodeInfo {
   static PigeonActionCodeInfo decode(Object result) {
     result as List<Object?>;
     return PigeonActionCodeInfo(
-      operation: ActionCodeInfoOperation.values[result[0]! as int],
+      operation: ActionCodeInfoOperation.values[(result[0]! as num).toInt()],
       data: PigeonActionCodeInfoData.decode(result[1]! as List<Object?>),
     );
   }
@@ -278,7 +278,7 @@ class PigeonAuthCredential {
     return PigeonAuthCredential(
       providerId: result[0]! as String,
       signInMethod: result[1]! as String,
-      nativeId: result[2]! as int,
+      nativeId: (result[2]! as num).toInt(),
       accessToken: result[3] as String?,
     );
   }
@@ -354,8 +354,8 @@ class PigeonUserInfo {
       providerId: result[7] as String?,
       tenantId: result[8] as String?,
       refreshToken: result[9] as String?,
-      creationTimestamp: result[10] as int?,
-      lastSignInTimestamp: result[11] as int?,
+      creationTimestamp: (result[10] as num?)?.toInt(),
+      lastSignInTimestamp: (result[11] as num?)?.toInt(),
     );
   }
 }
@@ -585,8 +585,8 @@ class PigeonVerifyPhoneNumberRequest {
     result as List<Object?>;
     return PigeonVerifyPhoneNumberRequest(
       phoneNumber: result[0] as String?,
-      timeout: result[1]! as int,
-      forceResendingToken: result[2] as int?,
+      timeout: (result[1]! as num).toInt(),
+      forceResendingToken: (result[2] as num?)?.toInt(),
       autoRetrievedSmsCodeForTesting: result[3] as String?,
       multiFactorInfoId: result[4] as String?,
       multiFactorSessionId: result[5] as String?,
@@ -635,9 +635,9 @@ class PigeonIdTokenResult {
     result as List<Object?>;
     return PigeonIdTokenResult(
       token: result[0] as String?,
-      expirationTimestamp: result[1] as int?,
-      authTimestamp: result[2] as int?,
-      issuedAtTimestamp: result[3] as int?,
+      expirationTimestamp: (result[1] as num?)?.toInt(),
+      authTimestamp: (result[2] as num?)?.toInt(),
+      issuedAtTimestamp: (result[3] as num?)?.toInt(),
       signInProvider: result[4] as String?,
       claims: (result[5] as Map<Object?, Object?>?)?.cast<String?, Object?>(),
       signInSecondFactor: result[6] as String?,
@@ -713,9 +713,9 @@ class PigeonTotpSecret {
   static PigeonTotpSecret decode(Object result) {
     result as List<Object?>;
     return PigeonTotpSecret(
-      codeIntervalSeconds: result[0] as int?,
-      codeLength: result[1] as int?,
-      enrollmentCompletionDeadline: result[2] as int?,
+      codeIntervalSeconds: (result[0] as num?).toInt(),
+      codeLength: (result[1] as num?)?.toInt(),
+      enrollmentCompletionDeadline: (result[2] as num?)?.toInt(),
       hashingAlgorithm: result[3] as String?,
       secretKey: result[4]! as String,
     );

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/user_info.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/user_info.dart
@@ -25,8 +25,8 @@ class UserInfo {
           providerId: data['providerId'] as String?,
           tenantId: data['tenantId'] as String?,
           refreshToken: data['refreshToken'] as String?,
-          creationTimestamp: data['creationTimestamp'] as int?,
-          lastSignInTimestamp: data['lastSignInTimestamp'] as int?,
+          creationTimestamp: (data['creationTimestamp'] as num?)?.toInt(),
+          lastSignInTimestamp: (data['lastSignInTimestamp'] as num?)?.toInt(),
         );
 
   final PigeonUserInfo _data;

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/pigeon/test_api.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/pigeon/test_api.dart
@@ -258,7 +258,7 @@ abstract class TestFirebaseAuthHostApi {
           final String? arg_host = (args[1] as String?);
           assert(arg_host != null,
               'Argument for dev.flutter.pigeon.firebase_auth_platform_interface.FirebaseAuthHostApi.useEmulator was null, expected non-null String.');
-          final int? arg_port = (args[2] as int?);
+          final int? arg_port = (args[2] as num?)?.toInt();
           assert(arg_port != null,
               'Argument for dev.flutter.pigeon.firebase_auth_platform_interface.FirebaseAuthHostApi.useEmulator was null, expected non-null int.');
           await api.useEmulator(arg_app!, arg_host!, arg_port!);

--- a/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_web_recaptcha_verifier_factory.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_web_recaptcha_verifier_factory.dart
@@ -154,7 +154,7 @@ class RecaptchaVerifierFactoryWeb extends RecaptchaVerifierFactoryPlatform {
   @override
   Future<int> render() async {
     try {
-      return await _delegate.render() as int;
+      return (await _delegate.render()).toInt();
     } catch (e) {
       throw getFirebaseAuthException(e);
     }

--- a/packages/firebase_database/firebase_database/example/lib/main.dart
+++ b/packages/firebase_database/firebase_database/example/lib/main.dart
@@ -105,7 +105,7 @@ class _MyHomePageState extends State<MyHomePage> {
       (DatabaseEvent event) {
         setState(() {
           _error = null;
-          _counter = (event.snapshot.value ?? 0) as int;
+          _counter = ((event.snapshot.value ?? 0) as num).toInt();
         });
       },
       onError: (Object o) {
@@ -147,7 +147,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Future<void> _incrementAsTransaction() async {
     try {
       final transactionResult = await _counterRef.runTransaction((mutableData) {
-        return Transaction.success((mutableData as int? ?? 0) + 1);
+        return Transaction.success((mutableData as num? ?? 0).toInt() + 1);
       });
 
       if (transactionResult.committed) {

--- a/packages/firebase_remote_config/firebase_remote_config_web/test/firebase_remote_config_web_test.mocks.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_web/test/firebase_remote_config_web_test.mocks.dart
@@ -245,7 +245,7 @@ class MockFirebaseRemoteConfigWeb extends _i1.Mock
         ),
         returnValue: 0,
         returnValueForMissingStub: 0,
-      ) as int);
+      ) as num).toInt();
   @override
   double getDouble(String? key) => (super.noSuchMethod(
         Invocation.method(
@@ -254,7 +254,7 @@ class MockFirebaseRemoteConfigWeb extends _i1.Mock
         ),
         returnValue: 0.0,
         returnValueForMissingStub: 0.0,
-      ) as double);
+      ) as num).toDouble();
   @override
   String getString(String? key) => (super.noSuchMethod(
         Invocation.method(

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/pigeon/messages.pigeon.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/pigeon/messages.pigeon.dart
@@ -139,7 +139,7 @@ class PigeonListOptions {
   static PigeonListOptions decode(Object result) {
     result as List<Object?>;
     return PigeonListOptions(
-      maxResults: result[0]! as int,
+      maxResults: (result[0]! as num).toInt(),
       pageToken: result[1] as String?,
     );
   }

--- a/packages/firebase_storage/firebase_storage_platform_interface/test/pigeon/test_api.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/test/pigeon/test_api.dart
@@ -184,7 +184,7 @@ abstract class TestFirebaseStorageHostApi {
               (args[0] as PigeonStorageFirebaseApp?);
           assert(arg_app != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.setMaxOperationRetryTime was null, expected non-null PigeonStorageFirebaseApp.');
-          final int? arg_time = (args[1] as int?);
+          final int? arg_time = (args[1] as num?)?.toInt();
           assert(arg_time != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.setMaxOperationRetryTime was null, expected non-null int.');
           await api.setMaxOperationRetryTime(arg_app!, arg_time!);
@@ -211,7 +211,7 @@ abstract class TestFirebaseStorageHostApi {
               (args[0] as PigeonStorageFirebaseApp?);
           assert(arg_app != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.setMaxUploadRetryTime was null, expected non-null PigeonStorageFirebaseApp.');
-          final int? arg_time = (args[1] as int?);
+          final int? arg_time = (args[1] as num?)?.toInt();
           assert(arg_time != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.setMaxUploadRetryTime was null, expected non-null int.');
           await api.setMaxUploadRetryTime(arg_app!, arg_time!);
@@ -238,7 +238,7 @@ abstract class TestFirebaseStorageHostApi {
               (args[0] as PigeonStorageFirebaseApp?);
           assert(arg_app != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.setMaxDownloadRetryTime was null, expected non-null PigeonStorageFirebaseApp.');
-          final int? arg_time = (args[1] as int?);
+          final int? arg_time = (args[1] as num?).toInt();
           assert(arg_time != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.setMaxDownloadRetryTime was null, expected non-null int.');
           await api.setMaxDownloadRetryTime(arg_app!, arg_time!);
@@ -268,7 +268,7 @@ abstract class TestFirebaseStorageHostApi {
           final String? arg_host = (args[1] as String?);
           assert(arg_host != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.useStorageEmulator was null, expected non-null String.');
-          final int? arg_port = (args[2] as int?);
+          final int? arg_port = (args[2] as num?).toInt();
           assert(arg_port != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.useStorageEmulator was null, expected non-null int.');
           await api.useStorageEmulator(arg_app!, arg_host!, arg_port!);
@@ -447,7 +447,7 @@ abstract class TestFirebaseStorageHostApi {
               (args[1] as PigeonStorageReference?);
           assert(arg_reference != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.referenceGetData was null, expected non-null PigeonStorageReference.');
-          final int? arg_maxSize = (args[2] as int?);
+          final int? arg_maxSize = (args[2] as num?).toInt();
           assert(arg_maxSize != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.referenceGetData was null, expected non-null int.');
           final Uint8List? output = await api.referenceGetData(
@@ -486,7 +486,7 @@ abstract class TestFirebaseStorageHostApi {
               (args[3] as PigeonSettableMetadata?);
           assert(arg_settableMetaData != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.referencePutData was null, expected non-null PigeonSettableMetadata.');
-          final int? arg_handle = (args[4] as int?);
+          final int? arg_handle = (args[4] as num?)?.toInt();
           assert(arg_handle != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.referencePutData was null, expected non-null int.');
           final String output = await api.referencePutData(arg_app!,
@@ -521,14 +521,14 @@ abstract class TestFirebaseStorageHostApi {
           final String? arg_data = (args[2] as String?);
           assert(arg_data != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.referencePutString was null, expected non-null String.');
-          final int? arg_format = (args[3] as int?);
+          final int? arg_format = (args[3] as num?)?.toInt();
           assert(arg_format != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.referencePutString was null, expected non-null int.');
           final PigeonSettableMetadata? arg_settableMetaData =
               (args[4] as PigeonSettableMetadata?);
           assert(arg_settableMetaData != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.referencePutString was null, expected non-null PigeonSettableMetadata.');
-          final int? arg_handle = (args[5] as int?);
+          final int? arg_handle = (args[5] as num?)?.toInt();
           assert(arg_handle != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.referencePutString was null, expected non-null int.');
           final String output = await api.referencePutString(
@@ -570,7 +570,7 @@ abstract class TestFirebaseStorageHostApi {
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.referencePutFile was null, expected non-null String.');
           final PigeonSettableMetadata? arg_settableMetaData =
               (args[3] as PigeonSettableMetadata?);
-          final int? arg_handle = (args[4] as int?);
+          final int? arg_handle = (args[4] as num?)?.toInt();
           assert(arg_handle != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.referencePutFile was null, expected non-null int.');
           final String output = await api.referencePutFile(arg_app!,
@@ -605,7 +605,7 @@ abstract class TestFirebaseStorageHostApi {
           final String? arg_filePath = (args[2] as String?);
           assert(arg_filePath != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.referenceDownloadFile was null, expected non-null String.');
-          final int? arg_handle = (args[3] as int?);
+          final int? arg_handle = (args[3] as num?)?.toInt();
           assert(arg_handle != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.referenceDownloadFile was null, expected non-null int.');
           final String output = await api.referenceDownloadFile(
@@ -666,7 +666,7 @@ abstract class TestFirebaseStorageHostApi {
               (args[0] as PigeonStorageFirebaseApp?);
           assert(arg_app != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.taskPause was null, expected non-null PigeonStorageFirebaseApp.');
-          final int? arg_handle = (args[1] as int?);
+          final int? arg_handle = (args[1] as num?)?.toInt();
           assert(arg_handle != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.taskPause was null, expected non-null int.');
           final Map<String?, Object?> output =
@@ -694,7 +694,7 @@ abstract class TestFirebaseStorageHostApi {
               (args[0] as PigeonStorageFirebaseApp?);
           assert(arg_app != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.taskResume was null, expected non-null PigeonStorageFirebaseApp.');
-          final int? arg_handle = (args[1] as int?);
+          final int? arg_handle = (args[1] as num?)?.toInt();
           assert(arg_handle != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.taskResume was null, expected non-null int.');
           final Map<String?, Object?> output =
@@ -722,7 +722,7 @@ abstract class TestFirebaseStorageHostApi {
               (args[0] as PigeonStorageFirebaseApp?);
           assert(arg_app != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.taskCancel was null, expected non-null PigeonStorageFirebaseApp.');
-          final int? arg_handle = (args[1] as int?);
+          final int? arg_handle = (args[1] as num?)?.toInt();
           assert(arg_handle != null,
               'Argument for dev.flutter.pigeon.firebase_storage_platform_interface.FirebaseStorageHostApi.taskCancel was null, expected non-null int.');
           final Map<String?, Object?> output =

--- a/tests/integration_test/firebase_database/database_reference_e2e.dart
+++ b/tests/integration_test/firebase_database/database_reference_e2e.dart
@@ -114,7 +114,7 @@ void setupDatabaseReferenceTests() {
         expect(snapshot.value, 5);
 
         final result = await ref.runTransaction((value) {
-          final nextValue = (value as int? ?? 0) + 1;
+          final nextValue = (value as num? ?? 0).toInt() + 1;
           if (nextValue > 5) {
             return Transaction.abort();
           }
@@ -127,13 +127,13 @@ void setupDatabaseReferenceTests() {
 
       test('executes transaction', () async {
         final snapshot = await ref.get();
-        final value = (snapshot.value ?? 0) as int;
+        final value = (snapshot.value as num? ?? 0).toInt();
         final result = await ref.runTransaction((value) {
-          return Transaction.success((value as int? ?? 0) + 1);
+          return Transaction.success((value as num? ?? 0).toInt() + 1);
         });
 
         expect(result.committed, true);
-        expect((result.snapshot.value ?? 0) as int > value, true);
+        expect((result.snapshot.value as num? ?? 0).toInt() > value, true);
         expect(result.snapshot.key, ref.key);
       });
 


### PR DESCRIPTION
Taking values from JSON and directly casting them to `int` or `double` makes them incompatible with dart2wasm, since in wasm they are two distinct types (as opposed to JavaScript where they are actually the same under the hood).