### PR TITLE
fix(firestore, ios): fix document stream handler options.

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTDocumentSnapshotStreamHandler.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTDocumentSnapshotStreamHandler.m
@@ -62,7 +62,8 @@
   FIRSnapshotListenOptions *optionsWithSourceAndMetadata = [[options
       optionsWithIncludeMetadataChanges:_includeMetadataChanges] optionsWithSource:_source];
 
-  self.listenerRegistration = [_reference addSnapshotListenerWithOptions:options listener:listener];
+  self.listenerRegistration = [_reference addSnapshotListenerWithOptions:optionsWithSourceAndMetadata
+                                                          listener:listener];
 
   return nil;
 }

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTDocumentSnapshotStreamHandler.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTDocumentSnapshotStreamHandler.m
@@ -63,7 +63,7 @@
       optionsWithIncludeMetadataChanges:_includeMetadataChanges] optionsWithSource:_source];
 
   self.listenerRegistration = [_reference addSnapshotListenerWithOptions:optionsWithSourceAndMetadata
-                                                          listener:listener];
+                                                                listener:listener];
 
   return nil;
 }


### PR DESCRIPTION
## Description

On an iOS device, using `includeMetadataChanges` does not work stream correct metadata events for single document snapshots.
These events are not handled correctly:
- First query execution (works correctly on first app launch [because data is not yet in cache, but any subsequent launch will be handled incorrectly])
- Regaining/Losing connection to the database

## Related Issues

Fixes: https://github.com/firebase/flutterfire/issues/12761

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
