### PR TITLE
feat(vertexai): Add repetition penalties to GenerationConfig

### DIFF
--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/api.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/api.dart
@@ -724,6 +724,8 @@ final class GenerationConfig extends BaseGenerationConfig {
     super.topK,
     this.responseMimeType,
     this.responseSchema,
+    this.presencePenalty,
+    this.frequencyPenalty,
   });
 
   /// The set of character sequences (up to 5) that will stop output generation.
@@ -745,6 +747,39 @@ final class GenerationConfig extends BaseGenerationConfig {
   ///   a schema; currently this is limited to `application/json`.
   final Schema? responseSchema;
 
+  /// Controls the likelihood of repeating the same words or phrases already
+  /// generated in the text.
+  ///
+  /// Higher values increase the penalty of repetition, resulting in more
+  /// diverse output.
+  ///
+  /// Note: While both `presencePenalty` and `frequencyPenalty` discourage
+  /// repetition, `presencePenalty` applies the same penalty regardless of how
+  /// many times the word/phrase has already appeared, whereas
+  /// `frequencyPenalty` increases the penalty for *each* repetition of a
+  /// word/phrase.
+  ///
+  /// Important: The range of supported `presencePenalty` values depends on the
+  /// model; see the [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+  /// for more details.
+  final double? presencePenalty;
+
+  /// Controls the likelihood of repeating words or phrases, with the penalty
+  /// increasing for each repetition.
+  ///
+  /// Higher values increase the penalty of repetition, resulting in more
+  /// diverse output.
+  ///
+  /// Note: While both `frequencyPenalty` and `presencePenalty` discourage
+  /// repetition, `frequencyPenalty` increases the penalty for *each* repetition
+  /// of a word/phrase, whereas `presencePenalty` applies the same penalty
+  /// regardless of how many times the word/phrase has already appeared.
+  ///
+  /// Important: The range of supported `frequencyPenalty` values depends on the
+  /// model; see the [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+  /// for more details.
+  final double? frequencyPenalty;
+
   @override
   Map<String, Object?> toJson() => {
         ...super.toJson(),
@@ -755,7 +790,11 @@ final class GenerationConfig extends BaseGenerationConfig {
           'responseMimeType': responseMimeType,
         if (responseSchema case final responseSchema?)
           'responseSchema': responseSchema,
-      };
++        if (presencePenalty case final presencePenalty?)
++          'presencePenalty': presencePenalty,
++        if (frequencyPenalty case final frequencyPenalty?)
++          'frequencyPenalty': frequencyPenalty,
++      };
 }
 
 /// Type of task for which the embedding will be used.

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/api.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/api.dart
@@ -702,11 +702,11 @@ abstract class BaseGenerationConfig {
   /// Note: The default value varies by model.
   final int? topK;
 
-  /// Controls the likelihood of repeating the same words or phrases already
-  /// generated in the text.
+  /// The penalty for repeating the same words or phrases already generated in
+  /// the text.
   ///
-  /// Higher values increase the penalty of repetition, resulting in more
-  /// diverse output.
+  /// Controls the likelihood of repetition. Higher penalty values result in
+  /// more diverse output.
   ///
   /// **Note:** While both [presencePenalty] and [frequencyPenalty] discourage
   /// repetition, [presencePenalty] applies the same penalty regardless of how
@@ -720,11 +720,11 @@ abstract class BaseGenerationConfig {
   /// for more details.
   final double? presencePenalty;
 
-  /// Controls the likelihood of repeating words or phrases, with the penalty
-  /// increasing for each repetition.
+  /// The penalty for repeating words or phrases, with the penalty increasing
+  /// for each repetition.
   ///
-  /// Higher values increase the penalty of repetition, resulting in more
-  /// diverse output.
+  /// Controls the likelihood of repetition. Higher values increase the penalty
+  /// of repetition, resulting in more diverse output.
   ///
   /// **Note:** While both [frequencyPenalty] and [presencePenalty] discourage
   /// repetition, [frequencyPenalty] increases the penalty for *each* repetition

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/api.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/api.dart
@@ -659,6 +659,8 @@ abstract class BaseGenerationConfig {
     this.temperature,
     this.topP,
     this.topK,
+    this.presencePenalty,
+    this.frequencyPenalty,
   });
 
   /// Number of generated responses to return.
@@ -700,53 +702,6 @@ abstract class BaseGenerationConfig {
   /// Note: The default value varies by model.
   final int? topK;
 
-  // ignore: public_member_api_docs
-  Map<String, Object?> toJson() => {
-        if (candidateCount case final candidateCount?)
-          'candidateCount': candidateCount,
-        if (maxOutputTokens case final maxOutputTokens?)
-          'maxOutputTokens': maxOutputTokens,
-        if (temperature case final temperature?) 'temperature': temperature,
-        if (topP case final topP?) 'topP': topP,
-        if (topK case final topK?) 'topK': topK,
-      };
-}
-
-/// Configuration options for model generation and outputs.
-final class GenerationConfig extends BaseGenerationConfig {
-  // ignore: public_member_api_docs
-  GenerationConfig({
-    super.candidateCount,
-    this.stopSequences,
-    super.maxOutputTokens,
-    super.temperature,
-    super.topP,
-    super.topK,
-    this.responseMimeType,
-    this.responseSchema,
-    this.presencePenalty,
-    this.frequencyPenalty,
-  });
-
-  /// The set of character sequences (up to 5) that will stop output generation.
-  ///
-  /// If specified, the API will stop at the first appearance of a stop
-  /// sequence. The stop sequence will not be included as part of the response.
-  final List<String>? stopSequences;
-
-  /// Output response mimetype of the generated candidate text.
-  ///
-  /// Supported mimetype:
-  /// - `text/plain`: (default) Text output.
-  /// - `application/json`: JSON response in the candidates.
-  final String? responseMimeType;
-
-  /// Output response schema of the generated candidate text.
-  ///
-  /// - Note: This only applies when the [responseMimeType] supports
-  ///   a schema; currently this is limited to `application/json`.
-  final Schema? responseSchema;
-
   /// Controls the likelihood of repeating the same words or phrases already
   /// generated in the text.
   ///
@@ -782,6 +737,57 @@ final class GenerationConfig extends BaseGenerationConfig {
   /// for more details.
   final double? frequencyPenalty;
 
+  // ignore: public_member_api_docs
+  Map<String, Object?> toJson() => {
+        if (candidateCount case final candidateCount?)
+          'candidateCount': candidateCount,
+        if (maxOutputTokens case final maxOutputTokens?)
+          'maxOutputTokens': maxOutputTokens,
+        if (temperature case final temperature?) 'temperature': temperature,
+        if (topP case final topP?) 'topP': topP,
+        if (topK case final topK?) 'topK': topK,
+        if (presencePenalty case final presencePenalty?)
+          'presencePenalty': presencePenalty,
+        if (frequencyPenalty case final frequencyPenalty?)
+          'frequencyPenalty': frequencyPenalty,
+      };
+}
+
+/// Configuration options for model generation and outputs.
+final class GenerationConfig extends BaseGenerationConfig {
+  // ignore: public_member_api_docs
+  GenerationConfig({
+    super.candidateCount,
+    this.stopSequences,
+    super.maxOutputTokens,
+    super.temperature,
+    super.topP,
+    super.topK,
+    super.presencePenalty,
+    super.frequencyPenalty,
+    this.responseMimeType,
+    this.responseSchema,
+  });
+
+  /// The set of character sequences (up to 5) that will stop output generation.
+  ///
+  /// If specified, the API will stop at the first appearance of a stop
+  /// sequence. The stop sequence will not be included as part of the response.
+  final List<String>? stopSequences;
+
+  /// Output response mimetype of the generated candidate text.
+  ///
+  /// Supported mimetype:
+  /// - `text/plain`: (default) Text output.
+  /// - `application/json`: JSON response in the candidates.
+  final String? responseMimeType;
+
+  /// Output response schema of the generated candidate text.
+  ///
+  /// - Note: This only applies when the [responseMimeType] supports
+  ///   a schema; currently this is limited to `application/json`.
+  final Schema? responseSchema;
+
   @override
   Map<String, Object?> toJson() => {
         ...super.toJson(),
@@ -792,10 +798,6 @@ final class GenerationConfig extends BaseGenerationConfig {
           'responseMimeType': responseMimeType,
         if (responseSchema case final responseSchema?)
           'responseSchema': responseSchema,
-        if (presencePenalty case final presencePenalty?)
-          'presencePenalty': presencePenalty,
-        if (frequencyPenalty case final frequencyPenalty?)
-          'frequencyPenalty': frequencyPenalty,
       };
 }
 

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/api.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/api.dart
@@ -753,14 +753,15 @@ final class GenerationConfig extends BaseGenerationConfig {
   /// Higher values increase the penalty of repetition, resulting in more
   /// diverse output.
   ///
-  /// Note: While both `presencePenalty` and `frequencyPenalty` discourage
-  /// repetition, `presencePenalty` applies the same penalty regardless of how
+  /// **Note:** While both [presencePenalty] and [frequencyPenalty] discourage
+  /// repetition, [presencePenalty] applies the same penalty regardless of how
   /// many times the word/phrase has already appeared, whereas
-  /// `frequencyPenalty` increases the penalty for *each* repetition of a
+  /// [frequencyPenalty] increases the penalty for *each* repetition of a
   /// word/phrase.
   ///
-  /// Important: The range of supported `presencePenalty` values depends on the
-  /// model; see the [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+  /// **Important:** The range of supported [presencePenalty] values depends on
+  /// the model; see the
+  /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
   /// for more details.
   final double? presencePenalty;
 
@@ -770,13 +771,14 @@ final class GenerationConfig extends BaseGenerationConfig {
   /// Higher values increase the penalty of repetition, resulting in more
   /// diverse output.
   ///
-  /// Note: While both `frequencyPenalty` and `presencePenalty` discourage
-  /// repetition, `frequencyPenalty` increases the penalty for *each* repetition
-  /// of a word/phrase, whereas `presencePenalty` applies the same penalty
+  /// **Note:** While both [frequencyPenalty] and [presencePenalty] discourage
+  /// repetition, [frequencyPenalty] increases the penalty for *each* repetition
+  /// of a word/phrase, whereas [presencePenalty] applies the same penalty
   /// regardless of how many times the word/phrase has already appeared.
   ///
-  /// Important: The range of supported `frequencyPenalty` values depends on the
-  /// model; see the [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+  /// **Important:** The range of supported [frequencyPenalty] values depends on
+  /// the model; see the
+  /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
   /// for more details.
   final double? frequencyPenalty;
 
@@ -790,11 +792,11 @@ final class GenerationConfig extends BaseGenerationConfig {
           'responseMimeType': responseMimeType,
         if (responseSchema case final responseSchema?)
           'responseSchema': responseSchema,
-+        if (presencePenalty case final presencePenalty?)
-+          'presencePenalty': presencePenalty,
-+        if (frequencyPenalty case final frequencyPenalty?)
-+          'frequencyPenalty': frequencyPenalty,
-+      };
+        if (presencePenalty case final presencePenalty?)
+          'presencePenalty': presencePenalty,
+        if (frequencyPenalty case final frequencyPenalty?)
+          'frequencyPenalty': frequencyPenalty,
+      };
 }
 
 /// Type of task for which the embedding will be used.

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/api.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/api.dart
@@ -716,7 +716,7 @@ abstract class BaseGenerationConfig {
   ///
   /// **Important:** The range of supported [presencePenalty] values depends on
   /// the model; see the
-  /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+  /// [documentation](https://firebase.google.com/docs/vertex-ai/model-parameters?platform=flutter#configure-model-parameters-gemini)
   /// for more details.
   final double? presencePenalty;
 
@@ -733,7 +733,7 @@ abstract class BaseGenerationConfig {
   ///
   /// **Important:** The range of supported [frequencyPenalty] values depends on
   /// the model; see the
-  /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+  /// [documentation](https://firebase.google.com/docs/vertex-ai/model-parameters?platform=flutter#configure-model-parameters-gemini)
   /// for more details.
   final double? frequencyPenalty;
 

--- a/packages/firebase_vertexai/firebase_vertexai/lib/src/live_api.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/lib/src/live_api.dart
@@ -89,6 +89,8 @@ final class LiveGenerationConfig extends BaseGenerationConfig {
     super.temperature,
     super.topP,
     super.topK,
+    super.presencePenalty,
+    super.frequencyPenalty,
   });
 
   /// The speech configuration.

--- a/packages/firebase_vertexai/firebase_vertexai/test/model_test.dart
+++ b/packages/firebase_vertexai/firebase_vertexai/test/model_test.dart
@@ -176,6 +176,23 @@ void main() {
         );
       });
 
+      test('can override GenerationConfig repetition penalties', () async {
+        final (client, model) = createModel();
+        const prompt = 'Some prompt';
+        await client.checkRequest(
+          () => model.generateContent([Content.text(prompt)],
+              generationConfig: GenerationConfig(
+                  presencePenalty: 0.5, frequencyPenalty: 0.2)),
+          verifyRequest: (_, request) {
+            expect(request['generationConfig'], {
+              'presencePenalty': 0.5,
+              'frequencyPenalty': 0.2,
+            });
+          },
+          response: arbitraryGenerateContentResponse,
+        );
+      });
+
       test('can pass system instructions', () async {
         const instructions = 'Do a good job';
         final (client, model) = createModel(


### PR DESCRIPTION
## Description

Added support for repetition penalties (`presencePenalty` and `frequencyPenalty`) in `GenerationConfig` in the Vertex AI in Firebase SDK. This brings it in alignment with the other SDKs.

<details>
<summary>AI Prompt</summary>

The initial commit was generated with [Jules](http://labs.google.com/jules) using the following prompt:

> I need you to add two new instance variables (`presencePenalty` and `frequencyPenalty`) to `GenerationConfig` in the file packages/firebase_vertexai/firebase_vertexai/lib/src
> /api.dart . Both of them should be `double` values in Dart.
> 
> To help you out, this is the equivalent implementation of `GenerationConfig` in the Swift SDK:
> 
> ```swift
> /// A struct defining model parameters to be used when sending generative AI
> /// requests to the backend model.
> @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
> public struct GenerationConfig: Sendable {
> /// Controls the degree of randomness in token selection.
> let temperature: Float?
> 
> /// Controls diversity of generated text.
> let topP: Float?
> 
> /// Limits the number of highest probability words considered.
> let topK: Int?
> 
> /// The number of response variations to return.
> let candidateCount: Int?
> 
> /// Maximum number of tokens that can be generated in the response.
> let maxOutputTokens: Int?
> 
> /// Controls the likelihood of repeating the same words or phrases already generated in the text.
> let presencePenalty: Float?
> 
> /// Controls the likelihood of repeating words, with the penalty increasing for each repetition.
> let frequencyPenalty: Float?
> 
> /// A set of up to 5 `String`s that will stop output generation.
> let stopSequences: [String]?
> 
> /// Output response MIME type of the generated candidate text.
> let responseMIMEType: String?
> 
> /// Output schema of the generated candidate text.
> let responseSchema: Schema?
> 
> /// Creates a new `GenerationConfig` value.
> ///
> /// See the
> /// [Configure model parameters](https://firebase.google.com/docs/vertex-ai/model-parameters)
> /// guide and the
> /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
> /// for more details.
> ///
> /// - Parameters:
> /// - temperature:Controls the randomness of the language model's output. Higher values (for
> /// example, 1.0) make the text more random and creative, while lower values (for example,
> /// 0.1) make it more focused and deterministic.
> ///
> /// > Note: A temperature of 0 means that the highest probability tokens are always selected.
> /// > In this case, responses for a given prompt are mostly deterministic, but a small amount
> /// > of variation is still possible.
> ///
> /// > Important: The range of supported temperature values depends on the model; see the
> /// > [documentation](https://firebase.google.com/docs/vertex-ai/model-parameters?platform=ios#temperature)
> /// > for more details.
> /// - topP: Controls diversity of generated text. Higher values (e.g., 0.9) produce more diverse
> /// text, while lower values (e.g., 0.5) make the output more focused.
> ///
> /// The supported range is 0.0 to 1.0.
> ///
> /// > Important: The default `topP` value depends on the model; see the
> /// > [documentation](https://firebase.google.com/docs/vertex-ai/model-parameters?platform=ios#top-p)
> /// > for more details.
> /// - topK: Limits the number of highest probability words the model considers when generating
> /// text. For example, a topK of 40 means only the 40 most likely words are considered for the
> /// next token. A higher value increases diversity, while a lower value makes the output more
> /// deterministic.
> ///
> /// The supported range is 1 to 40.
> ///
> /// > Important: Support for `topK` and the default value depends on the model; see the
> /// [documentation](https://firebase.google.com/docs/vertex-ai/model-parameters?platform=ios#top-k)
> /// for more details.
> /// - candidateCount: The number of response variations to return; defaults to 1 if not set.
> /// Support for multiple candidates depends on the model; see the
> /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
> /// for more details.
> /// - maxOutputTokens: Maximum number of tokens that can be generated in the response.
> /// See the configure model parameters [documentation](https://firebase.google.com/docs/vertex-ai/model-parameters?platform=ios#max-output-tokens)
> /// for more details.
> /// - presencePenalty: Controls the likelihood of repeating the same words or phrases already
> /// generated in the text. Higher values increase the penalty of repetition, resulting in more
> /// diverse output.
> ///
> /// > Note: While both `presencePenalty` and `frequencyPenalty` discourage repetition,
> /// > `presencePenalty` applies the same penalty regardless of how many times the word/phrase
> /// > has already appeared, whereas `frequencyPenalty` increases the penalty for *each*
> /// > repetition of a word/phrase.
> ///
> /// > Important: The range of supported `presencePenalty` values depends on the model; see the
> /// > [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
> /// > for more details
> /// - frequencyPenalty: Controls the likelihood of repeating words or phrases, with the penalty
> /// increasing for each repetition. Higher values increase the penalty of repetition,
> /// resulting in more diverse output.
> ///
> /// > Note: While both `frequencyPenalty` and `presencePenalty` discourage repetition,
> /// > `frequencyPenalty` increases the penalty for *each* repetition of a word/phrase, whereas
> /// > `presencePenalty` applies the same penalty regardless of how many times the word/phrase
> /// > has already appeared.
> ///
> /// > Important: The range of supported `frequencyPenalty` values depends on the model; see
> /// > the
> /// > [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
> /// > for more details
> /// - stopSequences: A set of up to 5 `String`s that will stop output generation. If specified,
> /// the API will stop at the first appearance of a stop sequence. The stop sequence will not
> /// be included as part of the response. See the
> /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
> /// for more details.
> /// - responseMIMEType: Output response MIME type of the generated candidate text.
> ///
> /// Supported MIME types:
> /// - `text/plain`: Text output; the default behavior if unspecified.
> /// - `application/json`: JSON response in the candidates.
> /// - `text/x.enum`: For classification tasks, output an enum value as defined in the
> /// `responseSchema`.
> /// - responseSchema: Output schema of the generated candidate text. If set, a compatible
> /// `responseMIMEType` must also be set.
> ///
> /// Compatible MIME types:
> /// - `application/json`: Schema for JSON response.
> ///
> /// Refer to the
> /// [Generate structured
> /// output](https://firebase.google.com/docs/vertex-ai/structured-output?platform=ios) guide
> /// for more details.
> public init(temperature: Float? = nil, topP: Float? = nil, topK: Int? = nil,
> candidateCount: Int? = nil, maxOutputTokens: Int? = nil,
> presencePenalty: Float? = nil, frequencyPenalty: Float? = nil,
> stopSequences: [String]? = nil, responseMIMEType: String? = nil,
> responseSchema: Schema? = nil) {
> // Explicit init because otherwise if we re-arrange the above variables it changes the API
> // surface.
> self.temperature = temperature
> self.topP = topP
> self.topK = topK
> self.candidateCount = candidateCount
> self.maxOutputTokens = maxOutputTokens
> self.presencePenalty = presencePenalty
> self.frequencyPenalty = frequencyPenalty
> self.stopSequences = stopSequences
> self.responseMIMEType = responseMIMEType
> self.responseSchema = responseSchema
> }
> }
> ```
> 
> Use the documentation and naming from Swift, where possible, but make sure to format it similarly to the existing Dart code in that class. Don't forget to add the new variables to the `toJson` method too.

</details>

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/