### PR TITLE
test(firestore): additional coverage for `startAfterDocument()`

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'website/**'
       - '**/example/**'
+      - '!**/example/integration_test/**'
       - '**/flutterfire_ui/**'
       - '**.md'
   push:
@@ -19,6 +20,7 @@ on:
       - 'docs/**'
       - 'website/**'
       - '**/example/**'
+      - '!**/example/integration_test/**'
       - '**/flutterfire_ui/**'
       - '**.md'
 

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'website/**'
       - '**/example/**'
+      - '!**/example/integration_test/**'
       - '**/flutterfire_ui/**'
       - '**.md'
   push:
@@ -19,6 +20,7 @@ on:
       - 'docs/**'
       - 'website/**'
       - '**/example/**'
+      - '!**/example/integration_test/**'
       - '**/flutterfire_ui/**'
       - '**.md'
 

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'website/**'
       - '**/example/**'
+      - '!**/example/integration_test/**'
       - '**/flutterfire_ui/**'
       - '**.md'
   push:
@@ -19,6 +20,7 @@ on:
       - 'docs/**'
       - 'website/**'
       - '**/example/**'
+      - '!**/example/integration_test/**'
       - '**/flutterfire_ui/**'
       - '**.md'
 

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'website/**'
       - '**/example/**'
+      - '!**/example/integration_test/**'
       - '**/flutterfire_ui/**'
       - '**.md'
   push:
@@ -19,6 +20,7 @@ on:
       - 'docs/**'
       - 'website/**'
       - '**/example/**'
+      - '!**/example/integration_test/**'
       - '**/flutterfire_ui/**'
       - '**.md'
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'website/**'
       - '**/example/**'
+      - '!**/example/integration_test/**'
       - '**/flutterfire_ui/**'
       - '**.md'
   push:
@@ -19,6 +20,7 @@ on:
       - 'docs/**'
       - 'website/**'
       - '**/example/**'
