### PR TITLE
docs(messaging, android): update inline documentation on behavior

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
@@ -87,6 +87,9 @@ class FirebaseMessaging extends FirebasePluginPlatform {
   /// This should be used to determine whether specific notification interaction
   /// should open the app with a specific purpose (e.g. opening a chat message,
   /// specific screen etc).
+  /// 
+  /// on Android, if the message was received in the foreground, and the notification was 
+  /// pressed whilst the app is in a background/terminated state, this will return `null`.
   Future<RemoteMessage?> getInitialMessage() {
     return _delegate.getInitialMessage();
   }

--- a/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
@@ -87,8 +87,8 @@ class FirebaseMessaging extends FirebasePluginPlatform {
   /// This should be used to determine whether specific notification interaction
   /// should open the app with a specific purpose (e.g. opening a chat message,
   /// specific screen etc).
-  /// 
-  /// on Android, if the message was received in the foreground, and the notification was 
+  ///
+  /// on Android, if the message was received in the foreground, and the notification was
   /// pressed whilst the app is in a background/terminated state, this will return `null`.
   Future<RemoteMessage?> getInitialMessage() {
     return _delegate.getInitialMessage();

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
@@ -141,6 +141,9 @@ abstract class FirebaseMessagingPlatform extends PlatformInterface {
   /// This should be used to determine whether specific notification interaction
   /// should open the app with a specific purpose (e.g. opening a chat message,
   /// specific screen etc).
+  /// 
+  /// on Android, if the message was received in the foreground, and the notification was 
+  /// pressed whilst the app is in a background/terminated state, this will return `null`.
   Future<RemoteMessage?> getInitialMessage() {
     throw UnimplementedError('getInitialMessage() is not implemented');
   }

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
@@ -141,8 +141,8 @@ abstract class FirebaseMessagingPlatform extends PlatformInterface {
   /// This should be used to determine whether specific notification interaction
   /// should open the app with a specific purpose (e.g. opening a chat message,
   /// specific screen etc).
-  /// 
-  /// on Android, if the message was received in the foreground, and the notification was 
+  ///
+  /// on Android, if the message was received in the foreground, and the notification was
   /// pressed whilst the app is in a background/terminated state, this will return `null`.
   Future<RemoteMessage?> getInitialMessage() {
     throw UnimplementedError('getInitialMessage() is not implemented');


### PR DESCRIPTION
## Description

I don't think there is any way around this problem. The intent passed on notification has no data to tie it to the message received.

## Related Issues

closes https://github.com/firebase/flutterfire/issues/12885

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
