### PR TITLE
feat(auth): add support for initializeRecaptchaConfig

### DIFF
--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -679,6 +679,25 @@ public class FlutterFirebaseAuthPlugin
   }
 
   @Override
+  public void initializeRecaptchaConfig(
+      @NonNull GeneratedAndroidFirebaseAuth.AuthPigeonFirebaseApp app,
+      @NonNull GeneratedAndroidFirebaseAuth.VoidResult result) {
+    FirebaseAuth firebaseAuth = getAuthFromPigeon(app);
+    firebaseAuth
+        .initializeRecaptchaConfig()
+        .addOnCompleteListener(
+            task -> {
+              if (task.isSuccessful()) {
+                result.success();
+              } else {
+                result.error(
+                    FlutterFirebaseAuthPluginException.parserExceptionToFlutter(
+                        task.getException()));
+              }
+            });
+  }
+
+  @Override
   public Task<Map<String, Object>> getPluginConstantsForFirebaseApp(FirebaseApp firebaseApp) {
     TaskCompletionSource<Map<String, Object>> taskCompletionSource = new TaskCompletionSource<>();
 

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/GeneratedAndroidFirebaseAuth.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/GeneratedAndroidFirebaseAuth.java
@@ -2642,6 +2642,8 @@ public class GeneratedAndroidFirebaseAuth {
         @NonNull String authorizationCode,
         @NonNull VoidResult result);
 
+    void initializeRecaptchaConfig(@NonNull AuthPigeonFirebaseApp app, @NonNull VoidResult result);
+
     /** The codec used by FirebaseAuthHostApi. */
     static @NonNull MessageCodec<Object> getCodec() {
       return FirebaseAuthHostApiCodec.INSTANCE;
@@ -3390,6 +3392,38 @@ public class GeneratedAndroidFirebaseAuth {
                     };
 
                 api.revokeTokenWithAuthorizationCode(appArg, authorizationCodeArg, resultCallback);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger,
+                "dev.flutter.pigeon.firebase_auth_platform_interface.FirebaseAuthHostApi.initializeRecaptchaConfig"
+                    + messageChannelSuffix,
+                getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                AuthPigeonFirebaseApp appArg = (AuthPigeonFirebaseApp) args.get(0);
+                VoidResult resultCallback =
+                    new VoidResult() {
+                      public void success() {
+                        wrapped.add(0, null);
+                        reply.reply(wrapped);
+                      }
+
+                      public void error(Throwable error) {
+                        ArrayList<Object> wrappedError = wrapError(error);
+                        reply.reply(wrappedError);
+                      }
+                    };
+
+                api.initializeRecaptchaConfig(appArg, resultCallback);
               });
         } else {
           channel.setMessageHandler(null);

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
@@ -2172,4 +2172,16 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
                                     }];
 }
 
+- (void)initializeRecaptchaConfigApp:(AuthPigeonFirebaseApp *)app
+                          completion:(void (^)(FlutterError *_Nullable))completion {
+  FIRAuth *auth = [self getFIRAuthFromAppNameFromPigeon:app];
+  [auth initializeRecaptchaConfigWithCompletion:^(NSError *_Nullable error) {
+    if (error != nil) {
+      completion([FLTFirebaseAuthPlugin convertToFlutterError:error]);
+    } else {
+      completion(nil);
+    }
+  }];
+}
+
 @end

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
@@ -2177,7 +2177,7 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
 #if TARGET_OS_OSX
   NSLog(@"initializeRecaptchaConfigWithCompletion is not supported on the "
         @"MacOS platform.");
