### PR TITLE
fix(core, ios): ensure iOS SDK version can be found from Package.swift

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -124,7 +124,7 @@ jobs:
             "flutter build web"
   swift-integration:
     runs-on: macos-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
@@ -135,10 +135,10 @@ jobs:
         with:
           melos-version: '5.3.0'
       - name: 'Swift Integration Setup'
-        run: flutter config --enable-swift-package-manager 
+        run: flutter config --enable-swift-package-manager
       - name: 'Build Apps with Swift Package Manager'
         run: ./.github/workflows/scripts/swift-integration.sh
-            
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
+++ b/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
@@ -14,11 +14,11 @@ enum ConfigurationError: Error {
   case invalidFormat(String)
 }
 
-let iosRootDirectory = String(URL(string: #file)!.deletingLastPathComponent().absoluteString
+let firebaseCoreDirectory = String(URL(string: #file)!.deletingLastPathComponent().absoluteString
   .dropLast())
 
 func loadPubspecVersion() throws -> String {
-  let pubspecPath = NSString.path(withComponents: [iosRootDirectory, "..", "..", "pubspec.yaml"])
+  let pubspecPath = NSString.path(withComponents: [firebaseCoreDirectory, "..", "..", "pubspec.yaml"])
   do {
     let yamlString = try String(contentsOfFile: pubspecPath, encoding: .utf8)
     if let versionLine = yamlString.split(separator: "\n")
@@ -35,12 +35,8 @@ func loadPubspecVersion() throws -> String {
 
 func loadFirebaseSDKVersion() throws -> String {
   let firebaseCoreScriptPath = NSString.path(withComponents: [
-    iosRootDirectory,
+    firebaseCoreDirectory,
     "..",
-    "..",
-    "..",
-    "firebase_core",
-    "ios",
     "firebase_sdk_version.rb",
   ])
   do {

--- a/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
+++ b/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
@@ -18,7 +18,12 @@ let firebaseCoreDirectory = String(URL(string: #file)!.deletingLastPathComponent
   .dropLast())
 
 func loadPubspecVersion() throws -> String {
-  let pubspecPath = NSString.path(withComponents: [firebaseCoreDirectory, "..", "..", "pubspec.yaml"])
+  let pubspecPath = NSString.path(withComponents: [
+    firebaseCoreDirectory,
+    "..",
+    "..",
+    "pubspec.yaml",
+  ])
   do {
     let yamlString = try String(contentsOfFile: pubspecPath, encoding: .utf8)
     if let versionLine = yamlString.split(separator: "\n")


### PR DESCRIPTION
## Description

- Increased swift integration test timeout which was the reason why it was failing. It also matches the timeout set in Firestore PR: https://github.com/firebase/flutterfire/pull/13329/files#diff-61a085d0578afbe6a13da0c8926054ea59e83ce30bd655a6349e78afe7940351R127

- I was able to reproduce the bug on a throwaway Flutter app outside of Flutterfire. I tested by pointing to firebase_core on path with the fix and I was able to build successfully:
<img width="968" alt="Screenshot 2024-11-07 at 10 57 36" src="https://github.com/user-attachments/assets/d102b401-d0db-4fba-8a5c-cff113ec14b8">



## Related Issues

fixes https://github.com/firebase/flutterfire/issues/13726

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
