### PR TITLE
test(storage): ensure both standard localhost and Android localhost are handled

### DIFF
--- a/packages/firebase_storage/firebase_storage/lib/src/utils.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/utils.dart
@@ -43,13 +43,13 @@ Map<String, String?>? partsFromHttpUrl(String url) {
     return null;
   }
 
-  // firebase storage url
-  // 10.0.2.2 is for Android when using firebase emulator
-  if (decodedUrl.contains(_firebaseStorageHost) ||
-      decodedUrl.contains('localhost') ||
-      decodedUrl.contains('10.0.2.2')) {
+  // 10.0.2.2 is used on Android emulators for connecting to the host machine's Firebase emulator.
+  final isEmulatorHost =
+      decodedUrl.contains('localhost') || decodedUrl.contains('10.0.2.2');
+  final isFirebaseStorageUrl = decodedUrl.contains(_firebaseStorageHost);
+  if (isFirebaseStorageUrl || isEmulatorHost) {
     String origin;
-    if (decodedUrl.contains('localhost') || decodedUrl.contains('10.0.2.2')) {
+    if (isEmulatorHost) {
       Uri uri = Uri.parse(url);
       origin = '^http?://${uri.host}:${uri.port}';
     } else {
@@ -71,8 +71,8 @@ Map<String, String?>? partsFromHttpUrl(String url) {
       'bucket': match.group(1),
       'path': match.group(3),
     };
-    // google cloud storage url
   } else {
+    // Google Cloud storage url
     RegExp cloudStorageRegExp = RegExp(
       '^https?://$_cloudStorageHost$_optionalPort/$_bucketDomain/$_cloudStoragePath',
       caseSensitive: false,

--- a/packages/firebase_storage/firebase_storage/test/utils_test.dart
+++ b/packages/firebase_storage/firebase_storage/test/utils_test.dart
@@ -104,6 +104,38 @@ void main() {
       expect(result?['path'], 'path/to/foo_bar.jpg');
     });
 
+    test(
+        'parses HTTP URL correctly when using Android emulator localhost (10.0.2.2)',
+        () {
+      const androidLocalhost = '10.0.2.2';
+
+      final result = partsFromHttpUrl(
+          'http://$androidLocalhost:9199/v0/b/myapp.appspot.com/o/path/to/foo_bar.jpg');
+
+      expect(
+        result,
+        isNotNull,
+        reason:
+            'partsFromHttpUrl should not return null for Android localhost URLs',
+      );
+      expect(result?['bucket'], 'myapp.appspot.com');
+      expect(result?['path'], 'path/to/foo_bar.jpg');
+    });
+
+    test('parses HTTP URL correctly when using standard localhost (127.0.0.1)',
+        () {
+      final result = partsFromHttpUrl(
+          'http://localhost:9199/v0/b/myapp.appspot.com/o/path/to/foo_bar.jpg');
+
+      expect(
+        result,
+        isNotNull,
+        reason: 'partsFromHttpUrl should not return null for localhost URLs',
+      );
+      expect(result?['bucket'], 'myapp.appspot.com');
+      expect(result?['path'], 'path/to/foo_bar.jpg');
+    });
+
     // TODO(helenaford): regexp can't handle no paths
     // test('sets path to default if null', () {
     //   String url =


### PR DESCRIPTION
## Description

*Add unit tests to ensure that `partsFromHttpUrl` does not return null for localhost URLs on all platforms.*

The PR #7003 fixed an issue where `refFromUrl` returns null when the URL is localhost, which is required when connecting to the Firebase emulator of the machine. While that fix works on all platforms that use the standard `localhost`, it does not work on Android emulators, where the only way to connect to the machine of the emulator is by using the `127.0.0.1` address, so #12047 patched it to work on Android as well.

The PR #12047 was sent by me, and I just came across this code. I improved it a bit by:

* Adding unit tests to handle both `localhost` and `127.0.0.1`, so adding these two unit tests while removing these two PRs will cause the tests to fail as expected.
* Refactoring the related code to improve the readability and avoid duplicating `localhost` and `127.0.0.1`

## Related Issues

* *Related #12047*
* *Related #7003*

## Emulators vs Firebase Emulators?

It might be confusing, but by emulators I mean Android and iOS emulators, and by Firebase emulators I mean [Firebase Local Emulator Suite](https://firebase.google.com/docs/emulator-suite).

To test and use Firebase fully, only the development machine without a real Android/iOS device and a Firebase project, the emulators are used to run the mobile app, and Firebase emulators are used on the development machine for local hosting, so the apps can connect to them locally.

All platforms, including iOS simulators, desktop, and web, need `localhost` to connect to Firebase emulators, while Android emulators need `127.0.0.1` (special case).

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (comments with `//`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
