### PR TITLE
Concept for instanceFor function

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -34,6 +34,12 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
     return _instance!;
   }
 
+  /// Returns an instance using a specified [FirebaseApp].
+  static FirebaseCrashlytics instanceFor({required FirebaseApp app}) {
+    _instance ??= FirebaseCrashlytics._(app: app);
+    return _instance!;
+  }
+
   /// Whether the current Crashlytics instance is collecting reports. If false,
   /// then no crash reporting data is sent to Firebase.
   ///


### PR DESCRIPTION
## Description

I've had issues with occasionally on particular emulators (usually android) where trying to instance crashlytics results in no default firebase being found, as I don't use the default, I've created a named firebase instance as:

```
final mainFirebase = await Firebase.initializeApp(
    name: 'master',
    options: DefaultFirebaseOptions.currentPlatform,
);
```

Shouldn't there be an instanceFor method in crashlytics? My changes in this PR are incomplete and likely not functional, but I don't understand why every other firebase system has instanceFor functionality but crashlytics does not...

Note: I have no experience in the backend of these firebase services, hence this is conceptual and will need advice and clarification from someone with experience :)