### PR TITLE
docs: Use Swift for notification service extension

### DIFF
--- a/docs/cloud-messaging/receive.md
+++ b/docs/cloud-messaging/receive.md
@@ -489,91 +489,144 @@ On Apple devices, in order for incoming FCM Notifications to display images from
 
 If you are using Firebase phone authentication, you must add the Firebase Auth pod to your Podfile.
 
+Note: The iOS simulator does not display images in push notifications. You must test on a physical device.
+
 ### Step 1 - Add a notification service extension
 
 1.  In Xcode, click **File > New > Target...**
 1.  A modal will present a list of possible targets; scroll down or use the filter to select **Notification Service Extension**. Click **Next**.
-1.  Add a product name (use "ImageNotification" to follow along with this tutorial), set the language to Objective-C, and click **Finish**.
+1.  Add a product name (use "ImageNotification" to follow along with this tutorial), select either `Swift` or `Objective-C`, and click **Finish**.
 1.  Enable the scheme by clicking **Activate**.
 
 ### Step 2 - Add target to the Podfile
 
-Ensure that your new extension has access to the `Firebase/Messaging` pod by adding it in the Podfile:
+* {Swift}
 
-1.  From the Navigator, open the Podfile: **Pods > Podfile**
+  Ensure that your new extension has access to the `FirebaseMessaging` swift package by adding it to your `Runner` target:
 
