### PR TITLE
fix(firestore, web): only set long polling options if it has a value

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/e2e_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/e2e_test.dart
@@ -35,6 +35,10 @@ void main() {
       await Firebase.initializeApp(
         options: DefaultFirebaseOptions.currentPlatform,
       );
+      // Web by default doesn't have persistence enabled
+      FirebaseFirestore.instance.settings = const Settings(
+        persistenceEnabled: true,
+      );
 
       if (kUseFirestoreEmulator) {
         FirebaseFirestore.instance.useFirestoreEmulator('localhost', 8080);

--- a/packages/cloud_firestore/cloud_firestore/lib/src/utils/codec_utility.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/utils/codec_utility.dart
@@ -6,8 +6,9 @@ part of cloud_firestore;
 
 // ignore: do_not_use_environment
 const kIsWasm = bool.fromEnvironment('dart.library.js_interop') &&
+    // html package is not available in wasm
     // ignore: do_not_use_environment
-    bool.fromEnvironment('dart.library.ffi');
+    !bool.fromEnvironment('dart.library.html');
 
 class _CodecUtility {
   static Map<String, dynamic>? replaceValueWithDelegatesInMap(

--- a/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
@@ -151,12 +151,6 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
         cacheSizeBytes: firestoreSettings.cacheSizeBytes?.toJS,
       ));
     }
-
-    JSAny experimentalLongPollingOptions =
-        firestore_interop.ExperimentalLongPollingOptions(
-            timeoutSeconds: firestoreSettings.webExperimentalLongPollingOptions
-                ?.timeoutDuration?.inSeconds.toJS) as JSAny;
-
     if (firestoreSettings.host != null &&
         firestoreSettings.sslEnabled != null) {
       _interopSettings = firestore_interop.FirestoreSettings(
@@ -167,7 +161,6 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
             firestoreSettings.webExperimentalForceLongPolling?.toJS,
         experimentalAutoDetectLongPolling:
             firestoreSettings.webExperimentalAutoDetectLongPolling?.toJS,
-        experimentalLongPollingOptions: experimentalLongPollingOptions,
         ignoreUndefinedProperties:
             firestoreSettings.ignoreUndefinedProperties.toJS,
       );
@@ -178,10 +171,18 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
             firestoreSettings.webExperimentalForceLongPolling?.toJS,
         experimentalAutoDetectLongPolling:
             firestoreSettings.webExperimentalAutoDetectLongPolling?.toJS,
-        experimentalLongPollingOptions: experimentalLongPollingOptions,
         ignoreUndefinedProperties:
             firestoreSettings.ignoreUndefinedProperties.toJS,
       );
+    }
+    if (firestoreSettings.webExperimentalLongPollingOptions != null) {
+      // If this is null, it will throw an exception when initializing the Firestore instance via interop
+      JSAny experimentalLongPollingOptions =
+        firestore_interop.ExperimentalLongPollingOptions(
+            timeoutSeconds: firestoreSettings.webExperimentalLongPollingOptions
+                ?.timeoutDuration?.inSeconds.toJS) as JSAny;
+      _interopSettings?.experimentalLongPollingOptions =
+          experimentalLongPollingOptions;
     }
   }
 

--- a/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
@@ -178,9 +178,12 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
     if (firestoreSettings.webExperimentalLongPollingOptions != null) {
       // If this is null, it will throw an exception when initializing the Firestore instance via interop
       JSAny experimentalLongPollingOptions =
-        firestore_interop.ExperimentalLongPollingOptions(
-            timeoutSeconds: firestoreSettings.webExperimentalLongPollingOptions
-                ?.timeoutDuration?.inSeconds.toJS) as JSAny;
+          firestore_interop.ExperimentalLongPollingOptions(
+              timeoutSeconds: firestoreSettings
+                  .webExperimentalLongPollingOptions
+                  ?.timeoutDuration
+                  ?.inSeconds
+                  .toJS) as JSAny;
       _interopSettings?.experimentalLongPollingOptions =
           experimentalLongPollingOptions;
     }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore_interop.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore_interop.dart
@@ -749,6 +749,8 @@ extension FirestoreSettingsExtension on FirestoreSettings {
   /// Union type MemoryLocalCache | PersistentLocalCache;
   //ignore: avoid_setters_without_getters
   external set localCache(JSObject u);
+
+  external set experimentalLongPollingOptions(JSAny v);
 }
 
 /// Options that configure the SDK’s underlying network transport (WebChannel) when long-polling is used


### PR DESCRIPTION
## Description

- Only set `webExperimentalLongPollingOptions` if there is a value set by the user. 
- This ought to fix our web firestore e2e tests. The tests were failing because [we wrap in try/catch here](https://github.com/firebase/flutterfire/blob/fix-firestore-web/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart#L34-L44). When we tried to initialise, it would throw an exception because `webExperimentalLongPollingOptions` was null. Then the firestore instance would be reinitialised without settings and that means we wouldn't have cache option set.
- e2e tests now work which is proof of fix as previously getting doc from cache was failing because initialising firestore without settings wasn't occurring properly. See example test failure that is now fixed from this PR: https://github.com/firebase/flutterfire/actions/runs/10774838129/job/29877877726?pr=13292#step:11:87
- fixed firestore web wasm, the env var:
```dart
bool.fromEnvironment('dart.library.ffi');
```
is no longer available causing test failures as integers were now doubles again. I have updated to double check html package is not available instead as it isn't compatible with wasm.

## Related Issues
Closes [13293](https://github.com/firebase/flutterfire/issues/13293)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
