### PR TITLE
fix(crashlytics): read firebase_crashlytics_collection_enabled from AndroidManifest.xml

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/ios/Runner.xcodeproj/project.pbxproj
@@ -171,7 +171,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/tests/android/app/src/main/AndroidManifest.xml
+++ b/tests/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:usesCleartextTraffic="true">
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/tests/integration_test/firebase_crashlytics/firebase_crashlytics_e2e_test.dart
+++ b/tests/integration_test/firebase_crashlytics/firebase_crashlytics_e2e_test.dart
@@ -21,6 +21,17 @@ void main() {
         );
       });
 
+      group('isCrashlyticsCollectionEnabled', () {
+        test(
+            'checks isCrashlyticsCollectionEnabled value set from AndroidManifest.xml',
+            () async {
+          bool isCrashlyticsCollectionEnabled =
+              FirebaseCrashlytics.instance.isCrashlyticsCollectionEnabled;
+
+          expect(isCrashlyticsCollectionEnabled, false);
+        });
+      });
+
       group('checkForUnsentReports', () {
         test('should throw if automatic crash report is enabled', () async {
           await FirebaseCrashlytics.instance


### PR DESCRIPTION
## Description

Crashylytics does not read `firebase_crashlytics_collection_enabled` meta data from AndroidManifest.xml

## Related Issues

Closes [13105](https://github.com/firebase/flutterfire/issues/13105)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
