### PR TITLE
feat(firebase_core_platform_interface): Add copyWith to FirebaseOptions

### DIFF
--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_options.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_options.dart
@@ -73,6 +73,42 @@ class FirebaseOptions {
         iosBundleId = options.iosBundleId,
         appGroupId = options.appGroupId;
 
+  /// Returns a copy of this FirebaseOptions with the given fields replaced with
+  /// the new values.
+  FirebaseOptions copyWith({
+    String? apiKey,
+    String? appId,
+    String? messagingSenderId,
+    String? projectId,
+    String? authDomain,
+    String? databaseURL,
+    String? storageBucket,
+    String? measurementId,
+    String? trackingId,
+    String? deepLinkURLScheme,
+    String? androidClientId,
+    String? iosClientId,
+    String? iosBundleId,
+    String? appGroupId,
+  }) {
+    return FirebaseOptions(
+      apiKey: apiKey ?? this.apiKey,
+      appId: appId ?? this.appId,
+      messagingSenderId: messagingSenderId ?? this.messagingSenderId,
+      projectId: projectId ?? this.projectId,
+      authDomain: authDomain ?? this.authDomain,
+      databaseURL: databaseURL ?? this.databaseURL,
+      storageBucket: storageBucket ?? this.storageBucket,
+      measurementId: measurementId ?? this.measurementId,
+      trackingId: trackingId ?? this.trackingId,
+      deepLinkURLScheme: deepLinkURLScheme ?? this.deepLinkURLScheme,
+      androidClientId: androidClientId ?? this.androidClientId,
+      iosClientId: iosClientId ?? this.iosClientId,
+      iosBundleId: iosBundleId ?? this.iosBundleId,
+      appGroupId: appGroupId ?? this.appGroupId,
+    );
+  }
+
   /// An API key used for authenticating requests from your app to Google
   /// servers.
   final String apiKey;

--- a/packages/firebase_core/firebase_core_platform_interface/test/firebase_options_test.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/test/firebase_options_test.dart
@@ -67,6 +67,52 @@ void main() {
       expect(options1 == options2, isTrue);
     });
 
+    test('should copyWith new values', () {
+      const options = FirebaseOptions(
+        apiKey: 'apiKey',
+        appId: 'appId',
+        messagingSenderId: 'messagingSenderId',
+        projectId: 'projectId',
+      );
+
+      final newOptions = options.copyWith(
+        apiKey: 'newApiKey',
+        appId: 'newAppId',
+        messagingSenderId: 'newMessagingSenderId',
+        projectId: 'newProjectId',
+        authDomain: 'newAuthDomain',
+        databaseURL: 'newDatabaseURL',
+        storageBucket: 'newStorageBucket',
+        measurementId: 'newMeasurementId',
+        trackingId: 'newTrackingId',
+        deepLinkURLScheme: 'newDeepLinkURLScheme',
+        androidClientId: 'newAndroidClientId',
+        iosClientId: 'newIosClientId',
+        iosBundleId: 'newIosBundleId',
+        appGroupId: 'newAppGroupId',
+      );
+
+      expect(
+        newOptions,
+        const FirebaseOptions(
+          apiKey: 'newApiKey',
+          appId: 'newAppId',
+          messagingSenderId: 'newMessagingSenderId',
+          projectId: 'newProjectId',
+          authDomain: 'newAuthDomain',
+          databaseURL: 'newDatabaseURL',
+          storageBucket: 'newStorageBucket',
+          measurementId: 'newMeasurementId',
+          trackingId: 'newTrackingId',
+          deepLinkURLScheme: 'newDeepLinkURLScheme',
+          androidClientId: 'newAndroidClientId',
+          iosClientId: 'newIosClientId',
+          iosBundleId: 'newIosBundleId',
+          appGroupId: 'newAppGroupId',
+        ),
+      );
+    });
+
     test('should return a Map', () {
       const options = FirebaseOptions(
         apiKey: 'apiKey',


### PR DESCRIPTION
## Description

I need to change the `authDomain` and a `copyWith` method makes this a lot easier

## Related Issues

Tangentially related: https://github.com/firebase/flutterfire/issues/12819

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