-  completion(nil, nil);
+  completion(nil);
 #else
   FIRAuth *auth = [self getFIRAuthFromAppNameFromPigeon:app];
   [auth initializeRecaptchaConfigWithCompletion:^(NSError *_Nullable error) {

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
@@ -2174,6 +2174,11 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
 
 - (void)initializeRecaptchaConfigApp:(AuthPigeonFirebaseApp *)app
                           completion:(void (^)(FlutterError *_Nullable))completion {
+#if TARGET_OS_OSX
+  NSLog(@"initializeRecaptchaConfigWithCompletion is not supported on the "
+        @"MacOS platform.");
+  completion(nil, nil);
+#else
   FIRAuth *auth = [self getFIRAuthFromAppNameFromPigeon:app];
   [auth initializeRecaptchaConfigWithCompletion:^(NSError *_Nullable error) {
     if (error != nil) {
@@ -2182,6 +2187,7 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
       completion(nil);
     }
   }];
+#endif
 }
 
 @end

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/firebase_auth_messages.g.m
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/firebase_auth_messages.g.m
@@ -1553,6 +1553,32 @@ void SetUpFirebaseAuthHostApiWithSuffix(id<FlutterBinaryMessenger> binaryMesseng
       [channel setMessageHandler:nil];
     }
   }
+  {
+    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
+           initWithName:[NSString
+                            stringWithFormat:@"%@%@",
+                                             @"dev.flutter.pigeon.firebase_auth_platform_interface."
+                                             @"FirebaseAuthHostApi.initializeRecaptchaConfig",
+                                             messageChannelSuffix]
+        binaryMessenger:binaryMessenger
+                  codec:FirebaseAuthHostApiGetCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(initializeRecaptchaConfigApp:completion:)],
+                @"FirebaseAuthHostApi api (%@) doesn't respond to "
+                @"@selector(initializeRecaptchaConfigApp:completion:)",
+                api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        NSArray *args = message;
+        AuthPigeonFirebaseApp *arg_app = GetNullableObjectAtIndex(args, 0);
+        [api initializeRecaptchaConfigApp:arg_app
+                               completion:^(FlutterError *_Nullable error) {
+                                 callback(wrapResult(nil, error));
+                               }];
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
 }
 @interface FirebaseAuthUserHostApiCodecReader : FlutterStandardReader
 @end

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/include/Public/firebase_auth_messages.g.h
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/include/Public/firebase_auth_messages.g.h
@@ -385,6 +385,8 @@ NSObject<FlutterMessageCodec> *FirebaseAuthHostApiGetCodec(void);
 - (void)revokeTokenWithAuthorizationCodeApp:(AuthPigeonFirebaseApp *)app
                           authorizationCode:(NSString *)authorizationCode
                                  completion:(void (^)(FlutterError *_Nullable))completion;
+- (void)initializeRecaptchaConfigApp:(AuthPigeonFirebaseApp *)app
+                          completion:(void (^)(FlutterError *_Nullable))completion;
 @end
 
 extern void SetUpFirebaseAuthHostApi(id<FlutterBinaryMessenger> binaryMessenger,

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -819,6 +819,12 @@ class FirebaseAuth extends FirebasePluginPlatform {
     return _delegate.revokeTokenWithAuthorizationCode(authorizationCode);
   }
 
+  /// Initializes the reCAPTCHA Enterprise client proactively to enhance reCAPTCHA signal collection and
+  /// to complete reCAPTCHA-protected flows in a single attempt.
+  Future<void> initializeRecaptchaConfig() {
+    return _delegate.initializeRecaptchaConfig();
+  }
+
   @override
   String toString() {
     return 'FirebaseAuth(app: ${app.name})';

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_firebase_auth.dart
@@ -667,6 +667,15 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
       );
     }
   }
+
+  @override
+  Future<void> initializeRecaptchaConfig() async {
+    try {
+      await _api.initializeRecaptchaConfig(pigeonDefault);
+    } catch (e, stack) {
+      convertPlatformException(e, stack);
+    }
+  }
 }
 
 /// Simple helper class to make nullable values transferable through StreamControllers.

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/pigeon/messages.pigeon.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/pigeon/messages.pigeon.dart
@@ -1478,6 +1478,30 @@ class FirebaseAuthHostApi {
       return;
     }
   }
+
+  Future<void> initializeRecaptchaConfig(AuthPigeonFirebaseApp app) async {
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.firebase_auth_platform_interface.FirebaseAuthHostApi.initializeRecaptchaConfig$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList =
+        await __pigeon_channel.send(<Object?>[app]) as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
 }
 
 class _FirebaseAuthUserHostApiCodec extends StandardMessageCodec {

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_firebase_auth.dart
@@ -706,4 +706,10 @@ abstract class FirebaseAuthPlatform extends PlatformInterface {
     throw UnimplementedError(
         'revokeTokenWithAuthorizationCode() is not implemented');
   }
+
+  /// Initializes the reCAPTCHA Enterprise client proactively to enhance reCAPTCHA signal collection and
+  /// to complete reCAPTCHA-protected flows in a single attempt.
+  Future<void> initializeRecaptchaConfig() {
+    throw UnimplementedError('initializeRecaptchaConfig() is not implemented');
+  }
 }

--- a/packages/firebase_auth/firebase_auth_platform_interface/pigeons/messages.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pigeons/messages.dart
@@ -419,6 +419,11 @@ abstract class FirebaseAuthHostApi {
     AuthPigeonFirebaseApp app,
     String authorizationCode,
   );
