### PR TITLE
fix(core, web): resolve type error in release mode

### DIFF
--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -202,8 +202,13 @@ class FirebaseCoreWeb extends FirebasePlatform {
   List<FirebaseAppPlatform> get apps {
     try {
       return firebase.apps.map(_createFromJsApp).toList(growable: false);
-    } catch (exception) {
-      if (exception.toString().contains('of undefined')) {
+    } catch (exception, stackTrace) {
+      final exceptionMessage = exception.toString();
+      final stackTraceMessage = stackTrace.toString();
+      const undefinedError = 'of undefined';
+
+      if (exceptionMessage.contains(undefinedError) ||
+          stackTraceMessage.contains(undefinedError)) {
         // Keeps behavior consistent with other platforms which can access list without initializing app.
         return [];
       } else {


### PR DESCRIPTION
## Description

Added an additional condition to check the stackTrace message for `TypeError: Cannot read properties of undefined (reading 'getApps')`. I observed that this error appears in the `exception` output in debug mode but is not present in `exception` for release mode, instead appearing only in the `stackTrace`.

## Related Issues
fixes https://github.com/firebase/flutterfire/issues/17111

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
