### PR TITLE
fix(messaging, android): stop app from crashing when `DartCallback` or `Context` is `null`

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundExecutor.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundExecutor.java
@@ -55,6 +55,10 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
    */
   public static void setCallbackDispatcher(long callbackHandle) {
     Context context = ContextHolder.getApplicationContext();
+    if(context == null) {
+      Log.e(TAG, "Context is null, cannot continue.");
+      return;
+    }
     SharedPreferences prefs =
         context.getSharedPreferences(FlutterFirebaseMessagingUtils.SHARED_PREFERENCES_KEY, 0);
     prefs.edit().putLong(CALLBACK_HANDLE_KEY, callbackHandle).apply();

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundExecutor.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundExecutor.java
@@ -182,8 +182,6 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
                     return;
                   }
 
-                  // Essentially, the above fails because the flutterCallback is null
-
                   DartExecutor executor = backgroundFlutterEngine.getDartExecutor();
                   initializeMethodChannel(executor);
 

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundExecutor.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundExecutor.java
@@ -55,7 +55,7 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
    */
   public static void setCallbackDispatcher(long callbackHandle) {
     Context context = ContextHolder.getApplicationContext();
-    if(context == null) {
+    if (context == null) {
       Log.e(TAG, "Context is null, cannot continue.");
       return;
     }
@@ -181,7 +181,7 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
                   FlutterCallbackInformation flutterCallback =
                       FlutterCallbackInformation.lookupCallbackInformation(callbackHandle);
 
-                  if(flutterCallback == null) {
+                  if (flutterCallback == null) {
                     Log.e(TAG, "Failed to find registered callback");
                     return;
                   }

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundExecutor.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundExecutor.java
@@ -176,6 +176,14 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
                   // lookup will fail.
                   FlutterCallbackInformation flutterCallback =
                       FlutterCallbackInformation.lookupCallbackInformation(callbackHandle);
+
+                  if(flutterCallback == null) {
+                    Log.e(TAG, "Failed to find registered callback");
+                    return;
+                  }
+
+                  // Essentially, the above fails because the flutterCallback is null
+
                   DartExecutor executor = backgroundFlutterEngine.getDartExecutor();
                   initializeMethodChannel(executor);
 

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -87,6 +87,7 @@ public class FlutterFirebaseMessagingPlugin
 
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
+    ContextHolder.setApplicationContext(binding.getApplicationContext());
     initInstance(binding.getBinaryMessenger());
   }
 

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingReceiver.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingReceiver.java
@@ -20,7 +20,12 @@ public class FlutterFirebaseMessagingReceiver extends BroadcastReceiver {
   public void onReceive(Context context, Intent intent) {
     Log.d(TAG, "broadcast received for message");
     if (ContextHolder.getApplicationContext() == null) {
-      ContextHolder.setApplicationContext(context.getApplicationContext());
+      Context aContext = context;
+      if (context.getApplicationContext() != null) {
+        aContext = context.getApplicationContext();
+      }
+
+      ContextHolder.setApplicationContext(aContext);
     }
 
     if (intent.getExtras() == null) {


### PR DESCRIPTION
## Description



## [issue 9345](https://github.com/firebase/flutterfire/issues/9345)

This crash occurs because the `DartCallback` is `null` in some instances when retrieving.

Other notification plugins appear to check if the `DartCallback` instance is `null` or not:

See [awesome notifications](https://github.com/rafaelsetragni/awesome_notifications/blob/0f484c73bf76665049df46767170c563d5842a61/android/src/main/java/me/carda/awesome_notifications/DartBackgroundExecutor.java#L160-L171)

See [flutter local notifications](https://github.com/MaikuB/flutter_local_notifications/blob/5375645b01c845998606b58a3d97b278c5b2cefa/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/ActionBroadcastReceiver.java#L82-L88)

[This fixes this issue](https://github.com/firebase/flutterfire/compare/messaging-fix-crashes?expand=1#diff-8744f314855e43edf01113d2879fac031b610ea00b7c578ee86dc8426fe62c1dR180-R183).

## [issue 12840](https://github.com/firebase/flutterfire/issues/12840)
 
This crash occurs because `Context.getSharedPreferences()` is called when the `context` object is `null`.

This is fixed by checking if `context` is `null` before calling `getSharedPreferences()`. 

Upon further investigation, I noticed that [this class](https://github.com/firebase/flutterfire/blob/master/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingInitProvider.java) doesn't appear to be instantiated or called at least from my local testing which is one of two methods we set context for the plugin.

The other method, [is here](https://github.com/firebase/flutterfire/blob/master/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingReceiver.java#L22-L24). What is interesting about this occurrence is we don't actually check whether `context.getApplicationContext()` actually has a Context object. It seems that in some occurrences this must be `null` which makes the application crash in rare instances when calling `Context.getSharedPreferences()`.

I've added a speculative way to set context on [plugin initialisation here](https://github.com/firebase/flutterfire/pull/12842/files#diff-dfa7b361e0d81e322b54ae9c73c768eb30d17505f5a4dff9a1b4f72b7e57058eR90) to ensure there is a context object set.

Also safeguard that there is a `context` object [here](https://github.com/firebase/flutterfire/pull/12842/files#diff-966ccf7315853a6a8ab2375d10631c70cd33127e682c1b9c0d5e3cd96e3f29c4R23-R28).

## Related Issues

closes https://github.com/firebase/flutterfire/issues/9345
closes #12840

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
