### PR TITLE
fix(storage, android): stream handler & event channel clean up on completion

### DIFF
--- a/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStoragePlugin.java
+++ b/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStoragePlugin.java
@@ -455,9 +455,11 @@ public class FlutterFirebaseStoragePlugin
             handle.intValue(), androidReference, data, androidMetaData);
     try {
       String identifier = UUID.randomUUID().toString().toLowerCase(Locale.US);
-      TaskStateChannelStreamHandler handler = storageTask.startTaskWithMethodChannel(channel, identifier);
-      result.success(registerEventChannel(
-        STORAGE_METHOD_CHANNEL_NAME + "/" + STORAGE_TASK_EVENT_NAME, identifier, handler));
+      TaskStateChannelStreamHandler handler =
+          storageTask.startTaskWithMethodChannel(channel, identifier);
+      result.success(
+          registerEventChannel(
+              STORAGE_METHOD_CHANNEL_NAME + "/" + STORAGE_TASK_EVENT_NAME, identifier, handler));
     } catch (Exception e) {
       result.error(FlutterFirebaseStorageException.parserExceptionToFlutter(e));
     }
@@ -485,7 +487,8 @@ public class FlutterFirebaseStoragePlugin
 
     try {
       String identifier = UUID.randomUUID().toString().toLowerCase(Locale.US);
-      TaskStateChannelStreamHandler handler = storageTask.startTaskWithMethodChannel(channel, identifier);
+      TaskStateChannelStreamHandler handler =
+          storageTask.startTaskWithMethodChannel(channel, identifier);
       result.success(
           registerEventChannel(
               STORAGE_METHOD_CHANNEL_NAME + "/" + STORAGE_TASK_EVENT_NAME, identifier, handler));
@@ -514,7 +517,8 @@ public class FlutterFirebaseStoragePlugin
 
     try {
       String identifier = UUID.randomUUID().toString().toLowerCase(Locale.US);
-      TaskStateChannelStreamHandler handler = storageTask.startTaskWithMethodChannel(channel, identifier);
+      TaskStateChannelStreamHandler handler =
+          storageTask.startTaskWithMethodChannel(channel, identifier);
       result.success(
           registerEventChannel(
               STORAGE_METHOD_CHANNEL_NAME + "/" + STORAGE_TASK_EVENT_NAME, identifier, handler));
@@ -538,7 +542,8 @@ public class FlutterFirebaseStoragePlugin
 
     try {
       String identifier = UUID.randomUUID().toString().toLowerCase(Locale.US);
-      TaskStateChannelStreamHandler handler = storageTask.startTaskWithMethodChannel(channel, identifier);
+      TaskStateChannelStreamHandler handler =
+          storageTask.startTaskWithMethodChannel(channel, identifier);
       result.success(
           registerEventChannel(
               STORAGE_METHOD_CHANNEL_NAME + "/" + STORAGE_TASK_EVENT_NAME, identifier, handler));

--- a/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStoragePlugin.java
+++ b/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStoragePlugin.java
@@ -42,8 +42,8 @@ public class FlutterFirebaseStoragePlugin
   static final String STORAGE_TASK_EVENT_NAME = "taskEvent";
   static final String DEFAULT_ERROR_CODE = "firebase_storage";
 
-  private final Map<String, EventChannel> eventChannels = new HashMap<>();
-  private final Map<String, StreamHandler> streamHandlers = new HashMap<>();
+  static final Map<String, EventChannel> eventChannels = new HashMap<>();
+  static final Map<String, StreamHandler> streamHandlers = new HashMap<>();
 
   static Map<String, String> getExceptionDetails(Exception exception) {
     Map<String, String> details = new HashMap<>();
@@ -143,11 +143,6 @@ public class FlutterFirebaseStoragePlugin
     channel = new MethodChannel(messenger, STORAGE_METHOD_CHANNEL_NAME);
     GeneratedAndroidFirebaseStorage.FirebaseStorageHostApi.setup(messenger, this);
     this.messenger = messenger;
-  }
-
-  private String registerEventChannel(String prefix, StreamHandler handler) {
-    String identifier = UUID.randomUUID().toString().toLowerCase(Locale.US);
-    return registerEventChannel(prefix, identifier, handler);
   }
 
   private String registerEventChannel(String prefix, String identifier, StreamHandler handler) {
@@ -459,10 +454,10 @@ public class FlutterFirebaseStoragePlugin
         FlutterFirebaseStorageTask.uploadBytes(
             handle.intValue(), androidReference, data, androidMetaData);
     try {
-      TaskStateChannelStreamHandler handler = storageTask.startTaskWithMethodChannel(channel);
-      result.success(
-          registerEventChannel(
-              STORAGE_METHOD_CHANNEL_NAME + "/" + STORAGE_TASK_EVENT_NAME, handler));
+      String identifier = UUID.randomUUID().toString().toLowerCase(Locale.US);
+      TaskStateChannelStreamHandler handler = storageTask.startTaskWithMethodChannel(channel, identifier);
+      result.success(registerEventChannel(
+        STORAGE_METHOD_CHANNEL_NAME + "/" + STORAGE_TASK_EVENT_NAME, identifier, handler));
     } catch (Exception e) {
       result.error(FlutterFirebaseStorageException.parserExceptionToFlutter(e));
     }
@@ -489,10 +484,11 @@ public class FlutterFirebaseStoragePlugin
             androidMetaData);
 
     try {
-      TaskStateChannelStreamHandler handler = storageTask.startTaskWithMethodChannel(channel);
+      String identifier = UUID.randomUUID().toString().toLowerCase(Locale.US);
+      TaskStateChannelStreamHandler handler = storageTask.startTaskWithMethodChannel(channel, identifier);
       result.success(
           registerEventChannel(
-              STORAGE_METHOD_CHANNEL_NAME + "/" + STORAGE_TASK_EVENT_NAME, handler));
+              STORAGE_METHOD_CHANNEL_NAME + "/" + STORAGE_TASK_EVENT_NAME, identifier, handler));
     } catch (Exception e) {
       result.error(FlutterFirebaseStorageException.parserExceptionToFlutter(e));
     }
@@ -517,10 +513,11 @@ public class FlutterFirebaseStoragePlugin
             settableMetaData == null ? null : getMetaDataFromPigeon(settableMetaData));
 
     try {
-      TaskStateChannelStreamHandler handler = storageTask.startTaskWithMethodChannel(channel);
+      String identifier = UUID.randomUUID().toString().toLowerCase(Locale.US);
+      TaskStateChannelStreamHandler handler = storageTask.startTaskWithMethodChannel(channel, identifier);
       result.success(
           registerEventChannel(
-              STORAGE_METHOD_CHANNEL_NAME + "/" + STORAGE_TASK_EVENT_NAME, handler));
+              STORAGE_METHOD_CHANNEL_NAME + "/" + STORAGE_TASK_EVENT_NAME, identifier, handler));
     } catch (Exception e) {
       result.error(FlutterFirebaseStorageException.parserExceptionToFlutter(e));
     }
