### PR TITLE
docs(firebase_auth): Update federated-auth.md for Facebook limited login

### DIFF
--- a/docs/auth/federated-auth.md
+++ b/docs/auth/federated-auth.md
@@ -136,13 +136,25 @@ with the Facebook App ID and Secret set.
 
   Future<UserCredential> signInWithFacebook() async {
     // Trigger the sign-in flow
+    final rawNonce = _generateRandomString();
+    final nonce = sha256ofString(rawNonce);
     final LoginResult loginResult = await FacebookAuth.instance.login();
 
     // Create a credential from the access token
-    final OAuthCredential facebookAuthCredential = FacebookAuthProvider.credential(loginResult.accessToken.token);
+    OAuthCredential? facebookAuthCredential;
+    if (loginResult.accessToken is LimitedToken) {
+      facebookAuthCredential = OAuthCredential(
+        providerId: 'facebook.com',
+        signInMethod: 'oauth',
+        idToken: loginResult.accessToken.tokenString,
+        rawNonce: rawNonce,
+      );
+    } else {
+      facebookAuthCredential = FacebookAuthProvider.credential(loginResult.accessToken.token);
+    }
 
     // Once signed in, return the UserCredential
-    return FirebaseAuth.instance.signInWithCredential(facebookAuthCredential);
+    return FirebaseAuth.instance.signInWithCredential(facebookAuthCredential!);
   }
   ```
 

--- a/docs/auth/federated-auth.md
+++ b/docs/auth/federated-auth.md
@@ -136,8 +136,8 @@ with the Facebook App ID and Secret set.
 
   Future<UserCredential> signInWithFacebook() async {
     // Trigger the sign-in flow
-    final rawNonce = _generateRandomString();
-    final nonce = sha256ofString(rawNonce);
+    final rawNonce = _generateRandomString(); // You should implement this function
+    final nonce = _sha256ofString(rawNonce); // You should implement this function
     final LoginResult loginResult = await FacebookAuth.instance.login();
 
     // Create a credential from the access token


### PR DESCRIPTION
## Description

Currently the documentation shows an example that works only with the classic access tokens. In many situations on iOS, the Limited Facebook Login is used, which provides JWT instead of the classic token. To be able to handle it, Firebase Auth needs to include the raw value of the *nonce*, to be able to validate the JWT.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
