### PR TITLE
fix(vertexai): make token-based metrics non nullable

### DIFF
--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/api.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/api.dart
@@ -19,8 +19,8 @@ import 'schema.dart';
 /// Response for Count Tokens
 final class CountTokensResponse {
   /// Constructor
-  CountTokensResponse(this.totalTokens,
-      {this.totalBillableCharacters, this.promptTokensDetails});
+  CountTokensResponse(
+      this.totalTokens, this.totalBillableCharacters, this.promptTokensDetails);
 
   /// The number of tokens that the `model` tokenizes the `prompt` into.
   ///
@@ -33,7 +33,7 @@ final class CountTokensResponse {
   final int? totalBillableCharacters;
 
   /// List of modalities that were processed in the request input.
-  final List<ModalityTokenCount>? promptTokensDetails;
+  final List<ModalityTokenCount> promptTokensDetails;
 }
 
 /// Response from the model; supports multiple candidates.
@@ -133,11 +133,11 @@ final class PromptFeedback {
 final class UsageMetadata {
   /// Constructor
   UsageMetadata._(
-      {this.promptTokenCount,
+      this.promptTokenCount,
       this.candidatesTokenCount,
       this.totalTokenCount,
       this.promptTokensDetails,
-      this.candidatesTokensDetails});
+      this.candidatesTokensDetails);
 
   /// Number of tokens in the prompt.
   final int? promptTokenCount;
@@ -149,10 +149,10 @@ final class UsageMetadata {
   final int? totalTokenCount;
 
   /// List of modalities that were processed in the request input.
-  final List<ModalityTokenCount>? promptTokensDetails;
+  final List<ModalityTokenCount> promptTokensDetails;
 
   /// List of modalities that were returned in the response.
-  final List<ModalityTokenCount>? candidatesTokensDetails;
+  final List<ModalityTokenCount> candidatesTokensDetails;
 }
 
 /// Response candidate generated from a [GenerativeModel].
@@ -777,13 +777,13 @@ CountTokensResponse parseCountTokensResponse(Object jsonObject) {
   final promptTokensDetails = switch (jsonObject) {
     {'promptTokensDetails': final List<Object?> promptTokensDetails} =>
       promptTokensDetails.map(_parseModalityTokenCount).toList(),
-    _ => null,
+    _ => <ModalityTokenCount>[],
   };
 
   return CountTokensResponse(
     totalTokens,
-    totalBillableCharacters: totalBillableCharacters,
-    promptTokensDetails: promptTokensDetails,
+    totalBillableCharacters,
+    promptTokensDetails,
   );
 }
 
@@ -859,19 +859,15 @@ UsageMetadata _parseUsageMetadata(Object jsonObject) {
   final promptTokensDetails = switch (jsonObject) {
     {'promptTokensDetails': final List<Object?> promptTokensDetails} =>
       promptTokensDetails.map(_parseModalityTokenCount).toList(),
-    _ => null,
+    _ => <ModalityTokenCount>[],
   };
   final candidatesTokensDetails = switch (jsonObject) {
     {'candidatesTokensDetails': final List<Object?> candidatesTokensDetails} =>
       candidatesTokensDetails.map(_parseModalityTokenCount).toList(),
-    _ => null,
+    _ => <ModalityTokenCount>[],
   };
-  return UsageMetadata._(
-      promptTokenCount: promptTokenCount,
-      candidatesTokenCount: candidatesTokenCount,
-      totalTokenCount: totalTokenCount,
-      promptTokensDetails: promptTokensDetails,
-      candidatesTokensDetails: candidatesTokensDetails);
+  return UsageMetadata._(promptTokenCount, candidatesTokenCount,
+      totalTokenCount, promptTokensDetails, candidatesTokensDetails);
 }
 
 ModalityTokenCount _parseModalityTokenCount(Object? jsonObject) {

--- a/packages/firebase_vertexai/firebase_vertexai/test/model_test.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/test/model_test.dart
@@ -434,7 +434,8 @@ void main() {
           },
           response: {'totalTokens': 2},
         );
-        expect(response, matchesCountTokensResponse(CountTokensResponse(2)));
+        expect(response,
+            matchesCountTokensResponse(CountTokensResponse(2, null, [])));
       });
     });
   });

