### PR TITLE
fix(firebase_analytics): fixed type assertion that ignored nullable fields

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
@@ -1498,8 +1498,8 @@ List<Map<String, dynamic>>? _marshalItems(List<AnalyticsEventItem>? items) {
 void _assertParameterTypesAreCorrect(Map<String, Object?>? parameters) =>
     parameters?.forEach((key, value) {
       assert(
-        value is String || value is num,
-        "'string' OR 'number' must be set as the value of the parameter: $key. $value found instead",
+        value is String || value is num || value == null,
+        "'string' OR 'number' or 'null' must be set as the value of the parameter: $key. $value found instead",
       );
     });
 

--- a/packages/firebase_analytics/firebase_analytics/test/firebase_analytics_test.dart
+++ b/packages/firebase_analytics/firebase_analytics/test/firebase_analytics_test.dart
@@ -593,7 +593,7 @@ void main() {
           shipping: SHIPPING_DOUBLE,
           transactionId: TRANSACTION_ID,
           affiliation: AFFILIATION,
-          parameters: {'a': 'b'},
+          parameters: {'a': 'b', 'c': null,},
         );
 
         expect(


### PR DESCRIPTION
## Description

In Firebase Analytics, when passing `parameters` to `logPurchase`, the signature allows for nullable values (`Map<String, Object?>?`). However, down the line, there is a method called `_assertParameterTypesAreCorrect` that asserts value types but ignored `null` values, creating a runtime issue.

More details in #12790 

## Related Issues

Fixes #12790 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
