### PR TITLE
ci: use emulator for firestore 2nd database

### DIFF
--- a/.github/workflows/scripts/firebase.json
+++ b/.github/workflows/scripts/firebase.json
@@ -1,8 +1,15 @@
 {
-  "firestore": {
-    "rules": "firestore.rules",
-    "indexes": "firestore.indexes.json"
-  },
+  "firestore": [
+    {
+      "database": "(default)",
+      "rules": "firestore.rules",
+      "indexes": "firestore.indexes.json"
+    },
+    {
+      "database": "flutterfire-2",
+      "rules": "firestore.flutterfire-2.rules"
+    }
+  ],
   "database": {
     "rules": "database.rules.json"
   },

--- a/.github/workflows/scripts/firestore.flutterfire-2.rules
+++ b/.github/workflows/scripts/firestore.flutterfire-2.rules
@@ -1,0 +1,12 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+
+    match /flutterfire-2/{document=**} {
+    	allow read, write: if true;
+    }
+  }
+}

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/second_database.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/second_database.dart
@@ -39,6 +39,8 @@ void runSecondDatabaseTests() {
           app: Firebase.app(),
           databaseId: 'flutterfire-2',
         );
+
+        firestore.useFirestoreEmulator('localhost', 8080);
       });
 
       Future<CollectionReference<Map<String, dynamic>>> initializeTest(
@@ -190,6 +192,8 @@ void runSecondDatabaseTests() {
             }
             fail('Should have thrown a [FirebaseException]');
           },
+          // Emulator for 2nd database allows this request, the live project correctly throws a "permission-denied" error
+          skip: true,
         );
       });
 
@@ -335,6 +339,8 @@ void runSecondDatabaseTests() {
 
             fail('Should have thrown a [FirebaseException]');
           },
+          // Emulator for 2nd database allows this request, the live project correctly throws a "permission-denied" error
+          skip: true,
         );
       });
 
@@ -1838,6 +1844,8 @@ void runSecondDatabaseTests() {
               ),
             );
           },
+          // Emulator for 2nd database allows this request, the live project correctly throws a "permission-denied" error
+          skip: true,
         );
 
         testWidgets(
@@ -1898,6 +1906,8 @@ void runSecondDatabaseTests() {
               ),
             );
           },
+          // Emulator for 2nd database allows this request, the live project correctly throws a "permission-denied" error
+          skip: true,
         );
 
         testWidgets('isEqualTo filter', (_) async {


### PR DESCRIPTION
## Description

- Uses emulator for 2nd database, one of the reasons (amongst others) for flakey tests is the use of live project for firestore 2nd database e2e tests. This ought to improve CI flow.
- Some tests are skipped because they do not throw permission-denied exception for 2nd database emulator, I'll raise an issue on the firebase-tools repository.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
