### PR TITLE
ci: improve e2e workflows & fix failing tests

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
+      fail-fast: false
       matrix:
         working_directory:
           ['tests', 'packages/cloud_firestore/cloud_firestore/example']
@@ -90,6 +91,7 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 45
     strategy:
+      fail-fast: false
       matrix:
         working_directory:
           ['tests', 'packages/cloud_firestore/cloud_firestore/example']
@@ -165,6 +167,7 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 45
     strategy:
+      fail-fast: false
       matrix:
         working_directory:
           ['tests', 'packages/cloud_firestore/cloud_firestore/example']
@@ -235,7 +238,6 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     strategy:
-      # Temp measure for testing web tests. Please remove as soon as e2e tests are stable.
       fail-fast: false
       matrix:
         working_directory:
@@ -291,7 +293,6 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     strategy:
-      # Temp measure for testing web tests. Please remove as soon as e2e tests are stable.
       fail-fast: false
       matrix:
         working_directory:

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/second_database.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/second_database.dart
@@ -1775,128 +1775,79 @@ void runSecondDatabaseTests() {
 
       group('Query.where() with Filter class', () {
         testWidgets(
-          'Exception thrown when combining `arrayContainsAny` & `isNotEqualTo` in multiple disjunctive queries',
+          'Can combine `arrayContainsAny` & `isNotEqualTo` in multiple disjunctive queries',
           (_) async {
             CollectionReference<Map<String, dynamic>> collection =
                 await initializeTest('multiple-disjunctive-queries');
 
-            await expectLater(
-              collection
-                  .where(
-                    Filter.or(
-                      Filter('rating', isEqualTo: 3.8),
-                      Filter('year', isEqualTo: 1970),
-                      Filter('runtime', isEqualTo: 90),
-                      Filter('director', isEqualTo: 'Director2'),
-                      Filter('country', isEqualTo: 'Wales'),
-                      Filter('budget', isEqualTo: 20000000),
-                      Filter('boxOffice', isEqualTo: 50000000),
-                      Filter('genre', arrayContainsAny: ['sci-fi']),
-                      Filter('actor', isEqualTo: 'Actor2'),
-                      Filter('language', isEqualTo: 'English'),
-                      Filter('award', isEqualTo: 'Award2'),
-                      Filter('screenWriter', isEqualTo: 'ScreenWriter2'),
-                      Filter('editor', isEqualTo: 'Editor2'),
-                      Filter('cinematographer', isEqualTo: 'Cinematographer2'),
-                      Filter('releaseCountry', isEqualTo: 'Country2'),
-                      Filter('distributor', isEqualTo: 'Distributor2'),
-                      Filter('ratingSystem', isEqualTo: 'RatingSystem2'),
-                      Filter('soundtrackComposer', isEqualTo: 'Composer2'),
-                      Filter(
-                        'visualEffectsCompany',
-                        isEqualTo: 'EffectsCompany2',
-                      ),
-                      Filter(
-                        'productionCompany',
-                        isEqualTo: 'ProductionCompany2',
-                      ),
-                      Filter('filmFormat', isEqualTo: 'FilmFormat2'),
-                      Filter('aspectRatio', isEqualTo: 'AspectRatio2'),
-                      Filter('colorProcess', isEqualTo: 'ColorProcess2'),
-                      Filter('soundProcess', isEqualTo: 'SoundProcess2'),
-                      Filter('numberOfTheaters', isEqualTo: 2000),
-                      Filter('openingWeekendRevenue', isEqualTo: 10000000),
-                      Filter('totalDomesticRevenue', isEqualTo: 60000000),
-                      Filter('totalWorldwideRevenue', isEqualTo: 200000000),
-                      Filter('estimatedProfit', isEqualTo: 140000000),
-                      // Inequality causes "failed-precondition" exception and asks user to create an index
-                      Filter('mainCharacter', isNotEqualTo: 'MainCharacter2'),
-                    ),
-                  )
-                  .orderBy('rating', descending: true)
-                  .get(),
-              throwsA(
-                isA<FirebaseException>()
-                    .having((e) => e.code, 'code', 'failed-precondition')
-                    .having(
-                      (e) => e.message,
-                      'message',
-                      contains(
-                        'The query contains range and inequality filters on multiple fields',
-                      ),
-                    ),
-              ),
-            );
+            await Future.wait([
+              collection.add({
+                'genre': 'sci-fi',
+                'mainCharacter': 'Tim',
+                'rating': 1,
+              }),
+              collection.add({
+                'mainCharacter': 'MainCharacter2',
+                'genre': 'action',
+                'rating': 1,
+              }),
+              collection.add({
+                'mainCharacter': 'MainCharacter2',
+                'genre': 'action',
+                'rating': 1,
+              }),
+            ]);
+            final result = await collection
+                .where(
+                  Filter.or(
+                    Filter('genre', arrayContainsAny: ['sci-fi']),
+                    Filter('mainCharacter', isNotEqualTo: 'MainCharacter2'),
+                  ),
+                )
+                .orderBy('rating', descending: true)
+                .get();
+
+            expect(result.docs.length, equals(1));
+            expect(result.docs[0].data()['genre'], equals('sci-fi'));
           },
         );
 
         testWidgets(
-          'Exception thrown when combining `arrayContainsAny` & `isNotEqualTo` in multiple conjunctive queries',
+          'Can combine `arrayContainsAny` & `isNotEqualTo` in multiple conjunctive queries',
           (_) async {
             CollectionReference<Map<String, dynamic>> collection =
-                await initializeTest('multiple-conjunctive-queries');
-
-            await expectLater(
-              collection
-                  .where(
-                    Filter.and(
-                      Filter('rating1', isEqualTo: 3.8),
-                      Filter('year1', isEqualTo: 1970),
-                      Filter('runtime1', isEqualTo: 90),
-                      Filter('director1', isEqualTo: 'Director2'),
-                      Filter('producer1', isEqualTo: 'Producer2'),
-                      Filter('budget1', isEqualTo: 20000000),
-                      Filter('boxOffice1', isEqualTo: 50000000),
-                      Filter('actor1', isEqualTo: 'Actor2'),
-                      Filter('language1', isEqualTo: 'English'),
-                      Filter('award1', isEqualTo: 'Award2'),
-                      Filter('genre1', arrayContainsAny: ['sci-fi']),
-                      Filter('country1', isEqualTo: 'USA'),
-                      Filter('released1', isEqualTo: true),
-                      Filter('screenplay1', isEqualTo: 'Screenplay2'),
-                      Filter('cinematography1', isEqualTo: 'Cinematography2'),
-                      Filter('music1', isEqualTo: 'Music2'),
-                      Filter('rating2', isEqualTo: 4.2),
-                      Filter('year2', isEqualTo: 1982),
-                      Filter('runtime2', isEqualTo: 60),
-                      Filter('director2', isEqualTo: 'Director3'),
-                      Filter('producer2', isEqualTo: 'Producer3'),
-                      Filter('budget2', isEqualTo: 30000000),
-                      Filter('boxOffice2', isEqualTo: 60000000),
-                      Filter('actor2', isEqualTo: 'Actor3'),
-                      Filter('language2', isEqualTo: 'Korean'),
-                      Filter('award2', isEqualTo: 'Award3'),
-                      Filter('genre2', isEqualTo: ['sci-fi', 'action']),
-                      Filter('country2', isEqualTo: 'South Korea'),
-                      Filter('released2', isEqualTo: false),
-                      // Inequality causes "failed-precondition" exception and asks user to create an index
-                      Filter('screenplay2', isNotEqualTo: 'blah'),
-                    ),
-                  )
-                  .orderBy('rating1', descending: true)
-                  .get(),
-              throwsA(
-                isA<FirebaseException>()
-                    .having((e) => e.code, 'code', 'failed-precondition')
-                    .having(
-                      (e) => e.message,
-                      'message',
-                      contains(
-                        'The query contains range and inequality filters on multiple fields',
-                      ),
-                    ),
-              ),
+                await initializeTest(
+              'array-contain-not-equal-conjunctive-queries',
             );
+
+            await Future.wait([
+              collection.doc('doc1').set({
+                'genre': ['fantasy', 'sci-fi'],
+                'screenplay2': 'bar',
+              }),
+              collection.doc('doc2').set({
+                'genre': ['fantasy', 'sci-fi'],
+                'screenplay2': 'bar',
+              }),
+              collection.doc('doc3').set({
+                'genre': ['fantasy', 'sci-fi'],
+                'screenplay2': 'foo',
+              }),
+            ]);
+
+            final results = await collection
+                .where(
+                  Filter.and(
+                    Filter('genre', arrayContainsAny: ['sci-fi']),
+                    Filter('screenplay2', isNotEqualTo: 'foo'),
+                  ),
+                )
+                .orderBy('screenplay2', descending: true)
+                .get();
+
+            expect(results.docs.length, equals(2));
+            expect(results.docs[0].id, equals('doc2'));
+            expect(results.docs[1].id, equals('doc1'));
           },
         );
 


### PR DESCRIPTION
## Description

- I've changed to `fail-fast: false` to stop flakey tests on either firestore e2e or tests e2e from cancelling the other test job in the matrix which ultimately has led to a lot more test runs.
- Updated firestore tests that are now permissible queries.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
