### PR TITLE
fix(fdc): Fixed readme link

### DIFF
--- a/packages/firebase_data_connect/firebase_data_connect/README.md
+++ b/packages/firebase_data_connect/firebase_data_connect/README.md
@@ -14,7 +14,7 @@ To get started with Data Connect for Flutter, please [see the documentation](htt
 
 ## Usage
 
-To use this plugin, please visit the [Data Connect Usage documentation](https://firebase.google.com/docs/data-connect/gp/schemas-queries-mutations)
+To use this plugin, please visit the [Data Connect Usage documentation](https://firebase.google.com/docs/data-connect/schemas-guide)
 
 ## Issues and feedback
 


### PR DESCRIPTION
Old link pointed towards schema page that required an ACL. This updates to the public link.