### PR TITLE
refactor(storage)!: remove deprecated API ahead of breaking change

### DIFF
--- a/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
@@ -152,33 +152,6 @@ class FirebaseStorage extends FirebasePluginPlatform {
 
   /// Changes this instance to point to a Storage emulator running locally.
   ///
-  /// Set the [host] (ex: localhost) and [port] (ex: 9199) of the local emulator.
-  ///
-  /// Note: Must be called immediately, prior to accessing storage methods.
-  /// Do not use with production credentials as emulator traffic is not encrypted.
-  @Deprecated(
-    'Will be removed in future release. '
-    'Use useStorageEmulator().',
-  )
-  Future<void> useEmulator({required String host, required int port}) async {
-    assert(host.isNotEmpty);
-    assert(!port.isNegative);
-
-    String mappedHost = host;
-    // Android considers localhost as 10.0.2.2 - automatically handle this for users.
-    if (defaultTargetPlatform == TargetPlatform.android && !kIsWeb) {
-      if (mappedHost == 'localhost' || mappedHost == '127.0.0.1') {
-        // ignore: avoid_print
-        print('Mapping Storage Emulator host "$mappedHost" to "10.0.2.2".');
-        mappedHost = '10.0.2.2';
-      }
-    }
-
-    await useStorageEmulator(host, port);
-  }
-
-  /// Changes this instance to point to a Storage emulator running locally.
-  ///
   /// Set the [host] of the local emulator, such as "localhost"
   /// Set the [port] of the local emulator, such as "9199" (port 9199 is default for storage package)
   ///


### PR DESCRIPTION
## Description

Removed `useEmulator()` API. [Deprecated](https://github.com/firebase/flutterfire/commit/747f1b61bb66067c8528555cef125a11cfedb3d6#diff-eb1d5f7023d5b3aafdee60e56c19b2f594c1cebc44b9cfeed149fce706322750R158) 3 years ago.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
