### PR TITLE
refactor(vertexai): Split into separate libraries

### DIFF
--- a/packages/firebase_vertexai/firebase_vertexai/lib/firebase_vertexai.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/firebase_vertexai.dart
@@ -12,25 +12,58 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library firebase_vertexai;
-
-import 'dart:async';
-import 'dart:convert';
-import 'dart:typed_data';
-
-import 'package:firebase_app_check/firebase_app_check.dart';
-import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
-    show FirebasePluginPlatform;
-import 'package:google_generative_ai/google_generative_ai.dart' as google_ai;
-// ignore: implementation_imports, tightly coupled packages
-import 'package:google_generative_ai/src/vertex_hooks.dart';
-
-import 'src/vertex_version.dart';
-
-part 'src/firebase_vertexai.dart';
-part 'src/vertex_api.dart';
-part 'src/vertex_chat.dart';
-part 'src/vertex_content.dart';
-part 'src/vertex_function_calling.dart';
-part 'src/vertex_model.dart';
+export 'src/firebase_vertexai.dart'
+    show
+        // TODO(next breaking): Remove defaultTimeout
+        defaultTimeout,
+        FirebaseVertexAI,
+        RequestOptions;
+export 'src/vertex_api.dart'
+    show
+        BatchEmbedContentsResponse,
+        BlockReason,
+        Candidate,
+        CitationMetadata,
+        CitationSource,
+        ContentEmbedding,
+        CountTokensResponse,
+        // TODO(next breaking): Remove CountTokensResponseFields
+        CountTokensResponseFields,
+        EmbedContentRequest,
+        EmbedContentResponse,
+        FinishReason,
+        GenerateContentResponse,
+        GenerationConfig,
+        HarmBlockThreshold,
+        HarmCategory,
+        HarmProbability,
+        PromptFeedback,
+        SafetyRating,
+        SafetySetting,
+        TaskType,
+        // TODO(next breaking): Remove parse* methods
+        parseCountTokensResponse,
+        parseEmbedContentResponse,
+        parseGenerateContentResponse;
+export 'src/vertex_chat.dart' show ChatSession, StartChatExtension;
+export 'src/vertex_content.dart'
+    show
+        Content,
+        DataPart,
+        FileData,
+        FunctionCall,
+        FunctionResponse,
+        Part,
+        TextPart,
+        // TODO(next breaking): Remove parseContent
+        parseContent;
+export 'src/vertex_function_calling.dart'
+    show
+        FunctionCallingConfig,
+        FunctionCallingMode,
+        FunctionDeclaration,
+        Schema,
+        SchemaType,
+        Tool,
+        ToolConfig;
+export 'src/vertex_model.dart' show GenerativeModel;

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
@@ -12,7 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-part of firebase_vertexai;
+import 'package:firebase_app_check/firebase_app_check.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
+    show FirebasePluginPlatform;
+
+import 'vertex_api.dart';
+import 'vertex_content.dart';
+import 'vertex_function_calling.dart';
+import 'vertex_model.dart';
 
 const _defaultLocation = 'us-central1';
 
