### PR TITLE
fix(storage, web): clean up stream handlers on "hot restart"

### DIFF
--- a/packages/firebase_storage/firebase_storage_web/lib/src/interop/storage.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/interop/storage.dart
@@ -343,8 +343,17 @@ class UploadTask extends JsObjectWrapper<storage_interop.UploadTaskJsImpl> {
   /// Returns [:true:] if it had an effect.
   bool cancel() => jsObject.cancel().toDart;
 
+  String _taskSnapshotWindowsKey(String appName, String bucket, String path) =>
+      'flutterfire-${appName}_${bucket}_${path}_storageTask';
+
   /// Stream for upload task state changed event.
-  Stream<UploadTaskSnapshot> get onStateChanged {
+  Stream<UploadTaskSnapshot> onStateChanged(
+    String appName,
+    String bucket,
+    String path,
+  ) {
+    final windowsKey = _taskSnapshotWindowsKey(appName, bucket, path);
+    unsubscribeWindowsListener(windowsKey);
     late StreamController<UploadTaskSnapshot> changeController;
     late JSFunction onStateChangedUnsubscribe;
 
@@ -367,11 +376,16 @@ class UploadTask extends JsObjectWrapper<storage_interop.UploadTaskJsImpl> {
         errorWrapper,
         onCompletion,
       );
+      setWindowsListener(
+        windowsKey,
+        onStateChangedUnsubscribe,
+      );
     }
 
     void stopListen() {
       onStateChangedUnsubscribe.callAsFunction();
       changeController.close();
+      removeWindowsListener(windowsKey);
     }
 
     changeController = StreamController<UploadTaskSnapshot>.broadcast(

--- a/packages/firebase_storage/firebase_storage_web/lib/src/task_web.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/task_web.dart
@@ -46,8 +46,13 @@ class TaskWeb extends TaskPlatform {
 
       // This stream converts the UploadTask Snapshots from JS to the plugins'
       // It can also throw a FirebaseError internally, so we handle it.
-      final onStateChangedStream =
-          _task.onStateChanged.map<TaskSnapshotPlatform>((snapshot) {
+      final onStateChangedStream = _task
+          .onStateChanged(
+        _reference.storage.app.name,
+        _reference.bucket,
+        _reference.fullPath,
+      )
+          .map<TaskSnapshotPlatform>((snapshot) {
         return fbUploadTaskSnapshotToTaskSnapshot(_reference, snapshot);
       });
 

--- a/packages/firebase_storage/firebase_storage_web/lib/src/task_web.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/task_web.dart
@@ -28,6 +28,8 @@ class TaskWeb extends TaskPlatform {
 
   final storage_interop.UploadTask _task;
 
+  Stream<TaskSnapshotPlatform>? _stream;
+
   /// Returns a [Stream] of [TaskSnapshot] events.
   ///
   /// If the task is canceled or fails, the stream will send an error event.
@@ -37,7 +39,7 @@ class TaskWeb extends TaskPlatform {
   /// wait for the stream to complete via [onComplete].
   @override
   Stream<TaskSnapshotPlatform> get snapshotEvents {
-    return guard(() {
+    _stream ??= guard(() {
       // The mobile version of the plugin pushes a "success" snapshot to the
       // onStateChanged stream, but the Firebase JS SDK does *not*.
       // We use a StreamGroup + Future.asStream to simulate that feature:
@@ -71,6 +73,8 @@ class TaskWeb extends TaskPlatform {
 
       return group.stream;
     });
+
+    return _stream!;
   }
 
   /// Returns a [Future] once the task has completed.
@@ -106,8 +110,7 @@ class TaskWeb extends TaskPlatform {
     final paused = _task.pause();
     // Wait until the snapshot is paused, then return the value of paused...
     return snapshotEvents
-        .takeWhile((snapshot) => snapshot.state != TaskState.paused)
-        .last
+        .firstWhere((snapshot) => snapshot.state == TaskState.paused)
         .then<bool>((_) => paused);
   }
 


### PR DESCRIPTION
## Description

1. [This commit](https://github.com/firebase/flutterfire/pull/12927/commits/12afd28616f47259fc01349497b8049843687e82) fixed an issue where stream was being recreated again (on `task.pause()` it was calling `snapshotEvents` again). Also fixed `task.pause()` so it paused when paused state came through. Also throwing exception.
2. Usual clean up on "hot restart" of stream handlers.

## Related Issues

closes: https://github.com/firebase/flutterfire/issues/7064

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
