### PR TITLE
chore: change template default emoji for feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,7 +1,7 @@
 ---
-name: "🚀Feature Request"
+name: "🚀 Feature Request"
 about: Make a feature request for FlutterFire.
-title: "\U0001F41B [PLUGIN_NAME_HERE] Your feature request title here"
+title: "\U0001F680 [PLUGIN_NAME_HERE] Your feature request title here"
 labels: 'Needs Attention, type: enhancement'
 assignees: ''
 


### PR DESCRIPTION
Currently we use the bug 🐛 emoji for both feature requests and bugs. Which doesn't make sense.
Changes the feature request default emoji to be a 🚀 