### PR TITLE
fix(firebase_auth): added supporting rawNonce for OAuth credential on Windows platform

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,3 +64,4 @@ Mohd Faheem Ansari <codefaheem@gmail.com>
 Om Phatak <everythingoutdated@gmail.com>
 Horváth István <horvatska01@gmail.com>
 Liu Zhisong <liuzs0666@gmail.com>
+Ievgenii Kovtun <jeka.ns@gmail.com>

--- a/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
@@ -26,6 +26,7 @@ void main() {
   const String kMockEmail = 'test@example.com';
   const String kMockPassword = 'passw0rd';
   const String kMockIdToken = '12345';
+  const String kMockRawNonce = 'abcde12345';
   const String kMockAccessToken = '67890';
   const String kMockGithubToken = 'github';
   const String kMockCustomToken = '12345';
@@ -587,6 +588,45 @@ void main() {
         expect(captured.providerId, equals('apple.com'));
         expect(captured.idToken, equals(kMockIdToken));
         expect(captured.accessToken, equals(kMockAccessToken));
+        expect(captured.rawNonce, equals(null));
+      });
+
+      test('OAuthProvider signInWithCredential for Apple with rawNonce',
+          () async {
+        OAuthProvider oAuthProvider = OAuthProvider('apple.com');
+        final AuthCredential credential = oAuthProvider.credential(
+          idToken: kMockIdToken,
+          rawNonce: kMockRawNonce,
+          accessToken: kMockAccessToken,
+        );
+        await auth.signInWithCredential(credential);
+        final captured =
+            verify(mockAuthPlatform.signInWithCredential(captureAny))
+                .captured
+                .single;
+        expect(captured.providerId, equals('apple.com'));
+        expect(captured.idToken, equals(kMockIdToken));
+        expect(captured.rawNonce, equals(kMockRawNonce));
+        expect(captured.accessToken, equals(kMockAccessToken));
+      });
+
+      test(
+          'OAuthProvider signInWithCredential for Apple with rawNonce (empty accessToken)',
+          () async {
+        OAuthProvider oAuthProvider = OAuthProvider('apple.com');
+        final AuthCredential credential = oAuthProvider.credential(
+          idToken: kMockIdToken,
+          rawNonce: kMockRawNonce,
+        );
+        await auth.signInWithCredential(credential);
+        final captured =
+            verify(mockAuthPlatform.signInWithCredential(captureAny))
+                .captured
+                .single;
+        expect(captured.providerId, equals('apple.com'));
+        expect(captured.idToken, equals(kMockIdToken));
+        expect(captured.rawNonce, equals(kMockRawNonce));
+        expect(captured.accessToken, equals(null));
       });
 
       test('PhoneAuthProvider signInWithCredential', () async {

--- a/packages/firebase_auth/firebase_auth/windows/firebase_auth_plugin.cpp
+++ b/packages/firebase_auth/firebase_auth/windows/firebase_auth_plugin.cpp
@@ -665,10 +665,9 @@ firebase::auth::Credential getCredentialFromArguments(
     std::optional<std::string> rawNonce = getStringOpt(kArgumentRawNonce);
     // If rawNonce provided use corresponding credential builder
     // e.g. AppleID auth through the webView
-    if(rawNonce) {
+    if (rawNonce) {
       return firebase::auth::OAuthProvider::GetCredential(
-          providerId.c_str(), idToken.value().c_str(),
-          rawNonce.value().c_str(),
+          providerId.c_str(), idToken.value().c_str(), rawNonce.value().c_str(),
           accessToken ? accessToken.value().c_str() : nullptr);
     } else {
       return firebase::auth::OAuthProvider::GetCredential(

--- a/packages/firebase_auth/firebase_auth/windows/firebase_auth_plugin.cpp
+++ b/packages/firebase_auth/firebase_auth/windows/firebase_auth_plugin.cpp
@@ -662,9 +662,19 @@ firebase::auth::Credential getCredentialFromArguments(
   if (signInMethod == kSignInMethodOAuth) {
     std::string providerId =
         std::get<std::string>(arguments[kArgumentProviderId]);
-    return firebase::auth::OAuthProvider::GetCredential(
-        providerId.c_str(), idToken.value().c_str(),
-        accessToken.value().c_str());
+    std::optional<std::string> rawNonce = getStringOpt(kArgumentRawNonce);
+    // If rawNonce provided use corresponding credential builder
+    // e.g. AppleID auth through the webView
+    if(rawNonce) {
+      return firebase::auth::OAuthProvider::GetCredential(
+          providerId.c_str(), idToken.value().c_str(),
+          rawNonce.value().c_str(),
+          accessToken ? accessToken.value().c_str() : nullptr);
+    } else {
+      return firebase::auth::OAuthProvider::GetCredential(
+          providerId.c_str(), idToken.value().c_str(),
+          accessToken.value().c_str());
+    }
   }
 
   // If no known auth method matched


### PR DESCRIPTION
## Description

Added support for the rawNonce field in credential builder on the Windows platform.

Since there is no implementation of AppleAuthProvider on Windows platform, I am trying to use OAuthProvider. This works on MacOS, but on Windows I couldn't pass an idToken with a rawNonce and no accessToken to the credential builder. And signInWithCredentials threw an exception.

With this PR if rawNonce is provided then will be used overloaded credential builder firebase::auth::OAuthProvider::GetCredential that accept rawNonce argument.

Example of use:

```dart
    final credential = OAuthProvider("apple.com").credential(idToken: webAuthRes.idToken, rawNonce: webAuthRes.nonce);
    FirebaseAuth.instance.signInWithCredential(credential);
```

## Related Issues

No existing issues found ((

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
