### PR TITLE
fix(firestore): not passing correctly the ListenSource when listening to as single `DocumentReference`

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/document_reference_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/document_reference_e2e.dart
@@ -110,6 +110,30 @@ void runDocumentReferenceTests() {
           });
         });
 
+        testWidgets('listens to a document from cache', (_) async {
+          DocumentReference<Map<String, dynamic>> document =
+              await initializeTest('document-snapshot-cache');
+          await document.set({'foo': 'bar'});
+          Stream<DocumentSnapshot<Map<String, dynamic>>> stream =
+              document.snapshots(source: ListenSource.cache);
+          StreamSubscription<DocumentSnapshot<Map<String, dynamic>>>?
+              subscription;
+
+          subscription = stream.listen(
+            expectAsync1(
+              (DocumentSnapshot<Map<String, dynamic>> snapshot) {
+                expect(snapshot.exists, isTrue);
+                expect(snapshot.data(), equals({'foo': 'bar'}));
+              },
+              reason: 'Stream should only have been called once.',
+            ),
+          );
+
+          addTearDown(() async {
+            await subscription?.cancel();
+          });
+        });
+
         testWidgets('listens to multiple documents', (_) async {
           DocumentReference<Map<String, dynamic>> doc1 =
               await initializeTest('document-snapshot-1');

--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
@@ -167,7 +167,10 @@ class _JsonDocumentReference
     }
 
     return _delegate
-        .snapshots(includeMetadataChanges: includeMetadataChanges)
+        .snapshots(
+          includeMetadataChanges: includeMetadataChanges,
+          listenSource: source,
+        )
         .map(
           (delegateSnapshot) =>
               _JsonDocumentSnapshot(firestore, delegateSnapshot),

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -466,7 +466,7 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
     return _delegate
         .snapshots(
           includeMetadataChanges: includeMetadataChanges,
-          source: source,
+          listenSource: source,
         )
         .map((item) => _JsonQuerySnapshot(firestore, item));
   }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_document_reference.dart
@@ -110,7 +110,7 @@ class MethodChannelDocumentReference extends DocumentReferencePlatform {
     bool includeMetadataChanges = false,
     ServerTimestampBehavior serverTimestampBehavior =
         ServerTimestampBehavior.none,
-    ListenSource source = ListenSource.defaultSource,
+    required ListenSource listenSource,
   }) {
     // It's fine to let the StreamController be garbage collected once all the
     // subscribers have cancelled; this analyzer warning is safe to ignore.
@@ -128,7 +128,7 @@ class MethodChannelDocumentReference extends DocumentReferencePlatform {
             serverTimestampBehavior: serverTimestampBehavior,
           ),
           includeMetadataChanges,
-          source,
+          listenSource,
         );
         snapshotStreamSubscription =
             MethodChannelFirebaseFirestore.documentSnapshotChannel(observerId)

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query.dart
@@ -153,7 +153,7 @@ class MethodChannelQuery extends QueryPlatform {
     bool includeMetadataChanges = false,
     ServerTimestampBehavior serverTimestampBehavior =
         ServerTimestampBehavior.none,
-    ListenSource source = ListenSource.defaultSource,
+    required ListenSource listenSource,
   }) {
     // It's fine to let the StreamController be garbage collected once all the
     // subscribers have cancelled; this analyzer warning is safe to ignore.
@@ -175,7 +175,7 @@ class MethodChannelQuery extends QueryPlatform {
             serverTimestampBehavior: serverTimestampBehavior,
           ),
           includeMetadataChanges,
-          source,
+          listenSource,
         );
 
         snapshotStreamSubscription =

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_document_reference.dart
@@ -73,7 +73,7 @@ abstract class DocumentReferencePlatform extends PlatformInterface {
   /// Notifies of documents at this location
   Stream<DocumentSnapshotPlatform> snapshots({
     bool includeMetadataChanges = false,
-    ListenSource source = ListenSource.defaultSource,
+    required ListenSource listenSource,
   }) {
     throw UnimplementedError('snapshots() is not implemented');
   }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_query.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_query.dart
@@ -135,7 +135,7 @@ abstract class QueryPlatform extends PlatformInterface {
   /// Notifies of query results at this location
   Stream<QuerySnapshotPlatform> snapshots({
     bool includeMetadataChanges = false,
-    ListenSource source = ListenSource.defaultSource,
+    required ListenSource listenSource,
   }) {
     throw UnimplementedError('snapshots() is not implemented');
   }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/document_reference_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/document_reference_web.dart
@@ -67,12 +67,12 @@ class DocumentReferenceWeb extends DocumentReferencePlatform {
   @override
   Stream<DocumentSnapshotPlatform> snapshots({
     bool includeMetadataChanges = false,
-    ListenSource source = ListenSource.defaultSource,
+    required ListenSource listenSource,
   }) {
     Stream<firestore_interop.DocumentSnapshot> querySnapshots =
         _delegate.onSnapshot(
       includeMetadataChanges: includeMetadataChanges,
-      source: source,
+      source: listenSource,
     );
 
     return convertWebExceptions(

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -553,12 +553,12 @@ class Query<T extends firestore_interop.QueryJsImpl>
 
   Stream<QuerySnapshot> onSnapshot(
           {bool includeMetadataChanges = false,
-          ListenSource source = ListenSource.defaultSource,
+          required ListenSource listenSource,
           required int hashCode}) =>
       _createSnapshotStream(
         firestore_interop.DocumentListenOptions(
           includeMetadataChanges: includeMetadataChanges.toJS,
-          source: convertListenSource(source),
+          source: convertListenSource(listenSource),
         ),
         hashCode,
       ).stream;

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
@@ -182,12 +182,12 @@ class QueryWeb extends QueryPlatform {
   @override
   Stream<QuerySnapshotPlatform> snapshots({
     bool includeMetadataChanges = false,
-    ListenSource source = ListenSource.defaultSource,
+    required ListenSource listenSource,
   }) {
     Stream<firestore_interop.QuerySnapshot> querySnapshots =
         _buildWebQueryWithParameters().onSnapshot(
       includeMetadataChanges: includeMetadataChanges,
-      source: source,
+      source: listenSource,
       hashCode: hashCode,
     );
 

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
@@ -187,7 +187,7 @@ class QueryWeb extends QueryPlatform {
     Stream<firestore_interop.QuerySnapshot> querySnapshots =
         _buildWebQueryWithParameters().onSnapshot(
       includeMetadataChanges: includeMetadataChanges,
-      source: listenSource,
+      listenSource: listenSource,
       hashCode: hashCode,
     );
 


### PR DESCRIPTION
## Description

Cleaned up the platform channel code so we don't give default value everywhere but only on the user-facing interface.

## Related Issues

closes #13174

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
