### PR TITLE
fix(messaging, ios): remove dummy APNS token for simulator

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -26,7 +26,6 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   NSObject<FlutterPluginRegistrar> *_registrar;
   NSData *_apnsToken;
   NSDictionary *_initialNotification;
-  bool simulatorToken;
 
   // Used to track if everything as been initialized before answering
   // to the initialNotification request
@@ -57,7 +56,6 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     _initialNotificationGathered = NO;
     _channel = channel;
     _registrar = registrar;
-    simulatorToken = false;
     // Application
     // Dart -> `getInitialNotification`
     // ObjC -> Initialize other delegates & observers
@@ -1005,29 +1003,12 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 - (void)ensureAPNSTokenSetting {
   FIRMessaging *messaging = [FIRMessaging messaging];
 
-  // With iOS SDK >= 10.4, an APNS token is required for getting/deleting token. We set a dummy
-  // token for the simulator for test environments. Historically, a simulator will not work for
-  // messaging. It will work if environment: iOS 16, running on macOS 13+ & silicon chip. We check
-  // the `_apnsToken` is nil. If it is, then the environment does not support and we set dummy
-  // token.
-#if TARGET_IPHONE_SIMULATOR
-  if (simulatorToken == false && _apnsToken == nil) {
-    NSString *str = @"fake-apns-token-for-simulator";
-    NSData *data = [str dataUsingEncoding:NSUTF8StringEncoding];
-    [[FIRMessaging messaging] setAPNSToken:data type:FIRMessagingAPNSTokenTypeSandbox];
-  }
-  // We set this either way. We set dummy token once as `_apnsToken` could be nil next time
-  // which could possibly set dummy token unnecessarily
-  simulatorToken = true;
-#endif
-
   if (messaging.APNSToken == nil && _apnsToken != nil) {
 #ifdef DEBUG
     [[FIRMessaging messaging] setAPNSToken:_apnsToken type:FIRMessagingAPNSTokenTypeSandbox];
 #else
     [[FIRMessaging messaging] setAPNSToken:_apnsToken type:FIRMessagingAPNSTokenTypeProd];
 #endif
-
     _apnsToken = nil;
   }
 }

--- a/tests/integration_test/firebase_messaging/firebase_messaging_e2e_test.dart
+++ b/tests/integration_test/firebase_messaging/firebase_messaging_e2e_test.dart
@@ -124,13 +124,6 @@ void main() {
           skip: defaultTargetPlatform != TargetPlatform.android,
         );
 
-        test(
-          'resolves dummy APNS token on ios if using simulator',
-          () async {
-            expect(await messaging.getAPNSToken(), isA<String>());
-          },
-          skip: defaultTargetPlatform != TargetPlatform.iOS,
-        );
       });
 
       group('getInitialMessage', () {


### PR DESCRIPTION
## Description

It seems an APNS token is already received/set for iOS simulator and we no longer need to set a dummy APNS token.

Tested on iOS 17 and 18.

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/13558

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
