### PR TITLE
fix(firestore, web): ensure streams are removed on "hot restart"

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/web/wasm_index.html
+++ b/packages/cloud_firestore/cloud_firestore/example/web/wasm_index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Flutter web app</title>
+  <script src="flutter.js"></script>
+</head>
+<body>
+  <script>
+    {{flutter_build_config}}
+    _flutter.loader.load();
+  </script>
+</body>
+</html>

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -100,7 +100,11 @@ class Firestore extends JsObjectWrapper<firestore_interop.FirestoreJsImpl> {
         firestore_interop.enableIndexedDbPersistence(jsObject).toDart;
   }
 
+  String get _snapshotInSyncWindowsKey =>
+      'flutterfire-${app.name}_snapshotInSync';
+
   Stream<void> snapshotsInSync() {
+    unsubscribeWindowsListener(_snapshotInSyncWindowsKey);
     late StreamController<void> controller;
     late JSFunction onSnapshotsInSyncUnsubscribe;
     var nextWrapper = ((JSObject? noValue) {
@@ -110,11 +114,16 @@ class Firestore extends JsObjectWrapper<firestore_interop.FirestoreJsImpl> {
     void startListen() {
       onSnapshotsInSyncUnsubscribe =
           firestore_interop.onSnapshotsInSync(jsObject, nextWrapper);
+      setWindowsListener(
+        _snapshotInSyncWindowsKey,
+        onSnapshotsInSyncUnsubscribe,
+      );
     }
 
     void stopListen() {
       onSnapshotsInSyncUnsubscribe.callAsFunction();
       controller.close();
+      removeWindowsListener(_snapshotInSyncWindowsKey);
     }
 
     controller = StreamController<void>.broadcast(
@@ -364,6 +373,9 @@ class DocumentReference
         (result)! as firestore_interop.DocumentSnapshotJsImpl);
   }
 
+  String get _documentSnapshotWindowsKey =>
+      'flutterfire-${firestore.app.name}_${path}_documentSnapshot';
+
   /// Attaches a listener for [DocumentSnapshot] events.
   Stream<DocumentSnapshot> onSnapshot({
     bool includeMetadataChanges = false,
@@ -379,8 +391,9 @@ class DocumentReference
   StreamController<DocumentSnapshot> _createSnapshotStream([
     firestore_interop.DocumentListenOptions? options,
   ]) {
+    unsubscribeWindowsListener(_documentSnapshotWindowsKey);
     late JSFunction onSnapshotUnsubscribe;
-    // ignore: close_sinks, the controler is returned
+    // ignore: close_sinks, the controller is returned
     late StreamController<DocumentSnapshot> controller;
 
     final nextWrapper = ((firestore_interop.DocumentSnapshotJsImpl snapshot) {
@@ -395,10 +408,12 @@ class DocumentReference
               jsObject as JSObject, options as JSAny, nextWrapper, errorWrapper)
           : firestore_interop.onSnapshot(
               jsObject as JSObject, nextWrapper, errorWrapper);
+      setWindowsListener(_documentSnapshotWindowsKey, onSnapshotUnsubscribe);
     }
 
     void stopListen() {
       onSnapshotUnsubscribe.callAsFunction();
+      removeWindowsListener(_documentSnapshotWindowsKey);
     }
 
     return controller = StreamController<DocumentSnapshot>.broadcast(
@@ -471,20 +486,26 @@ class Query<T extends firestore_interop.QueryJsImpl>
   Query limitToLast(num limit) => Query.fromJsObject(firestore_interop.query(
       jsObject, firestore_interop.limitToLast(limit.toJS)));
 
-  Stream<QuerySnapshot> onSnapshot({
-    bool includeMetadataChanges = false,
-    ListenSource source = ListenSource.defaultSource,
-  }) =>
+  String _querySnapshotWindowsKey(hashCode) =>
+      'flutterfire-${firestore.app.name}_${hashCode}_querySnapshot';
+
+  Stream<QuerySnapshot> onSnapshot(
+          {bool includeMetadataChanges = false,
+          ListenSource source = ListenSource.defaultSource,
+          required int hashCode}) =>
       _createSnapshotStream(
         firestore_interop.DocumentListenOptions(
           includeMetadataChanges: includeMetadataChanges.toJS,
           source: convertListenSource(source),
         ),
+        hashCode,
       ).stream;
 
   StreamController<QuerySnapshot> _createSnapshotStream(
     firestore_interop.DocumentListenOptions options,
+    int hashCode,
   ) {
+    unsubscribeWindowsListener(_querySnapshotWindowsKey(hashCode));
     late JSFunction onSnapshotUnsubscribe;
     // ignore: close_sinks, the controller is returned
     late StreamController<QuerySnapshot> controller;
@@ -497,10 +518,13 @@ class Query<T extends firestore_interop.QueryJsImpl>
     void startListen() {
       onSnapshotUnsubscribe = firestore_interop.onSnapshot(
           jsObject as JSObject, options as JSObject, nextWrapper, errorWrapper);
+      setWindowsListener(
+          _querySnapshotWindowsKey(hashCode), onSnapshotUnsubscribe);
     }
 
     void stopListen() {
       onSnapshotUnsubscribe.callAsFunction();
+      removeWindowsListener(_querySnapshotWindowsKey(hashCode));
     }
 
     return controller = StreamController<QuerySnapshot>.broadcast(

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
@@ -188,6 +188,7 @@ class QueryWeb extends QueryPlatform {
         _buildWebQueryWithParameters().onSnapshot(
       includeMetadataChanges: includeMetadataChanges,
       source: source,
+      hashCode: hashCode,
     );
 
     return convertWebExceptions(

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -393,7 +393,8 @@ class Auth extends JsObjectWrapper<auth_interop.AuthJsImpl> {
   StreamController<User?>? _changeController;
 
   String get _authStateWindowsKey => 'flutterfire-${app.name}_authStateChanges';
-  String get _idTokenStateWindowsKey => 'flutterfire-${app.name}_idTokenChanges';
+  String get _idTokenStateWindowsKey =>
+      'flutterfire-${app.name}_idTokenChanges';
 
   /// Sends events when the users sign-in state changes.
   ///

--- a/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
@@ -61,6 +61,8 @@ void setWindowsListener(String key, JSFunction unsubscribe) {
 
 void removeWindowsListener(String key) {
   if (kDebugMode) {
-    web.window.delete(key.toJS);
+    if (web.window.hasProperty(key.toJS) == true.toJS) {
+      web.window.delete(key.toJS);
+    }
   }
 }

--- a/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
@@ -10,6 +10,8 @@
 import 'dart:async';
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
+import 'package:web/web.dart' as web;
+import 'package:flutter/foundation.dart';
 
 import 'func.dart';
 
@@ -37,4 +39,28 @@ JSPromise handleFutureWithMapper<T, S>(
       return wrapper;
     });
   }.toJS);
+}
+
+// No way to unsubscribe from event listeners on hot reload so we set on the windows object
+// and clean up on hot restart if it exists.
+// See: https://github.com/firebase/flutterfire/issues/7064
+void unsubscribeWindowsListener(String key) {
+  if (kDebugMode) {
+    final unsubscribe = web.window.getProperty(key.toJS);
+    if (unsubscribe != null) {
+      (unsubscribe as JSFunction).callAsFunction();
+    }
+  }
+}
+
+void setWindowsListener(String key, JSFunction unsubscribe) {
+  if (kDebugMode) {
+    web.window.setProperty(key.toJS, unsubscribe);
+  }
+}
+
+void removeWindowsListener(String key) {
+  if (kDebugMode) {
+    web.window.delete(key.toJS);
+  }
 }

--- a/packages/firebase_core/firebase_core_web/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_web/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.17.1
 
 environment:
   sdk: '>=3.2.0 <4.0.0'
-  flutter: '>=3.3.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   firebase_core_platform_interface: ^5.0.0


### PR DESCRIPTION
## Description

- moved reusable functions to core web.
- Used `hashCode` for queries to ensure we target the correct `unsubscribe()` function. See example key: `flutterfire-[DEFAULT]_10335377_querySnapshot`.
- Tested on Firestore example, queries now only fire once after "hot restart".

## Related Issues

Related to: #7064 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
