### PR TITLE
fix(installations, apple): update the plugin to support parallels method calling

### DIFF
--- a/tests/integration_test/firebase_app_installations/firebase_app_installations_e2e_test.dart
+++ b/tests/integration_test/firebase_app_installations/firebase_app_installations_e2e_test.dart
@@ -32,6 +32,20 @@ void main() {
       );
 
       test(
+        'running get id in parallel',
+        () async {
+          final ids = await Future.wait([
+            FirebaseInstallations.instance.getId(),
+            FirebaseInstallations.instance.getId(),
+            FirebaseInstallations.instance.getId(),
+            FirebaseInstallations.instance.getId(),
+            FirebaseInstallations.instance.getId(),
+          ]);
+          expect(ids, isNotNull);
+        },
+      );
+
+      test(
         '.delete',
         () async {
           final id = await FirebaseInstallations.instance.getId();


### PR DESCRIPTION

## Description

Currently, each call would assign `arguments` and `result` to a global context. If 2 calls were done at the same time, the result only 1 result would be sent back.

## Related Issues

closes #13240 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
