### PR TITLE
fix(firestore, web): stop cleaning up snapshot listeners in debug

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/e2e_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/e2e_test.dart
@@ -22,6 +22,7 @@ import 'snapshot_metadata_e2e.dart';
 import 'timestamp_e2e.dart';
 import 'transaction_e2e.dart';
 import 'write_batch_e2e.dart';
+import 'web_snapshot_listeners.dart';
 
 bool kUseFirestoreEmulator = true;
 
@@ -52,6 +53,7 @@ void main() {
     runTransactionTests();
     runWriteBatchTests();
     runLoadBundleTests();
+    runWebSnapshotListenersTests();
     if (defaultTargetPlatform != TargetPlatform.windows) {
       runSecondDatabaseTests();
     }

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/web_snapshot_listeners.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/web_snapshot_listeners.dart
@@ -1,0 +1,144 @@
+// Copyright 2020, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Run only on web for demonstrating snapshot listener clean up in debug mode does not clean up the listeners incorrectly.
+// See: https://github.com/firebase/flutterfire/issues/13019
+void runWebSnapshotListenersTests() {
+  group('Web snapshot listeners', () {
+    late FirebaseFirestore firestore;
+    late CollectionReference<Map<String, dynamic>> collection;
+    late DocumentReference<Map<String, dynamic>> document;
+    setUpAll(() async {
+      firestore = FirebaseFirestore.instance;
+      collection = firestore
+          .collection('flutter-tests/web-snapshot-listeners/query-tests');
+      document = collection.doc('doc1');
+
+      await Future.wait([
+        document.set({'foo': 1}),
+        collection.add({'foo': 2}),
+        collection.add({'foo': 3}),
+      ]);
+    });
+
+    testWidgets(
+      'document snapshot listeners in debug',
+      (_) async {
+        Completer<bool> completer = Completer<bool>();
+        Completer<bool> completer2 = Completer<bool>();
+        Completer<bool> completer3 = Completer<bool>();
+        document.snapshots().listen((snapshot) {
+          if (completer.isCompleted) {
+            return;
+          }
+          completer.complete(true);
+        });
+
+        document.snapshots().listen((snapshot) {
+          if (completer2.isCompleted) {
+            return;
+          }
+          completer2.complete(true);
+        });
+
+        document.snapshots().listen((snapshot) {
+          if (completer3.isCompleted) {
+            return;
+          }
+          completer3.complete(true);
+        });
+
+        final one = await completer.future;
+        final two = await completer2.future;
+        final three = await completer3.future;
+
+        expect(one, true);
+        expect(two, true);
+        expect(three, true);
+      },
+      skip: !kIsWeb,
+    );
+
+    testWidgets(
+      'query snapshot listeners in debug',
+      (_) async {
+        Completer<bool> completer = Completer<bool>();
+        Completer<bool> completer2 = Completer<bool>();
+        Completer<bool> completer3 = Completer<bool>();
+        collection.snapshots().listen((snapshot) {
+          if (completer.isCompleted) {
+            return;
+          }
+          completer.complete(true);
+        });
+
+        collection.snapshots().listen((snapshot) {
+          if (completer2.isCompleted) {
+            return;
+          }
+          completer2.complete(true);
+        });
+
+        collection.snapshots().listen((snapshot) {
+          if (completer3.isCompleted) {
+            return;
+          }
+          completer3.complete(true);
+        });
+        final one = await completer.future;
+        final two = await completer2.future;
+        final three = await completer3.future;
+
+        expect(one, true);
+        expect(two, true);
+        expect(three, true);
+      },
+      skip: !kIsWeb,
+    );
+
+    testWidgets(
+      'snapshot in sync listeners in debug',
+      (_) async {
+        Completer<bool> completer = Completer<bool>();
+        Completer<bool> completer2 = Completer<bool>();
+        Completer<bool> completer3 = Completer<bool>();
+        firestore.snapshotsInSync().listen((snapshot) {
+          if (completer.isCompleted) {
+            return;
+          }
+          completer.complete(true);
+        });
+
+        firestore.snapshotsInSync().listen((snapshot) {
+          if (completer2.isCompleted) {
+            return;
+          }
+          completer2.complete(true);
+        });
+
+        firestore.snapshotsInSync().listen((snapshot) {
+          if (completer3.isCompleted) {
+            return;
+          }
+          completer3.complete(true);
+        });
+
+        final one = await completer.future;
+        final two = await completer2.future;
+        final three = await completer3.future;
+
+        expect(one, true);
+        expect(two, true);
+        expect(three, true);
+      },
+      skip: !kIsWeb,
+    );
+  });
+}

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -101,7 +101,7 @@ class Firestore extends JsObjectWrapper<firestore_interop.FirestoreJsImpl> {
   }
 
 // purely for debug mode and tracking listeners to clean up on "hot restart"
-  final Map<String, int> _snapshotInSyncListeners = {};
+  static final Map<String, int> _snapshotInSyncListeners = {};
   String _snapshotInSyncWindowsKey() {
     if (kDebugMode) {
       final key = 'flutterfire-${app.name}_snapshotInSync';
@@ -411,7 +411,7 @@ class DocumentReference
   }
 
   // purely for debug mode and tracking listeners to clean up on "hot restart"
-  final Map<String, int> _docListeners = {};
+  static final Map<String, int> _docListeners = {};
   String _documentSnapshotWindowsKey() {
     if (kDebugMode) {
       final key = 'flutterfire-${firestore.app.name}_${path}_documentSnapshot';
@@ -440,7 +440,7 @@ class DocumentReference
   StreamController<DocumentSnapshot> _createSnapshotStream([
     firestore_interop.DocumentListenOptions? options,
   ]) {
-    final documentKey = _documentSnapshotWindowsKey();
+    final documentKey = _documentSnapshotWindowsKey();  
     unsubscribeWindowsListener(documentKey);
     late JSFunction onSnapshotUnsubscribe;
     // ignore: close_sinks, the controller is returned
@@ -537,7 +537,7 @@ class Query<T extends firestore_interop.QueryJsImpl>
       jsObject, firestore_interop.limitToLast(limit.toJS)));
 
   // purely for debug mode and tracking listeners to clean up on "hot restart"
-  final Map<String, int> _snapshotListeners = {};
+  static final Map<String, int> _snapshotListeners = {};
   String _querySnapshotWindowsKey(hashCode) {
     if (kDebugMode) {
       final key = 'flutterfire-${firestore.app.name}_${hashCode}_querySnapshot';


### PR DESCRIPTION
## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/13019

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
