### PR TITLE
feat(app-check): Debug token support for the activate method

### DIFF
--- a/docs/app-check/debug-provider.md
+++ b/docs/app-check/debug-provider.md
@@ -146,3 +146,48 @@ Because this token allows access to your Firebase resources without a
 valid device, it is crucial that you keep it private. Don't commit it to a
 public repository, and if a registered token is ever compromised, revoke it
 immediately in the Firebase console.
+
+## Manually setting up the App Check Debug Token for CI environment or development
+
+If you want to use the debug provider in a testing environment or CI, you can
+manually set the debug token in your app. This is useful when you want to run
+your app in an environment where the debug token is not automatically generated.
+
+To manually set the debug token, use the `androidDebugToken` and `appleDebugToken`
+parameters when activating App Check. For example:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+
+// Import the firebase_app_check plugin
+import 'package:firebase_app_check/firebase_app_check.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  await FirebaseAppCheck.instance.activate(
+    webRecaptchaSiteKey: 'recaptcha-v3-site-key',
+    // Set androidProvider to `AndroidProvider.debug`
+    androidProvider: AndroidProvider.debug,
+    // Set appleProvider to `AppleProvider.debug`
+    appleProvider: AppleProvider.debug,
+    // Set the androidDebugToken for Android
+    androidDebugToken: '123a4567-b89c-12d3-e456-789012345678',
+    // Set the appleDebugToken for Apple platforms
+    appleDebugToken: '123a4567-b89c-12d3-e456-789012345678',
+  );
+  runApp(App());
+}
+
+```
+
+{# Google-internal common file: #}
+<<../_includes/manage-debug-tokens.md>>
+
+After you register the token, Firebase backend services will accept it as valid.
+
+Because this token allows access to your Firebase resources without a
+valid device, it is crucial that you keep it private. Don't commit it to a
+public repository, and if a registered token is ever compromised, revoke it
+immediately in the Firebase console.

--- a/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppCheckPlugin.java
+++ b/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppCheckPlugin.java
@@ -102,6 +102,8 @@ public class FlutterFirebaseAppCheckPlugin
               case debugProvider:
                 {
                   FirebaseAppCheck firebaseAppCheck = getAppCheck(arguments);
+                  FlutterFirebaseAppRegistrar.debugToken =
+                      (String) arguments.get("androidDebugToken");
                   firebaseAppCheck.installAppCheckProviderFactory(
                       DebugAppCheckProviderFactory.getInstance());
                   break;

--- a/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_app_check/firebase_app_check/android/src/main/java/io/flutter/plugins/firebase/appcheck/FlutterFirebaseAppRegistrar.java
@@ -5,17 +5,38 @@
 package io.flutter.plugins.firebase.appcheck;
 
 import androidx.annotation.Keep;
+import androidx.annotation.Nullable;
+import com.google.firebase.appcheck.debug.InternalDebugSecretProvider;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 @Keep
-public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
+public class FlutterFirebaseAppRegistrar
+    implements ComponentRegistrar, InternalDebugSecretProvider {
+
+  private static final String DEBUG_SECRET_NAME = "fire-app-check-debug-secret";
+  public static String debugToken;
+
   @Override
   public List<Component<?>> getComponents() {
-    return Collections.<Component<?>>singletonList(
-        LibraryVersionComponent.create(BuildConfig.LIBRARY_NAME, BuildConfig.LIBRARY_VERSION));
+    Component<?> library =
+        LibraryVersionComponent.create(BuildConfig.LIBRARY_NAME, BuildConfig.LIBRARY_VERSION);
+
+    Component<InternalDebugSecretProvider> debugSecretProvider =
+        Component.builder(InternalDebugSecretProvider.class)
+            .name(DEBUG_SECRET_NAME)
+            .factory(container -> this)
+            .build();
+
+    return Arrays.asList(library, debugSecretProvider);
+  }
+
+  @Nullable
+  @Override
+  public String getDebugSecret() {
+    return debugToken;
   }
 }

--- a/packages/firebase_app_check/firebase_app_check/example/lib/main.dart
+++ b/packages/firebase_app_check/firebase_app_check/example/lib/main.dart
@@ -26,6 +26,8 @@ Future<void> main() async {
     androidProvider: AndroidProvider.debug,
     appleProvider: AppleProvider.debug,
     webProvider: ReCaptchaV3Provider(kWebRecaptchaSiteKey),
+    androidDebugToken: 'your-debug-token',
+    appleDebugToken: 'your-debug-token',
   );
 
   runApp(MyApp());

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTAppCheckProvider.m
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTAppCheckProvider.m
@@ -14,10 +14,18 @@
   return self;
 }
 
-- (void)configure:(FIRApp *)app providerName:(NSString *)providerName {
+- (void)configure:(FIRApp *)app
+     providerName:(NSString *)providerName
+       debugToken:(NSString *)debugToken {
   if ([providerName isEqualToString:@"debug"]) {
+    if (debugToken != nil) {
+      // We have a debug token, so just need to stuff it in the environment and it will hook up
+      char *key = "FIRAAppCheckDebugToken", *value = (char *)[debugToken UTF8String];
+      int overwrite = 1;
+      setenv(key, value, overwrite);
+    }
     FIRAppCheckDebugProvider *provider = [[FIRAppCheckDebugProvider alloc] initWithApp:app];
-    NSLog(@"Firebase App Check Debug Token: %@", [provider localDebugToken]);
+    if (debugToken == nil) NSLog(@"Firebase App Check Debug Token: %@", [provider localDebugToken]);
     self.delegateProvider = provider;
   }
 

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTAppCheckProviderFactory.m
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTAppCheckProviderFactory.m
@@ -25,13 +25,15 @@
     self.providers[app.name] = [FLTAppCheckProvider new];
     FLTAppCheckProvider *provider = self.providers[app.name];
     // We set "deviceCheck" as this is currently what is default. Backward compatible.
-    [provider configure:app providerName:@"deviceCheck"];
+    [provider configure:app providerName:@"deviceCheck" debugToken:nil];
   }
 
   return self.providers[app.name];
 }
 
-- (void)configure:(FIRApp *)app providerName:(NSString *)providerName {
+- (void)configure:(FIRApp *)app
+     providerName:(NSString *)providerName
+       debugToken:(NSString *)debugToken {
   if (self.providers == nil) {
     self.providers = [NSMutableDictionary new];
   }
@@ -41,7 +43,7 @@
   }
 
   FLTAppCheckProvider *provider = self.providers[app.name];
-  [provider configure:app providerName:providerName];
+  [provider configure:app providerName:providerName debugToken:debugToken];
 }
 
 @end

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTFirebaseAppCheckPlugin.m
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FLTFirebaseAppCheckPlugin.m
@@ -123,9 +123,10 @@ NSString *const kFLTFirebaseAppCheckChannelName = @"plugins.flutter.io/firebase_
 - (void)activate:(id)arguments withMethodCallResult:(FLTFirebaseMethodCallResult *)result {
   NSString *appNameDart = arguments[@"appName"];
   NSString *providerName = arguments[@"appleProvider"];
+  NSString *debugToken = arguments[@"appleDebugToken"];
 
   FIRApp *app = [FLTFirebasePlugin firebaseAppNamed:appNameDart];
-  [self->providerFactory configure:app providerName:providerName];
+  [self->providerFactory configure:app providerName:providerName debugToken:debugToken];
   result.success(nil);
 }
 

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/include/FLTAppCheckProvider.h
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/include/FLTAppCheckProvider.h
@@ -10,7 +10,9 @@
 
 @property id<FIRAppCheckProvider> delegateProvider;
 
-- (void)configure:(FIRApp *)app providerName:(NSString *)providerName;
+- (void)configure:(FIRApp *)app
+     providerName:(NSString *)providerName
+       debugToken:(NSString *)debugToken;
 
 - (id)initWithApp:(FIRApp *)app;
 

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/include/FLTAppCheckProviderFactory.h
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/include/FLTAppCheckProviderFactory.h
@@ -7,6 +7,8 @@
 
 @property NSMutableDictionary *_Nullable providers;
 
-- (void)configure:(FIRApp *_Nonnull)app providerName:(NSString *_Nonnull)providerName;
+- (void)configure:(FIRApp *_Nonnull)app
+     providerName:(NSString *_Nonnull)providerName
+       debugToken:(NSString *_Nullable)debugToken;
 
 @end

--- a/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
@@ -55,16 +55,23 @@ class FirebaseAppCheck extends FirebasePluginPlatform {
   /// On iOS or macOS, the default provider is "device check". If you wish to set the provider to "app attest", "debug" or "app attest with fallback to device check"
   /// ("app attest" is only available on iOS 14.0+, macOS 14.0+), you may set the `appleProvider` property using the `AppleProvider` enum
   ///
+  /// `androidDebugToken` and `appleDebugToken` allow you to set a debug token for the "debug" provider on Android and iOS respectively.
+  /// On iOS you have to re-run app after changing `appleDebugToken`.
+  ///
   /// For more information, see [the Firebase Documentation](https://firebase.google.com/docs/app-check)
   Future<void> activate({
     WebProvider? webProvider,
     AndroidProvider androidProvider = AndroidProvider.playIntegrity,
     AppleProvider appleProvider = AppleProvider.deviceCheck,
+    String? androidDebugToken,
+    String? appleDebugToken,
   }) {
     return _delegate.activate(
       webProvider: webProvider,
       androidProvider: androidProvider,
       appleProvider: appleProvider,
+      androidDebugToken: androidDebugToken,
+      appleDebugToken: appleDebugToken,
     );
   }
 

--- a/packages/firebase_app_check/firebase_app_check/test/firebase_app_check_test.dart
+++ b/packages/firebase_app_check/firebase_app_check/test/firebase_app_check_test.dart
@@ -57,6 +57,8 @@ void main() {
       test('successful call', () async {
         await appCheck.activate(
           webProvider: ReCaptchaV3Provider('key'),
+          androidDebugToken: 'androidDebug',
+          appleDebugToken: 'appleDebug',
         );
 
         expect(
@@ -68,6 +70,8 @@ void main() {
                 'appName': defaultFirebaseAppName,
                 'androidProvider': 'playIntegrity',
                 'appleProvider': 'deviceCheck',
+                'androidDebugToken': 'androidDebug',
+                'appleDebugToken': 'appleDebug',
               },
             ),
           ],

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
@@ -78,6 +78,8 @@ class MethodChannelFirebaseAppCheck extends FirebaseAppCheckPlatform {
     WebProvider? webProvider,
     AndroidProvider? androidProvider,
     AppleProvider? appleProvider,
+    String? androidDebugToken,
+    String? appleDebugToken,
   }) async {
     try {
       await channel.invokeMethod<void>('FirebaseAppCheck#activate', {
@@ -85,10 +87,12 @@ class MethodChannelFirebaseAppCheck extends FirebaseAppCheckPlatform {
         // Allow value to pass for debug mode for unit testing
         if (defaultTargetPlatform == TargetPlatform.android || kDebugMode)
           'androidProvider': getAndroidProviderString(androidProvider),
+        if (androidDebugToken != null) 'androidDebugToken': androidDebugToken,
         if (defaultTargetPlatform == TargetPlatform.iOS ||
             defaultTargetPlatform == TargetPlatform.macOS ||
             kDebugMode)
           'appleProvider': getAppleProviderString(appleProvider),
+        if (appleDebugToken != null) 'appleDebugToken': appleDebugToken,
       });
     } on PlatformException catch (e, s) {
       convertPlatformException(e, s);

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/platform_interface/platform_interface_firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/platform_interface/platform_interface_firebase_app_check.dart
@@ -61,11 +61,16 @@ abstract class FirebaseAppCheckPlatform extends PlatformInterface {
   /// On iOS or macOS, the default provider is "device check". If you wish to set the provider to "app attest", "debug" or "app attest with fallback to device check"
   /// ("app attest" is only available on iOS 14.0+, macOS 14.0+), you may set the `appleProvider` property using the `AppleProvider` enum
   ///
+  /// `androidDebugToken` and `appleDebugToken` allow you to set a debug token for the "debug" provider on Android and iOS respectively.
+  /// On iOS you have to re-run app after changing `appleDebugToken`.
+  ///
   /// For more information, see [the Firebase Documentation](https://firebase.google.com/docs/app-check)
   Future<void> activate({
     WebProvider? webProvider,
     AndroidProvider? androidProvider,
     AppleProvider? appleProvider,
+    String? androidDebugToken,
+    String? appleDebugToken,
   }) {
     throw UnimplementedError('activate() is not implemented');
   }

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/test/method_channel_tests/method_channel_firebase_app_check_test.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/test/method_channel_tests/method_channel_firebase_app_check_test.dart
@@ -69,6 +69,8 @@ void main() {
     test('activate', () async {
       await appCheck.activate(
         webProvider: ReCaptchaV3Provider('test-key'),
+        androidDebugToken: 'androidDebug',
+        appleDebugToken: 'appleDebug',
       );
       expect(
         methodCallLogger,
@@ -79,6 +81,8 @@ void main() {
               'appName': defaultFirebaseAppName,
               'androidProvider': 'playIntegrity',
               'appleProvider': 'deviceCheck',
+              'androidDebugToken': 'androidDebug',
+              'appleDebugToken': 'appleDebug',
             },
           ),
         ],

--- a/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
@@ -99,6 +99,8 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
     WebProvider? webProvider,
     AndroidProvider? androidProvider,
     AppleProvider? appleProvider,
+    String? androidDebugToken,
+    String? appleDebugToken,
   }) async {
     // save the recaptcha type and site key for future startups
     if (webProvider != null) {

--- a/packages/firebase_app_check/firebase_app_check_web/test/firebase_app_check_web_test.mocks.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/test/firebase_app_check_web_test.mocks.dart
@@ -131,6 +131,8 @@ class MockFirebaseAppCheckWeb extends _i1.Mock
     _i3.WebProvider? webProvider,
     _i3.AndroidProvider? androidProvider,
     _i3.AppleProvider? appleProvider,
+    String? androidDebugToken,
+    String? appleDebugToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -140,6 +142,8 @@ class MockFirebaseAppCheckWeb extends _i1.Mock
             #webProvider: webProvider,
             #androidProvider: androidProvider,
             #appleProvider: appleProvider,
+            #androidDebugToken: androidDebugToken,
+            #appleDebugToken: appleDebugToken,
           },
         ),
         returnValue: _i5.Future<void>.value(),

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.mocks.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.mocks.dart
@@ -781,6 +781,8 @@ class MockFirebaseAppCheck extends _i1.Mock implements _i10.FirebaseAppCheck {
     _i11.WebProvider? webProvider,
     _i11.AndroidProvider? androidProvider = _i11.AndroidProvider.playIntegrity,
     _i11.AppleProvider? appleProvider = _i11.AppleProvider.deviceCheck,
+    String? androidDebugToken,
+    String? appleDebugToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -790,6 +792,8 @@ class MockFirebaseAppCheck extends _i1.Mock implements _i10.FirebaseAppCheck {
             #webProvider: webProvider,
             #androidProvider: androidProvider,
             #appleProvider: appleProvider,
+            #androidDebugToken: androidDebugToken,
+            #appleDebugToken: appleDebugToken,
           },
         ),
         returnValue: _i6.Future<void>.value(),

--- a/tests/integration_test/firebase_app_check/firebase_app_check_e2e_test.dart
+++ b/tests/integration_test/firebase_app_check/firebase_app_check_e2e_test.dart
@@ -77,6 +77,34 @@ void main() {
         },
         skip: kIsWeb,
       );
+
+      test(
+        'debugToken on Android',
+            () async {
+          await expectLater(
+            FirebaseAppCheck.instance.activate(
+              androidProvider: AndroidProvider.debug,
+              androidDebugToken: 'debug_token',
+            ),
+            completes,
+          );
+        },
+        skip: defaultTargetPlatform != TargetPlatform.android,
+      );
+
+      test(
+        'debugToken on iOS',
+            () async {
+          await expectLater(
+            FirebaseAppCheck.instance.activate(
+              appleProvider: AppleProvider.debug,
+              appleDebugToken: 'debug_token',
+            ),
+            completes,
+          );
+        },
+        skip: defaultTargetPlatform != TargetPlatform.iOS,
+      );
     },
   );
 }


### PR DESCRIPTION
## Description

This feature enables developers to use a pre-generated debug token rather than generating one at runtime. It is particularly beneficial in CI environments where manually copying the token from logs and pasting it into the Firebase Console is not feasible. 
By using a pre-generated token, the setup becomes more automated and less error-prone, streamlining the development and testing process.
This PR is an improved version of #13101. Since the maintainer doesn't follow his PR, I wanted to improve it and open another PR. The improvements include better spelling and an added documentation section for how to add a debug token.

## Related Issues

Fixes #11719

## Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
