### PR TITLE
fix(messaging, ios): foreground notification appears twice on iOS 18

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -35,6 +35,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 
   NSString *_initialNotificationID;
   NSString *_notificationOpenedAppID;
+  NSString *_foregroundUniqueIdentifier;
 
 #ifdef __FF_NOTIFICATIONS_SUPPORTED_PLATFORM
   API_AVAILABLE(ios(10), macosx(10.14))
@@ -316,10 +317,17 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
              (void (^)(UNNotificationPresentationOptions options))completionHandler
     API_AVAILABLE(macos(10.14), ios(10.0)) {
   // We only want to handle FCM notifications.
-  if (notification.request.content.userInfo[@"gcm.message_id"]) {
+
+  // FIX - bug on iOS 18 which results in duplicate foreground notifications posted
+  // See this Apple issue: https://forums.developer.apple.com/forums/thread/761597
+  // when it has been resolved, "_foregroundUniqueIdentifier" can be removed (i.e. the commit for
+  // this fix)
+  NSString *notificationIdentifier = notification.request.identifier;
+
+  if (notification.request.content.userInfo[@"gcm.message_id"] &&
+      ![notificationIdentifier isEqualToString:_foregroundUniqueIdentifier]) {
     NSDictionary *notificationDict =
         [FLTFirebaseMessagingPlugin NSDictionaryFromUNNotification:notification];
-
     [_channel invokeMethod:@"Messaging#onMessage" arguments:notificationDict];
   }
 
@@ -346,6 +354,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     }
     completionHandler(presentationOptions);
   }
+  _foregroundUniqueIdentifier = notificationIdentifier;
 }
 
 // Called when a user interacts with a notification.


### PR DESCRIPTION
## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

fixes https://github.com/firebase/flutterfire/issues/13366

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
