### PR TITLE
fix: allow `logEvent` to accept `items` inside `parameters`

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/test/firebase_analytics_test.dart
+++ b/packages/firebase_analytics/firebase_analytics/test/firebase_analytics_test.dart
@@ -136,10 +136,74 @@ void main() {
         expect(analytics!.logEvent(name: 'firebase_foo'), throwsArgumentError);
       });
 
+      test('reject events with wrong param value', () async {
+        expect(
+          () => analytics!.logEvent(
+            name: 'test_event',
+            parameters: {
+              'a': true,
+            },
+          ),
+          throwsAssertionError,
+        );
+      });
+
+      test('reject events with wrong param items', () async {
+        expect(
+          () => analytics!.logEvent(
+            name: 'test_event',
+            parameters: {
+              'items': true,
+            },
+          ),
+          throwsAssertionError,
+        );
+      });
+
+      test('reject events with wrong param items values', () async {
+        expect(
+          () => analytics!.logEvent(
+            name: 'test_event',
+            parameters: {
+              'items': [
+                {
+                  'a': 123,
+                },
+                true,
+              ],
+            },
+          ),
+          throwsAssertionError,
+        );
+      });
+
+      test('reject events with wrong param items items', () async {
+        expect(
+          () => analytics!.logEvent(
+            name: 'test_event',
+            parameters: {
+              'items': [
+                {
+                  'items': [],
+                },
+              ],
+            },
+          ),
+          throwsAssertionError,
+        );
+      });
+
       test('custom event with correct parameters', () async {
         await analytics!.logEvent(
           name: 'test-event',
-          parameters: {'a': 'b'},
+          parameters: {
+            'a': 'b',
+            'items': [
+              {
+                'c': 'd',
+              },
+            ],
+          },
         );
         expect(
           methodCallLog,
@@ -148,7 +212,14 @@ void main() {
               'Analytics#logEvent',
               arguments: {
                 'eventName': 'test-event',
-                'parameters': {'a': 'b'},
+                'parameters': {
+                  'a': 'b',
+                  'items': [
+                    {
+                      'c': 'd',
+                    },
+                  ],
+                },
               },
             ),
           ],


### PR DESCRIPTION
## Description

Before this PR: `logEvent` did not accept `items` inside `parameters`
After this PR: `logEvent` can accept `items` inside `parameters`

Reason for this PR: On my project, our backend can send all data for analytics event, including `items` - this PR extends checks in `_assertParameterTypesAreCorrect` to allow this behavior

## Related Issues

-

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
