### PR TITLE
fix(fdc): Fix serializing errors

### DIFF
--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/core/ref.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/core/ref.dart
@@ -111,7 +111,6 @@ class QueryRef<Data, Variables> extends OperationRef<Data, Variables> {
           serializer(variables as Variables), this, res.data, null);
       return res;
     } on Exception catch (e) {
-      print(e);
       await _queryManager.triggerCallback<Data, Variables>(
           operationName, serializer(variables as Variables), this, null, e);
       rethrow;
@@ -124,7 +123,11 @@ class QueryRef<Data, Variables> extends OperationRef<Data, Variables> {
         .addQuery(operationName, variables, varsSerialized)
         .cast<QueryResult<Data, Variables>>();
     if (_queryManager.containsQuery(operationName, variables, varsSerialized)) {
-      this.execute().ignore();
+      try {
+        this.execute();
+      } catch (_) {
+        // Call to `execute` should properly pass the error to the Stream.
+      }
     }
     return res;
   }

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/core/ref.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/core/ref.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:developer';
 
 import '../../firebase_data_connect.dart';
 import '../common/common_library.dart';
@@ -127,6 +128,7 @@ class QueryRef<Data, Variables> extends OperationRef<Data, Variables> {
         this.execute();
       } catch (_) {
         // Call to `execute` should properly pass the error to the Stream.
+        log("Error thrown by execute. The error will propagate via onError.");
       }
     }
     return res;

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/optional.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/optional.dart
@@ -90,6 +90,12 @@ T nativeFromJson<T>(dynamic input) {
     } else if (T == String) {
       return input as T;
     }
+  } else if (input is num) {
+    if (input is double && T == int) {
+      return input.toInt() as T;
+    } else if (input is int && T == double) {
+      return input.toDouble() as T;
+    }
   }
   throw UnimplementedError('This type is unimplemented: ${T.runtimeType}');
 }

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/optional_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/optional_test.dart
@@ -79,6 +79,15 @@ void main() {
       expect(nativeFromJson<bool>(true), equals(true));
       expect(nativeFromJson<String>('Test'), equals('Test'));
     });
+
+    // Since protobuf doesn't distinguish between int and double, we need to do the parsing outselves
+    test('nativeFromJson correctly matches int to int and double to double',
+        () {
+      double expectedDouble = 42;
+      int expectedInt = 42;
+      expect(nativeFromJson<double>(42), equals(expectedDouble));
+      expect(nativeFromJson<int>(expectedDouble), equals(expectedInt));
+    });
     test('nativeFromJson correctly deserializes DateTime strings', () {
       expect(nativeFromJson<DateTime>('2024-01-01'),
           equals(DateTime.parse('2024-01-01')));


### PR DESCRIPTION
* Fix issue where on GRPC, since protobuf doesn't distinguish between double and int, all numbers were being parsed as doubles.
* Fix issue where `execute.ignore` was called, causing errors not being thrown.