### PR TITLE
fix(cloud_firestore): correct nanoseconds calculation for pre-1970 dates

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/timestamp_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/timestamp_e2e.dart
@@ -53,5 +53,22 @@ void runTimestampTests() {
         equals(date.millisecondsSinceEpoch),
       );
     });
+
+    test('set pre-1970 $Timestamp and return', () async {
+      DocumentReference<Map<String, dynamic>> doc =
+          await initializeTest('timestamp');
+      final date = DateTime(1969, 06, 22, 0, 0, 0, 123);
+      final localTimestamp = Timestamp.fromDate(date);
+
+      await doc.set({'foo': localTimestamp});
+
+      DocumentSnapshot<Map<String, dynamic>> snapshot = await doc.get();
+      Timestamp retievedTimestamp = snapshot.data()!['foo'];
+      expect(retievedTimestamp, isA<Timestamp>());
+      expect(
+        retievedTimestamp,
+        equals(localTimestamp),
+      );
+    });
   });
 }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/timestamp.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/timestamp.dart
@@ -42,6 +42,9 @@ class Timestamp implements Comparable<Timestamp> {
   factory Timestamp.fromMicrosecondsSinceEpoch(int microseconds) {
     int seconds = microseconds ~/ _kMillion;
     int nanoseconds = (microseconds - seconds * _kMillion) * _kThousand;
+
+    // Matches implementation in Android SDK:
+    // https://github.com/firebase/firebase-android-sdk/blob/master/firebase-common/src/main/java/com/google/firebase/Timestamp.kt#L114-L121
     if (nanoseconds < 0) {
       seconds -= 1;
       nanoseconds += _kBillion;

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/timestamp.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/timestamp.dart
@@ -40,8 +40,12 @@ class Timestamp implements Comparable<Timestamp> {
 
   /// Create a [Timestamp] fromMicrosecondsSinceEpoch
   factory Timestamp.fromMicrosecondsSinceEpoch(int microseconds) {
-    final int seconds = microseconds ~/ _kMillion;
-    final int nanoseconds = (microseconds - seconds * _kMillion) * _kThousand;
+    int seconds = microseconds ~/ _kMillion;
+    int nanoseconds = (microseconds - seconds * _kMillion) * _kThousand;
+    if (nanoseconds < 0) {
+      seconds -= 1;
+      nanoseconds += _kBillion;
+    }
     return Timestamp(seconds, nanoseconds);
   }
 

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/timestamp_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/timestamp_test.dart
@@ -80,5 +80,24 @@ void main() {
 
       expect(epoch, equals(-9999999999));
     });
+
+    test('Timestamp should not throw for dates before 1970', () {
+      final dates = [
+        DateTime(1969, 06, 22, 0, 0, 0, 123),
+        DateTime(1969, 12, 31, 23, 59, 59, 999),
+        DateTime(1900, 01, 01, 12, 30, 45, 500),
+        DateTime(1800, 07, 04, 18, 15, 30, 250),
+        DateTime(0001, 01, 01, 00, 00, 00, 001),
+      ];
+
+      for (final date in dates) {
+        try {
+          final timestamp = Timestamp.fromDate(date);
+          expect(timestamp, isA<Timestamp>());
+        } catch (e) {
+          fail('Timestamp.fromDate threw an error: $e');
+        }
+      }
+    });
   });
 }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/timestamp_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/timestamp_test.dart
@@ -99,5 +99,15 @@ void main() {
         }
       }
     });
+
+    test(
+        'pre-1970 Timestamps should match the original DateTime after conversion',
+        () {
+      final date = DateTime(1969, 06, 22, 0, 0, 0, 123);
+      final timestamp = Timestamp.fromDate(date);
+      final timestampAsDateTime = timestamp.toDate();
+
+      expect(date, equals(timestampAsDateTime));
+    });
   });
 }


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/firebase/flutterfire/issues/17189

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