--- a/packages/firebase_vertexai/firebase_vertexai/test/response_parsing_test.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/test/response_parsing_test.dart
@@ -769,9 +769,9 @@ void main() {
       final decoded = jsonDecode(response) as Object;
       final countTokensResponse = parseCountTokensResponse(decoded);
       expect(countTokensResponse.totalTokens, 1837);
-      expect(countTokensResponse.promptTokensDetails?.first.modality,
+      expect(countTokensResponse.promptTokensDetails.first.modality,
           ContentModality.image);
-      expect(countTokensResponse.promptTokensDetails?.first.tokenCount, 1806);
+      expect(countTokensResponse.promptTokensDetails.first.tokenCount, 1806);
     });
 
     test('text getter joins content', () async {

--- a/packages/firebase_vertexai/firebase_vertexai/test/response_parsing_test.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/test/response_parsing_test.dart
@@ -669,6 +669,38 @@ void main() {
   "usageMetadata": {
     "promptTokenCount": 1837,
     "candidatesTokenCount": 76,
+    "totalTokenCount": 1913
+  }
+}
+        ''';
+      final decoded = jsonDecode(response) as Object;
+      final generateContentResponse = parseGenerateContentResponse(decoded);
+      expect(
+          generateContentResponse.text, 'Here is a description of the image:');
+      expect(generateContentResponse.usageMetadata?.totalTokenCount, 1913);
+      expect(generateContentResponse.usageMetadata?.promptTokensDetails.isEmpty,
+          true);
+      expect(
+          generateContentResponse
+              .usageMetadata?.candidatesTokensDetails.isEmpty,
+          true);
+    });
+
+    test('response including usage metadata with token details', () async {
+      const response = '''
+{
+  "candidates": [{
+    "content": {
+      "role": "model",
+      "parts": [{
+        "text": "Here is a description of the image:"
+      }]
+    },
+    "finishReason": "STOP"
+  }],
+  "usageMetadata": {
+    "promptTokenCount": 1837,
+    "candidatesTokenCount": 76,
     "totalTokenCount": 1913,
     "promptTokensDetails": [{
       "modality": "TEXT",
@@ -691,20 +723,33 @@ void main() {
       expect(generateContentResponse.usageMetadata?.totalTokenCount, 1913);
       expect(
           generateContentResponse
-              .usageMetadata?.promptTokensDetails?[1].modality,
+              .usageMetadata?.promptTokensDetails[1].modality,
           ContentModality.image);
       expect(
           generateContentResponse
-              .usageMetadata?.promptTokensDetails?[1].tokenCount,
+              .usageMetadata?.promptTokensDetails[1].tokenCount,
           1806);
       expect(
           generateContentResponse
-              .usageMetadata?.candidatesTokensDetails?.first.modality,
+              .usageMetadata?.candidatesTokensDetails.first.modality,
           ContentModality.text);
       expect(
           generateContentResponse
-              .usageMetadata?.candidatesTokensDetails?.first.tokenCount,
+              .usageMetadata?.candidatesTokensDetails.first.tokenCount,
           76);
+    });
+
+    test('countTokens simple response', () async {
+      const response = '''
+{
+  "totalTokens": 1837,
+  "totalBillableCharacters": 117
+}
+        ''';
+      final decoded = jsonDecode(response) as Object;
+      final countTokensResponse = parseCountTokensResponse(decoded);
+      expect(countTokensResponse.totalTokens, 1837);
+      expect(countTokensResponse.promptTokensDetails.isEmpty, true);
     });
 
     test('countTokens with modality fields returned', () async {


### PR DESCRIPTION
If missing, they'll default to empty.

