### PR TITLE
fix(storage): do not set metadata property unless it has a value

### DIFF
--- a/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStoragePlugin.java
+++ b/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStoragePlugin.java
@@ -391,13 +391,23 @@ public class FlutterFirebaseStoragePlugin
 
   StorageMetadata getMetaDataFromPigeon(
       GeneratedAndroidFirebaseStorage.PigeonSettableMetadata pigeonSettableMetatdata) {
-    StorageMetadata.Builder androidMetaDataBuilder =
-        new StorageMetadata.Builder()
-            .setCacheControl(pigeonSettableMetatdata.getCacheControl())
-            .setContentDisposition(pigeonSettableMetatdata.getContentDisposition())
-            .setContentEncoding(pigeonSettableMetatdata.getContentEncoding())
-            .setContentLanguage(pigeonSettableMetatdata.getContentLanguage())
-            .setContentType(pigeonSettableMetatdata.getContentType());
+    StorageMetadata.Builder androidMetaDataBuilder = new StorageMetadata.Builder();
+
+    if (pigeonSettableMetatdata.getContentType() != null) {
+      androidMetaDataBuilder.setContentType(pigeonSettableMetatdata.getContentType());
+    }
+    if (pigeonSettableMetatdata.getCacheControl() != null) {
+      androidMetaDataBuilder.setCacheControl(pigeonSettableMetatdata.getCacheControl());
+    }
+    if (pigeonSettableMetatdata.getContentDisposition() != null) {
+      androidMetaDataBuilder.setContentDisposition(pigeonSettableMetatdata.getContentDisposition());
+    }
+    if (pigeonSettableMetatdata.getContentEncoding() != null) {
+      androidMetaDataBuilder.setContentEncoding(pigeonSettableMetatdata.getContentEncoding());
+    }
+    if (pigeonSettableMetatdata.getContentLanguage() != null) {
+      androidMetaDataBuilder.setContentLanguage(pigeonSettableMetatdata.getContentLanguage());
+    }
 
     Map<String, String> pigeonCustomMetadata = pigeonSettableMetatdata.getCustomMetadata();
     if (pigeonCustomMetadata != null) {

--- a/packages/firebase_storage/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.m
+++ b/packages/firebase_storage/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.m
@@ -175,13 +175,28 @@ typedef NS_ENUM(NSUInteger, FLTFirebaseStorageStringType) {
 
 - (FIRStorageMetadata *)getFIRStorageMetadataFromPigeon:(PigeonSettableMetadata *)pigeonMetadata {
   FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] init];
-  metadata.cacheControl = pigeonMetadata.cacheControl;
-  metadata.contentDisposition = pigeonMetadata.contentDisposition;
-  metadata.contentEncoding = pigeonMetadata.contentEncoding;
-  metadata.contentLanguage = pigeonMetadata.contentLanguage;
-  metadata.contentType = pigeonMetadata.contentType;
 
-  metadata.customMetadata = pigeonMetadata.customMetadata;
+  if (pigeonMetadata.cacheControl != nil) {
+    metadata.cacheControl = pigeonMetadata.cacheControl;
+  }
+  if (pigeonMetadata.contentType != nil) {
+    metadata.contentType = pigeonMetadata.contentType;
+  }
+  if (pigeonMetadata.contentDisposition != nil) {
+    metadata.contentDisposition = pigeonMetadata.contentDisposition;
+  }
+
+  if (pigeonMetadata.contentEncoding != nil) {
+    metadata.contentEncoding = pigeonMetadata.contentEncoding;
+  }
+
+  if (pigeonMetadata.contentLanguage != nil) {
+    metadata.contentLanguage = pigeonMetadata.contentLanguage;
+  }
+
+  if (pigeonMetadata.customMetadata != nil) {
+    metadata.customMetadata = pigeonMetadata.customMetadata;
+  }
 
   return metadata;
 }

--- a/packages/firebase_storage/firebase_storage_web/lib/src/interop/storage.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/interop/storage.dart
@@ -251,25 +251,38 @@ class UploadMetadata
     extends _UploadMetadataBase<storage_interop.UploadMetadataJsImpl> {
   /// Creates a new UploadMetadata with optional metadata parameters.
   factory UploadMetadata(
-          {String? md5Hash,
-          String? cacheControl,
-          String? contentDisposition,
-          String? contentEncoding,
-          String? contentLanguage,
-          String? contentType,
-          Map<String, String>? customMetadata}) =>
-      UploadMetadata.fromJsObject(
-        storage_interop.UploadMetadataJsImpl(
-          md5Hash: md5Hash?.toJS,
-          cacheControl: cacheControl?.toJS,
-          contentDisposition: contentDisposition?.toJS,
-          contentEncoding: contentEncoding?.toJS,
-          contentLanguage: contentLanguage?.toJS,
-          contentType: contentType?.toJS,
-          customMetadata:
-              (customMetadata != null) ? customMetadata.jsify() : null,
-        ),
-      );
+      {String? md5Hash,
+      String? cacheControl,
+      String? contentDisposition,
+      String? contentEncoding,
+      String? contentLanguage,
+      String? contentType,
+      Map<String, String>? customMetadata}) {
+    final metadata = storage_interop.UploadMetadataJsImpl();
+
+    if (md5Hash != null) {
+      metadata.md5Hash = md5Hash.toJS;
+    }
+    if (cacheControl != null) {
+      metadata.cacheControl = cacheControl.toJS;
+    }
+    if (contentDisposition != null) {
+      metadata.contentDisposition = contentDisposition.toJS;
+    }
+    if (contentEncoding != null) {
+      metadata.contentEncoding = contentEncoding.toJS;
+    }
+    if (contentLanguage != null) {
+      metadata.contentLanguage = contentLanguage.toJS;
+    }
+    if (contentType != null) {
+      metadata.contentType = contentType.toJS;
+    }
+    if (customMetadata != null) {
+      metadata.customMetadata = customMetadata.jsify();
+    }
+    return UploadMetadata.fromJsObject(metadata);
+  }
 
   /// Creates a new UploadMetadata from a [jsObject].
   UploadMetadata.fromJsObject(storage_interop.UploadMetadataJsImpl jsObject)
@@ -437,20 +450,34 @@ class SettableMetadata
     extends _SettableMetadataBase<storage_interop.SettableMetadataJsImpl> {
   /// Creates a new SettableMetadata with optional metadata parameters.
   factory SettableMetadata(
-          {String? cacheControl,
-          String? contentDisposition,
-          String? contentEncoding,
-          String? contentLanguage,
-          String? contentType,
-          Map? customMetadata}) =>
-      SettableMetadata.fromJsObject(storage_interop.SettableMetadataJsImpl(
-          cacheControl: cacheControl?.toJS,
-          contentDisposition: contentDisposition?.toJS,
-          contentEncoding: contentEncoding?.toJS,
-          contentLanguage: contentLanguage?.toJS,
-          contentType: contentType?.toJS,
-          customMetadata:
-              (customMetadata != null) ? customMetadata.jsify() : null));
+      {String? cacheControl,
+      String? contentDisposition,
+      String? contentEncoding,
+      String? contentLanguage,
+      String? contentType,
+      Map? customMetadata}) {
+    final metadata = storage_interop.SettableMetadataJsImpl();
+
+    if (cacheControl != null) {
+      metadata.cacheControl = cacheControl.toJS;
+    }
+    if (contentDisposition != null) {
+      metadata.contentDisposition = contentDisposition.toJS;
+    }
+    if (contentEncoding != null) {
+      metadata.contentEncoding = contentEncoding.toJS;
+    }
+    if (contentLanguage != null) {
+      metadata.contentLanguage = contentLanguage.toJS;
+    }
+    if (contentType != null) {
+      metadata.contentType = contentType.toJS;
+    }
+    if (customMetadata != null) {
+      metadata.customMetadata = customMetadata.jsify();
+    }
+    return SettableMetadata.fromJsObject(metadata);
+  }
 
   /// Creates a new SettableMetadata from a [jsObject].
   SettableMetadata.fromJsObject(storage_interop.SettableMetadataJsImpl jsObject)

--- a/tests/android/app/build.gradle
+++ b/tests/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/tests/android/app/build.gradle
+++ b/tests/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.plugins.firebase.tests"
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/tests/android/app/build.gradle
+++ b/tests/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.plugins.firebase.tests"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/tests/integration_test/firebase_storage/reference_e2e.dart
+++ b/tests/integration_test/firebase_storage/reference_e2e.dart
@@ -258,8 +258,7 @@ void setupReferenceTests() {
           );
 
           expect(complete.metadata?.size, text.length);
-          // Metadata isn't saved on objects when using the emulator which fails test
-          // expect(complete.metadata?.contentLanguage, 'en');
+          expect(complete.metadata?.contentLanguage, 'en');
 
           // Download the file from Firebase Storage
           final downloadedData = await ref.getData();
@@ -332,15 +331,15 @@ void setupReferenceTests() {
               file,
               SettableMetadata(
                 contentLanguage: 'en',
+                contentType: 'text/plain',
                 customMetadata: <String, String>{'activity': 'test'},
               ),
             );
-
+            // metadata.contentType appears as application/octet-stream if not set. contentType is not inferred on emulator
             expect(complete.metadata?.size, kTestString.length);
-            // Metadata isn't saved on objects when using the emulator which fails test
-            // expect(complete.metadata?.contentLanguage, 'en');
-            // expect(complete.metadata?.customMetadata!['activity'], 'test');
-
+            expect(complete.metadata?.contentLanguage, 'en');
+            expect(complete.metadata?.customMetadata!['activity'], 'test');
+            expect(complete.metadata?.contentType, 'text/plain');
             // Check without SettableMetadata
             final Reference ref2 =
                 storage.ref('flutter-tests').child('flt-ok-2.txt');
@@ -348,6 +347,7 @@ void setupReferenceTests() {
               file,
             );
             expect(complete2.metadata?.size, kTestString.length);
+            expect(complete2.metadata?.customMetadata, isA<Map>());
           },
           // putFile is not supported on the web platform.
           skip: kIsWeb,


### PR DESCRIPTION
## Description

This fixes a bug where if we set one property on `SettableMetadata` (e.g. `customMetadata`), it would also set every other metadata property to `null`. This was stopping `contentType` from being inferred for android at least.

Unfortunately, the emulator doesn't infer `contentType`, so I tested on a live project and it is now inferring type if SettableMetadata is used without setting `contentType`.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/12801

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
