### PR TITLE
[DO NOT MERGE] feat(vertexai): Add support for setting the API version - wait for the release date

### DIFF
--- a/packages/firebase_vertexai/firebase_vertexai/example/lib/main.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/example/lib/main.dart
@@ -102,12 +102,14 @@ class _ChatWidgetState extends State<ChatWidget> {
           FirebaseVertexAI.instanceFor(auth: FirebaseAuth.instance);
       _model = vertex_instance.generativeModel(
         model: 'gemini-1.5-flash',
+        requestOptions: RequestOptions(apiVersion: ApiVersion.v1beta),
       );
       _functionCallModel = vertex_instance.generativeModel(
         model: 'gemini-1.5-flash',
         tools: [
           Tool.functionDeclarations([fetchWeatherTool]),
         ],
+        requestOptions: RequestOptions(apiVersion: ApiVersion.v1beta),
       );
       _chat = _model.startChat();
     });

--- a/packages/firebase_vertexai/firebase_vertexai/lib/firebase_vertexai.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/firebase_vertexai.dart
@@ -56,4 +56,5 @@ export 'src/function_calling.dart'
         Tool,
         ToolConfig;
 export 'src/model.dart' show GenerativeModel;
+export 'src/request_options.dart' show ApiVersion, RequestOptions;
 export 'src/schema.dart' show Schema, SchemaType;

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
@@ -22,6 +22,7 @@ import 'api.dart';
 import 'content.dart';
 import 'function_calling.dart';
 import 'model.dart';
+import 'request_options.dart';
 
 const _defaultLocation = 'us-central1';
 
