### PR TITLE
fix(auth, apple): bug with cached `AuthCredential`, hash key was producing different value

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -193,9 +193,7 @@ static NSMutableDictionary<NSNumber *, FIRAuthCredential *> *credentialsMap;
     additionalData[kArgumentEmail] = [error userInfo][FIRAuthErrorUserInfoEmailKey];
   }
   // We want to store the credential if present for future sign in if the exception contains a
-  // credential
-  // Nullable token to pass back to Flutter to allow retreival of cached error.credential
-  // if the user wishes to use it to sign-in
+  // credential, we pass a token back to Flutter to allow retreival of the credential.
   NSNumber *token = [FLTFirebaseAuthPlugin storeAuthCredentialIfPresent:error];
 
   // additionalData.authCredential

--- a/packages/firebase_auth/firebase_auth/ios/Classes/PigeonParser.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/PigeonParser.m
@@ -15,7 +15,7 @@
             makeWithUser:[self getPigeonDetails:authResult.user]
       additionalUserInfo:[self getPigeonAdditionalUserInfo:authResult.additionalUserInfo
                                          authorizationCode:authorizationCode]
-              credential:[self getPigeonAuthCredential:authResult.credential]];
+              credential:[self getPigeonAuthCredential:authResult.credential token:nil]];
 }
 
 + (PigeonUserCredential *)getPigeonUserCredentialFromFIRUser:(nonnull FIRUser *)user {
@@ -88,7 +88,8 @@
                                              secretKey:secret.sharedSecretKey];
 }
 
-+ (PigeonAuthCredential *)getPigeonAuthCredential:(FIRAuthCredential *)authCredential {
++ (PigeonAuthCredential *)getPigeonAuthCredential:(FIRAuthCredential *)authCredential
+                                            token:(NSNumber *_Nullable)token {
   if (authCredential == nil) {
     return nil;
   }
@@ -103,9 +104,12 @@
     }
   }
 
+  NSUInteger nativeId =
+      token != nil ? [token unsignedLongValue] : (NSUInteger)[authCredential hash];
+
   return [PigeonAuthCredential makeWithProviderId:authCredential.provider
                                      signInMethod:authCredential.provider
-                                         nativeId:@([authCredential hash])
+                                         nativeId:nativeId
                                       accessToken:accessToken ?: nil];
 }
 

--- a/packages/firebase_auth/firebase_auth/ios/Classes/Private/PigeonParser.h
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/Private/PigeonParser.h
@@ -23,5 +23,6 @@
 + (PigeonIdTokenResult *_Nonnull)parseIdTokenResult:(nonnull FIRAuthTokenResult *)tokenResult;
 + (PigeonTotpSecret *_Nonnull)getPigeonTotpSecret:(nonnull FIRTOTPSecret *)secret;
 + (PigeonAuthCredential *_Nullable)getPigeonAuthCredential:
-    (FIRAuthCredential *_Nullable)authCredential;
+                                       (FIRAuthCredential *_Nullable)authCredentialToken
+                                                     token:(NSNumber *_Nullable)token;
 @end


### PR DESCRIPTION
## Description

Invoking this `@([authCredential hash])` produce two different hash keys which meant we were unable to retrieve from cache if the user `linkWithCredential()` threw exception "credential-already-in-use" containing a credential to sign-in with. 

This change ensures the same hash key is used to retrieve the exception in native code to allow `signInWithCredential()`.

Both users confirmed it is working.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/12931

fixes: https://github.com/firebase/flutterfire/issues/12944

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
