### PR TITLE
refactor(auth)!: remove deprecated API ahead of breaking change release

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -76,47 +76,6 @@ class FirebaseAuth extends FirebasePluginPlatform {
 
   /// Changes this instance to point to an Auth emulator running locally.
   ///
-  /// Set the [origin] of the local emulator, such as "http://localhost:9099"
-  ///
-  /// Note: Must be called immediately, prior to accessing auth methods.
-  /// Do not use with production credentials as emulator traffic is not encrypted.
-  ///
-  /// Note: auth emulator is not supported for web yet. firebase-js-sdk does not support
-  /// auth.useEmulator until v8.2.4, but FlutterFire does not support firebase-js-sdk v8+ yet
-  @Deprecated(
-    'Will be removed in future release. '
-    'Use useAuthEmulator().',
-  )
-  Future<void> useEmulator(String origin) async {
-    assert(origin.isNotEmpty);
-    String mappedOrigin = origin;
-
-    // Android considers localhost as 10.0.2.2 - automatically handle this for users.
-    if (defaultTargetPlatform == TargetPlatform.android && !kIsWeb) {
-      if (mappedOrigin.startsWith('http://localhost')) {
-        mappedOrigin =
-            mappedOrigin.replaceFirst('http://localhost', 'http://10.0.2.2');
-      } else if (mappedOrigin.startsWith('http://127.0.0.1')) {
-        mappedOrigin =
-            mappedOrigin.replaceFirst('http://127.0.0.1', 'http://10.0.2.2');
-      }
-    }
-
-    // Native calls take the host and port split out
-    final hostPortRegex = RegExp(r'^http:\/\/([\w\d.]+):(\d+)$');
-    final RegExpMatch? match = hostPortRegex.firstMatch(mappedOrigin);
-    if (match == null) {
-      throw ArgumentError('firebase.auth().useEmulator() origin format error');
-    }
-    // Two non-empty groups in RegExp match - which is null-tested - these are non-null now
-    final String host = match.group(1)!;
-    final int port = int.parse(match.group(2)!);
-
-    await useAuthEmulator(host, port);
-  }
-
-  /// Changes this instance to point to an Auth emulator running locally.
-  ///
   /// Set the [host] of the local emulator, such as "localhost"
   /// Set the [port] of the local emulator, such as "9099" (port 9099 is default for auth package)
   ///
@@ -644,19 +603,6 @@ class FirebaseAuth extends FirebasePluginPlatform {
     } catch (e) {
       rethrow;
     }
-  }
-
-  /// Signs in with an AuthProvider using native authentication flow. This is
-  /// deprecated in favor of `signInWithProvider()`.
-  ///
-  /// A [FirebaseAuthException] maybe thrown with the following error code:
-  /// - **user-disabled**:
-  ///  - Thrown if the user corresponding to the given email has been disabled.
-  @Deprecated('You should use signInWithProvider instead')
-  Future<UserCredential> signInWithAuthProvider(
-    AuthProvider provider,
-  ) async {
-    return signInWithProvider(provider);
   }
 
   /// Signs in with an AuthProvider using native authentication flow.

--- a/packages/firebase_auth/firebase_auth/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/user.dart
@@ -641,10 +641,6 @@ class User {
   }
 
   /// Updates a user's profile data.
-  @Deprecated(
-    'Will be removed in version 2.0.0. '
-    'Use updatePhotoURL and updateDisplayName instead.',
-  )
   Future<void> updateProfile({String? displayName, String? photoURL}) {
     return _delegate.updateProfile(<String, String?>{
       'displayName': displayName,


### PR DESCRIPTION
## Description

Removed `useEmulator()` API. [Deprecated over 3 years ago](https://github.com/firebase/flutterfire/commit/747f1b61bb66067c8528555cef125a11cfedb3d6).

Removed `signInWithAuthProvider()` API. [Deprecated over a year ago](https://github.com/firebase/flutterfire/commit/ca340ea19c8dbb340f083e48cf1b0de36f7d64c4)

Removed deprecated annotation from `updateProfile()` API as it is not deprecated on Firebase native SDKs. [Example](https://firebase.google.com/docs/reference/android/com/google/firebase/auth/FirebaseUser?_gl=1*i1z2u3*_up*MQ..*_ga*MTY3Nzg0NjUzOS4xNzE3MTYwNTEx*_ga_CW55HF8NVT*MTcxNzE2MDUxMC4xLjAuMTcxNzE2MDUxMC4wLjAuMA..#updateProfile(com.google.firebase.auth.UserProfileChangeRequest))

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
