### PR TITLE
chore: update flutter_facebook_auth to 7.0.1

### DIFF
--- a/packages/firebase_auth/firebase_auth/example/lib/auth.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/auth.dart
@@ -573,7 +573,7 @@ class _AuthGateState extends State<AuthGate> {
 
       // Login with token
       await auth.signInWithCredential(
-        FacebookAuthProvider.credential(accessToken.token),
+        FacebookAuthProvider.credential(accessToken.tokenString),
       );
     } else {
       print('Facebook login did not succeed');

--- a/packages/firebase_auth/firebase_auth/example/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   firebase_messaging: ^15.0.3
   flutter:
     sdk: flutter
-  flutter_facebook_auth: ^6.0.0
+  flutter_facebook_auth: ^7.0.1
   flutter_signin_button: ^2.0.0
   google_sign_in: ^6.1.0
   google_sign_in_dartio: ^0.3.0


### PR DESCRIPTION
## Description

Updates the flutter_facebook_auth to 7.0.1 for the firebase_auth example.

`token` had to be changed to `tokenString` in order to compile auth.dart for this update, otherwise you'll get the error below when building the example app.
```bash
Failed to build iOS app
Error (Xcode): lib/auth.dart:576:53: Error: The getter 'token' isn't defined for the class 'AccessToken'.


Encountered error while building for device.
```

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
