### PR TITLE
docs(auth): Correct  documentation for Authorized Domains location in Firebase Console

### DIFF
--- a/docs/auth/email-link-auth.md
+++ b/docs/auth/email-link-auth.md
@@ -50,7 +50,7 @@ To initiate the authentication flow, present an interface that prompts the user 
 
 1.  Construct the ActionCodeSettings object, which provides Firebase with instructions on how to construct the email link. Set the following fields:
 
-    * `url`: The deep link to embed and any additional state to be passed along. The link's domain has to be whitelisted in the Firebase Console list of authorized domains, which can be found by going to the Sign-in method tab (Authentication -> Sign-in method). The link will redirect the user to this URL if the app is not installed on their device and the app was not able to be installed.
+    * `url`: The deep link to embed and any additional state to be passed along. The link's domain has to be whitelisted in the Firebase Console list of authorized domains, which can be found by going to the Settings tab (Authentication -> Settings -> Authorized Domains). The link will redirect the user to this URL if the app is not installed on their device and the app was not able to be installed.
 
     * `androidPackageName` and `IOSBundleId`: The apps to use when the sign-in link is opened on an Android or iOS device. Learn more on how to configure Firebase Dynamic Links to open email action links via mobile apps.
 


### PR DESCRIPTION
Documentation Error regarding the location of the Authorized Domains.
Sign-in method tab (Authentication -> Sign-in method). 
but the right location is
![image](https://github.com/user-attachments/assets/342781b0-1817-49b4-bc8d-ff5d36661be0)

Settings tab (Authentication -> Settings -> Authorized Domains).

## Description

*This PR addresses a documentation error regarding the location of the Authorized Domains settings in the Firebase Console. The previous documentation incorrectly stated the navigation path as "Sign-in method tab (Authentication -> Sign-in method)". The correct path is "Settings tab (Authentication -> Settings -> Authorized Domains)".*

## Related Issues

*It does not relate to any reported issues.*

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.


