### PR TITLE
fix(firebase_vertexai): Remove unnecessary trailing whitespace

### DIFF
--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/api.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/api.dart
@@ -386,11 +386,11 @@ enum HarmSeverity {
   // ignore: unused_element
   static HarmSeverity _parseValue(Object jsonObject) {
     return switch (jsonObject) {
-      'HARM_SEVERITY_UNSPECIFIED ' => HarmSeverity.unknown,
+      'HARM_SEVERITY_UNSPECIFIED' => HarmSeverity.unknown,
       'HARM_SEVERITY_NEGLIGIBLE' => HarmSeverity.negligible,
       'HARM_SEVERITY_LOW' => HarmSeverity.low,
       'HARM_SEVERITY_MEDIUM' => HarmSeverity.medium,
-      'HARM_SEVERITY_HIGH ' => HarmSeverity.high,
+      'HARM_SEVERITY_HIGH' => HarmSeverity.high,
       _ => throw FormatException('Unhandled HarmSeverity format', jsonObject),
     };
   }


### PR DESCRIPTION
## Description

### Removed trailing whitespaces
- Removed trailing whitespaces in 'HARM_SEVERITY_UNSPECIFIED ' and 'HARM_SEVERITY_HIGH '.

This issue needs to be fixed to ensure proper handling and avoid unexpected behavior


## Related Issues

Nothing

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
