### PR TITLE
fix(auth, web): get auth credential from exception and pass to user if one is available

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
@@ -518,6 +518,8 @@ class OAuthProviderJsImpl extends AuthProviderJsImpl {
   external static OAuthCredential? credentialFromResult(
     UserCredentialJsImpl userCredential,
   );
+
+  external static OAuthCredential? credentialFromError(JSError error);
 }
 
 extension OAuthProviderJsImplExtension on OAuthProviderJsImpl {

--- a/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
@@ -64,6 +64,20 @@ FirebaseAuthException getFirebaseAuthException(
   auth_interop.Auth? auth,
 ]) {
   final exception = objectException as JSError;
+  final authJsCredential =
+      auth_interop.OAuthProviderJsImpl.credentialFromError(exception);
+
+  OAuthCredential? credential;
+
+  if (authJsCredential != null) {
+    credential = OAuthProvider(authJsCredential.providerId.toDart).credential(
+      signInMethod: authJsCredential.signInMethod.toDart,
+      accessToken: authJsCredential.accessToken?.toDart,
+      secret: authJsCredential.secret?.toDart,
+      idToken: authJsCredential.idToken?.toDart,
+    );
+  }
+
   if (!_hasFirebaseAuthErrorCodeAndMessage(exception)) {
     return FirebaseAuthException(
       code: 'unknown',
@@ -116,6 +130,7 @@ FirebaseAuthException getFirebaseAuthException(
     email: customData.email?.toDart,
     phoneNumber: customData.phoneNumber?.toDart,
     tenantId: customData.tenantId?.toDart,
+    credential: credential,
   );
 }
 


### PR DESCRIPTION
## Description

I tested this with user's example and it worked as intended. The JS error is correctly parsed and instantiated as a Dart credential if it exists. If not, `null` is passed as `credential` which is a nullable argument on FirebaseAuthException:

```dart
final AuthCredential? credential;
```

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/12771

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
