### PR TITLE
chore(dynamic-links): mark all relevant APIs as deprecated

### DIFF
--- a/packages/firebase_dynamic_links/firebase_dynamic_links/example/lib/main.dart
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/example/lib/main.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 
 import 'package:firebase_core/firebase_core.dart';

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
@@ -7,13 +7,25 @@ part of firebase_dynamic_links;
 /// Firebase Dynamic Links API.
 ///
 /// You can get an instance by calling [FirebaseDynamicLinks.instance].
+@Deprecated(
+    'Note: Firebase Dynamic Links is deprecated and the service will shut down on August 25, 2025. '
+    'Please see our Dynamic Links Deprecation FAQ documentation > for guidance on alternative solutions and migration options: '
+    'https://firebase.google.com/support/dynamic-links-faq')
 class FirebaseDynamicLinks extends FirebasePluginPlatform {
+  @Deprecated(
+      'Note: Firebase Dynamic Links is deprecated and the service will shut down on August 25, 2025. '
+      'Please see our Dynamic Links Deprecation FAQ documentation > for guidance on alternative solutions and migration options: '
+      'https://firebase.google.com/support/dynamic-links-faq')
   FirebaseDynamicLinks._({required this.app})
       : super(app.name, 'plugins.flutter.io/firebase_dynamic_links');
 
   static final Map<String, FirebaseDynamicLinks> _cachedInstances = {};
 
   /// Returns an instance using the default [FirebaseApp].
+  @Deprecated(
+      'Note: Firebase Dynamic Links is deprecated and the service will shut down on August 25, 2025. '
+      'Please see our Dynamic Links Deprecation FAQ documentation > for guidance on alternative solutions and migration options: '
+      'https://firebase.google.com/support/dynamic-links-faq')
   static FirebaseDynamicLinks get instance {
     return FirebaseDynamicLinks.instanceFor(
       app: Firebase.app(),
@@ -22,6 +34,10 @@ class FirebaseDynamicLinks extends FirebasePluginPlatform {
 
   /// Returns an instance using a specified [FirebaseApp].
   /// Note; multi-app support is only supported on android.
+  @Deprecated(
+      'Note: Firebase Dynamic Links is deprecated and the service will shut down on August 25, 2025. '
+      'Please see our Dynamic Links Deprecation FAQ documentation > for guidance on alternative solutions and migration options: '
+      'https://firebase.google.com/support/dynamic-links-faq')
   static FirebaseDynamicLinks instanceFor({required FirebaseApp app}) {
     if (defaultTargetPlatform == TargetPlatform.android ||
         app.name == defaultFirebaseAppName) {
@@ -53,6 +69,10 @@ class FirebaseDynamicLinks extends FirebasePluginPlatform {
   /// This method always returns a Future. That Future completes to null if
   /// there is no pending dynamic link or any call to this method after the
   /// the first attempt.
+  @Deprecated(
+      'Note: Firebase Dynamic Links is deprecated and the service will shut down on August 25, 2025. '
+      'Please see our Dynamic Links Deprecation FAQ documentation > for guidance on alternative solutions and migration options: '
+      'https://firebase.google.com/support/dynamic-links-faq')
   Future<PendingDynamicLinkData?> getInitialLink() async {
     return _delegate.getInitialLink();
   }
@@ -63,21 +83,37 @@ class FirebaseDynamicLinks extends FirebasePluginPlatform {
   /// may be present in the dynamicLinkUri parameter. If both are present,
   /// the previously captured dynamic link will take precedence. The captured
   /// data will be removed after first access.
+  @Deprecated(
+      'Note: Firebase Dynamic Links is deprecated and the service will shut down on August 25, 2025. '
+      'Please see our Dynamic Links Deprecation FAQ documentation > for guidance on alternative solutions and migration options: '
+      'https://firebase.google.com/support/dynamic-links-faq')
   Future<PendingDynamicLinkData?> getDynamicLink(Uri url) async {
     return _delegate.getDynamicLink(url);
   }
 
   /// Listen to a stream for the latest dynamic link events.
+  @Deprecated(
+      'Note: Firebase Dynamic Links is deprecated and the service will shut down on August 25, 2025. '
+      'Please see our Dynamic Links Deprecation FAQ documentation > for guidance on alternative solutions and migration options: '
+      'https://firebase.google.com/support/dynamic-links-faq')
   Stream<PendingDynamicLinkData> get onLink {
     return _delegate.onLink;
   }
 
   /// Creates a Dynamic Link from the parameters.
+  @Deprecated(
+      'Note: Firebase Dynamic Links is deprecated and the service will shut down on August 25, 2025. '
+      'Please see our Dynamic Links Deprecation FAQ documentation > for guidance on alternative solutions and migration options: '
+      'https://firebase.google.com/support/dynamic-links-faq')
   Future<Uri> buildLink(DynamicLinkParameters parameters) async {
     return _delegate.buildLink(parameters);
   }
 
   /// Creates a shortened Dynamic Link from the parameters.
+  @Deprecated(
+      'Note: Firebase Dynamic Links is deprecated and the service will shut down on August 25, 2025. '
+      'Please see our Dynamic Links Deprecation FAQ documentation > for guidance on alternative solutions and migration options: '
+      'https://firebase.google.com/support/dynamic-links-faq')
   Future<ShortDynamicLink> buildShortLink(
     DynamicLinkParameters parameters, {
     ShortDynamicLinkType shortLinkType = ShortDynamicLinkType.short,

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/test/firebase_dynamic_links_test.dart
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/test/firebase_dynamic_links_test.dart
@@ -12,6 +12,8 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import './mock.dart';
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 MockFirebaseDynamicLinks mockDynamicLinksPlatform = MockFirebaseDynamicLinks();
 
 DynamicLinkParameters buildDynamicLinkParameters() {

--- a/tests/integration_test/firebase_dynamic_links/firebase_dynamic_links_e2e_test.dart
+++ b/tests/integration_test/firebase_dynamic_links/firebase_dynamic_links_e2e_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 
 import 'package:firebase_core/firebase_core.dart';


### PR DESCRIPTION
## Description

Mark dynamic link APIs as deprecated ahead of August 25, 2025 removal of service.

## Related Issues

closes https://github.com/firebase/flutterfire/issues/12803

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