@@ -96,6 +97,7 @@ class FirebaseVertexAI extends FirebasePluginPlatform {
     List<Tool>? tools,
     ToolConfig? toolConfig,
     Content? systemInstruction,
+    RequestOptions? requestOptions,
   }) {
     return createGenerativeModel(
       model: model,

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/firebase_vertexai.dart
@@ -110,6 +110,7 @@ class FirebaseVertexAI extends FirebasePluginPlatform {
       tools: tools,
       toolConfig: toolConfig,
       systemInstruction: systemInstruction,
+      requestOptions: requestOptions,
     );
   }
 }

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/model.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/model.dart
@@ -313,6 +313,7 @@ GenerativeModel createGenerativeModel({
       tools: tools,
       toolConfig: toolConfig,
       systemInstruction: systemInstruction,
+      requestOptions: requestOptions,
     );
 
 /// Creates a model with an overridden [ApiClient] for testing.
@@ -330,6 +331,7 @@ GenerativeModel createModelWithClient({
   List<SafetySetting>? safetySettings,
   List<Tool>? tools,
   ToolConfig? toolConfig,
+  RequestOptions? requestOptions,
 }) =>
     GenerativeModel._constructTestModel(
         model: model,
@@ -342,4 +344,5 @@ GenerativeModel createModelWithClient({
         systemInstruction: systemInstruction,
         tools: tools,
         toolConfig: toolConfig,
+        requestOptions: requestOptions,
         apiClient: client);

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/model.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/model.dart
@@ -30,7 +30,7 @@ import 'request_options.dart';
 import 'vertex_version.dart';
 
 const _baseUrl = 'firebasevertexai.googleapis.com';
-const _defaultApiVersion = 'v1beta';
+const _defaultApiVersion = ApiVersion.v1beta;
 
 /// [Task] enum class for [GenerativeModel] to make request.
 enum Task {
@@ -141,11 +141,10 @@ final class GenerativeModel {
   static Uri _vertexUri(
       FirebaseApp app, String location, RequestOptions? requestOptions) {
     final projectId = app.options.projectId;
-    final apiVersion =
-        requestOptions?.apiVersion?.versionIdentifier ?? _defaultApiVersion;
+    final apiVersion = requestOptions?.apiVersion ?? _defaultApiVersion;
     return Uri.https(
       _baseUrl,
-      '/$apiVersion/projects/$projectId/locations/$location/publishers/google',
+      '/${apiVersion.versionIdentifier}/projects/$projectId/locations/$location/publishers/google',
     );
   }
 

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/model.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/model.dart
@@ -26,10 +26,11 @@ import 'api.dart';
 import 'client.dart';
 import 'content.dart';
 import 'function_calling.dart';
+import 'request_options.dart';
 import 'vertex_version.dart';
 
 const _baseUrl = 'firebasevertexai.googleapis.com';
-const _apiVersion = 'v1beta';
+const _defaultApiVersion = 'v1beta';
 
 /// [Task] enum class for [GenerativeModel] to make request.
 enum Task {
@@ -77,9 +78,10 @@ final class GenerativeModel {
     List<Tool>? tools,
     ToolConfig? toolConfig,
     Content? systemInstruction,
+    RequestOptions? requestOptions,
     http.Client? httpClient,
   })  : _model = _normalizeModelName(model),
-        _baseUri = _vertexUri(app, location),
+        _baseUri = _vertexUri(app, location, requestOptions),
         _safetySettings = safetySettings ?? [],
         _generationConfig = generationConfig,
         _tools = tools,
@@ -101,9 +103,10 @@ final class GenerativeModel {
     List<Tool>? tools,
     ToolConfig? toolConfig,
     Content? systemInstruction,
+    RequestOptions? requestOptions,
     ApiClient? apiClient,
   })  : _model = _normalizeModelName(model),
-        _baseUri = _vertexUri(app, location),
+        _baseUri = _vertexUri(app, location, requestOptions),
         _safetySettings = safetySettings ?? [],
         _generationConfig = generationConfig,
         _tools = tools,
@@ -135,11 +138,14 @@ final class GenerativeModel {
     return (prefix: parts.first, name: parts.skip(1).join('/'));
   }
 
-  static Uri _vertexUri(FirebaseApp app, String location) {
-    var projectId = app.options.projectId;
+  static Uri _vertexUri(
+      FirebaseApp app, String location, RequestOptions? requestOptions) {
+    final projectId = app.options.projectId;
+    final apiVersion =
+        requestOptions?.apiVersion?.versionIdentifier ?? _defaultApiVersion;
     return Uri.https(
       _baseUrl,
-      '/$_apiVersion/projects/$projectId/locations/$location/publishers/google',
+      '/$apiVersion/projects/$projectId/locations/$location/publishers/google',
     );
   }
 
@@ -295,6 +301,7 @@ GenerativeModel createGenerativeModel({
   List<Tool>? tools,
   ToolConfig? toolConfig,
   Content? systemInstruction,
+  RequestOptions? requestOptions,
 }) =>
     GenerativeModel._(
       model: model,

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/request_options.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/request_options.dart
@@ -1,0 +1,39 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Configuration parameters for sending requests to the backend.
+final class RequestOptions {
+  /// Constructor
+  RequestOptions({this.apiVersion});
+
+  /// The API version to use in requests to the backend.
+  final ApiVersion? apiVersion;
+}
+
+/// API versions for the Vertex AI in Firebase endpoint.
+enum ApiVersion {
+  /// The stable channel for version 1 of the API.
+  v1('v1'),
+
+  /// The beta channel for version 1 of the API.
+  v1beta('v1beta');
+
+  const ApiVersion(this.versionIdentifier);
+
+  /// The identifier for the API version.
+  final String versionIdentifier;
+
+  @override
+  String toString() => name;
+}


### PR DESCRIPTION
## Description

WIP - See [go/firebase-vertex-set-api-version](https://goto.corp.google.com/firebase-vertex-set-api-version) (Google-internal only) for more details.

Added the ability to specify an API version (e.g., v1 or v1beta) when initializing a `GenerativeModel` using a new `RequestOptions` class to match the other SDKs. This is the Flutter/Dart equivalent of https://github.com/firebase/firebase-ios-sdk/pull/14356.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## TODOs

- [ ] API review and approval
- [ ] Add unit tests
- [ ] Update the default API version to v1 when the backend is ready
- [ ] Add a CHANGELOG entry