### PR TITLE
Fix issue where if null is set, an empty value was being sent

### DIFF
--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/optional.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/optional.dart
@@ -65,6 +65,8 @@ class Optional<T> {
   dynamic toJson() {
     if (_value != null) {
       return serializer(_value as T);
+    } else if (state == OptionalState.set) {
+      return null;
     }
     return '';
   }

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/optional_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/optional_test.dart
@@ -75,7 +75,7 @@ void main() {
       final optional = Optional.optional(stringDeserializer, stringSerializer);
 
       optional.value = null;
-      expect(optional.toJson(), equals(''));
+      expect(optional.toJson(), equals(null));
     });
 
     test('nativeToJson correctly serializes primitive types', () {
@@ -89,6 +89,15 @@ void main() {
       expect(nativeFromJson<int>(42), equals(42));
       expect(nativeFromJson<bool>(true), equals(true));
       expect(nativeFromJson<String>('Test'), equals('Test'));
+    });
+
+    test('nativeToJson correctly serializes null primitive types', () {
+      Optional intValue = Optional(nativeFromJson, nativeToJson);
+      intValue.value = null;
+      expect(intValue.toJson(), equals(null));
+      Optional floatValue = Optional(nativeFromJson, nativeToJson);
+      floatValue.value = null;
+      expect(floatValue.toJson(), equals(null));
     });
 
     // Since protobuf doesn't distinguish between int and double, we need to do the parsing ourselves


### PR DESCRIPTION
When calling `setInt` on an optional type with null, an empty string is returned instead. 