### PR TITLE
feat(crashlytics, android): Support deferred component crash stack trace

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/com/google/firebase/crashlytics/FlutterFirebaseCrashlyticsInternal.java
+++ b/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/com/google/firebase/crashlytics/FlutterFirebaseCrashlyticsInternal.java
@@ -8,10 +8,12 @@ package com.google.firebase.crashlytics;
 
 import android.annotation.SuppressLint;
 import com.google.firebase.crashlytics.internal.Logger;
+import java.util.List;
 
 /** @hide */
 public final class FlutterFirebaseCrashlyticsInternal {
-  private static final String FLUTTER_BUILD_ID_KEY = "com.crashlytics.flutter.build-id.0";
+  private static final String LOADING_UNIT_KEY = "com.crashlytics.flutter.build-id.";
+  private static final String FLUTTER_BUILD_ID_KEY = LOADING_UNIT_KEY + 0;
 
   @SuppressLint("VisibleForTests")
   public static void recordFatalException(Throwable throwable) {
@@ -25,6 +27,15 @@ public final class FlutterFirebaseCrashlyticsInternal {
   @SuppressLint("VisibleForTests")
   public static void setFlutterBuildId(String buildId) {
     FirebaseCrashlytics.getInstance().core.setInternalKey(FLUTTER_BUILD_ID_KEY, buildId);
+  }
+
+  @SuppressLint("VisibleForTests")
+  public static void setLoadingUnits(List<String> loadingUnits) {
+    int unit = 0;
+    for (String loadingUnit : loadingUnits) {
+      unit++;
+      FirebaseCrashlytics.getInstance().core.setInternalKey(LOADING_UNIT_KEY + unit, loadingUnit);
+    }
   }
 
   private FlutterFirebaseCrashlyticsInternal() {}

--- a/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/com/google/firebase/crashlytics/FlutterFirebaseCrashlyticsInternal.java
+++ b/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/com/google/firebase/crashlytics/FlutterFirebaseCrashlyticsInternal.java
@@ -13,7 +13,7 @@ import java.util.List;
 /** @hide */
 public final class FlutterFirebaseCrashlyticsInternal {
   private static final String LOADING_UNIT_KEY = "com.crashlytics.flutter.build-id.";
-  private static final String FLUTTER_BUILD_ID_KEY = LOADING_UNIT_KEY + 0;
+  private static final String FLUTTER_BUILD_ID_DEFAULT_KEY = LOADING_UNIT_KEY + 0;
 
   @SuppressLint("VisibleForTests")
   public static void recordFatalException(Throwable throwable) {
@@ -26,7 +26,7 @@ public final class FlutterFirebaseCrashlyticsInternal {
 
   @SuppressLint("VisibleForTests")
   public static void setFlutterBuildId(String buildId) {
-    FirebaseCrashlytics.getInstance().core.setInternalKey(FLUTTER_BUILD_ID_KEY, buildId);
+    FirebaseCrashlytics.getInstance().core.setInternalKey(FLUTTER_BUILD_ID_DEFAULT_KEY, buildId);
   }
 
   @SuppressLint("VisibleForTests")

--- a/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/Constants.java
+++ b/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/Constants.java
@@ -27,6 +27,7 @@ public class Constants {
   public static final String IS_CRASHLYTICS_COLLECTION_ENABLED = "isCrashlyticsCollectionEnabled";
   public static final String FATAL = "fatal";
   public static final String BUILD_ID = "buildId";
+  public static final String LOADING_UNITS = "loadingUnits";
   public static final String TIMESTAMP = "timestamp";
   public static final String FIREBASE_APPLICATION_EXCEPTION = "_ae";
   public static final String CRASH_EVENT_KEY = "com.firebase.crashlytics.flutter.fatal";

--- a/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/FlutterFirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/FlutterFirebaseCrashlyticsPlugin.java
@@ -148,10 +148,14 @@ public class FlutterFirebaseCrashlyticsPlugin
             final boolean fatal = (boolean) Objects.requireNonNull(arguments.get(Constants.FATAL));
             final String buildId =
                 (String) Objects.requireNonNull(arguments.get(Constants.BUILD_ID));
+            final List<String> loadingUnits =
+                (List<String>) Objects.requireNonNull(arguments.get(Constants.LOADING_UNITS));
 
             if (buildId.length() > 0) {
               FlutterFirebaseCrashlyticsInternal.setFlutterBuildId(buildId);
             }
+
+            FlutterFirebaseCrashlyticsInternal.setLoadingUnits(loadingUnits);
 
             Exception exception;
             if (reason != null) {

--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -123,6 +123,7 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
     final List<Map<String, String>> stackTraceElements =
         getStackTraceElements(stackTrace);
     final String? buildId = getBuildId(stackTrace);
+    final List<String> loadingUnits = getLoadingUnits(stackTrace);
 
     return _delegate.recordError(
       exception: exception.toString(),
@@ -130,6 +131,7 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
       information: _information,
       stackTraceElements: stackTraceElements,
       buildId: buildId,
+      loadingUnits: loadingUnits,
       fatal: fatal,
     );
   }

--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/utils.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/utils.dart
@@ -64,3 +64,12 @@ String? getBuildId(StackTrace stackTrace) {
 
   return null;
 }
+
+List<String> getLoadingUnits(StackTrace stackTrace) =>
+    Trace.parseVM(stackTrace.toString())
+        .terse
+        .frames
+        .whereType<UnparsedFrame>()
+        .map((frame) => frame.member)
+        .where((member) => member.startsWith('loading_unit: '))
+        .toList();

--- a/packages/firebase_crashlytics/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -79,6 +79,7 @@ void main() {
             'fatal': false,
             'stackTraceElements': getStackTraceElements(stack),
             'buildId': '',
+            'loadingUnits': [],
           })
         ]);
         // Confirm that the stack trace contains current stack.
@@ -141,6 +142,7 @@ void main() {
             'information': '$exceptionFirstMessage\n$exceptionSecondMessage',
             'stackTraceElements': getStackTraceElements(stack),
             'buildId': '',
+            'loadingUnits': [],
           })
         ]);
       } finally {

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/method_channel/method_channel_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/method_channel/method_channel_crashlytics.dart
@@ -95,6 +95,7 @@ class MethodChannelFirebaseCrashlytics extends FirebaseCrashlyticsPlatform {
     required String? reason,
     bool fatal = false,
     String? buildId,
+    List<String> loadingUnits = const [],
     List<Map<String, String>>? stackTraceElements,
   }) async {
     try {
@@ -105,6 +106,7 @@ class MethodChannelFirebaseCrashlytics extends FirebaseCrashlyticsPlatform {
         'reason': reason,
         'fatal': fatal,
         'buildId': buildId ?? '',
+        'loadingUnits': loadingUnits,
         'stackTraceElements': stackTraceElements ?? [],
       });
     } on PlatformException catch (e, s) {

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/platform_interface/platform_interface_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/platform_interface/platform_interface_crashlytics.dart
@@ -114,6 +114,7 @@ abstract class FirebaseCrashlyticsPlatform extends PlatformInterface {
     required String? reason,
     bool fatal = false,
     String? buildId,
+    List<String> loadingUnits = const [],
     List<Map<String, String>>? stackTraceElements,
   }) {
     throw UnimplementedError('recordError() is not implemented');

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/test/method_channel_tests/method_channel_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/test/method_channel_tests/method_channel_crashlytics_test.dart
@@ -30,6 +30,7 @@ void main() {
     'fatal': false,
     'information': 'This is a test exception',
     'buildId': '',
+    'loadingUnits': [],
     'stackTraceElements': <Map<String, String>>[
       <String, String>{
         'declaringClass': 'MethodChannelCrashlyticsTest',
@@ -219,6 +220,7 @@ void main() {
               'information': kMockError['information'],
               'stackTraceElements': kMockError['stackTraceElements'],
               'buildId': '',
+              'loadingUnits': [],
             },
           ),
         ]);


### PR DESCRIPTION
Add loading unit data to Crashlytics reports as internal keys. This is needed to symbolicate Dart stack traces in Flutter apps built with Deferred Components on Android, as Android Dynamic Modules.

Tested by unit tests, and manual end-to-end tests with the plugin built locally.

Doc: [go/crashlytics-deferred-components](http://go/crashlytics-deferred-components)