### PR TITLE
fix(auth): deprecate Microsoft provider method not used for authentication

### DIFF
--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/microsoft_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/microsoft_auth.dart
@@ -24,22 +24,22 @@ const _kProviderId = 'microsoft.com';
 ///   .then(...);
 /// ```
 ///
-/// If authenticating with Microsoft via a 3rd party, use the returned
-/// `accessToken` to sign-in or link the user with the created credential, for
-/// example:
-///
+/// For native apps, you may also sign-in with [signInWithProvider]. Ensure you have
+/// an app configured in the Microsoft Azure portal.
+/// See Firebase documentation for more information: https://firebase.google.com/docs/auth/flutter/federated-auth?#microsoft
 /// ```dart
-/// String accessToken = '...'; // From 3rd party provider
-/// var microsoftAuthCredential = MicrosoftAuthProvider.credential(accessToken);
-///
-/// FirebaseAuth.instance.signInWithCredential(microsoftAuthCredential)
-///   .then(...);
+/// MicrosoftAuthProvider microsoftProvider = MicrosoftAuthProvider();
+/// microsoftProvider.setCustomParameters({'tenant': 'TENANT ID FROM AZURE PORTAL'},);
+/// await FirebaseAuth.instance.signInWithProvider(microsoftProvider);
 /// ```
 class MicrosoftAuthProvider extends AuthProvider {
   /// Creates a new instance.
   MicrosoftAuthProvider() : super(_kProviderId);
 
   /// Create a new [MicrosoftAuthCredential] from a provided [accessToken];
+  @Deprecated(
+      '`credential()` has been deprecated. Sign-in cannot be directly achieved with OAuth access token based credentials for Microsoft',
+    )
   static OAuthCredential credential(String accessToken) {
     return MicrosoftAuthCredential._credential(
       accessToken,


### PR DESCRIPTION
## Description

Flutter Auth documentation already uses correct sign-in method: https://firebase.google.com/docs/auth/flutter/federated-auth?#microsoft

Both Firebase android and iOS documentation use provider to sign-in with Microsoft. 

Firebase documentation states you cannot use access token based credentials to sign in: https://firebase.google.com/docs/auth/ios/microsoft-oauth?_gl=1*1rjsp43*_up*MQ..*_ga*OTM3NzY0NDIuMTczOTUzMjc1Mw..*_ga_CW55HF8NVT*MTczOTUzMjc1My4xLjAuMTczOTUzMjc1My4wLjAuMA..#expandable-2

## Related Issues

closes https://github.com/firebase/flutterfire/issues/16598

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