@@ -96,7 +104,7 @@ class FirebaseVertexAI extends FirebasePluginPlatform {
       Content? systemInstruction,
       List<Tool>? tools,
       ToolConfig? toolConfig}) {
-    return GenerativeModel._(
+    return createGenerativeModel(
         model: model,
         app: app,
         appCheck: appCheck,
@@ -108,6 +116,7 @@ class FirebaseVertexAI extends FirebasePluginPlatform {
         toolConfig: toolConfig);
   }
 }
+
 
 /// Options for request to backend.
 class RequestOptions {

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
@@ -114,7 +114,6 @@ class FirebaseVertexAI extends FirebasePluginPlatform {
     Content? systemInstruction,
     List<Tool>? tools,
     ToolConfig? toolConfig,
-    FirebaseAuth? auth,
   }) {
     return createGenerativeModel(
         model: model,

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
@@ -107,13 +107,15 @@ class FirebaseVertexAI extends FirebasePluginPlatform {
   /// The optional [safetySettings] and [generationConfig] can be used to
   /// control and guide the generation. See [SafetySetting] and
   /// [GenerationConfig] for details.
-  GenerativeModel generativeModel(
-      {required String model,
-      List<SafetySetting>? safetySettings,
-      GenerationConfig? generationConfig,
-      Content? systemInstruction,
-      List<Tool>? tools,
-      ToolConfig? toolConfig}) {
+  GenerativeModel generativeModel({
+    required String model,
+    List<SafetySetting>? safetySettings,
+    GenerationConfig? generationConfig,
+    Content? systemInstruction,
+    List<Tool>? tools,
+    ToolConfig? toolConfig,
+    FirebaseAuth? auth,
+  }) {
     return createGenerativeModel(
         model: model,
         app: app,

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
@@ -107,14 +107,13 @@ class FirebaseVertexAI extends FirebasePluginPlatform {
   /// The optional [safetySettings] and [generationConfig] can be used to
   /// control and guide the generation. See [SafetySetting] and
   /// [GenerationConfig] for details.
-  GenerativeModel generativeModel({
-    required String model,
-    List<SafetySetting>? safetySettings,
-    GenerationConfig? generationConfig,
-    Content? systemInstruction,
-    List<Tool>? tools,
-    ToolConfig? toolConfig,
-  }) {
+  GenerativeModel generativeModel(
+      {required String model,
+      List<SafetySetting>? safetySettings,
+      GenerationConfig? generationConfig,
+      Content? systemInstruction,
+      List<Tool>? tools,
+      ToolConfig? toolConfig}) {
     return createGenerativeModel(
         model: model,
         app: app,

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
@@ -117,7 +117,6 @@ class FirebaseVertexAI extends FirebasePluginPlatform {
   }
 }
 
-
 /// Options for request to backend.
 class RequestOptions {
   /// [timeout] duration for the request.

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_api.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_api.dart
@@ -34,8 +34,10 @@ final class CountTokensResponse {
   final int? totalBillableCharacters;
 }
 
+/// Conversion utilities for [google_ai.CountTokensResponse].
 extension GoogleAICountTokensResponseConversion
     on google_ai.CountTokensResponse {
+  /// Returns this response as a [CountTokensResponse].
   CountTokensResponse toVertex() => CountTokensResponse(
         totalTokens,
         totalBillableCharacters: totalBillableCharacters,
@@ -115,8 +117,10 @@ final class GenerateContentResponse {
       const [];
 }
 
+/// Conversion utilities for [google_ai.GenerateContentResponse].
 extension GoogleAIGenerateContentResponseConversion
     on google_ai.GenerateContentResponse {
+  /// Returns this response as a [GenerateContentResponse].
   GenerateContentResponse toVertex() => GenerateContentResponse(
         candidates.map((c) => c.toVertex()).toList(),
         promptFeedback?.toVertex(),
@@ -132,8 +136,10 @@ final class EmbedContentResponse {
   final ContentEmbedding embedding;
 }
 
+/// Conversion utilities for [google_ai.EmbedContentResponse].
 extension GoogleAIEmbedContentResponseConvesion
     on google_ai.EmbedContentResponse {
+  /// Returns this response as a [EmbedContentResponse].
   EmbedContentResponse toVertex() => EmbedContentResponse(embedding.toVertex());
 }
 
@@ -147,8 +153,10 @@ final class BatchEmbedContentsResponse {
   final List<ContentEmbedding> embeddings;
 }
 
+/// Conversion utilities for [google_ai.BatchEmbedContentsResponse].
 extension GoogleAIBatchEmbedContentsResponseConversion
     on google_ai.BatchEmbedContentsResponse {
+  /// Returns this response as a [BatchEmbedContentsResponse].
   BatchEmbedContentsResponse toVertex() =>
       BatchEmbedContentsResponse(embeddings.map((e) => e.toVertex()).toList());
 }
@@ -179,9 +187,9 @@ final class EmbedContentRequest {
       };
 }
 
+/// Conversion utilities for [EmbedContentRequest].
 extension EmbedContentRequestConversion on EmbedContentRequest {
   /// Converts this response to a [EmbedContentResponse].
-  // ignore: unused_element
   google_ai.EmbedContentRequest toGoogleAI() =>
       google_ai.EmbedContentRequest(content.toGoogleAI(),
           taskType: taskType?.toGoogleAI(), title: title, model: model);
@@ -196,7 +204,9 @@ final class ContentEmbedding {
   final List<double> values;
 }
 
+/// Conversion utilities for [google_ai.ContentEmbedding].
 extension GoogleAIContentEmbeddingConversion on google_ai.ContentEmbedding {
+  /// Returns this embedding as a [ContentEmbedding].
   ContentEmbedding toVertex() => ContentEmbedding(values);
 }
 
@@ -219,7 +229,9 @@ final class PromptFeedback {
   final List<SafetyRating> safetyRatings;
 }
 
+/// Conversion utilities for [google_ai.PromptFeedback].
 extension GoogleAIPromptFeedback on google_ai.PromptFeedback {
+  /// Returns this feedback a [PromptFeedback].
   PromptFeedback toVertex() => PromptFeedback(
         blockReason?.toVertex(),
         blockReasonMessage,
@@ -258,7 +270,9 @@ final class Candidate {
   final String? finishMessage;
 }
 
+/// Conversion utilities for [google_ai.Candidate].
 extension GooglAICandidateConversion on google_ai.Candidate {
+  /// Returns this candidate as a [Candidate].
   Candidate toVertex() => Candidate(
         content.toVertex(),
         safetyRatings?.map((r) => r.toVertex()).toList(),
@@ -285,7 +299,9 @@ final class SafetyRating {
   final HarmProbability probability;
 }
 
+/// Conversion utilities for [google_ai.SafetyRating].
 extension GoogleAISafetyRatingConversion on google_ai.SafetyRating {
+  /// Returns this safety rating as a [SafetyRating].
   SafetyRating toVertex() =>
       SafetyRating(category.toVertex(), probability.toVertex());
 }
@@ -325,7 +341,9 @@ enum BlockReason {
   String toString() => name;
 }
 
+/// Conversion utilities for [google_ai.BlockReason].
 extension GoogleAIBlockReasonConversion on google_ai.BlockReason {
+  /// Returns this block reason as a [BlockReason].
   BlockReason toVertex() => switch (this) {
         google_ai.BlockReason.unspecified => BlockReason.unspecified,
         google_ai.BlockReason.safety => BlockReason.safety,
@@ -376,7 +394,9 @@ enum HarmCategory {
   String toJson() => _jsonString;
 }
 
+/// Conversion utilities for [google_ai.HarmCategory].
 extension GoogleAIHarmCategoryConversion on google_ai.HarmCategory {
+  /// Returns this harm category as a [HarmCategory].
   HarmCategory toVertex() => switch (this) {
         google_ai.HarmCategory.unspecified => HarmCategory.unspecified,
         google_ai.HarmCategory.harassment => HarmCategory.harassment,
@@ -388,7 +408,9 @@ extension GoogleAIHarmCategoryConversion on google_ai.HarmCategory {
       };
 }
 
+/// Conversion utilities for [HarmCategory].
 extension HarmCategoryConversion on HarmCategory {
+  /// Returns this harm category as a [google_ai.HarmCategory].
   google_ai.HarmCategory toGoogleAI() {
     return switch (this) {
       HarmCategory.unspecified => google_ai.HarmCategory.unspecified,
@@ -443,7 +465,9 @@ enum HarmProbability {
   String toString() => name;
 }
 
+/// Conversion utilities for [google_ai.HarmProbability].
 extension GoogleAIHarmProbabilityConverison on google_ai.HarmProbability {
+  /// Returns this harm probability as a [HarmProbability].
   HarmProbability toVertex() => switch (this) {
         google_ai.HarmProbability.unspecified => HarmProbability.unspecified,
         google_ai.HarmProbability.negligible => HarmProbability.negligible,
@@ -462,7 +486,9 @@ final class CitationMetadata {
   final List<CitationSource> citationSources;
 }
 
+/// Conversion utilities for [google_ai.CitationMetadata].
 extension GoogleAICitationMetadataConversion on google_ai.CitationMetadata {
+  /// Returns this citation metadata as a [CitationMetadata].
   CitationMetadata toVertex() =>
       CitationMetadata(citationSources.map((s) => s.toVertex()).toList());
 }
@@ -489,7 +515,9 @@ final class CitationSource {
   final String? license;
 }
 
+/// Conversion utilities for [google_ai.CitationSource].
 extension GoogleAICitationSourceConversion on google_ai.CitationSource {
+  /// Returns this citation source as a [CitationSource].
   CitationSource toVertex() =>
       CitationSource(startIndex, endIndex, uri, license);
 }
@@ -539,7 +567,9 @@ enum FinishReason {
   String toString() => name;
 }
 
+/// Conversion utilities for [google_ai.FinishReason].
 extension GoogleAIFinishReasonConversion on google_ai.FinishReason {
+  /// Returns this finish reason as a [FinishReason].
   FinishReason toVertex() => switch (this) {
         google_ai.FinishReason.unspecified => FinishReason.unspecified,
         google_ai.FinishReason.stop => FinishReason.stop,
@@ -576,7 +606,9 @@ final class SafetySetting {
       {'category': category.toJson(), 'threshold': threshold.toJson()};
 }
 
+/// Conversion utilities for [SafetySetting].
 extension SafetySettingConversion on SafetySetting {
+  /// Returns this safety setting as a [google_ai.SafetySetting].
   google_ai.SafetySetting toGoogleAI() =>
       google_ai.SafetySetting(category.toGoogleAI(), threshold.toGoogleAI());
 }
@@ -635,7 +667,9 @@ enum HarmBlockThreshold {
   Object toJson() => _jsonString;
 }
 
+/// Conversion utilities for [HarmBlockThreshold].
 extension HarmBlockThresholdConversion on HarmBlockThreshold {
+  /// Returns this block threshold as a [toGoogleAI()].
   google_ai.HarmBlockThreshold toGoogleAI() {
     return switch (this) {
       HarmBlockThreshold.unspecified =>
@@ -648,7 +682,9 @@ extension HarmBlockThresholdConversion on HarmBlockThreshold {
   }
 }
 
+/// Conversion utilities for [google_ai.HarmBlockThreshold].
 extension GoogleAIHarmBlockThresholdConversion on google_ai.HarmBlockThreshold {
+  /// Returns this harm block threshold as a [HarmBlockThreshold].
   HarmBlockThreshold toVertex() => switch (this) {
         google_ai.HarmBlockThreshold.unspecified =>
           HarmBlockThreshold.unspecified,
@@ -750,7 +786,9 @@ final class GenerationConfig {
       };
 }
 
+/// Conversion utilities for [GenerationConfig].
 extension GenerationConfigConversion on GenerationConfig {
+  /// Returns this generation config as a [google_ai.GenerationConfig].
   google_ai.GenerationConfig toGoogleAI() => google_ai.GenerationConfig(
         candidateCount: candidateCount,
         stopSequences: stopSequences,
@@ -814,7 +852,9 @@ enum TaskType {
   Object toJson() => _jsonString;
 }
 
+/// Conversion utilities for [TaskType].
 extension TaskTypeConversion on TaskType {
+  /// Returns this task type as a [google_ai.TaskType].
   google_ai.TaskType toGoogleAI() => switch (this) {
         TaskType.unspecified => google_ai.TaskType.unspecified,
         TaskType.retrievalQuery => google_ai.TaskType.retrievalQuery,

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_api.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_api.dart
@@ -137,7 +137,7 @@ final class EmbedContentResponse {
 }
 
 /// Conversion utilities for [google_ai.EmbedContentResponse].
-extension GoogleAIEmbedContentResponseConvesion
+extension GoogleAIEmbedContentResponseConversion
     on google_ai.EmbedContentResponse {
   /// Returns this response as a [EmbedContentResponse].
   EmbedContentResponse toVertex() => EmbedContentResponse(embedding.toVertex());

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_chat.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_chat.dart
@@ -12,7 +12,13 @@
 // // See the License for the specific language governing permissions and
 // // limitations under the License.
 
-part of firebase_vertexai;
+import 'dart:async';
+
+import 'package:google_generative_ai/google_generative_ai.dart' as google_ai;
+
+import 'vertex_api.dart';
+import 'vertex_content.dart';
+import 'vertex_model.dart';
 
 /// A back-and-forth chat with a generative model.
 ///
@@ -25,15 +31,14 @@ final class ChatSession {
 
   ChatSession._(this._history, List<SafetySetting>? _safetySettings,
       GenerationConfig? _generationConfig, GenerativeModel _model)
-      : _googleAIChatSession = _model._googleAIModel.startChat(
-            history: _history.map((e) => e._toGoogleAIContent()).toList(),
+      : _googleAIChatSession = _model.googleAIModel.startChat(
+            history: _history.map((e) => e.toGoogleAI()).toList(),
             safetySettings: _safetySettings != null
                 ? _safetySettings
-                    .map((setting) => setting._toGoogleAISafetySetting())
+                    .map((setting) => setting.toGoogleAI())
                     .toList()
                 : [],
-            generationConfig:
-                GenerativeModel._googleAIGenerationConfig(_generationConfig));
+            generationConfig: _generationConfig?.toGoogleAI());
   final List<Content> _history;
 
   final google_ai.ChatSession _googleAIChatSession;
@@ -61,8 +66,8 @@ final class ChatSession {
   /// be reflected in the history sent for this message.
   Future<GenerateContentResponse> sendMessage(Content message) async {
     return _googleAIChatSession
-        .sendMessage(message._toGoogleAIContent())
-        .then(GenerateContentResponse._fromGoogleAIGenerateContentResponse);
+        .sendMessage(message.toGoogleAI())
+        .then((r) => r.toVertex());
   }
 
   /// Continues the chat with a new [message].
@@ -84,8 +89,8 @@ final class ChatSession {
   /// and response and allowing pending messages to be sent.
   Stream<GenerateContentResponse> sendMessageStream(Content message) {
     return _googleAIChatSession
-        .sendMessageStream(message._toGoogleAIContent())
-        .map(GenerateContentResponse._fromGoogleAIGenerateContentResponse);
+        .sendMessageStream(message.toGoogleAI())
+        .map((r) => r.toVertex());
   }
 }
 

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_content.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_content.dart
@@ -62,12 +62,16 @@ final class Content {
       };
 }
 
+/// Conversion utilities for [Content].
 extension ContentConversion on Content {
+  /// Returns this content as a [google_ai.Content].
   google_ai.Content toGoogleAI() =>
       google_ai.Content(role, parts.map((p) => p.toPart()).toList());
 }
 
+/// Conversion utilities for [google_ai.Content].
 extension GoogleAIContentConversion on google_ai.Content {
+  /// Returns this content as a [Content].
   Content toVertex() =>
       Content(role, parts.map(Part._fromGoogleAIPart).toList());
 }

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_content.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_content.dart
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-part of firebase_vertexai;
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:google_generative_ai/google_generative_ai.dart' as google_ai;
 
 /// The base structured datatype containing multi-part content of a message.
 final class Content {
   /// Constructor
   Content(this.role, this.parts);
-  factory Content._fromGoogleAIContent(google_ai.Content content) =>
-      Content(content.role, content.parts.map(Part._fromGoogleAIPart).toList());
 
   /// The producer of the content.
   ///
@@ -59,8 +60,16 @@ final class Content {
         if (role case final role?) 'role': role,
         'parts': parts.map((p) => p.toJson()).toList()
       };
-  google_ai.Content _toGoogleAIContent() =>
+}
+
+extension ContentConversion on Content {
+  google_ai.Content toGoogleAI() =>
       google_ai.Content(role, parts.map((p) => p.toPart()).toList());
+}
+
+extension GoogleAIContentConversion on google_ai.Content {
+  Content toVertex() =>
+      Content(role, parts.map(Part._fromGoogleAIPart).toList());
 }
 
 /// Parse the [Content] from json object.

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_function_calling.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_function_calling.dart
@@ -41,7 +41,9 @@ final class Tool {
       };
 }
 
+/// Conversion utilities for [Tool].
 extension ToolConversion on Tool {
+  /// Returns this tool as a [google_ai.Tool].
   google_ai.Tool toGoogleAI() => google_ai.Tool(
         functionDeclarations: functionDeclarations
             ?.map((f) => f._toGoogleAIToolFunctionDeclaration())
@@ -101,8 +103,9 @@ final class ToolConfig {
       };
 }
 
-
+/// Conversion utilities for [ToolConfig].
 extension ToolConfigConversion on ToolConfig {
+  /// Returns this tool config as a [google_ai.ToolConfig].
   google_ai.ToolConfig toGoogleAI() => google_ai.ToolConfig(
         functionCallingConfig:
             functionCallingConfig?._toGoogleAIFunctionCallingConfig(),

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_function_calling.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_function_calling.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-part of firebase_vertexai;
+import 'package:google_generative_ai/google_generative_ai.dart' as google_ai;
 
 /// Tool details that the model may use to generate a response.
 ///
@@ -39,8 +39,10 @@ final class Tool {
           'functionDeclarations':
               functionDeclarations.map((f) => f.toJson()).toList(),
       };
+}
 
-  google_ai.Tool _toGoogleAITool() => google_ai.Tool(
+extension ToolConversion on Tool {
+  google_ai.Tool toGoogleAI() => google_ai.Tool(
         functionDeclarations: functionDeclarations
             ?.map((f) => f._toGoogleAIToolFunctionDeclaration())
             .toList(),
@@ -97,7 +99,11 @@ final class ToolConfig {
         if (functionCallingConfig case final config?)
           'functionCallingConfig': config.toJson(),
       };
-  google_ai.ToolConfig _toGoogleAIToolConfig() => google_ai.ToolConfig(
+}
+
+
+extension ToolConfigConversion on ToolConfig {
+  google_ai.ToolConfig toGoogleAI() => google_ai.ToolConfig(
         functionCallingConfig:
             functionCallingConfig?._toGoogleAIFunctionCallingConfig(),
       );

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_model.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_model.dart
@@ -228,10 +228,13 @@ final class GenerativeModel {
   }
 }
 
+/// Conversion utilities for [GenerativeModel].
 extension GoogleAIGenerativeModelConversion on GenerativeModel {
+  /// Return this model as a [google_ai.GenerativeModel].
   google_ai.GenerativeModel get googleAIModel => _googleAIModel;
 }
 
+/// Returns a [GenerativeModel] using it's private constructor.
 GenerativeModel createGenerativeModel({
   required FirebaseApp app,
   required String location,

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_model.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_model.dart
@@ -14,7 +14,18 @@
 
 // ignore_for_file: use_late_for_private_fields_and_variables
 
-part of firebase_vertexai;
+import 'dart:async';
+
+import 'package:firebase_app_check/firebase_app_check.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:google_generative_ai/google_generative_ai.dart' as google_ai;
+// ignore: implementation_imports, tightly coupled packages
+import 'package:google_generative_ai/src/vertex_hooks.dart';
+
+import 'vertex_api.dart';
+import 'vertex_content.dart';
+import 'vertex_function_calling.dart';
+import 'vertex_version.dart';
 
 const _baseUrl = 'firebaseml.googleapis.com';
 const _apiVersion = 'v2beta';
@@ -53,16 +64,14 @@ final class GenerativeModel {
           baseUri: _vertexUri(app, location),
           requestHeaders: _appCheckToken(appCheck),
           safetySettings: safetySettings != null
-              ? safetySettings
-                  .map((setting) => setting._toGoogleAISafetySetting())
-                  .toList()
+              ? safetySettings.map((setting) => setting.toGoogleAI()).toList()
               : [],
-          generationConfig: generationConfig?._toGoogleAIGenerationConfig(),
-          systemInstruction: systemInstruction?._toGoogleAIContent(),
+          generationConfig: generationConfig?.toGoogleAI(),
+          systemInstruction: systemInstruction?.toGoogleAI(),
           tools: tools != null
-              ? tools.map((tool) => tool._toGoogleAITool()).toList()
+              ? tools.map((tool) => tool.toGoogleAI()).toList()
               : [],
-          toolConfig: toolConfig?._toGoogleAIToolConfig(),
+          toolConfig: toolConfig?.toGoogleAI(),
         );
   final FirebaseApp _firebaseApp;
   final google_ai.GenerativeModel _googleAIModel;
@@ -86,7 +95,7 @@ final class GenerativeModel {
     if (config == null) {
       return google_ai.GenerationConfig();
     } else {
-      return config._toGoogleAIGenerationConfig();
+      return config.toGoogleAI();
     }
   }
 
@@ -106,11 +115,6 @@ final class GenerativeModel {
     };
   }
 
-  static google_ai.GenerationConfig? _googleAIGenerationConfig(
-      GenerationConfig? config) {
-    return config?._toGoogleAIGenerationConfig();
-  }
-
   /// Generates content responding to [prompt].
   ///
   /// Sends a "generateContent" API request for the configured model,
@@ -125,18 +129,15 @@ final class GenerativeModel {
       {List<SafetySetting>? safetySettings,
       GenerationConfig? generationConfig}) async {
     Iterable<google_ai.Content> googlePrompt =
-        prompt.map((content) => content._toGoogleAIContent());
+        prompt.map((content) => content.toGoogleAI());
     List<google_ai.SafetySetting> googleSafetySettings = safetySettings != null
-        ? safetySettings
-            .map((setting) => setting._toGoogleAISafetySetting())
-            .toList()
+        ? safetySettings.map((setting) => setting.toGoogleAI()).toList()
         : [];
-    return _googleAIModel
-        .generateContent(googlePrompt,
-            safetySettings: googleSafetySettings,
-            generationConfig:
-                _convertGenerationConfig(generationConfig, _firebaseApp))
-        .then(GenerateContentResponse._fromGoogleAIGenerateContentResponse);
+    final response = await _googleAIModel.generateContent(googlePrompt,
+        safetySettings: googleSafetySettings,
+        generationConfig:
+            _convertGenerationConfig(generationConfig, _firebaseApp));
+    return response.toVertex();
   }
 
   /// Generates a stream of content responding to [prompt].
@@ -156,15 +157,12 @@ final class GenerativeModel {
       {List<SafetySetting>? safetySettings,
       GenerationConfig? generationConfig}) {
     return _googleAIModel
-        .generateContentStream(
-            prompt.map((content) => content._toGoogleAIContent()),
+        .generateContentStream(prompt.map((content) => content.toGoogleAI()),
             safetySettings: safetySettings != null
-                ? safetySettings
-                    .map((setting) => setting._toGoogleAISafetySetting())
-                    .toList()
+                ? safetySettings.map((setting) => setting.toGoogleAI()).toList()
                 : [],
-            generationConfig: generationConfig?._toGoogleAIGenerationConfig())
-        .map(GenerateContentResponse._fromGoogleAIGenerateContentResponse);
+            generationConfig: generationConfig?.toGoogleAI())
+        .map((r) => r.toVertex());
   }
 
   /// Counts the total number of tokens in [contents].
@@ -186,8 +184,8 @@ final class GenerativeModel {
   /// ```
   Future<CountTokensResponse> countTokens(Iterable<Content> contents) async {
     return _googleAIModel
-        .countTokens(contents.map((e) => e._toGoogleAIContent()))
-        .then(CountTokensResponse._fromGoogleAICountTokensResponse);
+        .countTokens(contents.map((e) => e.toGoogleAI()))
+        .then((r) => r.toVertex());
   }
 
   /// Creates an embedding (list of float values) representing [content].
@@ -203,9 +201,9 @@ final class GenerativeModel {
   Future<EmbedContentResponse> embedContent(Content content,
       {TaskType? taskType, String? title}) async {
     return _googleAIModel
-        .embedContent(content._toGoogleAIContent(),
-            taskType: taskType?._toGoogleAITaskType(), title: title)
-        .then(EmbedContentResponse._fromGoogleAIEmbedContentResponse);
+        .embedContent(content.toGoogleAI(),
+            taskType: taskType?.toGoogleAI(), title: title)
+        .then((r) => r.toVertex());
   }
 
   /// Creates embeddings (list of float values) representing each content in
@@ -225,9 +223,34 @@ final class GenerativeModel {
   Future<BatchEmbedContentsResponse> batchEmbedContents(
       Iterable<EmbedContentRequest> requests) async {
     return _googleAIModel
-        .batchEmbedContents(
-            requests.map((e) => e._toGoogleAIEmbedContentRequest()))
-        .then(
-            BatchEmbedContentsResponse._fromGoogleAIBatchEmbedContentsResponse);
+        .batchEmbedContents(requests.map((e) => e.toGoogleAI()))
+        .then((r) => r.toVertex());
   }
 }
+
+extension GoogleAIGenerativeModelModel on GenerativeModel {
+  google_ai.GenerativeModel get googleAIModel => _googleAIModel;
+}
+
+GenerativeModel createGenerativeModel({
+  required FirebaseApp app,
+  required String location,
+  required String model,
+  Content? systemInstruction,
+  FirebaseAppCheck? appCheck,
+  GenerationConfig? generationConfig,
+  List<SafetySetting>? safetySettings,
+  List<Tool>? tools,
+  ToolConfig? toolConfig,
+}) =>
+    GenerativeModel._(
+      model: model,
+      app: app,
+      appCheck: appCheck,
+      location: location,
+      safetySettings: safetySettings,
+      generationConfig: generationConfig,
+      systemInstruction: systemInstruction,
+      tools: tools,
+      toolConfig: toolConfig,
+    );

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_model.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_model.dart
@@ -17,6 +17,7 @@
 import 'dart:async';
 
 import 'package:firebase_app_check/firebase_app_check.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:google_generative_ai/google_generative_ai.dart' as google_ai;
 // ignore: implementation_imports, tightly coupled packages
@@ -248,6 +249,7 @@ GenerativeModel createGenerativeModel({
   required String model,
   Content? systemInstruction,
   FirebaseAppCheck? appCheck,
+  FirebaseAuth? auth,
   GenerationConfig? generationConfig,
   List<SafetySetting>? safetySettings,
   List<Tool>? tools,
@@ -257,6 +259,7 @@ GenerativeModel createGenerativeModel({
       model: model,
       app: app,
       appCheck: appCheck,
+      auth: auth,
       location: location,
       safetySettings: safetySettings,
       generationConfig: generationConfig,

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_model.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/vertex_model.dart
@@ -228,7 +228,7 @@ final class GenerativeModel {
   }
 }
 
-extension GoogleAIGenerativeModelModel on GenerativeModel {
+extension GoogleAIGenerativeModelConversion on GenerativeModel {
   google_ai.GenerativeModel get googleAIModel => _googleAIModel;
 }
 


### PR DESCRIPTION
The current approach uses `part` files which cannot be imported
separately. One drawback of this approach is that any members which need
to be referenced by test code must be public to the library. Using
`src/` libraries, as opposed to `src/` part files, allows making APIs
that are "package private" by convention - they are public to the
library, but only exported through the `src/` import.

One potential downside (alternatively seen as a benefit) of using
separate libraries is that private members are truly private to their
library, and we cannot make a member of a class private to the package.
The convention for package imports only allows top level declarations to
be considered non-public implementation details.

- Remove imports from the top level library. Replace `part` lines with
  `export` of the same files.
- Add explicit `show` clauses to the exports. This is what allows an API
  to be public when imported from the `src/` library, but not exposed
  through the package public library.
- Change some private `_toGoogleAI<TypeName>` methods to extension
  methods. Use the name `toGoogleAI` since the specific type names are
  clear from context.
- Change some private `_fromGoogleAI<TypeName>` factory constructors to
  extension methods on the google AI SDk types. Name `toVertex()`.
- Remove some unused private methods that were filled in for
  consistency. More extension members can be added as needed.
- Add an extension to expose the private field `_googleAiModel` from
  `GenerativeModel`.
- Add a top level method to forward to the private `GenerativeModel`
  constructor.
- Add TODO comments to stop exporting some methods that don't need to be
  public. These could have been private in the `part` pattern. For now
  they are exported for backwards compatibility, and we can remove them
  when we are ready for a major version bump.
