### PR TITLE
chore: tweak spam words

### DIFF
--- a/.github/workflows/spam-removal/index.js
+++ b/.github/workflows/spam-removal/index.js
@@ -46,19 +46,19 @@ async function closeSpamIssues() {
     });
 
     if (spam || detectedLanguage === 'ind') {
-      // await octokit.rest.issues.update({
-      //   owner: context.repo.owner,
-      //   repo: context.repo.repo,
-      //   issue_number: issue.number,
-      //   state: 'closed',
-      // });
+      await octokit.rest.issues.update({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: issue.number,
+        state: 'closed',
+      });
 
-      // await octokit.rest.issues.addLabels({
-      //   owner: context.repo.owner,
-      //   repo: context.repo.repo,
-      //   issue_number: issue.number,
-      //   labels: ['resolution: invalid', 'platform: all'],
-      // });
+      await octokit.rest.issues.addLabels({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: issue.number,
+        labels: ['resolution: invalid', 'platform: all'],
+      });
 
       console.log(
         `Closed issue #${issue.number} created by spam user: ${issueCreator} or detected as Indonesian language and added labels.`

--- a/.github/workflows/spam-removal/index.js
+++ b/.github/workflows/spam-removal/index.js
@@ -39,7 +39,7 @@ async function closeSpamIssues() {
       if (Array.isArray(wordOrArray)) {
         return wordOrArray.every((word) => issueContent.includes(word));
       } else {
-        const wordWithSpace = ` ${word} `;
+        const wordWithSpace = ` ${wordOrArray} `;
 
         return issueContent.includes(wordWithSpace);
       }

--- a/.github/workflows/spam-removal/index.js
+++ b/.github/workflows/spam-removal/index.js
@@ -18,6 +18,7 @@ const spamWords = [
   'crypto.com',
   'moonpay',
   'coinmama',
+  ['wallet', 'support'],
 ];
 
 async function closeSpamIssues() {
@@ -34,28 +35,30 @@ async function closeSpamIssues() {
     const issueContent = `${issue.title} ${issue.body || ''}`.toLowerCase();
     const detectedLanguage = franc(issueContent);
 
-    const spam = spamWords.find((word) => {
-      const wordWithSpace = ` ${word} `;
+    const spam = spamWords.find((wordOrArray) => {
+      if (Array.isArray(wordOrArray)) {
+        return wordOrArray.every((word) => issueContent.includes(word));
+      } else {
+        const wordWithSpace = ` ${word} `;
 
-      if (issueContent.includes(wordWithSpace)) return true;
-
-      return false;
+        return issueContent.includes(wordWithSpace);
+      }
     });
 
     if (spam || detectedLanguage === 'ind') {
-      await octokit.rest.issues.update({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        issue_number: issue.number,
-        state: 'closed',
-      });
+      // await octokit.rest.issues.update({
+      //   owner: context.repo.owner,
+      //   repo: context.repo.repo,
+      //   issue_number: issue.number,
+      //   state: 'closed',
+      // });
 
-      await octokit.rest.issues.addLabels({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        issue_number: issue.number,
-        labels: ['resolution: invalid', 'platform: all'],
-      });
+      // await octokit.rest.issues.addLabels({
+      //   owner: context.repo.owner,
+      //   repo: context.repo.repo,
+      //   issue_number: issue.number,
+      //   labels: ['resolution: invalid', 'platform: all'],
+      // });
 
       console.log(
         `Closed issue #${issue.number} created by spam user: ${issueCreator} or detected as Indonesian language and added labels.`


### PR DESCRIPTION
## Description

Closes out new batch of spam not captured with previous implementation:
<img width="948" alt="Screenshot 2024-11-13 at 13 38 06" src="https://github.com/user-attachments/assets/ef904bb4-994d-499b-bb19-180a79a37c51">


## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
