### PR TITLE
fix(auth, ios): fix the parsing of an error that could specifically happen when using MicrosoftProvider

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -595,7 +595,24 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
                             underlyingError.userInfo[@"FIRAuthErrorUserInfoDes"
                                                      @"erializedResponseKey"];
 
-                        if (firebaseDictionary != nil && firebaseDictionary[@"message"] != nil) {
+                        if (firebaseDictionary == nil &&
+                            userInfo[@"FIRAuthErrorUserInfoNameKey"] != nil) {
+                          // Removing since it's not parsed and causing issue when sending back the
+                          // object to Flutter
+                          NSMutableDictionary *mutableUserInfo = [userInfo mutableCopy];
+                          [mutableUserInfo
+                              removeObjectForKey:@"FIRAuthErrorUserInfoUpdatedCredentialKey"];
+                          NSError *modifiedError = [NSError errorWithDomain:error.domain
+                                                                       code:error.code
+                                                                   userInfo:mutableUserInfo];
+
+                          completion(nil,
+                                     [FlutterError errorWithCode:@"sign-in-failed"
+                                                         message:userInfo[@"NSLocalizedDescription"]
+                                                         details:modifiedError.userInfo]);
+
+                        } else if (firebaseDictionary != nil &&
+                                   firebaseDictionary[@"message"] != nil) {
                           // error from firebase-ios-sdk is
                           // buried in underlying error.
                           completion(nil,


### PR DESCRIPTION

## Description

The issue reported in the ticket is in fact an error that is not properly parsed. The Credential contained in the Map is causing the MethodChannel to fail.

## Related Issues

closes #12554 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
