### PR TITLE
fix(firestore, web): ensure exact same streams are not unsubscribed

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -100,11 +100,24 @@ class Firestore extends JsObjectWrapper<firestore_interop.FirestoreJsImpl> {
         firestore_interop.enableIndexedDbPersistence(jsObject).toDart;
   }
 
-  String get _snapshotInSyncWindowsKey =>
-      'flutterfire-${app.name}_snapshotInSync';
+// purely for debug mode and tracking listeners to clean up on "hot restart"
+  final Map<String, int> _snapshotInSyncListeners = {};
+  String _snapshotInSyncWindowsKey() {
+    if (kDebugMode) {
+      final key = 'flutterfire-${app.name}_snapshotInSync';
+      if (_snapshotInSyncListeners.containsKey(key)) {
+        _snapshotInSyncListeners[key] = _snapshotInSyncListeners[key]! + 1;
+      } else {
+        _snapshotInSyncListeners[key] = 0;
+      }
+      return '$key-${_snapshotInSyncListeners[key]}';
+    }
+    return 'no-op';
+  }
 
   Stream<void> snapshotsInSync() {
-    unsubscribeWindowsListener(_snapshotInSyncWindowsKey);
+    final snapshotKey = _snapshotInSyncWindowsKey();
+    unsubscribeWindowsListener(snapshotKey);
     late StreamController<void> controller;
     late JSFunction onSnapshotsInSyncUnsubscribe;
     var nextWrapper = ((JSObject? noValue) {
@@ -115,7 +128,7 @@ class Firestore extends JsObjectWrapper<firestore_interop.FirestoreJsImpl> {
       onSnapshotsInSyncUnsubscribe =
           firestore_interop.onSnapshotsInSync(jsObject, nextWrapper);
       setWindowsListener(
-        _snapshotInSyncWindowsKey,
+        snapshotKey,
         onSnapshotsInSyncUnsubscribe,
       );
     }
@@ -123,7 +136,7 @@ class Firestore extends JsObjectWrapper<firestore_interop.FirestoreJsImpl> {
     void stopListen() {
       onSnapshotsInSyncUnsubscribe.callAsFunction();
       controller.close();
-      removeWindowsListener(_snapshotInSyncWindowsKey);
+      removeWindowsListener(snapshotKey);
     }
 
     controller = StreamController<void>.broadcast(
@@ -373,8 +386,21 @@ class DocumentReference
         (result)! as firestore_interop.DocumentSnapshotJsImpl);
   }
 
-  String get _documentSnapshotWindowsKey =>
-      'flutterfire-${firestore.app.name}_${path}_documentSnapshot';
+  // purely for debug mode and tracking listeners to clean up on "hot restart"
+  final Map<String, int> _docListeners = {};
+  String _documentSnapshotWindowsKey() {
+    if (kDebugMode) {
+      final key = 'flutterfire-${firestore.app.name}_${path}_documentSnapshot';
+      if (_docListeners.containsKey(key)) {
+        _docListeners[key] = _docListeners[key]! + 1;
+      } else {
+        _docListeners[key] = 0;
+      }
+      print('DDD: $key-${_docListeners[key]}');
+      return '$key-${_docListeners[key]}';
+    }
+    return 'no-op';
+  }
 
   /// Attaches a listener for [DocumentSnapshot] events.
   Stream<DocumentSnapshot> onSnapshot({
@@ -391,7 +417,8 @@ class DocumentReference
   StreamController<DocumentSnapshot> _createSnapshotStream([
     firestore_interop.DocumentListenOptions? options,
   ]) {
-    unsubscribeWindowsListener(_documentSnapshotWindowsKey);
+    final documentKey = _documentSnapshotWindowsKey();
+    unsubscribeWindowsListener(documentKey);
     late JSFunction onSnapshotUnsubscribe;
     // ignore: close_sinks, the controller is returned
     late StreamController<DocumentSnapshot> controller;
@@ -408,12 +435,12 @@ class DocumentReference
               jsObject as JSObject, options as JSAny, nextWrapper, errorWrapper)
           : firestore_interop.onSnapshot(
               jsObject as JSObject, nextWrapper, errorWrapper);
-      setWindowsListener(_documentSnapshotWindowsKey, onSnapshotUnsubscribe);
+      setWindowsListener(documentKey, onSnapshotUnsubscribe);
     }
 
     void stopListen() {
       onSnapshotUnsubscribe.callAsFunction();
-      removeWindowsListener(_documentSnapshotWindowsKey);
+      removeWindowsListener(documentKey);
     }
 
     return controller = StreamController<DocumentSnapshot>.broadcast(
@@ -486,8 +513,20 @@ class Query<T extends firestore_interop.QueryJsImpl>
   Query limitToLast(num limit) => Query.fromJsObject(firestore_interop.query(
       jsObject, firestore_interop.limitToLast(limit.toJS)));
 
-  String _querySnapshotWindowsKey(hashCode) =>
-      'flutterfire-${firestore.app.name}_${hashCode}_querySnapshot';
+  // purely for debug mode and tracking listeners to clean up on "hot restart"
+  final Map<String, int> _snapshotListeners = {};
+  String _querySnapshotWindowsKey(hashCode) {
+    if (kDebugMode) {
+      final key = 'flutterfire-${firestore.app.name}_${hashCode}_querySnapshot';
+      if (_snapshotListeners.containsKey(key)) {
+        _snapshotListeners[key] = _snapshotListeners[key]! + 1;
+      } else {
+        _snapshotListeners[key] = 0;
+      }
+      return '$key-${_snapshotListeners[key]}';
+    }
+    return 'no-op';
+  }
 
   Stream<QuerySnapshot> onSnapshot(
           {bool includeMetadataChanges = false,
@@ -505,7 +544,8 @@ class Query<T extends firestore_interop.QueryJsImpl>
     firestore_interop.DocumentListenOptions options,
     int hashCode,
   ) {
-    unsubscribeWindowsListener(_querySnapshotWindowsKey(hashCode));
+    final snapshotKey = _querySnapshotWindowsKey(hashCode);
+    unsubscribeWindowsListener(snapshotKey);
     late JSFunction onSnapshotUnsubscribe;
     // ignore: close_sinks, the controller is returned
     late StreamController<QuerySnapshot> controller;
@@ -519,12 +559,14 @@ class Query<T extends firestore_interop.QueryJsImpl>
       onSnapshotUnsubscribe = firestore_interop.onSnapshot(
           jsObject as JSObject, options as JSObject, nextWrapper, errorWrapper);
       setWindowsListener(
-          _querySnapshotWindowsKey(hashCode), onSnapshotUnsubscribe);
+        snapshotKey,
+        onSnapshotUnsubscribe,
+      );
     }
 
     void stopListen() {
       onSnapshotUnsubscribe.callAsFunction();
-      removeWindowsListener(_querySnapshotWindowsKey(hashCode));
+      removeWindowsListener(snapshotKey);
     }
 
     return controller = StreamController<QuerySnapshot>.broadcast(

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -396,7 +396,6 @@ class DocumentReference
       } else {
         _docListeners[key] = 0;
       }
-      print('DDD: $key-${_docListeners[key]}');
       return '$key-${_docListeners[key]}';
     }
     return 'no-op';


### PR DESCRIPTION
## Description

I created a button to attach three listeners to a document ref:

```dart
ElevatedButton(
  onPressed: () async {
    final collection = FirebaseFirestore.instance
        .collection('flutter-tests')
        .doc('blah');

    collection.snapshots().listen((data) {
      print('Data: ${data.data()}');
    });
    collection.snapshots().listen((data) {
      print('Data: ${data.data()}');
    });
    collection.snapshots().listen((data) {
      print('Data: ${data.data()}');
    });
  },
  child: const Text('Create Listeners'),
),
```

Here are the logs. The following proves the fix: 
- On initial start up, I created listeners which correctly printed the data 3 times.
- "hot restart" 3 times and created listeners again. Correctly printed the data 3 times.
- "hot restart" 1 more time and created listeners again. Correctly printed the data 3 times.
- Updated the data on Firebase console by removing the property "ed". Correctly printed the data 3 times to prove their are no duplicate listeners.
```
The Flutter DevTools debugger and profiler on Chrome is available at: http://127.0.0.1:9101?uri=http://127.0.0.1:53058/tqTueP2OMDk=
Data: {foo: bar, ed: YYYYY}
Data: {foo: bar, ed: YYYYY}
Data: {foo: bar, ed: YYYYY}

Performing hot restart...                                           83ms
Restarted application in 83ms.

Performing hot restart...                                           39ms
Restarted application in 39ms.

Performing hot restart...                                           44ms
Restarted application in 44ms.
Data: {foo: bar, ed: YYYYY}
Data: {foo: bar, ed: YYYYY}
Data: {foo: bar, ed: YYYYY}

Performing hot restart...                                           49ms
Restarted application in 49ms.
Data: {foo: bar, ed: YYYYY}
Data: {foo: bar, ed: YYYYY}
Data: {foo: bar, ed: YYYYY}
Data: {foo: bar}
Data: {foo: bar}
Data: {foo: bar}
```

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/13019

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
