### PR TITLE
fix(data_connect)!: Correct UTF-8 decoding for international characters

### DIFF
--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
@@ -128,7 +128,7 @@ class RestTransport implements DataConnectTransport {
         );
       }
       Map<String, dynamic> bodyJson =
-          jsonDecode(r.body) as Map<String, dynamic>;
+          jsonDecode(utf8.decode(r.bodyBytes)) as Map<String, dynamic>;
 
       if (bodyJson.containsKey('errors') &&
           (bodyJson['errors'] as List).isNotEmpty) {

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.dart
@@ -115,7 +115,7 @@ void main() {
         'invokeOperation should correctly decode UTF-8 response body using bodyBytes',
         () async {
       const koreanString = '안녕하세요'; // Example Korean string
-      final jsonResponseWithKorean = '{"data": {"message": "$koreanString"}}';
+      const jsonResponseWithKorean = '{"data": {"message": "$koreanString"}}';
 
       // Create a mock response with bodyBytes containing the UTF-8 encoded string
       final mockResponse = http.Response.bytes(

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.dart
@@ -111,6 +111,44 @@ void main() {
       expect(result, 'Deserialized Data');
     });
 
+    test(
+        'invokeOperation should correctly decode UTF-8 response body using bodyBytes',
+        () async {
+      const koreanString = '안녕하세요'; // Example Korean string
+      final jsonResponseWithKorean = '{"data": {"message": "$koreanString"}}';
+
+      // Create a mock response with bodyBytes containing the UTF-8 encoded string
+      final mockResponse = http.Response.bytes(
+        utf8.encode(jsonResponseWithKorean), // Use utf8.encode for bytes
+        200,
+      );
+
+      when(
+        mockHttpClient.post(
+          any,
+          headers: anyNamed('headers'),
+          body: anyNamed('body'),
+        ),
+      ).thenAnswer((_) async => mockResponse);
+
+      // Simple deserializer to check if the Korean string is correctly decoded
+      final deserializer = (String data) {
+        final decodedJson = jsonDecode(data) as Map<String, dynamic>;
+        return decodedJson['message'];
+      };
+
+      final result = await transport.invokeOperation(
+        'testQuery',
+        'executeQuery',
+        deserializer,
+        null,
+        null,
+        null,
+      );
+
+      expect(result, koreanString);
+    });
+
     test('invokeOperation should throw unauthorized error on 401 response',
         () async {
       final mockResponse = http.Response('Unauthorized', 401);


### PR DESCRIPTION
## Description

Previously, text containing characters from languages such as Korean, which are encoded in UTF-8, was not being decoded correctly. This resulted in characters appearing garbled or "broken".

This commit updates the decoding logic to properly handle UTF-8 encoding, ensuring correct display and processing of international text.


## Related Issues

[firebase_data_connect] Response data Correct UTF-8 decoding for international characters Fixes #17290


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