+
+  @async
+  void initializeRecaptchaConfig(
+    AuthPigeonFirebaseApp app,
+  );
 }
 
 class PigeonIdTokenResult {

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/pigeon/test_api.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/pigeon/test_api.dart
@@ -187,6 +187,8 @@ abstract class TestFirebaseAuthHostApi {
   Future<void> revokeTokenWithAuthorizationCode(
       AuthPigeonFirebaseApp app, String authorizationCode);
 
+  Future<void> initializeRecaptchaConfig(AuthPigeonFirebaseApp app);
+
   static void setUp(
     TestFirebaseAuthHostApi? api, {
     BinaryMessenger? binaryMessenger,
@@ -983,6 +985,38 @@ abstract class TestFirebaseAuthHostApi {
           try {
             await api.revokeTokenWithAuthorizationCode(
                 arg_app!, arg_authorizationCode!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
+              Object?>(
+          'dev.flutter.pigeon.firebase_auth_platform_interface.FirebaseAuthHostApi.initializeRecaptchaConfig$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(__pigeon_channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(__pigeon_channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.firebase_auth_platform_interface.FirebaseAuthHostApi.initializeRecaptchaConfig was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final AuthPigeonFirebaseApp? arg_app =
+              (args[0] as AuthPigeonFirebaseApp?);
+          assert(arg_app != null,
+              'Argument for dev.flutter.pigeon.firebase_auth_platform_interface.FirebaseAuthHostApi.initializeRecaptchaConfig was null, expected non-null AuthPigeonFirebaseApp.');
+          try {
+            await api.initializeRecaptchaConfig(arg_app!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -633,6 +633,13 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
       'revokeTokenWithAuthorizationCode() is only available on apple platforms.',
     );
   }
+
+  @override
+  Future<void> initializeRecaptchaConfig() async {
+    await guardAuthExceptions(
+      () => delegate.initializeRecaptchaConfig(),
+    );
+  }
 }
 
 String getOriginName(String appName) {

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -804,6 +804,11 @@ class Auth extends JsObjectWrapper<auth_interop.AuthJsImpl> {
       .verifyPasswordResetCode(jsObject, code.toJS)
       .toDart
       .then((value) => (value! as JSString).toDart);
+
+  /// Initializes the reCAPTCHA Enterprise client proactively to enhance reCAPTCHA signal collection and
+  /// to complete reCAPTCHA-protected flows in a single attempt.
+  Future initializeRecaptchaConfig() =>
+      auth_interop.initializeRecaptchaConfig(jsObject).toDart;
 }
 
 /// Represents an auth provider.

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
@@ -984,3 +984,6 @@ class PhoneAuthCredentialJsImpl extends AuthCredential {
 extension PhoneAuthCredentialJsImplExtension on PhoneAuthCredentialJsImpl {
   external JSObject toJSON();
 }
+
+@JS()
+external JSPromise initializeRecaptchaConfig(AuthJsImpl auth);

--- a/tests/integration_test/firebase_auth/firebase_auth_instance_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_instance_e2e_test.dart
@@ -1053,7 +1053,11 @@ void main() {
               () async {
             // Skipping this test as initializeRecaptchaConfig is not supported
             // by the Firebase emulator suite.
-            await FirebaseAuth.instance.initializeRecaptchaConfig();
+            try {
+              await FirebaseAuth.instance.initializeRecaptchaConfig();
+            } catch (e) {
+              fail('Should not have thrown: $e');
+            }
           });
         },
         skip: true,

--- a/tests/integration_test/firebase_auth/firebase_auth_instance_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_instance_e2e_test.dart
@@ -1045,6 +1045,19 @@ void main() {
         },
         skip: true,
       );
+
+      group(
+        'initializeRecaptchaConfig',
+        () {
+          test('initializeRecaptchaConfig completes without throwing',
+              () async {
+            // Skipping this test as initializeRecaptchaConfig is not supported
+            // by the Firebase emulator suite.
+            await FirebaseAuth.instance.initializeRecaptchaConfig();
+          });
+        },
+        skip: true,
+      );
     },
     // macOS skipped because it needs keychain sharing entitlement. See: https://github.com/firebase/flutterfire/issues/9538
     skip: defaultTargetPlatform == TargetPlatform.macOS,


### PR DESCRIPTION
## Description
This PR adds support for `initializeRecaptchaConfig`

## Related Issues
Closes https://github.com/firebase/flutterfire/issues/17354

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
