### PR TITLE
style: address `use_string_in_part_of_directives` lints in package:firebase_vertexai

### DIFF
--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-part of firebase_vertexai;
+part of '../firebase_vertexai.dart';
 
 const _defaultLocation = 'us-central1';
 

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_api.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_api.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-part of firebase_vertexai;
+part of '../firebase_vertexai.dart';
 
 /// Response for Count Tokens
 final class CountTokensResponse {

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_chat.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_chat.dart
@@ -12,7 +12,7 @@
 // // See the License for the specific language governing permissions and
 // // limitations under the License.
 
-part of firebase_vertexai;
+part of '../firebase_vertexai.dart';
 
 /// A back-and-forth chat with a generative model.
 ///

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_content.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_content.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-part of firebase_vertexai;
+part of '../firebase_vertexai.dart';
 
 /// The base structured datatype containing multi-part content of a message.
 final class Content {

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_function_calling.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_function_calling.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-part of firebase_vertexai;
+part of '../firebase_vertexai.dart';
 
 /// Tool details that the model may use to generate a response.
 ///

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_model.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_model.dart
@@ -14,7 +14,7 @@
 
 // ignore_for_file: use_late_for_private_fields_and_variables
 
-part of firebase_vertexai;
+part of '../firebase_vertexai.dart';
 
 const _baseUrl = 'firebaseml.googleapis.com';
 const _apiVersion = 'v2beta';

--- a/packages/firebase_vertexai/firebase_vertexai/pubspec.yaml
+++ b/packages/firebase_vertexai/firebase_vertexai/pubspec.yaml
@@ -2,6 +2,7 @@ name: firebase_vertexai
 description: "Firebase Vertex AI SDK."
 version: 0.1.0
 homepage: https://firebase.google.com/docs/vertex-ai/get-started?platform=flutter
+repository: https://github.com/firebase/flutterfire/tree/master/packages/firebase_vertexai/firebase_vertexai
 
 environment:
   sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
## Description

- convert the `part of` directives to use file paths instead of library names (address the `use_string_in_part_of_directives` lint)
- add a `repository` field to the `firebase_vertexai` pubspec.yaml

## Related Issues

- none

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
