### PR TITLE
test: skip flakey subscribe to topic tests + sessionId() for iOS on CI

### DIFF
--- a/tests/integration_test/firebase_analytics/firebase_analytics_e2e_test.dart
+++ b/tests/integration_test/firebase_analytics/firebase_analytics_e2e_test.dart
@@ -9,6 +9,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:tests/firebase_options.dart';
 
+// ignore: do_not_use_environment
+const bool skipTestsOnCI = bool.fromEnvironment('CI');
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -40,6 +43,7 @@ void main() {
           expect(result, isA<int?>());
         }
       },
+      skip: skipTestsOnCI && defaultTargetPlatform == TargetPlatform.iOS,
     );
 
     test('isSupported', () async {

--- a/tests/integration_test/firebase_messaging/firebase_messaging_e2e_test.dart
+++ b/tests/integration_test/firebase_messaging/firebase_messaging_e2e_test.dart
@@ -178,9 +178,8 @@ void main() {
           },
           // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
           // android skipped due to consistently failing, works locally: https://github.com/firebase/flutterfire/pull/11260
-          skip: kIsWeb ||
-              defaultTargetPlatform == TargetPlatform.macOS ||
-              defaultTargetPlatform == TargetPlatform.android,
+          // iOS fails because APNS token handler doesn't have a chance to receive token before calling this method
+          skip: kIsWeb || skipTestsOnCI,
         );
       });
 
@@ -193,9 +192,8 @@ void main() {
           },
           // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
           // android skipped due to consistently failing, works locally: https://github.com/firebase/flutterfire/pull/11260
-          skip: kIsWeb ||
-              defaultTargetPlatform == TargetPlatform.macOS ||
-              defaultTargetPlatform == TargetPlatform.android,
+          // iOS fails because APNS token handler doesn't have a chance to receive token before calling this method
+          skip: kIsWeb || skipTestsOnCI,
         );
       });
 


### PR DESCRIPTION
## Description

- Tests consistently fail on iOS because [APNS token isn't received](https://github.com/firebase/flutterfire/blob/main/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m#L404) before `subscribeToTopic()` is called. Skipped on CI.
- analytics getSessionId() is flakey as well. Skipped on CI.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
