### PR TITLE
fix: Synchronize all access to firestoreInstanceCache.

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -108,11 +108,13 @@ public class FlutterFirebaseFirestorePlugin
 
   protected static FirebaseFirestore getFirestoreInstanceByNameAndDatabaseUrl(
       String appName, String databaseURL) {
-    for (Map.Entry<FirebaseFirestore, FlutterFirebaseFirestoreExtension> entry :
-        firestoreInstanceCache.entrySet()) {
-      if (entry.getValue().getInstance().getApp().getName().equals(appName)
-          && entry.getValue().getDatabaseURL().equals(databaseURL)) {
-        return entry.getKey();
+    synchronized (firestoreInstanceCache) {    
+      for (Map.Entry<FirebaseFirestore, FlutterFirebaseFirestoreExtension> entry :
+          firestoreInstanceCache.entrySet()) {
+        if (entry.getValue().getInstance().getApp().getName().equals(appName)
+            && entry.getValue().getDatabaseURL().equals(databaseURL)) {
+          return entry.getKey();
+        }
       }
     }
     return null;
@@ -200,12 +202,14 @@ public class FlutterFirebaseFirestorePlugin
         () -> {
           try {
             // Context is ignored by API so we don't send it over even though annotated non-null.
-            for (Map.Entry<FirebaseFirestore, FlutterFirebaseFirestoreExtension> entry :
-                firestoreInstanceCache.entrySet()) {
-              FirebaseFirestore firestore = entry.getKey();
-              Tasks.await(firestore.terminate());
-              FlutterFirebaseFirestorePlugin.destroyCachedFirebaseFirestoreInstanceForKey(
-                  firestore);
+            synchronized (firestoreInstanceCache) {
+              for (Map.Entry<FirebaseFirestore, FlutterFirebaseFirestoreExtension> entry :
+                  firestoreInstanceCache.entrySet()) {
+                FirebaseFirestore firestore = entry.getKey();
+                Tasks.await(firestore.terminate());
+                FlutterFirebaseFirestorePlugin.destroyCachedFirebaseFirestoreInstanceForKey(
+                    firestore);
+              }
             }
             removeEventListeners();
 


### PR DESCRIPTION
## Description

Synchronize access to `firestoreInstanceCache`.

## Related Issues

* https://github.com/firebase/flutterfire/issues/16668

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
