### PR TITLE
fix(firebase_ai): Added InlineDataPart for File response in Gemini Api

### DIFF
--- a/packages/firebase_ai/firebase_ai/lib/src/developer/api.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/developer/api.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
+
 import '../api.dart'
     show
         BlockReason,
@@ -31,7 +33,7 @@ import '../api.dart'
         SerializationStrategy,
         UsageMetadata,
         createUsageMetadata;
-import '../content.dart' show Content, FunctionCall, Part, TextPart;
+import '../content.dart' show Content, FunctionCall, Part, TextPart, InlineDataPart;
 import '../error.dart';
 import '../function_calling.dart' show Tool, ToolConfig;
 
@@ -317,8 +319,7 @@ Part _parsePart(Object? jsonObject) {
       'functionResponse': {'name': String _, 'response': Map<String, Object?> _}
     } =>
       throw UnimplementedError('FunctionResponse part not yet supported'),
-    {'inlineData': {'mimeType': String _, 'data': String _}} =>
-      throw UnimplementedError('inlineData content part not yet supported'),
+    {'inlineData': {'mimeType': String mimeType, 'data': String data}} =>InlineDataPart(mimeType,base64Decode(data)),
     _ => throw unhandledFormat('Part', jsonObject),
   };
 }


### PR DESCRIPTION
## Description

Fixed parsing File response using InlineDataPart in `developer/api.dart`

Previously it was throwing error on Image generation via Gemin API, even image base64 response was received by app.
`inlineData content part not yet supported`

## Related Issues

Issue fixed #17449 
[firebase_ai] FirebaseAI.googleAI() Does not support generating images 


## Checklist

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ x] I signed the [CLA].
- [x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
