### PR TITLE
fix(firebase_dynamic_links): add conditional for dynamic links intent…

### DIFF
--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -109,6 +109,9 @@ public class FlutterFirebaseDynamicLinksPlugin
 
   @Override
   public boolean onNewIntent(@NonNull Intent intent) {
+    if (FirebaseApp.getApps(activity.get()).isEmpty()) {
+      return false;
+    }
     getDynamicLinkInstance(null)
         .getDynamicLink(intent)
         .addOnSuccessListener(


### PR DESCRIPTION


## Description

*When using firebase dynamic links and the app receives an intent through a notification action, firebase will handle this action even when it's not initialized, which is not logical behavior, any call to firebase dynamic links should consider the initialization of firebase so no exceptions happens, especially that this code is injected in the user's app and we have no control over it as developers*

## Related Issues

*There's no reported issue.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
