### PR TITLE
docs: Update documentation for auth/user-not-found exception to reflect email enumeration protection

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -318,7 +318,7 @@ class FirebaseAuth extends FirebasePluginPlatform {
   /// - **auth/unauthorized-continue-uri**\
   ///   The domain of the continue URL is not whitelisted. Whitelist the domain in the Firebase console.
   /// - **auth/user-not-found**\
-  ///   Thrown if there is no user corresponding to the email address.
+  ///   Thrown if there is no user corresponding to the email address. Note: This exception is no longer thrown due to email enumeration protection being enabled by default.
   Future<void> sendPasswordResetEmail({
     required String email,
     ActionCodeSettings? actionCodeSettings,

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -318,7 +318,7 @@ class FirebaseAuth extends FirebasePluginPlatform {
   /// - **auth/unauthorized-continue-uri**\
   ///   The domain of the continue URL is not whitelisted. Whitelist the domain in the Firebase console.
   /// - **auth/user-not-found**\
-  ///   Thrown if there is no user corresponding to the email address. Note: This exception is no longer thrown due to email enumeration protection being enabled by default.
+  ///   Thrown if there is no user corresponding to the email address. Note: This exception is no longer thrown when enabling email enumeration protection.
   Future<void> sendPasswordResetEmail({
     required String email,
     ActionCodeSettings? actionCodeSettings,


### PR DESCRIPTION
### Description
This pull request updates the documentation for the `auth/user-not-found` exception in the `firebase_auth.dart` file. The update reflects the recent change where email enumeration protection is enabled by default as of September 15, 2023. With this protection, the `auth/user-not-found` exception is no longer thrown if the account with the specified email does not exist.

**Changes made:**
- Updated the documentation to include a note about the email enumeration protection.
- Clarified the conditions under which the `auth/user-not-found` exception is thrown.

This change ensures that developers are aware of the new behavior and can handle authentication flows accordingly.