### PR TITLE
feat: updates to write_batch to allow catching and removing errors

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/write_batch.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/write_batch.dart
@@ -76,4 +76,14 @@ class WriteBatch {
       _CodecUtility.replaceValueWithDelegatesInMap(data)!,
     );
   }
+
+  /// Remove fields in the batch referred to by [documentPath].
+  void removeFromBatch(String documentPath) {
+    _delegate.removeFromBatch(documentPath);
+  }
+
+  /// Used for debugging/crashlytics purposes
+  List<PigeonTransactionCommand> getBatchData() {
+    return _delegate.getBatchData();
+  }
 }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_write_batch.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_write_batch.dart
@@ -45,6 +45,9 @@ class MethodChannelWriteBatch extends WriteBatchPlatform {
       await MethodChannelFirebaseFirestore.pigeonChannel
           .writeBatchCommit(pigeonApp, _writes);
     } catch (e, stack) {
+      /// set _committed to false so that users can catch this platform
+      /// exception and try again if desired.
+      _committed = false;
       convertPlatformException(e, stack);
     }
   }
@@ -84,6 +87,18 @@ class MethodChannelWriteBatch extends WriteBatchPlatform {
       type: PigeonTransactionType.update,
       data: data,
     ));
+  }
+
+  @override
+  void removeFromBatch(String documentPath) {
+    _assertNotCommitted();
+    _writes.removeWhere((element) => element.path.compareTo(documentPath) == 0);
+  }
+
+  /// Used for debugging/crashlytics purposes
+  @override
+  List<PigeonTransactionCommand> getBatchData() {
+    return _writes;
   }
 
   /// Ensures that once a batch has been committed, it can not be modified again.

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_write_batch.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_write_batch.dart
@@ -63,4 +63,14 @@ abstract class WriteBatchPlatform extends PlatformInterface {
   ) {
     throw UnimplementedError('update() is not implemented');
   }
+
+  /// Remove fields in the batch referred to by [documentPath].
+  void removeFromBatch(String documentPath) {
+    throw UnimplementedError('removeFromBatch() is not implemented');
+  }
+
+  /// Used for debugging/crashlytics purposes
+  List<PigeonTransactionCommand> getBatchData() {
+    throw UnimplementedError('getBatchData() is not implemented');
+  }
 }


### PR DESCRIPTION
## Description

Existing behavior will throw a platform exception on error. Even if we wanted to re-try this commit, we couldn't because the _committed isn't reset on said error.

This change set allows us to catch the platform exception, determine which document is causing the issue, remove that document from the batch, then re-commit the rest of the batch.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