+      - '!**/example/integration_test/**'
       - '**/flutterfire_ui/**'
       - '**.md'
 

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
@@ -1033,91 +1033,99 @@ void runQueryTests() {
       });
 
       testWidgets(
-          'throws exception without orderBy() on field used for inequality query',
-          (_) async {
-        CollectionReference<Map<String, dynamic>> collection =
-            await initializeTest('startAfterDocument-inequality-field-throw');
-        await Future.wait([
-          collection.doc('doc1').set({
-            'bar': {'value': 2},
-          }),
-          collection.doc('doc2').set({
-            'bar': {'value': 10},
-          }),
-          collection.doc('doc3').set({
-            'bar': {'value': 10},
-          }),
-          collection.doc('doc4').set({
-            'bar': {'value': 10},
-          }),
-        ]);
+        'throws exception without orderBy() on field used for inequality query',
+        (_) async {
+          CollectionReference<Map<String, dynamic>> collection =
+              await initializeTest('startAfterDocument-inequality-field-throw');
+          await Future.wait([
+            collection.doc('doc1').set({
+              'bar': {'value': 2},
+            }),
+            collection.doc('doc2').set({
+              'bar': {'value': 10},
+            }),
+            collection.doc('doc3').set({
+              'bar': {'value': 10},
+            }),
+            collection.doc('doc4').set({
+              'bar': {'value': 10},
+            }),
+          ]);
 
-        DocumentSnapshot startAtSnapshot = await collection.doc('doc2').get();
-        Query inequalityQuery = collection.where('bar.value', isGreaterThan: 5);
+          DocumentSnapshot startAtSnapshot = await collection.doc('doc2').get();
+          Query inequalityQuery =
+              collection.where('bar.value', isGreaterThan: 5);
 
-        await expectLater(
-          inequalityQuery.startAfterDocument(startAtSnapshot).get(),
-          throwsA(
-            isA<FirebaseException>().having(
-              (e) => e.message,
-              'message',
-              contains(
-                'Client specified an invalid argument',
+          await expectLater(
+            inequalityQuery.startAfterDocument(startAtSnapshot).get(),
+            throwsA(
+              isA<FirebaseException>().having(
+                (e) => e.message,
+                'message',
+                contains(
+                  'Client specified an invalid argument',
+                ),
               ),
             ),
-          ),
-        );
-      });
+          );
+        },
+        // firebase-js-sdk does not require an orderBy() field to be set for this to work
+        skip: kIsWeb,
+      );
 
       testWidgets(
-          'throws exception without correct orderBy("wrong-field") field used for inequality query',
-          (_) async {
-        CollectionReference<Map<String, dynamic>> collection =
-            await initializeTest(
-          'startAfterDocument-wrong-inequality-field-throw',
-        );
-        await Future.wait([
-          collection.doc('doc1').set({
-            'bar': {'value': 2},
-          }),
-          collection.doc('doc2').set(
-            {
-              'bar': {'value': 10},
-              'wrong-field': 2,
-            },
-          ),
-          collection.doc('doc3').set(
-            {
-              'bar': {'value': 10},
-              'wrong-field': 2,
-            },
-          ),
-          collection.doc('doc4').set(
-            {
-              'bar': {'value': 10},
-              'wrong-field': 2,
-            },
-          ),
-        ]);
+        'throws exception without correct orderBy("wrong-field") field used for inequality query',
+        (_) async {
+          CollectionReference<Map<String, dynamic>> collection =
+              await initializeTest(
+            'startAfterDocument-wrong-inequality-field-throw',
+          );
+          await Future.wait([
+            collection.doc('doc1').set({
+              'bar': {'value': 2},
+            }),
+            collection.doc('doc2').set(
+              {
+                'bar': {'value': 10},
+                'wrong-field': 2,
+              },
+            ),
+            collection.doc('doc3').set(
+              {
+                'bar': {'value': 10},
+                'wrong-field': 2,
+              },
+            ),
+            collection.doc('doc4').set(
+              {
+                'bar': {'value': 10},
+                'wrong-field': 2,
+              },
+            ),
+          ]);
 
-        DocumentSnapshot startAtSnapshot = await collection.doc('doc2').get();
-        Query inequalityQuery = collection.where('bar.value', isGreaterThan: 5);
-        await expectLater(
-          inequalityQuery
-              .orderBy('wrong-field')
-              .startAfterDocument(startAtSnapshot)
-              .get(),
-          throwsA(
-            isA<FirebaseException>().having(
-              (e) => e.message,
-              'message',
-              contains(
-                'Client specified an invalid argument',
+          DocumentSnapshot startAtSnapshot = await collection.doc('doc2').get();
+          Query inequalityQuery =
+              collection.where('bar.value', isGreaterThan: 5);
+          await expectLater(
+            inequalityQuery
+                .orderBy('wrong-field')
+                .startAfterDocument(startAtSnapshot)
+                .get(),
+            throwsA(
+              isA<FirebaseException>().having(
+                (e) => e.message,
+                'message',
+                contains(
+                  'Client specified an invalid argument',
+                ),
               ),
             ),
-          ),
-        );
-      });
+          );
+        },
+        // firebase-js-sdk does not require an orderBy() field to be set for this to work
+        skip: kIsWeb,
+      );
 
       testWidgets(
           'Successful request when using orderBy() with same field used on inequality query',

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
@@ -1074,7 +1074,8 @@ void runQueryTests() {
           (_) async {
         CollectionReference<Map<String, dynamic>> collection =
             await initializeTest(
-                'startAfterDocument-wrong-inequality-field-throw');
+          'startAfterDocument-wrong-inequality-field-throw',
+        );
         await Future.wait([
           collection.doc('doc1').set({
             'bar': {'value': 2},


### PR DESCRIPTION
## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

closes: https://github.com/firebase/flutterfire/issues/13289

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
