### PR TITLE
feat(app_check, mobile): add option to pass debugTokens in initialization

### DIFF
--- a/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppCheckPlugin.java
+++ b/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppCheckPlugin.java
@@ -102,7 +102,8 @@ public class FlutterFirebaseAppCheckPlugin
               case debugProvider:
                 {
                   FirebaseAppCheck firebaseAppCheck = getAppCheck(arguments);
-                  FlutterFirebaseAppRegistrar.debugToken = (String) arguments.get("androidDebugToken");
+                  FlutterFirebaseAppRegistrar.debugToken =
+                      (String) arguments.get("androidDebugToken");
                   firebaseAppCheck.installAppCheckProviderFactory(
                       DebugAppCheckProviderFactory.getInstance());
                   break;

--- a/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppCheckPlugin.java
+++ b/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppCheckPlugin.java
@@ -102,6 +102,7 @@ public class FlutterFirebaseAppCheckPlugin
               case debugProvider:
                 {
                   FirebaseAppCheck firebaseAppCheck = getAppCheck(arguments);
+                  FlutterFirebaseAppRegistrar.debugToken = (String) arguments.get("androidDebugToken");
                   firebaseAppCheck.installAppCheckProviderFactory(
                       DebugAppCheckProviderFactory.getInstance());
                   break;

--- a/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppRegistrar.java
@@ -5,17 +5,38 @@
 package io.flutter.plugins.firebase.appcheck;
 
 import androidx.annotation.Keep;
+import androidx.annotation.Nullable;
+
+import com.google.firebase.appcheck.debug.InternalDebugSecretProvider;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
+
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 @Keep
-public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
+public class FlutterFirebaseAppRegistrar implements ComponentRegistrar, InternalDebugSecretProvider {
+  private static final String DEBUG_SECRET_NAME = "fire-app-check-debug-secret";
+
+  public static String debugToken;
+
   @Override
   public List<Component<?>> getComponents() {
-    return Collections.<Component<?>>singletonList(
-        LibraryVersionComponent.create(BuildConfig.LIBRARY_NAME, BuildConfig.LIBRARY_VERSION));
+    Component<?> library = LibraryVersionComponent.create(BuildConfig.LIBRARY_NAME,
+            BuildConfig.LIBRARY_VERSION);
+
+    Component<InternalDebugSecretProvider> debugSecretProvider = Component.builder(InternalDebugSecretProvider.class)
+            .name(DEBUG_SECRET_NAME)
+            .factory(container -> this).build();
+
+    return Arrays.<Component<?>>asList(library, debugSecretProvider);
+  }
+
+  @Nullable
+  @Override
+  public String getDebugSecret() {
+    return debugToken;
   }
 }

--- a/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppRegistrar.java
@@ -6,30 +6,30 @@ package io.flutter.plugins.firebase.appcheck;
 
 import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
-
 import com.google.firebase.appcheck.debug.InternalDebugSecretProvider;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
-
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 @Keep
-public class FlutterFirebaseAppRegistrar implements ComponentRegistrar, InternalDebugSecretProvider {
+public class FlutterFirebaseAppRegistrar
+    implements ComponentRegistrar, InternalDebugSecretProvider {
   private static final String DEBUG_SECRET_NAME = "fire-app-check-debug-secret";
 
   public static String debugToken;
 
   @Override
   public List<Component<?>> getComponents() {
-    Component<?> library = LibraryVersionComponent.create(BuildConfig.LIBRARY_NAME,
-            BuildConfig.LIBRARY_VERSION);
+    Component<?> library =
+        LibraryVersionComponent.create(BuildConfig.LIBRARY_NAME, BuildConfig.LIBRARY_VERSION);
 
-    Component<InternalDebugSecretProvider> debugSecretProvider = Component.builder(InternalDebugSecretProvider.class)
+    Component<InternalDebugSecretProvider> debugSecretProvider =
+        Component.builder(InternalDebugSecretProvider.class)
             .name(DEBUG_SECRET_NAME)
-            .factory(container -> this).build();
+            .factory(container -> this)
+            .build();
 
     return Arrays.<Component<?>>asList(library, debugSecretProvider);
   }

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTAppCheckProvider.m
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTAppCheckProvider.m
@@ -20,13 +20,13 @@
   if ([providerName isEqualToString:@"debug"]) {
     if (debugToken != nil) {
       // We have a debug token, so just need to stuff it in the environment and it will hook up
-      char *key = "FIRAAppCheckDebugToken", *value = (char *) [debugToken UTF8String];
+      char *key = "FIRAAppCheckDebugToken", *value = (char *)[debugToken UTF8String];
       int overwrite = 1;
       setenv(key, value, overwrite);
     }
 
     FIRAppCheckDebugProvider *provider = [[FIRAppCheckDebugProvider alloc] initWithApp:app];
-    if(debugToken == nil) NSLog(@"Firebase App Check Debug Token: %@", [provider localDebugToken]);
+    if (debugToken == nil) NSLog(@"Firebase App Check Debug Token: %@", [provider localDebugToken]);
     self.delegateProvider = provider;
   }
 

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTAppCheckProvider.m
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTAppCheckProvider.m
@@ -14,10 +14,19 @@
   return self;
 }
 
-- (void)configure:(FIRApp *)app providerName:(NSString *)providerName {
+- (void)configure:(FIRApp *)app
+     providerName:(NSString *)providerName
+       debugToken:(NSString *)debugToken {
   if ([providerName isEqualToString:@"debug"]) {
+    if (debugToken != nil) {
+      // We have a debug token, so just need to stuff it in the environment and it will hook up
+      char *key = "FIRAAppCheckDebugToken", *value = (char *) [debugToken UTF8String];
+      int overwrite = 1;
+      setenv(key, value, overwrite);
+    }
+
     FIRAppCheckDebugProvider *provider = [[FIRAppCheckDebugProvider alloc] initWithApp:app];
-    NSLog(@"Firebase App Check Debug Token: %@", [provider localDebugToken]);
+    if(debugToken == nil) NSLog(@"Firebase App Check Debug Token: %@", [provider localDebugToken]);
     self.delegateProvider = provider;
   }
 

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTAppCheckProviderFactory.m
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTAppCheckProviderFactory.m
@@ -25,13 +25,15 @@
     self.providers[app.name] = [FLTAppCheckProvider new];
     FLTAppCheckProvider *provider = self.providers[app.name];
     // We set "deviceCheck" as this is currently what is default. Backward compatible.
-    [provider configure:app providerName:@"deviceCheck"];
+    [provider configure:app providerName:@"deviceCheck" debugToken:nil];
   }
 
   return self.providers[app.name];
 }
 
-- (void)configure:(FIRApp *)app providerName:(NSString *)providerName {
+- (void)configure:(FIRApp *)app
+     providerName:(NSString *)providerName
+       debugToken:(NSString *)debugToken {
   if (self.providers == nil) {
     self.providers = [NSMutableDictionary new];
   }
@@ -41,7 +43,7 @@
   }
 
   FLTAppCheckProvider *provider = self.providers[app.name];
-  [provider configure:app providerName:providerName];
+  [provider configure:app providerName:providerName debugToken:debugToken];
 }
 
 @end

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTFirebaseAppCheckPlugin.m
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTFirebaseAppCheckPlugin.m
@@ -123,9 +123,10 @@ NSString *const kFLTFirebaseAppCheckChannelName = @"plugins.flutter.io/firebase_
 - (void)activate:(id)arguments withMethodCallResult:(FLTFirebaseMethodCallResult *)result {
   NSString *appNameDart = arguments[@"appName"];
   NSString *providerName = arguments[@"appleProvider"];
+  NSString *debugToken = arguments[@"iosDebugToken"];
 
   FIRApp *app = [FLTFirebasePlugin firebaseAppNamed:appNameDart];
-  [self->providerFactory configure:app providerName:providerName];
+  [self->providerFactory configure:app providerName:providerName debugToken:debugToken];
   result.success(nil);
 }
 

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTFirebaseAppCheckPlugin.m
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTFirebaseAppCheckPlugin.m
@@ -123,7 +123,7 @@ NSString *const kFLTFirebaseAppCheckChannelName = @"plugins.flutter.io/firebase_
 - (void)activate:(id)arguments withMethodCallResult:(FLTFirebaseMethodCallResult *)result {
   NSString *appNameDart = arguments[@"appName"];
   NSString *providerName = arguments[@"appleProvider"];
-  NSString *debugToken = arguments[@"iosDebugToken"];
+  NSString *debugToken = arguments[@"appleDebugToken"];
 
   FIRApp *app = [FLTFirebasePlugin firebaseAppNamed:appNameDart];
   [self->providerFactory configure:app providerName:providerName debugToken:debugToken];

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/include/FLTAppCheckProvider.h
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/include/FLTAppCheckProvider.h
@@ -10,7 +10,9 @@
 
 @property id<FIRAppCheckProvider> delegateProvider;
 
-- (void)configure:(FIRApp *)app providerName:(NSString *)providerName debugToken:(NSString *)debugToken;
+- (void)configure:(FIRApp *)app
+     providerName:(NSString *)providerName
+       debugToken:(NSString *)debugToken;
 
 - (id)initWithApp:(FIRApp *)app;
 

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/include/FLTAppCheckProvider.h
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/include/FLTAppCheckProvider.h
@@ -10,7 +10,7 @@
 
 @property id<FIRAppCheckProvider> delegateProvider;
 
-- (void)configure:(FIRApp *)app providerName:(NSString *)providerName;
+- (void)configure:(FIRApp *)app providerName:(NSString *)providerName debugToken:(NSString *)debugToken;
 
 - (id)initWithApp:(FIRApp *)app;
 

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/include/FLTAppCheckProviderFactory.h
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/include/FLTAppCheckProviderFactory.h
@@ -7,6 +7,8 @@
 
 @property NSMutableDictionary *_Nullable providers;
 
-- (void)configure:(FIRApp *_Nonnull)app providerName:(NSString *_Nonnull)providerName debugToken:(NSString *)debugToken;
+- (void)configure:(FIRApp *_Nonnull)app
+     providerName:(NSString *_Nonnull)providerName
+       debugToken:(NSString *)debugToken;
 
 @end

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/include/FLTAppCheckProviderFactory.h
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/include/FLTAppCheckProviderFactory.h
@@ -7,6 +7,6 @@
 
 @property NSMutableDictionary *_Nullable providers;
 
-- (void)configure:(FIRApp *_Nonnull)app providerName:(NSString *_Nonnull)providerName;
+- (void)configure:(FIRApp *_Nonnull)app providerName:(NSString *_Nonnull)providerName debugToken:(NSString *)debugToken;
 
 @end

--- a/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
@@ -55,8 +55,8 @@ class FirebaseAppCheck extends FirebasePluginPlatform {
   /// On iOS or macOS, the default provider is "device check". If you wish to set the provider to "app attest", "debug" or "app attest with fallback to device check"
   /// ("app attest" is only available on iOS 14.0+, macOS 14.0+), you may set the `appleProvider` property using the `AppleProvider` enum
   ///
-  /// `androidDebugToken` and `iosDebugToken` allow you to set a debug token for the "debug" provider on Android and iOS respectively.
-  /// On iOS you have to rerun app after changing `iosDebugToken`.
+  /// `androidDebugToken` and `appleDebugToken` allow you to set a debug token for the "debug" provider on Android and Apple's systems, respectively.
+  /// On iOS, you must restart the app after changing the appleDebugToken.
   ///
   /// For more information, see [the Firebase Documentation](https://firebase.google.com/docs/app-check)
   Future<void> activate({
@@ -64,14 +64,14 @@ class FirebaseAppCheck extends FirebasePluginPlatform {
     AndroidProvider androidProvider = AndroidProvider.playIntegrity,
     AppleProvider appleProvider = AppleProvider.deviceCheck,
     String? androidDebugToken,
-    String? iosDebugToken,
+    String? appleDebugToken,
   }) {
     return _delegate.activate(
       webProvider: webProvider,
       androidProvider: androidProvider,
       appleProvider: appleProvider,
       androidDebugToken: androidDebugToken,
-      iosDebugToken: iosDebugToken,
+      appleDebugToken: appleDebugToken,
     );
   }
 

--- a/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
@@ -55,16 +55,23 @@ class FirebaseAppCheck extends FirebasePluginPlatform {
   /// On iOS or macOS, the default provider is "device check". If you wish to set the provider to "app attest", "debug" or "app attest with fallback to device check"
   /// ("app attest" is only available on iOS 14.0+, macOS 14.0+), you may set the `appleProvider` property using the `AppleProvider` enum
   ///
+  /// `androidDebugToken` and `iosDebugToken` allow you to set a debug token for the "debug" provider on Android and iOS respectively.
+  /// On iOS you have to rerun app after changing `iosDebugToken`.
+  ///
   /// For more information, see [the Firebase Documentation](https://firebase.google.com/docs/app-check)
   Future<void> activate({
     WebProvider? webProvider,
     AndroidProvider androidProvider = AndroidProvider.playIntegrity,
     AppleProvider appleProvider = AppleProvider.deviceCheck,
+    String? androidDebugToken,
+    String? iosDebugToken,
   }) {
     return _delegate.activate(
       webProvider: webProvider,
       androidProvider: androidProvider,
       appleProvider: appleProvider,
+      androidDebugToken: androidDebugToken,
+      iosDebugToken: iosDebugToken,
     );
   }
 

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
@@ -79,7 +79,7 @@ class MethodChannelFirebaseAppCheck extends FirebaseAppCheckPlatform {
     AndroidProvider? androidProvider,
     AppleProvider? appleProvider,
     String? androidDebugToken,
-    String? iosDebugToken,
+    String? appleDebugToken,
   }) async {
     try {
       await channel.invokeMethod<void>('FirebaseAppCheck#activate', {
@@ -93,8 +93,8 @@ class MethodChannelFirebaseAppCheck extends FirebaseAppCheckPlatform {
             defaultTargetPlatform == TargetPlatform.macOS ||
             kDebugMode)
           'appleProvider': getAppleProviderString(appleProvider),
-        if(iosDebugToken != null)
-          'iosDebugToken': iosDebugToken,
+        if(appleDebugToken != null)
+          'appleDebugToken': appleDebugToken,
       });
     } on PlatformException catch (e, s) {
       convertPlatformException(e, s);

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
@@ -78,6 +78,8 @@ class MethodChannelFirebaseAppCheck extends FirebaseAppCheckPlatform {
     WebProvider? webProvider,
     AndroidProvider? androidProvider,
     AppleProvider? appleProvider,
+    String? androidDebugToken,
+    String? iosDebugToken,
   }) async {
     try {
       await channel.invokeMethod<void>('FirebaseAppCheck#activate', {
@@ -85,10 +87,14 @@ class MethodChannelFirebaseAppCheck extends FirebaseAppCheckPlatform {
         // Allow value to pass for debug mode for unit testing
         if (defaultTargetPlatform == TargetPlatform.android || kDebugMode)
           'androidProvider': getAndroidProviderString(androidProvider),
+        if(androidDebugToken != null)
+          'androidDebugToken': androidDebugToken,
         if (defaultTargetPlatform == TargetPlatform.iOS ||
             defaultTargetPlatform == TargetPlatform.macOS ||
             kDebugMode)
           'appleProvider': getAppleProviderString(appleProvider),
+        if(iosDebugToken != null)
+          'iosDebugToken': iosDebugToken,
       });
     } on PlatformException catch (e, s) {
       convertPlatformException(e, s);

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
@@ -87,14 +87,12 @@ class MethodChannelFirebaseAppCheck extends FirebaseAppCheckPlatform {
         // Allow value to pass for debug mode for unit testing
         if (defaultTargetPlatform == TargetPlatform.android || kDebugMode)
           'androidProvider': getAndroidProviderString(androidProvider),
-        if(androidDebugToken != null)
-          'androidDebugToken': androidDebugToken,
+        if (androidDebugToken != null) 'androidDebugToken': androidDebugToken,
         if (defaultTargetPlatform == TargetPlatform.iOS ||
             defaultTargetPlatform == TargetPlatform.macOS ||
             kDebugMode)
           'appleProvider': getAppleProviderString(appleProvider),
-        if(appleDebugToken != null)
-          'appleDebugToken': appleDebugToken,
+        if (appleDebugToken != null) 'appleDebugToken': appleDebugToken,
       });
     } on PlatformException catch (e, s) {
       convertPlatformException(e, s);

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/platform_interface/platform_interface_firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/platform_interface/platform_interface_firebase_app_check.dart
@@ -66,6 +66,8 @@ abstract class FirebaseAppCheckPlatform extends PlatformInterface {
     WebProvider? webProvider,
     AndroidProvider? androidProvider,
     AppleProvider? appleProvider,
+    String? androidDebugToken,
+    String? iosDebugToken,
   }) {
     throw UnimplementedError('activate() is not implemented');
   }

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/platform_interface/platform_interface_firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/platform_interface/platform_interface_firebase_app_check.dart
@@ -67,7 +67,7 @@ abstract class FirebaseAppCheckPlatform extends PlatformInterface {
     AndroidProvider? androidProvider,
     AppleProvider? appleProvider,
     String? androidDebugToken,
-    String? iosDebugToken,
+    String? appleDebugToken,
   }) {
     throw UnimplementedError('activate() is not implemented');
   }

--- a/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
@@ -99,6 +99,8 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
     WebProvider? webProvider,
     AndroidProvider? androidProvider,
     AppleProvider? appleProvider,
+    String? androidDebugToken,
+    String? appleDebugToken,
   }) async {
     // save the recaptcha type and site key for future startups
     if (webProvider != null) {

--- a/packages/firebase_app_check/firebase_app_check_web/test/firebase_app_check_web_test.mocks.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/test/firebase_app_check_web_test.mocks.dart
@@ -131,6 +131,8 @@ class MockFirebaseAppCheckWeb extends _i1.Mock
     _i3.WebProvider? webProvider,
     _i3.AndroidProvider? androidProvider,
     _i3.AppleProvider? appleProvider,
+    String? androidDebugToken,
+    String? appleDebugToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -140,6 +142,8 @@ class MockFirebaseAppCheckWeb extends _i1.Mock
             #webProvider: webProvider,
             #androidProvider: androidProvider,
             #appleProvider: appleProvider,
+            #androidDebugToken: androidDebugToken,
+            #appleDebugToken: appleDebugToken,
           },
         ),
         returnValue: _i5.Future<void>.value(),

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.mocks.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.mocks.dart
@@ -781,6 +781,8 @@ class MockFirebaseAppCheck extends _i1.Mock implements _i10.FirebaseAppCheck {
     _i11.WebProvider? webProvider,
     _i11.AndroidProvider? androidProvider = _i11.AndroidProvider.playIntegrity,
     _i11.AppleProvider? appleProvider = _i11.AppleProvider.deviceCheck,
+    String? androidDebugToken,
+    String? appleDebugToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -790,6 +792,8 @@ class MockFirebaseAppCheck extends _i1.Mock implements _i10.FirebaseAppCheck {
             #webProvider: webProvider,
             #androidProvider: androidProvider,
             #appleProvider: appleProvider,
+            #androidDebugToken: androidDebugToken,
+            #appleDebugToken: appleDebugToken,
           },
         ),
         returnValue: _i6.Future<void>.value(),

--- a/tests/integration_test/firebase_app_check/firebase_app_check_e2e_test.dart
+++ b/tests/integration_test/firebase_app_check/firebase_app_check_e2e_test.dart
@@ -99,7 +99,7 @@ void main() {
             () async {
           await expectLater(
             FirebaseAppCheck.instance.activate(
-              iosDebugToken: 'debug_token',
+              appleDebugToken: 'debug_token',
               appleProvider: AppleProvider.debug,
             ),
             completes,

--- a/tests/integration_test/firebase_app_check/firebase_app_check_e2e_test.dart
+++ b/tests/integration_test/firebase_app_check/firebase_app_check_e2e_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
@@ -76,6 +78,34 @@ void main() {
           // This will fail until this is resolved: https://github.com/dart-lang/sdk/issues/52572
         },
         skip: kIsWeb,
+      );
+
+      test(
+        'debugToken on Android',
+            () async {
+          await expectLater(
+            FirebaseAppCheck.instance.activate(
+              androidProvider: AndroidProvider.debug,
+              androidDebugToken: 'debug_token',
+            ),
+            completes,
+          );
+        },
+        skip: !Platform.isAndroid,
+      );
+
+      test(
+        'debugToken on iOS',
+            () async {
+          await expectLater(
+            FirebaseAppCheck.instance.activate(
+              iosDebugToken: 'debug_token',
+              appleProvider: AppleProvider.debug,
+            ),
+            completes,
+          );
+        },
+        skip: !Platform.isIOS,
       );
     },
   );


### PR DESCRIPTION
## Description

This feature allows a developer to use a pre-generated debug token instead of one that is generated at runtime. It's useful in CI environments, where you don't have an option to copy token from logs and paste it to Firebase Console.

## Related Issues

Fix for: https://github.com/firebase/flutterfire/issues/11719

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
