### PR TITLE
fix(database, web): ensure exact same streams are not unsubscribed in debug mode

### DIFF
--- a/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
@@ -250,7 +250,7 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
   /// DatabaseReference to the Query's location.
   DatabaseReference get ref => DatabaseReference.getInstance(jsObject.ref);
 
-  Stream<QueryEvent> _onValue(String appName, int hashCode) => _createStream(
+  Stream<QueryEvent> _onValue(String appName, String hashCode) => _createStream(
         'value',
         appName,
         hashCode,
@@ -258,10 +258,10 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
 
   /// Stream for a value event. Event is triggered once with the initial
   /// data stored at location, and then again each time the data changes.
-  Stream<QueryEvent> onValue(String appName, int hashCode) =>
+  Stream<QueryEvent> onValue(String appName, String hashCode) =>
       _onValue(appName, hashCode);
 
-  Stream<QueryEvent> _onChildAdded(String appName, int hashCode) =>
+  Stream<QueryEvent> _onChildAdded(String appName, String hashCode) =>
       _createStream(
         'child_added',
         appName,
@@ -270,10 +270,10 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
 
   /// Stream for a child_added event. Event is triggered once for each
   /// initial child at location, and then again every time a new child is added.
-  Stream<QueryEvent> onChildAdded(String appName, int hashCode) =>
+  Stream<QueryEvent> onChildAdded(String appName, String hashCode) =>
       _onChildAdded(appName, hashCode);
 
-  Stream<QueryEvent> _onChildRemoved(String appName, int hashCode) =>
+  Stream<QueryEvent> _onChildRemoved(String appName, String hashCode) =>
       _createStream(
         'child_removed',
         appName,
@@ -282,10 +282,10 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
 
   /// Stream for a child_removed event. Event is triggered once every time
   /// a child is removed.
-  Stream<QueryEvent> onChildRemoved(String appName, int hashCode) =>
+  Stream<QueryEvent> onChildRemoved(String appName, String hashCode) =>
       _onChildRemoved(appName, hashCode);
 
-  Stream<QueryEvent> _onChildChanged(String appName, int hashCode) =>
+  Stream<QueryEvent> _onChildChanged(String appName, String hashCode) =>
       _createStream(
         'child_changed',
         appName,
@@ -295,9 +295,9 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
   /// Stream for a child_changed event. Event is triggered when the data
   /// stored in a child (or any of its descendants) changes.
   /// Single child_changed event may represent multiple changes to the child.
-  Stream<QueryEvent> onChildChanged(String appName, int hashCode) =>
+  Stream<QueryEvent> onChildChanged(String appName, String hashCode) =>
       _onChildChanged(appName, hashCode);
-  Stream<QueryEvent> _onChildMoved(String appName, int hashCode) =>
+  Stream<QueryEvent> _onChildMoved(String appName, String hashCode) =>
       _createStream(
         'child_moved',
         appName,
@@ -306,7 +306,7 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
 
   /// Stream for a child_moved event. Event is triggered when a child's priority
   /// changes such that its position relative to its siblings changes.
-  Stream<QueryEvent> onChildMoved(String appName, int hashCode) =>
+  Stream<QueryEvent> onChildMoved(String appName, String hashCode) =>
       _onChildMoved(appName, hashCode);
 
   /// Creates a new Query from a [jsObject].
@@ -403,13 +403,13 @@ class Query<T extends database_interop.QueryJsImpl> extends JsObjectWrapper<T> {
     );
   }
 
-  String _streamWindowsKey(String appName, String eventType, int hashCode) =>
+  String _streamWindowsKey(String appName, String eventType, String hashCode) =>
       'flutterfire-${appName}_${eventType}_${hashCode}_snapshot';
 
   Stream<QueryEvent> _createStream(
     String eventType,
     String appName,
-    int hashCode,
+    String hashCode,
   ) {
     late StreamController<QueryEvent> streamController;
     unsubscribeWindowsListener(_streamWindowsKey(appName, eventType, hashCode));

--- a/packages/firebase_database/firebase_database_web/lib/src/query_web.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/query_web.dart
@@ -126,7 +126,7 @@ class QueryWeb extends QueryPlatform {
     database_interop.Query instance = _getQueryDelegateInstance(modifiers);
     final appName =
         _database.app != null ? _database.app!.name : Firebase.app().name;
-    
+
     // Purely for unsubscribing purposes in debug mode on "hot restart"
     // if not running in debug mode, hashCode won't be used
     String hashCode = _createHashCode(modifiers, eventType, appName);

--- a/packages/firebase_database/firebase_database_web/lib/src/query_web.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/query_web.dart
@@ -111,10 +111,11 @@ class QueryWeb extends QueryPlatform {
         int count = _streamHashCodeMap[hashCode] ?? 0;
         final updatedCount = count + 1;
         _streamHashCodeMap[hashCode] = updatedCount;
-        hashCode = hashCode + '-$updatedCount';
+        hashCode = '$hashCode-$updatedCount';
       } else {
+        // initial stream
         _streamHashCodeMap[hashCode] = 0;
-        hashCode = hashCode + '-0';
+        hashCode = '$hashCode-0';
       }
     }
     return hashCode;

--- a/packages/firebase_database/firebase_database_web/lib/src/query_web.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/query_web.dart
@@ -64,6 +64,8 @@ class QueryWeb extends QueryPlatform {
     return instance;
   }
 
+  final Map<String, int> _streamHashCodeMap = {};
+
   @override
   String get path {
     final refPath = Uri.parse(_queryDelegate.ref.toString()).path;
@@ -89,17 +91,13 @@ class QueryWeb extends QueryPlatform {
     throw UnsupportedError('keepSynced() is not supported on web');
   }
 
-  @override
-  Stream<DatabaseEventPlatform> observe(
-      QueryModifiers modifiers, DatabaseEventType eventType) {
-    database_interop.Query instance = _getQueryDelegateInstance(modifiers);
-
-    int hashCode = 0;
-    final appName =
-        _database.app != null ? _database.app!.name : Firebase.app().name;
+  String _createHashCode(
+    QueryModifiers modifiers,
+    DatabaseEventType eventType,
+    String appName,
+  ) {
+    String hashCode = '0';
     if (kDebugMode) {
-      // Purely for unsubscribing purposes in debug mode on "hot restart"
-      // if not running in debug mode, hashCode won't be used
       hashCode = Object.hashAll([
         appName,
         path,
@@ -107,8 +105,31 @@ class QueryWeb extends QueryPlatform {
             .toList()
             .map((e) => const DeepCollectionEquality().hash(e)),
         eventType.index,
-      ]);
+      ]).toString();
+      // Need to track as the same properties to create hash could be used multiple times
+      if (_streamHashCodeMap.containsKey(hashCode)) {
+        int count = _streamHashCodeMap[hashCode] ?? 0;
+        final updatedCount = count + 1;
+        _streamHashCodeMap[hashCode] = updatedCount;
+        hashCode = hashCode + '-$updatedCount';
+      } else {
+        _streamHashCodeMap[hashCode] = 0;
+        hashCode = hashCode + '-0';
+      }
     }
+    return hashCode;
+  }
+
+  @override
+  Stream<DatabaseEventPlatform> observe(
+      QueryModifiers modifiers, DatabaseEventType eventType) {
+    database_interop.Query instance = _getQueryDelegateInstance(modifiers);
+    final appName =
+        _database.app != null ? _database.app!.name : Firebase.app().name;
+    
+    // Purely for unsubscribing purposes in debug mode on "hot restart"
+    // if not running in debug mode, hashCode won't be used
+    String hashCode = _createHashCode(modifiers, eventType, appName);
 
     switch (eventType) {
       case DatabaseEventType.childAdded:


### PR DESCRIPTION
## Description

If exact same stream is created (i.e same hashCode generated from parameters), it will unsubscribe in debug mode.

I've created a map used in debug mode to track the count of the exact same stream and appended the count to the hashCode to ensure they are subscribed/unsubscribed separately.

Here is the user's code I used in example app:
```dart
ref.onValue.listen((data) {
                print('got them 1');
              }, onError: (e) => print('error: ${e}'), onDone: () => print('done'));
              ref.onValue.listen((data) {
                print('got them 2');
              }, onError: (e) => print('error ${e}'), onDone: () => print('done'));
              ref.onValue.listen((data) {
                print('got them 3');
              }, onError: (e) => print('error ${e}'), onDone: () => print('done'));
```

Here are console logs showing they all get the event as it was previously.
<img width="256" alt="Screenshot 2024-07-02 at 13 18 02" src="https://github.com/firebase/flutterfire/assets/16018629/7be15c6c-702d-475f-84d4-13f27366965f">


Here is a screenshot to show 3 hot restarts, after the third hot restart I updated the reference data in the Firebase console which is why there is an additional set of logs. This proves that they are still being cleaned up as expected on hot restarts otherwise we would expect an additional 9 set of logs instead of 3:
<img width="611" alt="Screenshot 2024-07-02 at 13 39 50" src="https://github.com/firebase/flutterfire/assets/16018629/4da0a9e5-b871-4205-b254-ec279b42428c">


## Related Issues

fixes https://github.com/firebase/flutterfire/issues/13003

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