@@ -540,10 +537,11 @@ public class FlutterFirebaseStoragePlugin
             handle.intValue(), androidReference, new File(filePath));
 
     try {
-      TaskStateChannelStreamHandler handler = storageTask.startTaskWithMethodChannel(channel);
+      String identifier = UUID.randomUUID().toString().toLowerCase(Locale.US);
+      TaskStateChannelStreamHandler handler = storageTask.startTaskWithMethodChannel(channel, identifier);
       result.success(
           registerEventChannel(
-              STORAGE_METHOD_CHANNEL_NAME + "/" + STORAGE_TASK_EVENT_NAME, handler));
+              STORAGE_METHOD_CHANNEL_NAME + "/" + STORAGE_TASK_EVENT_NAME, identifier, handler));
     } catch (Exception e) {
       result.error(FlutterFirebaseStorageException.parserExceptionToFlutter(e));
     }

--- a/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.java
+++ b/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.java
@@ -155,7 +155,7 @@ class FlutterFirebaseStorageTask {
     }
   }
 
-  TaskStateChannelStreamHandler startTaskWithMethodChannel(@NonNull MethodChannel channel)
+  TaskStateChannelStreamHandler startTaskWithMethodChannel(@NonNull MethodChannel channel, @NonNull String identifier)
       throws Exception {
     if (type == FlutterFirebaseStorageTaskType.BYTES && bytes != null) {
       if (metadata == null) {
@@ -175,7 +175,7 @@ class FlutterFirebaseStorageTask {
       throw new Exception("Unable to start task. Some arguments have no been initialized.");
     }
 
-    return new TaskStateChannelStreamHandler(this, reference.getStorage(), storageTask);
+    return new TaskStateChannelStreamHandler(this, reference.getStorage(), storageTask, identifier);
   }
 
   public Object getSnapshot() {

--- a/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.java
+++ b/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.java
@@ -155,8 +155,8 @@ class FlutterFirebaseStorageTask {
     }
   }
 
-  TaskStateChannelStreamHandler startTaskWithMethodChannel(@NonNull MethodChannel channel, @NonNull String identifier)
-      throws Exception {
+  TaskStateChannelStreamHandler startTaskWithMethodChannel(
+      @NonNull MethodChannel channel, @NonNull String identifier) throws Exception {
     if (type == FlutterFirebaseStorageTaskType.BYTES && bytes != null) {
       if (metadata == null) {
         storageTask = reference.putBytes(bytes);

--- a/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/TaskStateChannelStreamHandler.java
+++ b/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/TaskStateChannelStreamHandler.java
@@ -9,7 +9,6 @@ import androidx.annotation.Nullable;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageException;
 import com.google.firebase.storage.StorageTask;
-
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.EventChannel.EventSink;
 import io.flutter.plugin.common.EventChannel.StreamHandler;
@@ -30,7 +29,8 @@ public class TaskStateChannelStreamHandler implements StreamHandler {
   public TaskStateChannelStreamHandler(
       FlutterFirebaseStorageTask flutterTask,
       FirebaseStorage androidStorage,
-      StorageTask androidTask, String identifier) {
+      StorageTask androidTask,
+      String identifier) {
     this.flutterTask = flutterTask;
     this.androidStorage = androidStorage;
     this.androidTask = androidTask;


### PR DESCRIPTION
## Description

The stream handler and event channel were never cleaned up once the StorageTask had finished, causing memory leak and ultimately an out-of-memory exception.


## Test Setup
Using the following setup, I continued to create Storage Tasks.

```dart
ElevatedButton(
  onPressed: () async {
  Uint8List buffer = Uint8List(5000000);
  Reference ref =  FirebaseStorage.instance.ref();
  await ref.child('flutter-tests/putdata').putData(buffer);
},
child: const Text('Storage test'),
),
```

## Profiling App before fix
I profiled the app to see the memory footprint. 

Here is the baseline memory footprint starting the app, it starts with 269.1mb ( to the right of image, half way up):
<img width="1829" alt="Screenshot 2024-10-16 at 17 27 37" src="https://github.com/user-attachments/assets/7f83eadc-36c4-4ea1-95b8-0ab17d5aa2bc">

I pressed the button 10 times which creates 10 Storage tasks, here is the lastest memory footprint which has now risen to 317mb:
<img width="1674" alt="Screenshot 2024-10-16 at 17 28 56" src="https://github.com/user-attachments/assets/a1a0bf37-2415-4446-8ca0-9ab63107a1cc">


Finally, you can see that `eventChannels` and `streamHandlers` are retaining 10 objects as anticipated:
<img width="1673" alt="Screenshot 2024-10-16 at 17 29 46" src="https://github.com/user-attachments/assets/3920783a-6a40-456a-91b9-ae6d2f4a7274">
 


## Profiling App after fix

Profiled the app after pressing the button at least 10 times you can see that the memory remains similar to the baseline memory measured earlier:
<img width="1683" alt="Screenshot 2024-10-16 at 17 24 48" src="https://github.com/user-attachments/assets/c825e30e-714e-4ffb-9e1c-7f81477fb3c7">

Finally, looking at the size of `eventChannels` and `streamHandlers`, you can see they are at 0 as we would expect with a fix:
<img width="1677" alt="Screenshot 2024-10-16 at 17 25 49" src="https://github.com/user-attachments/assets/46b4e75b-20d7-488f-b5f7-ec375f478621">


## Related Issues

closes https://github.com/firebase/flutterfire/issues/13385
closes https://github.com/firebase/flutterfire/issues/13460

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
