### PR TITLE
fix(database, web): Stop transaction & stream handling exceptions from throwing twice

### DIFF
--- a/packages/firebase_database/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FlutterFirebaseDatabaseException.java
+++ b/packages/firebase_database/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FlutterFirebaseDatabaseException.java
@@ -128,7 +128,8 @@ public class FlutterFirebaseDatabaseException extends Exception {
       // detect it.
       code = "index-not-defined";
       message = message.replaceFirst("java.lang.Exception: ", "");
-    } else if (message.contains("Permission denied")) {
+    } else if (message.contains("Permission denied")
+        || message.contains("Client doesn't have permission")) {
       // Permission denied when using Firebase emulator does not correctly come
       // through as a DatabaseError.
       code = "permission-denied";

--- a/packages/firebase_database/firebase_database_web/lib/src/database_reference_web.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/database_reference_web.dart
@@ -91,12 +91,8 @@ class DatabaseReferenceWeb extends QueryWeb
     TransactionHandler transactionHandler, {
     bool applyLocally = true,
   }) async {
-    try {
-      return TransactionResultWeb._(
-          this, await _delegate.transaction(transactionHandler, applyLocally));
-    } catch (e, s) {
-      throw convertFirebaseDatabaseException(e, s);
-    }
+    return TransactionResultWeb._(
+        this, await _delegate.transaction(transactionHandler, applyLocally));
   }
 
   @override

--- a/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
@@ -211,9 +211,8 @@ class DatabaseReference<T extends database_interop.ReferenceJsImpl>
         committed: (castedJsTransaction.committed).toDart,
         snapshot: DataSnapshot._fromJsObject(castedJsTransaction.snapshot),
       );
-    } catch (e) {
-      final dartified = (e as JSObject).dartify();
-      throw convertFirebaseDatabaseException(dartified ?? {});
+    } catch (e, s) {
+      throw convertFirebaseDatabaseException(e, s);
     }
   }
 }
@@ -389,7 +388,7 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
     });
 
     final void Function(JSObject) cancelCallbackWrap = ((JSObject error) {
-      streamController.addError(error);
+      streamController.addError(convertFirebaseDatabaseException(error));
       streamController.close();
     });
 
@@ -452,8 +451,7 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
         c.complete(QueryEvent(DataSnapshot.getInstance(snapshot), string));
       }).toJS,
       ((JSAny error) {
-        final dartified = error.dartify();
-        c.completeError(convertFirebaseDatabaseException(dartified ?? {}));
+        c.completeError(convertFirebaseDatabaseException(error));
       }).toJS,
       database_interop.ListenOptions(onlyOnce: true.toJS),
     );

--- a/packages/firebase_database/firebase_database_web/lib/src/query_web.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/query_web.dart
@@ -126,16 +126,12 @@ class QueryWeb extends QueryPlatform {
     DatabaseEventType eventType,
     Stream<database_interop.QueryEvent> stream,
   ) {
-    return stream
-        .map(
+    return stream.map(
       (database_interop.QueryEvent event) => webEventToPlatformEvent(
         ref,
         eventType,
         event,
       ),
-    )
-        .handleError((e, s) {
-      throw convertFirebaseDatabaseException(e, s);
-    });
+    );
   }
 }

--- a/tests/integration_test/firebase_database/database_reference_e2e.dart
+++ b/tests/integration_test/firebase_database/database_reference_e2e.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:math';
 
 import 'package:firebase_core/firebase_core.dart';
@@ -149,6 +150,22 @@ void setupDatabaseReferenceTests() {
         var value = transactionResult.snapshot.value as dynamic;
         expect(value, isNotNull);
         expect(value['list'], data);
+      });
+
+      test('Exception handling', () async {
+        final FirebaseDatabase database = FirebaseDatabase.instance;
+        final DatabaseReference ref = database.ref('permission-denied');
+        final Completer<FirebaseException> errorReceived =
+        Completer<FirebaseException>();
+        await ref.runTransaction((value) => Transaction.success(1)).then((result) {
+          // No-op
+        }).catchError((e){
+          errorReceived.complete(e as FirebaseException);
+        });
+
+        final streamError = await errorReceived.future;
+        expect(streamError, isA<FirebaseException>());
+        expect(streamError.code, 'permission-denied');
       });
 
       test('Server.increment', () async {


### PR DESCRIPTION
## Description

1. Removed transaction handler from [throwing twice](https://github.com/firebase/flutterfire/compare/database-12675?expand=1#diff-8b979c4a2c5988c0951c38b09314bdcf73dc73d973e8a09c7a606e3adfc17f32L98). This is the main fix in the PR because we were using two exception handlers so when the second exception was passed into `convertFirebaseDatabaseException()`, it would pass in an already formed `FirebaseException` and cause the users issue.
2. [Moved exception stream](https://github.com/firebase/flutterfire/compare/database-12675?expand=1#diff-19abf2f5278bb16502160289df7e12535d5ab9c7a2e62ff6870537db777406dcR391) handling to the source so we can properly propagate exception without [unhandled exception](https://github.com/firebase/flutterfire/compare/database-12675?expand=1#diff-9da21a4056be815575c6284128d3d32e4aacc2d1dc32ebef5857fbfb16c93319L138). We already have test [catching exception](https://github.com/firebase/flutterfire/pull/12647/files#diff-8813ce6b4a8f801a900ee2b203224a095a3420f2a70ec4af1c55db2aec6b3983R505-R542), the problem here was an unhandled exception was also thown.
3. Implemented the same logic for stream exception handling for `once()` API function.
4. Wrote test for transaction exception handling.

## Related Issues

closes https://github.com/firebase/flutterfire/issues/12675

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