-1.  Scroll down to the bottom of the file and add:
+  1.  From the Navigator, [add the Firebase Apple platforms SDK](https://firebase.google.com/docs/ios/setup#add-sdks): **File > Add Package Dependencies...**
 
-    ```ruby
-    target 'ImageNotification' do
-      use_frameworks!
-      pod 'Firebase/Auth' # Add this line if you are using FirebaseAuth phone authentication
-      pod 'Firebase/Messaging'
-    end
-    ```
+  1.  Search or enter package URL:
+      ```
+      https://github.com/firebase/firebase-ios-sdk
+      ```
 
-1.  Install or update your pods using `pod install` from the `ios` or `macos` directory.
+  1. Add to Project `Runner`: **Add Package**
+
+  1. Choose FirebaseMessaging and add to target ImageNotification: **Add Package**
+
+* {Objective-C}
+
+  Ensure that your new extension has access to the `Firebase/Messaging` pod by adding it in the Podfile:
+
+  1.  From the Navigator, open the Podfile: **Pods > Podfile**
+
+  1.  Scroll down to the bottom of the file and add:
+
+      ```ruby
+      target 'ImageNotification' do
+        use_frameworks!
+        pod 'Firebase/Auth' # Add this line if you are using FirebaseAuth phone authentication
+        pod 'Firebase/Messaging'
+      end
+      ```
+
+  1.  Install or update your pods using `pod install` from the `ios` or `macos` directory.
 
 ### Step 3 - Use the extension helper
 
 At this point, everything should still be running normally. The final step is invoking the extension helper.
 
+* {Swift}
+
 1.  From the navigator, select your ImageNotification extension
 
-1.  Open the `NotificationService.m` file.
+1.  Open the `NotificationService.swift` file.
 
-1.  At the top of the file, import `FirebaseMessaging.h` right after the `NotificationService.h` as shown below.
+1.  Replace the content of `NotificationService.swift` with:
 
-    Replace the content of `NotificationService.m` with:
+    ```swift
+    import UserNotifications
+    import FirebaseMessaging
 
-    ```objc
-    #import "NotificationService.h"
-    #import "FirebaseMessaging.h"
-    #import <FirebaseAuth/FirebaseAuth-Swift.h> // Add this line if you are using FirebaseAuth phone authentication
-    #import <UIKit/UIKit.h> // Add this line if you are using FirebaseAuth phone authentication
+    class NotificationService: UNNotificationServiceExtension {
 
-    @interface NotificationService () <NSURLSessionDelegate>
+        var contentHandler: ((UNNotificationContent) -> Void)?
+        var bestAttemptContent: UNMutableNotificationContent?
 
-    @property(nonatomic) void (^contentHandler)(UNNotificationContent *contentToDeliver);
-    @property(nonatomic) UNMutableNotificationContent *bestAttemptContent;
+        override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
+            self.contentHandler = contentHandler
+            bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
 
-    @end
+            Messaging.serviceExtension().populateNotificationContent(bestAttemptContent!, withContentHandler: contentHandler)
+        }
 
-    @implementation NotificationService
-
-    /* Uncomment this if you are using Firebase Auth
-    - (BOOL)application:(UIApplication *)app
-                openURL:(NSURL *)url
-                options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
-      if ([[FIRAuth auth] canHandleURL:url]) {
-        return YES;
-      }
-      return NO;
+        override func serviceExtensionTimeWillExpire() {
+            if let contentHandler = contentHandler, let bestAttemptContent = bestAttemptContent {
+                contentHandler(bestAttemptContent)
+            }
+        }
     }
-
-    - (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts {
-      for (UIOpenURLContext *urlContext in URLContexts) {
-        [FIRAuth.auth canHandleURL:urlContext.URL];
-      }
-    }
-    */
-
-    - (void)didReceiveNotificationRequest:(UNNotificationRequest *)request withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler {
-        self.contentHandler = contentHandler;
-        self.bestAttemptContent = [request.content mutableCopy];
-
-        // Modify the notification content here...
-        [[FIRMessaging extensionHelper] populateNotificationContent:self.bestAttemptContent withContentHandler:contentHandler];
-    }
-
-    - (void)serviceExtensionTimeWillExpire {
-        // Called just before the extension will be terminated by the system.
-        // Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
-        self.contentHandler(self.bestAttemptContent);
-    }
-
-    @end
     ```
+
+* {Objective-C}
+
+  1.  From the navigator, select your ImageNotification extension
+
+  1.  Open the `NotificationService.m` file.
+
+  1.  At the top of the file, import `FirebaseMessaging.h` right after the `NotificationService.h` as shown below.
+
+      Replace the content of `NotificationService.m` with:
+
+      ```objc
+      #import "NotificationService.h"
+      #import "FirebaseMessaging.h"
+      #import <FirebaseAuth/FirebaseAuth-Swift.h> // Add this line if you are using FirebaseAuth phone authentication
+      #import <UIKit/UIKit.h> // Add this line if you are using FirebaseAuth phone authentication
+
+      @interface NotificationService () <NSURLSessionDelegate>
+
+      @property(nonatomic) void (^contentHandler)(UNNotificationContent *contentToDeliver);
+      @property(nonatomic) UNMutableNotificationContent *bestAttemptContent;
+
+      @end
+
+      @implementation NotificationService
+
+      /* Uncomment this if you are using Firebase Auth
+      - (BOOL)application:(UIApplication *)app
+                  openURL:(NSURL *)url
+                  options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
+        if ([[FIRAuth auth] canHandleURL:url]) {
+          return YES;
+        }
+        return NO;
+      }
+
+      - (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts {
+        for (UIOpenURLContext *urlContext in URLContexts) {
+          [FIRAuth.auth canHandleURL:urlContext.URL];
+        }
+      }
+      */
+
+      - (void)didReceiveNotificationRequest:(UNNotificationRequest *)request withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler {
+          self.contentHandler = contentHandler;
+          self.bestAttemptContent = [request.content mutableCopy];
+
+          // Modify the notification content here...
+          [[FIRMessaging extensionHelper] populateNotificationContent:self.bestAttemptContent withContentHandler:contentHandler];
+      }
+
+      - (void)serviceExtensionTimeWillExpire {
+          // Called just before the extension will be terminated by the system.
+          // Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
+          self.contentHandler(self.bestAttemptContent);
+      }
+
+      @end
+      ```
 
 ### Step 4 - Add the image to the payload
 


### PR DESCRIPTION
## Description

These docs provide a way to write a notification service extension in Swift instead of `Objective-C`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
