### PR TITLE
fix(firebaseai): Fix Imagen image format requests

### DIFF
--- a/packages/firebase_ai/firebase_ai/lib/src/imagen_api.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/imagen_api.dart
@@ -197,7 +197,7 @@ final class ImagenGenerationConfig {
         if (numberOfImages != null) 'numberOfImages': numberOfImages,
         if (aspectRatio != null) 'aspectRatio': aspectRatio!.toJson(),
         if (addWatermark != null) 'addWatermark': addWatermark,
-        if (imageFormat != null) 'outputOption': imageFormat!.toJson(),
+        if (imageFormat != null) 'outputOptions': imageFormat!.toJson(),
       };
 }
 


### PR DESCRIPTION
## Description

The rest request for Imagen expects the format as 'outputOptions', with an 's' at the end, so updating the toJson function to handle it correctly. See: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/imagen-api

## Related Issues

None reported.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
