### PR TITLE
fix(app-check, web): fixed broken `onTokenChanged` and ensured it is properly cleaned up. Streams are also cleaned up on "hot restart"

### DIFF
--- a/packages/firebase_app_check/firebase_app_check/example/web/index.html
+++ b/packages/firebase_app_check/firebase_app_check/example/web/index.html
@@ -33,6 +33,9 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
+  <script>
+    self.FIREBASE_APPCHECK_DEBUG_TOKEN = true;
+  </script>
   <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
@@ -132,7 +132,7 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
           _delegate!.idTokenChangedController?.close();
         },
       );
-      _delegate!.onTokenChanged().listen((event) {
+      _delegate!.onTokenChanged(app.name).listen((event) {
         _tokenChangesListeners[app.name]!.add(event.token.toDart);
       });
     }

--- a/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
@@ -20,6 +20,7 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
   static const recaptchaTypeV3 = 'recaptcha-v3';
   static const recaptchaTypeEnterprise = 'enterprise';
   static Map<String, StreamController<String?>> _tokenChangesListeners = {};
+
   /// Stub initializer to allow the [registerWith] to create an instance without
   /// registering the web delegates or listeners.
   FirebaseAppCheckWeb._()

--- a/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
@@ -19,9 +19,7 @@ import 'src/interop/app_check.dart' as app_check_interop;
 class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
   static const recaptchaTypeV3 = 'recaptcha-v3';
   static const recaptchaTypeEnterprise = 'enterprise';
-
   static Map<String, StreamController<String?>> _tokenChangesListeners = {};
-
   /// Stub initializer to allow the [registerWith] to create an instance without
   /// registering the web delegates or listeners.
   FirebaseAppCheckWeb._()
@@ -121,15 +119,23 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
     return convertWebExceptions<Future<void>>(() async {
       _webAppCheck ??= app_check_interop.getAppCheckInstance(
           core_interop.app(app.name), webProvider);
-      if (_tokenChangesListeners[app.name] == null) {
-        _tokenChangesListeners[app.name] =
-            StreamController<String?>.broadcast();
-
-        _delegate!.onTokenChanged().map((event) {
-          _tokenChangesListeners[app.name]!.add(event.token.toDart);
-        });
-      }
+      _initialiseStreamController();
     });
+  }
+
+  void _initialiseStreamController() {
+    if (_tokenChangesListeners[app.name] == null) {
+      _tokenChangesListeners[app.name] = StreamController<String?>.broadcast(
+        onCancel: () {
+          _tokenChangesListeners[app.name]!.close();
+          _tokenChangesListeners.remove(app.name);
+          _delegate!.idTokenChangedController?.close();
+        },
+      );
+      _delegate!.onTokenChanged().listen((event) {
+        _tokenChangesListeners[app.name]!.add(event.token.toDart);
+      });
+    }
   }
 
   @override
@@ -162,6 +168,9 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
 
   @override
   Stream<String?> get onTokenChange {
-    return _tokenChangesListeners[app.name]!.stream;
+    _initialiseStreamController();
+    return convertWebExceptions(
+      () => _tokenChangesListeners[app.name]!.stream,
+    );
   }
 }

--- a/packages/firebase_app_check/firebase_app_check_web/lib/src/interop/app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/src/interop/app_check.dart
@@ -70,6 +70,9 @@ class AppCheck extends JsObjectWrapper<app_check_interop.AppCheckJsImpl> {
   JSFunction? _idTokenChangedUnsubscribe;
 
   StreamController<app_check_interop.AppCheckTokenResult>?
+      get idTokenChangedController => _idTokenChangedController;
+
+  StreamController<app_check_interop.AppCheckTokenResult>?
       // ignore: close_sinks
       _idTokenChangedController;
 
@@ -83,7 +86,6 @@ class AppCheck extends JsObjectWrapper<app_check_interop.AppCheckJsImpl> {
           ((JSError e) => _idTokenChangedController!.addError(e)).toJS;
 
       void startListen() {
-        assert(_idTokenChangedUnsubscribe == null);
         _idTokenChangedUnsubscribe = app_check_interop.onTokenChanged(
           jsObject,
           nextWrapper,
@@ -94,6 +96,7 @@ class AppCheck extends JsObjectWrapper<app_check_interop.AppCheckJsImpl> {
       void stopListen() {
         _idTokenChangedUnsubscribe?.callAsFunction();
         _idTokenChangedUnsubscribe = null;
+        _idTokenChangedController = null;
       }
 
       _idTokenChangedController =

--- a/packages/firebase_app_check/firebase_app_check_web/lib/src/interop/app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/src/interop/app_check.dart
@@ -76,7 +76,11 @@ class AppCheck extends JsObjectWrapper<app_check_interop.AppCheckJsImpl> {
       // ignore: close_sinks
       _idTokenChangedController;
 
-  Stream<app_check_interop.AppCheckTokenResult> onTokenChanged() {
+  String _appCheckWindowsKey(String appName) =>
+      'flutterfire-${appName}_onTokenChanged';
+  Stream<app_check_interop.AppCheckTokenResult> onTokenChanged(String appName) {
+    final appCheckWindowsKey = _appCheckWindowsKey(appName);
+    unsubscribeWindowsListener(appCheckWindowsKey);
     if (_idTokenChangedController == null) {
       final nextWrapper = ((app_check_interop.AppCheckTokenResult result) {
         _idTokenChangedController!.add(result);
@@ -91,12 +95,14 @@ class AppCheck extends JsObjectWrapper<app_check_interop.AppCheckJsImpl> {
           nextWrapper,
           errorWrapper,
         );
+        setWindowsListener(appCheckWindowsKey, _idTokenChangedUnsubscribe!);
       }
 
       void stopListen() {
         _idTokenChangedUnsubscribe?.callAsFunction();
         _idTokenChangedUnsubscribe = null;
         _idTokenChangedController = null;
+        removeWindowsListener(appCheckWindowsKey);
       }
 
       _idTokenChangedController =


### PR DESCRIPTION
## Description

1. app check web `onTokenChanged` was broken. The stream was never listened ([it was just mapped](https://github.com/firebase/flutterfire/compare/app-check-7064?expand=1#diff-ced897c7c86bb9b2236d8676e1d80e16f3627802ef58545c1344676bdea434d8L128)) to which was [changed here to listen()](https://github.com/firebase/flutterfire/compare/app-check-7064?expand=1#diff-ced897c7c86bb9b2236d8676e1d80e16f3627802ef58545c1344676bdea434d8R135).
2. Properly cleaned up and initialised streams made [on this commit](https://github.com/firebase/flutterfire/commit/b485792c3e933078377c4ae0728515046ad01c3c).
3. Cleaned up streams on "hot restart" on [this commit](https://github.com/firebase/flutterfire/commit/8dd9ff516a5453966d88e42fa0490cbed77562dc).
4. Also [reinserted the debug token](https://github.com/firebase/flutterfire/compare/app-check-7064?expand=1#diff-7e1450232f8581088923cdd6999074d6f3cf4e31b9b83ec7322833d3b564fd25R37) for web on example app that was removed in the recent web folder clean up.

## Related Issues

related to: https://github.com/firebase/flutterfire/issues/7064

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
