### PR TITLE
fix(web): fixing some uncorrect type casting for Web

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -986,14 +986,14 @@ class AggregateQuerySnapshot
       : _data = Map.from(dartify(jsObject.data())),
         super.fromJsObject(jsObject);
 
-  int? get count => _data['count'] as int?;
+  int? get count => (_data['count'] as num?)?.toInt();
 
   double? getDataValue(platform_interface.AggregateQuery query) {
     final value = _data[AggregateQuery.name(query)];
     if (value == null) {
       return null;
     } else {
-      return value as double;
+      return (value as num).toDouble();
     }
   }
 }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/web_utils.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/web_utils.dart
@@ -85,8 +85,8 @@ DocumentChangePlatform convertWebDocumentChange(
 ) {
   return DocumentChangePlatform(
       convertWebDocumentChangeType(webDocumentChange.type),
-      webDocumentChange.oldIndex as int,
-      webDocumentChange.newIndex as int,
+      webDocumentChange.oldIndex.toInt(),
+      webDocumentChange.newIndex.toInt(),
       convertWebDocumentSnapshot(
         firestore,
         webDocumentChange.doc!,

--- a/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_web_recaptcha_verifier_factory.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_web_recaptcha_verifier_factory.dart
@@ -154,7 +154,7 @@ class RecaptchaVerifierFactoryWeb extends RecaptchaVerifierFactoryPlatform {
   @override
   Future<int> render() async {
     try {
-      return await _delegate.render() as int;
+      return (await _delegate.render()).toInt();
     } catch (e) {
       throw getFirebaseAuthException(e);
     }


### PR DESCRIPTION
## Description

Taking values from JSON and directly casting them to int or double makes them incompatible with dart2wasm, since in wasm they are two distinct types (as opposed to JavaScript where they are actually the same under the hood).

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
