### PR TITLE
fix(auth, web): stream handlers are properly cleaned up and recreated

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -24,6 +24,8 @@ import 'src/firebase_auth_web_user_credential.dart';
 import 'src/interop/auth.dart' as auth_interop;
 import 'src/interop/multi_factor.dart' as multi_factor;
 
+enum StateListener { authStateChange, userStateChange, idTokenChange }
+
 /// The web delegate implementation for [FirebaseAuth].
 class FirebaseAuthWeb extends FirebaseAuthPlatform {
   /// Stub initializer to allow the [registerWith] to create an instance without
@@ -37,50 +39,9 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   /// The entry point for the [FirebaseAuthWeb] class.
   FirebaseAuthWeb({required FirebaseApp app}) : super(appInstance: app) {
     // Create a app instance broadcast stream for both delegate listener events
-    _userChangesListeners[app.name] =
-        StreamController<UserPlatform?>.broadcast();
-    _authStateChangesListeners[app.name] =
-        StreamController<UserPlatform?>.broadcast();
-    _idTokenChangesListeners[app.name] =
-        StreamController<UserPlatform?>.broadcast();
-
-    // TODO(rrousselGit): close StreamSubscription
-    delegate.onAuthStateChanged.map((auth_interop.User? webUser) {
-      if (!_initialized.isCompleted) {
-        _initialized.complete();
-      }
-
-      if (webUser == null) {
-        return null;
-      } else {
-        return UserWeb(
-          this,
-          MultiFactorWeb(this, multi_factor.multiFactor(webUser)),
-          webUser,
-          _webAuth,
-        );
-      }
-    }).listen((UserWeb? webUser) {
-      _authStateChangesListeners[app.name]!.add(webUser);
-    });
-
-    // TODO(rrousselGit): close StreamSubscription
-    // Also triggers `userChanged` events
-    delegate.onIdTokenChanged.map((auth_interop.User? webUser) {
-      if (webUser == null) {
-        return null;
-      } else {
-        return UserWeb(
-          this,
-          MultiFactorWeb(this, multi_factor.multiFactor(webUser)),
-          webUser,
-          _webAuth,
-        );
-      }
-    }).listen((UserWeb? webUser) {
-      _idTokenChangesListeners[app.name]!.add(webUser);
-      _userChangesListeners[app.name]!.add(webUser);
-    });
+    _createStreamListener(app.name, StateListener.authStateChange);
+    _createStreamListener(app.name, StateListener.idTokenChange);
+    _createStreamListener(app.name, StateListener.userStateChange);
   }
 
   /// Called by PluginRegistry to register this plugin for Flutter Web
@@ -136,6 +97,104 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   /// Initializes a stub instance to allow the class to be registered.
   static FirebaseAuthWeb get instance {
     return FirebaseAuthWeb._();
+  }
+
+  bool _cancelUserStream = false;
+  bool _cancelIdTokenStream = false;
+
+  void _createStreamListener(String appName, StateListener stateListener) {
+    if (StateListener.authStateChange == stateListener) {
+      _authStateChangesListeners[appName] =
+          StreamController<UserPlatform?>.broadcast(
+        onCancel: () {
+          _authStateChangesListeners[appName]!.close();
+          _authStateChangesListeners.remove(appName);
+          delegate.authStateController?.close();
+        },
+      );
+      delegate.onAuthStateChanged.map((auth_interop.User? webUser) {
+        if (!_initialized.isCompleted) {
+          _initialized.complete();
+        }
+
+        if (webUser == null) {
+          return null;
+        } else {
+          return UserWeb(
+            this,
+            MultiFactorWeb(this, multi_factor.multiFactor(webUser)),
+            webUser,
+            _webAuth,
+          );
+        }
+      }).listen((UserWeb? webUser) {
+        _authStateChangesListeners[app.name]!.add(webUser);
+      });
+    }
+    if (StateListener.idTokenChange == stateListener) {
+      _cancelIdTokenStream = false;
+      _idTokenChangesListeners[appName] =
+          StreamController<UserPlatform?>.broadcast(
+        onCancel: () {
+          if (_userChangesListeners[appName] == null) {
+            // We cannot remove if there is a userChanges listener as we use this stream for it
+            _idTokenChangesListeners[appName]!.close();
+            _idTokenChangesListeners.remove(appName);
+            delegate.idTokenController?.close();
+          } else {
+            // We need to do this because if idTokenListener and userChanges are being listened to
+            // We need to cancel both at the same time otherwise neither will be closed & removed
+            _cancelIdTokenStream = true;
+          }
+
+          if (_cancelUserStream) {
+            _userChangesListeners[appName]!.close();
+            _userChangesListeners.remove(appName);
+          }
+        },
+      );
+
+      // Also triggers `userChanged` events
+      delegate.onIdTokenChanged.map((auth_interop.User? webUser) {
+        if (webUser == null) {
+          return null;
+        } else {
+          return UserWeb(
+            this,
+            MultiFactorWeb(this, multi_factor.multiFactor(webUser)),
+            webUser,
+            _webAuth,
+          );
+        }
+      }).listen((UserWeb? webUser) {
+        _idTokenChangesListeners[app.name]!.add(webUser);
+        _userChangesListeners[app.name]!.add(webUser);
+      });
+    }
+
+    if (StateListener.userStateChange == stateListener) {
+      _cancelUserStream = false;
+      _userChangesListeners[appName] =
+          StreamController<UserPlatform?>.broadcast(
+        onCancel: () {
+          if (_idTokenChangesListeners[appName] == null) {
+            _userChangesListeners[appName]!.close();
+            _userChangesListeners.remove(appName);
+            // There is no delegate for userChanges as we use idTokenChanges
+          } else {
+            _cancelUserStream = true;
+          }
+
+          if (_cancelIdTokenStream) {
+            // We need to do this because if idTokenListener and userChanges are being listened to
+            // We need to cancel both at the same time otherwise neither will be closed & removed
+            _idTokenChangesListeners[appName]!.close();
+            _idTokenChangesListeners.remove(appName);
+            delegate.idTokenController?.close();
+          }
+        },
+      );
+    }
   }
 
   /// instance of Auth from the web plugin
@@ -254,6 +313,9 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   Stream<UserPlatform?> authStateChanges() async* {
     await _initialized.future;
     yield currentUser;
+    if (_authStateChangesListeners[app.name] == null) {
+      _createStreamListener(app.name, StateListener.authStateChange);
+    }
     yield* _authStateChangesListeners[app.name]!.stream;
   }
 
@@ -261,6 +323,9 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   Stream<UserPlatform?> idTokenChanges() async* {
     await _initialized.future;
     yield currentUser;
+    if (_idTokenChangesListeners[app.name] == null) {
+      _createStreamListener(app.name, StateListener.idTokenChange);
+    }
     yield* _idTokenChangesListeners[app.name]!.stream;
   }
 
@@ -268,6 +333,9 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   Stream<UserPlatform?> userChanges() async* {
     await _initialized.future;
     yield currentUser;
+    if (_userChangesListeners[app.name] == null) {
+      _createStreamListener(app.name, StateListener.userStateChange);
+    }
     yield* _userChangesListeners[app.name]!.stream;
   }
 

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -388,7 +388,9 @@ class Auth extends JsObjectWrapper<auth_interop.AuthJsImpl> {
 
   JSFunction? _onAuthUnsubscribe;
 
-  // TODO(rrousselGit): fix memory leak – the controller isn't closed even in onCancel
+  StreamController<User?>? get authStateController => _changeController;
+  StreamController<User?>? get idTokenController => _idTokenChangedController;
+
   // ignore: close_sinks
   StreamController<User?>? _changeController;
 
@@ -412,9 +414,11 @@ class Auth extends JsObjectWrapper<auth_interop.AuthJsImpl> {
             jsObject.onAuthStateChanged(nextWrapper.toJS, errorWrapper.toJS);
       }
 
-      void stopListen() {
-        (_onAuthUnsubscribe!.dartify()! as Function)();
+      Future<void> stopListen() async {
+        await (_onAuthUnsubscribe!.callAsFunction() as JSPromise<JSAny?>?)
+            ?.toDart;
         _onAuthUnsubscribe = null;
+        _changeController = null;
       }
 
       _changeController = StreamController<User?>.broadcast(
@@ -430,7 +434,6 @@ class Auth extends JsObjectWrapper<auth_interop.AuthJsImpl> {
 
   JSFunction? _onIdTokenChangedUnsubscribe;
 
-  // TODO(rrousselGit): fix memory leak – the controller isn't closed even in onCancel
   // ignore: close_sinks
   StreamController<User?>? _idTokenChangedController;
 
@@ -454,9 +457,12 @@ class Auth extends JsObjectWrapper<auth_interop.AuthJsImpl> {
             jsObject.onIdTokenChanged(nextWrapper.toJS, errorWrapper.toJS);
       }
 
-      void stopListen() {
-        (_onIdTokenChangedUnsubscribe!.dartify()! as Function)();
+      Future<void> stopListen() async {
+        await (_onIdTokenChangedUnsubscribe!.callAsFunction()
+                as JSPromise<JSAny?>?)
+            ?.toDart;
         _onIdTokenChangedUnsubscribe = null;
+        _idTokenChangedController = null;
       }
 
       _idTokenChangedController = StreamController<User?>.broadcast(

--- a/tests/integration_test/firebase_auth/firebase_auth_instance_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_instance_e2e_test.dart
@@ -198,7 +198,7 @@ void main() {
 
       group('test all stream listeners', () {
         Matcher containsExactlyThreeUsers() => predicate<List>(
-              (list) => list.where((element) => element is User).length == 3,
+              (list) => list.whereType<User>().length == 3,
               'a list containing exactly 3 User instances',
             );
         test('create, cancel and reopen all user event stream handlers', () async {


### PR DESCRIPTION
## Description

I was going to fix [this issue](https://github.com/firebase/flutterfire/issues/7064), but realised web never properly cleans up the event listeners in the interop layer. i.e the `onDispose()` function was never called for [onAuthStateChanged](https://github.com/firebase/flutterfire/pull/12903/files#diff-073c6ae89d1947a587a79d2020e2cd9478a0d218a4aeb8dd6bce4b37344b92e1R417) & [onIdTokenChanged](https://github.com/firebase/flutterfire/pull/12903/files#diff-073c6ae89d1947a587a79d2020e2cd9478a0d218a4aeb8dd6bce4b37344b92e1R460-R466).

Ideally, I would've mocked to see the stream handlers created/removed in FirebaseAuthWeb, but mocking the interop layer with staticInterop was extremely difficult and I opted to create an integration test.

Also `userStateChanges` isn't a real API so it can't be cleaned up on JS side. The problem is; if you have both `userStateChanges` & `onIdTokenChanged` stream handlers and you want to clean them up, we have to check the other stream handler has no listeners which is the [purpose of these booleans](https://github.com/firebase/flutterfire/pull/12903/files#diff-17ed9aacd0e9db73ae34a051cb82db62cf843a13bb85fbc77acdf52c5918f2d5R102-R103).

I've also updated the [clean up code](https://github.com/firebase/flutterfire/pull/12903/files#diff-073c6ae89d1947a587a79d2020e2cd9478a0d218a4aeb8dd6bce4b37344b92e1R417-R421) to match what we already have when [initialising auth on web](https://github.com/firebase/flutterfire/blob/fix-web-hot-restart/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart#L386). My local testing shows that stream handlers are cleaned up.

Once this PR is merged, I'll fix the [multiple stream handler creation bug for web hot restarts](https://github.com/firebase/flutterfire/issues/7064)


## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
