### PR TITLE
fix(database, web): clean up stream handlers on "hot restart"

### DIFF
--- a/packages/firebase_database/firebase_database_web/lib/firebase_database_web.dart
+++ b/packages/firebase_database/firebase_database_web/lib/firebase_database_web.dart
@@ -6,12 +6,13 @@ library firebase_database_web;
 
 import 'dart:async';
 import 'dart:js_interop';
-
+import 'package:collection/collection.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_web/firebase_core_web.dart';
 import 'package:firebase_core_web/firebase_core_web_interop.dart'
     as core_interop;
 import 'package:firebase_database_platform_interface/firebase_database_platform_interface.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
 import 'src/interop/database.dart' as database_interop;

--- a/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
@@ -418,10 +418,8 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
       database_interop.DataSnapshotJsImpl data, [
       String? prevChild,
     ]) {
-      if (!streamController.isClosed) {
-        streamController
-            .add(QueryEvent(DataSnapshot.getInstance(data), prevChild));
-      }
+      streamController
+          .add(QueryEvent(DataSnapshot.getInstance(data), prevChild));
     });
 
     final void Function(JSObject) cancelCallbackWrap = ((JSObject error) {

--- a/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
@@ -472,6 +472,7 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
 
     void stopListen() {
       onUnsubscribe.callAsFunction();
+      streamController.close();
       removeWindowsListener(_streamWindowsKey(
         appName,
         eventType,

--- a/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
@@ -444,7 +444,6 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
         );
       }
       if (eventType == 'child_removed') {
-        //change callback, only snap
         onUnsubscribe = database_interop.onChildRemoved(
           jsObject,
           callbackWrap.toJS,

--- a/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
@@ -226,7 +226,6 @@ class DatabaseReference<T extends database_interop.ReferenceJsImpl>
 ///       DataSnapshot dataSnapshot = e.snapshot;
 ///       //...
 ///     });
-// TODO maybe it is the wrong one?
 class QueryEvent {
   /// Immutable copy of the data at a database location.
   final DataSnapshot snapshot;

--- a/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
@@ -226,6 +226,7 @@ class DatabaseReference<T extends database_interop.ReferenceJsImpl>
 ///       DataSnapshot dataSnapshot = e.snapshot;
 ///       //...
 ///     });
+// TODO maybe it is the wrong one?
 class QueryEvent {
   /// Immutable copy of the data at a database location.
   final DataSnapshot snapshot;
@@ -251,47 +252,64 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
   /// DatabaseReference to the Query's location.
   DatabaseReference get ref => DatabaseReference.getInstance(jsObject.ref);
 
-  Stream<QueryEvent> _onValue(int hashCode) => _createStream('value', hashCode);
+  Stream<QueryEvent> _onValue(String appName, int hashCode) => _createStream(
+        'value',
+        appName,
+        hashCode,
+      );
 
   /// Stream for a value event. Event is triggered once with the initial
   /// data stored at location, and then again each time the data changes.
-  Stream<QueryEvent> onValue(int hashCode) => _onValue(hashCode);
+  Stream<QueryEvent> onValue(String appName, int hashCode) =>
+      _onValue(appName, hashCode);
 
-  Stream<QueryEvent> _onChildAdded(int hashCode) => _createStream(
+  Stream<QueryEvent> _onChildAdded(String appName, int hashCode) =>
+      _createStream(
         'child_added',
+        appName,
         hashCode,
       );
 
   /// Stream for a child_added event. Event is triggered once for each
   /// initial child at location, and then again every time a new child is added.
-  Stream<QueryEvent> onChildAdded(int hashCode) => _onChildAdded(hashCode);
+  Stream<QueryEvent> onChildAdded(String appName, int hashCode) =>
+      _onChildAdded(appName, hashCode);
 
-  Stream<QueryEvent> _onChildRemoved(int hashCode) => _createStream(
+  Stream<QueryEvent> _onChildRemoved(String appName, int hashCode) =>
+      _createStream(
         'child_removed',
+        appName,
         hashCode,
       );
 
   /// Stream for a child_removed event. Event is triggered once every time
   /// a child is removed.
-  Stream<QueryEvent> onChildRemoved(int hashCode) => _onChildRemoved(hashCode);
+  Stream<QueryEvent> onChildRemoved(String appName, int hashCode) =>
+      _onChildRemoved(appName, hashCode);
 
-  Stream<QueryEvent> _onChildChanged(int hashCode) => _createStream(
+  Stream<QueryEvent> _onChildChanged(String appName, int hashCode) =>
+      _createStream(
         'child_changed',
+        appName,
         hashCode,
       );
 
   /// Stream for a child_changed event. Event is triggered when the data
   /// stored in a child (or any of its descendants) changes.
   /// Single child_changed event may represent multiple changes to the child.
-  Stream<QueryEvent> onChildChanged(int hashCode) => _onChildChanged(hashCode);
-  Stream<QueryEvent> _onChildMoved(int hashCode) => _createStream(
+  Stream<QueryEvent> onChildChanged(String appName, int hashCode) =>
+      _onChildChanged(appName, hashCode);
+  Stream<QueryEvent> _onChildMoved(String appName, int hashCode) =>
+      _createStream(
         'child_moved',
+        appName,
         hashCode,
       );
 
   /// Stream for a child_moved event. Event is triggered when a child's priority
   /// changes such that its position relative to its siblings changes.
-  Stream<QueryEvent> onChildMoved(int hashCode) => _onChildMoved(hashCode);
+  Stream<QueryEvent> onChildMoved(String appName, int hashCode) =>
+      _onChildMoved(appName, hashCode);
 
   /// Creates a new Query from a [jsObject].
   Query.fromJsObject(T jsObject) : super.fromJsObject(jsObject);
@@ -386,73 +404,89 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
       ),
     );
   }
-  // TODO - get appName
-  String _streamWindowsKey(String eventType, int hashCode) =>
-      'flutterfire-${eventType}_${hashCode}_documentSnapshot';
 
-  Stream<QueryEvent> _createStream(String eventType, int hashCode) {
+  String _streamWindowsKey(String appName, String eventType, int hashCode) =>
+      'flutterfire-${appName}_${eventType}_${hashCode}_snapshot';
+
+  Stream<QueryEvent> _createStream(
+    String eventType,
+    String appName,
+    int hashCode,
+  ) {
     late StreamController<QueryEvent> streamController;
-    unsubscribeWindowsListener(_streamWindowsKey(eventType, hashCode));
+    unsubscribeWindowsListener(_streamWindowsKey(appName, eventType, hashCode));
     final callbackWrap = ((
       database_interop.DataSnapshotJsImpl data, [
-      String? string,
+      String? prevChild,
     ]) {
-      streamController.add(QueryEvent(DataSnapshot.getInstance(data), string));
+      if (!streamController.isClosed) {
+        streamController
+            .add(QueryEvent(DataSnapshot.getInstance(data), prevChild));
+      }
     });
 
     final void Function(JSObject) cancelCallbackWrap = ((JSObject error) {
       streamController.addError(convertFirebaseDatabaseException(error));
-      streamController.close();
     });
 
+    late JSFunction onUnsubscribe;
+
     void startListen() {
-      var unsubscribe;
       if (eventType == 'child_added') {
-        unsubscribe = database_interop.onChildAdded(
+        onUnsubscribe = database_interop.onChildAdded(
           jsObject,
           callbackWrap.toJS,
           cancelCallbackWrap.toJS,
         );
       }
       if (eventType == 'value') {
-        unsubscribe = database_interop.onValue(
+        onUnsubscribe = database_interop.onValue(
           jsObject,
           callbackWrap.toJS,
           cancelCallbackWrap.toJS,
         );
       }
       if (eventType == 'child_removed') {
-        unsubscribe = database_interop.onChildRemoved(
+        //change callback, only snap
+        onUnsubscribe = database_interop.onChildRemoved(
           jsObject,
           callbackWrap.toJS,
           cancelCallbackWrap.toJS,
         );
       }
       if (eventType == 'child_changed') {
-        unsubscribe = database_interop.onChildChanged(
+        onUnsubscribe = database_interop.onChildChanged(
           jsObject,
           callbackWrap.toJS,
           cancelCallbackWrap.toJS,
         );
       }
       if (eventType == 'child_moved') {
-        unsubscribe = database_interop.onChildMoved(
+        onUnsubscribe = database_interop.onChildMoved(
           jsObject,
           callbackWrap.toJS,
           cancelCallbackWrap.toJS,
         );
       }
-      setWindowsListener(_streamWindowsKey(eventType, hashCode), unsubscribe);
+      setWindowsListener(
+        _streamWindowsKey(appName, eventType, hashCode),
+        onUnsubscribe,
+      );
     }
 
     void stopListen() {
-      database_interop.off(jsObject, eventType.toJS, callbackWrap.toJS);
-      removeWindowsListener(_streamWindowsKey(eventType, hashCode));
+      onUnsubscribe.callAsFunction();
+      removeWindowsListener(_streamWindowsKey(
+        appName,
+        eventType,
+        hashCode,
+      ));
     }
 
     streamController = StreamController<QueryEvent>.broadcast(
       onListen: startListen,
       onCancel: stopListen,
+      sync: true,
     );
     return streamController.stream;
   }
@@ -463,8 +497,8 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
 
     database_interop.onValue(
       jsObject,
-      ((database_interop.DataSnapshotJsImpl snapshot, [String? string]) {
-        c.complete(QueryEvent(DataSnapshot.getInstance(snapshot), string));
+      ((database_interop.DataSnapshotJsImpl snapshot, [String? prevChild]) {
+        c.complete(QueryEvent(DataSnapshot.getInstance(snapshot), prevChild));
       }).toJS,
       ((JSAny error) {
         c.completeError(convertFirebaseDatabaseException(error));

--- a/packages/firebase_database/firebase_database_web/lib/src/interop/database_interop.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/interop/database_interop.dart
@@ -79,7 +79,7 @@ external void off([
 
 @JS()
 @staticInterop
-external QueryConstraintJsImpl onChildAdded(
+external JSFunction onChildAdded(
   QueryJsImpl query,
   JSFunction callback,
   // JSAny Function(DataSnapshotJsImpl, [JSString previousChildName]) callback,
@@ -89,7 +89,7 @@ external QueryConstraintJsImpl onChildAdded(
 
 @JS()
 @staticInterop
-external QueryConstraintJsImpl onChildChanged(
+external JSFunction onChildChanged(
   QueryJsImpl query,
   JSFunction callback,
   // JSAny Function(DataSnapshotJsImpl, [JSString previousChildName]) callback,
@@ -99,7 +99,7 @@ external QueryConstraintJsImpl onChildChanged(
 
 @JS()
 @staticInterop
-external QueryConstraintJsImpl onChildMoved(
+external JSFunction onChildMoved(
   QueryJsImpl query,
   JSFunction callback,
   // JSAny Function(DataSnapshotJsImpl, [JSString previousChildName]) callback,
@@ -109,7 +109,7 @@ external QueryConstraintJsImpl onChildMoved(
 
 @JS()
 @staticInterop
-external QueryConstraintJsImpl onChildRemoved(
+external JSFunction onChildRemoved(
   QueryJsImpl query,
   JSFunction callback,
   // JSAny Function(DataSnapshotJsImpl, [JSString previousChildName]) callback,
@@ -123,7 +123,7 @@ external OnDisconnectJsImpl onDisconnect(ReferenceJsImpl ref);
 
 @JS()
 @staticInterop
-external void onValue(
+external JSFunction onValue(
     QueryJsImpl query,
     JSFunction callback,
     // JSAny Function(DataSnapshotJsImpl, [JSString previousChildName]) callback,

--- a/packages/firebase_database/firebase_database_web/lib/src/interop/database_interop.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/interop/database_interop.dart
@@ -115,8 +115,14 @@ external OnDisconnectJsImpl onDisconnect(ReferenceJsImpl ref);
 @JS()
 @staticInterop
 external JSFunction onValue(
-    QueryJsImpl query, JSFunction callback, JSFunction cancelCallback,
-    [ListenOptions options]);
+  QueryJsImpl query,
+  JSFunction callback,
+  // JSAny Function(DataSnapshotJsImpl, [JSString previousChildName]) callback,
+  JSFunction cancelCallback,
+  // JSAny Function(FirebaseError error) cancelCallback,
+  [
+  ListenOptions options,
+]);
 
 @JS()
 @staticInterop

--- a/packages/firebase_database/firebase_database_web/lib/src/interop/database_interop.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/interop/database_interop.dart
@@ -70,15 +70,6 @@ external JSAny increment(JSNumber delta);
 
 @JS()
 @staticInterop
-external void off([
-  QueryJsImpl query,
-  JSString eventType,
-  JSFunction callback,
-  /*JSAny Function(DataSnapshotJsImpl, [JSString previousChildName]) callback*/
-]);
-
-@JS()
-@staticInterop
 external JSFunction onChildAdded(
   QueryJsImpl query,
   JSFunction callback,
@@ -124,11 +115,7 @@ external OnDisconnectJsImpl onDisconnect(ReferenceJsImpl ref);
 @JS()
 @staticInterop
 external JSFunction onValue(
-    QueryJsImpl query,
-    JSFunction callback,
-    // JSAny Function(DataSnapshotJsImpl, [JSString previousChildName]) callback,
-    JSFunction cancelCallback,
-    // JSAny Function(FirebaseError error) cancelCallback,
+    QueryJsImpl query, JSFunction callback, JSFunction cancelCallback,
     [ListenOptions options]);
 
 @JS()

--- a/packages/firebase_database/firebase_database_web/lib/src/query_web.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/query_web.dart
@@ -94,29 +94,41 @@ class QueryWeb extends QueryPlatform {
       QueryModifiers modifiers, DatabaseEventType eventType) {
     database_interop.Query instance = _getQueryDelegateInstance(modifiers);
 
+    final hashCode = Object.hash(
+      runtimeType,
+      database,
+      path,
+      instance,
+      eventType,
+      modifiers,
+    );
+
     switch (eventType) {
       case DatabaseEventType.childAdded:
         return _webStreamToPlatformStream(
           eventType,
-          instance.onChildAdded,
+          instance.onChildAdded(hashCode),
         );
       case DatabaseEventType.childChanged:
         return _webStreamToPlatformStream(
           eventType,
-          instance.onChildChanged,
+          instance.onChildChanged(hashCode),
         );
       case DatabaseEventType.childMoved:
         return _webStreamToPlatformStream(
           eventType,
-          instance.onChildMoved,
+          instance.onChildMoved(hashCode),
         );
       case DatabaseEventType.childRemoved:
         return _webStreamToPlatformStream(
           eventType,
-          instance.onChildRemoved,
+          instance.onChildRemoved(hashCode),
         );
       case DatabaseEventType.value:
-        return _webStreamToPlatformStream(eventType, instance.onValue);
+        return _webStreamToPlatformStream(
+          eventType,
+          instance.onValue(hashCode),
+        );
       default:
         throw Exception("Invalid event type: $eventType");
     }

--- a/packages/firebase_database/firebase_database_web/lib/src/query_web.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/query_web.dart
@@ -94,40 +94,63 @@ class QueryWeb extends QueryPlatform {
       QueryModifiers modifiers, DatabaseEventType eventType) {
     database_interop.Query instance = _getQueryDelegateInstance(modifiers);
 
-    final hashCode = Object.hash(
-      runtimeType,
-      database,
-      path,
-      instance,
-      eventType,
-      modifiers,
-    );
+    int hashCode = 0;
+    final appName =
+        _database.app != null ? _database.app!.name : Firebase.app().name;
+    if (kDebugMode) {
+      // Purely for unsubscribing purposes in debug mode on "hot restart"
+      // if not running in debug mode, hashCode won't be used
+      hashCode = Object.hashAll([
+        appName,
+        path,
+        ...modifiers
+            .toList()
+            .map((e) => const DeepCollectionEquality().hash(e))
+            .toList(),
+        eventType.index,
+      ]);
+    }
 
     switch (eventType) {
       case DatabaseEventType.childAdded:
         return _webStreamToPlatformStream(
           eventType,
-          instance.onChildAdded(hashCode),
+          instance.onChildAdded(
+            appName,
+            hashCode,
+          ),
         );
       case DatabaseEventType.childChanged:
         return _webStreamToPlatformStream(
           eventType,
-          instance.onChildChanged(hashCode),
+          instance.onChildChanged(
+            appName,
+            hashCode,
+          ),
         );
       case DatabaseEventType.childMoved:
         return _webStreamToPlatformStream(
           eventType,
-          instance.onChildMoved(hashCode),
+          instance.onChildMoved(
+            appName,
+            hashCode,
+          ),
         );
       case DatabaseEventType.childRemoved:
         return _webStreamToPlatformStream(
           eventType,
-          instance.onChildRemoved(hashCode),
+          instance.onChildRemoved(
+            appName,
+            hashCode,
+          ),
         );
       case DatabaseEventType.value:
         return _webStreamToPlatformStream(
           eventType,
-          instance.onValue(hashCode),
+          instance.onValue(
+            appName,
+            hashCode,
+          ),
         );
       default:
         throw Exception("Invalid event type: $eventType");

--- a/packages/firebase_database/firebase_database_web/pubspec.yaml
+++ b/packages/firebase_database/firebase_database_web/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: '>=3.3.0'
 
 dependencies:
+  collection: ^1.18.0
   firebase_core: ^3.0.0
   firebase_core_web: ^2.17.1
   firebase_database_platform_interface: ^0.2.5+36


### PR DESCRIPTION
## Description

- Created a hash so each stream has a unique key, wrapped it in `kDebugMode` so it is only used in this mode, `hashCode` isn't used otherwise.
- Updated type returns in database interop layer as the stream handlers return an unsubscribe function and it is the recommended way to close event handlers.
- Now able to hot restart and streams will not throw exception and they will also only fire once.

## Related Issues

related to: https://github.com/firebase/flutterfire/issues/7064

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
