### PR TITLE
feat(firestore)!: remove deprecated functions

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
@@ -152,91 +152,6 @@ void runInstanceTests() {
       );
 
       test(
-        'setIndexConfiguration()',
-        () async {
-          Index index1 = Index(
-            collectionGroup: 'bar',
-            queryScope: QueryScope.collectionGroup,
-            fields: [
-              IndexField(
-                fieldPath: 'fieldPath',
-                order: Order.ascending,
-                arrayConfig: ArrayConfig.contains,
-              ),
-            ],
-          );
-
-          Index index2 = Index(
-            collectionGroup: 'baz',
-            queryScope: QueryScope.collection,
-            fields: [
-              IndexField(
-                fieldPath: 'foo',
-                arrayConfig: ArrayConfig.contains,
-              ),
-              IndexField(
-                fieldPath: 'bar',
-                order: Order.descending,
-                arrayConfig: ArrayConfig.contains,
-              ),
-              IndexField(
-                fieldPath: 'baz',
-                order: Order.descending,
-                arrayConfig: ArrayConfig.contains,
-              ),
-            ],
-          );
-
-          FieldOverrides fieldOverride1 = FieldOverrides(
-            fieldPath: 'fieldPath',
-            indexes: [
-              FieldOverrideIndex(
-                queryScope: 'foo',
-                order: Order.ascending,
-                arrayConfig: ArrayConfig.contains,
-              ),
-              FieldOverrideIndex(
-                queryScope: 'bar',
-                order: Order.descending,
-                arrayConfig: ArrayConfig.contains,
-              ),
-              FieldOverrideIndex(
-                queryScope: 'baz',
-                order: Order.descending,
-              ),
-            ],
-            collectionGroup: 'bar',
-          );
-          FieldOverrides fieldOverride2 = FieldOverrides(
-            fieldPath: 'anotherField',
-            indexes: [
-              FieldOverrideIndex(
-                queryScope: 'foo',
-                order: Order.ascending,
-                arrayConfig: ArrayConfig.contains,
-              ),
-              FieldOverrideIndex(
-                queryScope: 'bar',
-                order: Order.descending,
-                arrayConfig: ArrayConfig.contains,
-              ),
-              FieldOverrideIndex(
-                queryScope: 'baz',
-                order: Order.descending,
-              ),
-            ],
-            collectionGroup: 'collectiongroup',
-          );
-          // ignore_for_file: deprecated_member_use
-          await firestore.setIndexConfiguration(
-            indexes: [index1, index2],
-            fieldOverrides: [fieldOverride1, fieldOverride2],
-          );
-        },
-        skip: defaultTargetPlatform == TargetPlatform.windows,
-      );
-
-      test(
         'setIndexConfigurationFromJSON()',
         () async {
           final json = jsonEncode({
@@ -372,8 +287,8 @@ void runInstanceTests() {
               databaseId: 'web-disabled-2',
             );
 
-            // Now try using `enablePersistence()`, web only API
-            await firestore2.enablePersistence();
+            // Enable persistence using settings instead of deprecated enablePersistence()
+            firestore2.settings = const Settings(persistenceEnabled: true);
 
             PersistentCacheIndexManager? indexManager2 =
                 firestore2.persistentCacheIndexManager();

--- a/packages/cloud_firestore/cloud_firestore/lib/cloud_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/cloud_firestore.dart
@@ -2,11 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
-// TODO(Lyokone): remove once we bump Flutter SDK min version to 3.3
-// ignore: unnecessary_import
-import 'dart:typed_data';
-
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'

--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -18,10 +18,6 @@ part of '../cloud_firestore.dart';
 class FirebaseFirestore extends FirebasePluginPlatform {
   FirebaseFirestore._({
     required this.app,
-    @Deprecated(
-      '`databaseURL` has been deprecated. Please use `databaseId` instead.',
-    )
-    required this.databaseURL,
     required this.databaseId,
   }) : super(app.name, 'plugins.flutter.io/firebase_firestore');
 
@@ -37,23 +33,16 @@ class FirebaseFirestore extends FirebasePluginPlatform {
   /// Returns an instance using a specified [FirebaseApp].
   static FirebaseFirestore instanceFor({
     required FirebaseApp app,
-    @Deprecated(
-      '`databaseURL` has been deprecated. Please use `databaseId` instead.',
-    )
-    String? databaseURL,
     String? databaseId,
   }) {
-    String firestoreDatabaseId = databaseId ?? databaseURL ?? '(default)';
+    String firestoreDatabaseId = databaseId ?? '(default)';
     String cacheKey = '${app.name}|$firestoreDatabaseId';
     if (_cachedInstances.containsKey(cacheKey)) {
       return _cachedInstances[cacheKey]!;
     }
 
-    FirebaseFirestore newInstance =
-        // Both databaseURL and databaseId are required so we have to pass both for now. We can remove databaseURL in a future release.
-        FirebaseFirestore._(
+    FirebaseFirestore newInstance = FirebaseFirestore._(
       app: app,
-      databaseURL: firestoreDatabaseId,
       databaseId: firestoreDatabaseId,
     );
     _cachedInstances[cacheKey] = newInstance;
@@ -75,13 +64,6 @@ class FirebaseFirestore extends FirebasePluginPlatform {
 
   /// The [FirebaseApp] for this current [FirebaseFirestore] instance.
   FirebaseApp app;
-
-  /// Firestore Database ID for this instance. Falls back to default database: "(default)"
-  /// This is deprecated in favor of [databaseId].
-  @Deprecated(
-    '`databaseURL` has been deprecated. Please use `databaseId` instead.',
-  )
-  String databaseURL;
 
   /// Firestore Database ID for this instance. Falls back to default database: "(default)"
   String databaseId;
@@ -122,17 +104,6 @@ class FirebaseFirestore extends FirebasePluginPlatform {
   /// the disclosure of cached data in between user sessions, we strongly recommend not enabling persistence at all.
   Future<void> clearPersistence() {
     return _delegate.clearPersistence();
-  }
-
-  /// Enable persistence of Firestore data for web-only. Use [Settings.persistenceEnabled] for non-web platforms.
-  /// If `enablePersistence()` is not called, it defaults to Memory cache.
-  /// If `enablePersistence(const PersistenceSettings(synchronizeTabs: false))` is called, it persists data for a single browser tab.
-  /// If `enablePersistence(const PersistenceSettings(synchronizeTabs: true))` is called, it persists data across multiple browser tabs.
-  @Deprecated('Use Settings.persistenceEnabled instead.')
-  Future<void> enablePersistence([
-    PersistenceSettings? persistenceSettings,
-  ]) async {
-    return _delegate.enablePersistence(persistenceSettings);
   }
 
   LoadBundleTask loadBundle(Uint8List bundle) {
@@ -349,31 +320,6 @@ class FirebaseFirestore extends FirebasePluginPlatform {
   /// Any outstanding [waitForPendingWrites] calls are rejected during user changes.
   Future<void> waitForPendingWrites() {
     return _delegate.waitForPendingWrites();
-  }
-
-  /// Configures indexing for local query execution. Any previous index configuration is overridden.
-  ///
-  /// The index entries themselves are created asynchronously. You can continue to use queries that
-  /// require indexing even if the indices are not yet available. Query execution will automatically
-  /// start using the index once the index entries have been written.
-  ///
-  /// This API is now deprecated
-  @Deprecated(
-    'setIndexConfiguration() has been deprecated. Please use `PersistentCacheIndexManager` instead.',
-  )
-  Future<void> setIndexConfiguration({
-    required List<Index> indexes,
-    List<FieldOverrides>? fieldOverrides,
-  }) async {
-    String json = jsonEncode(
-      {
-        'indexes': indexes.map((index) => index.toMap()).toList(),
-        'fieldOverrides':
-            fieldOverrides?.map((index) => index.toMap()).toList() ?? [],
-      },
-    );
-
-    return _delegate.setIndexConfiguration(json);
   }
 
   PersistentCacheIndexManager? persistentCacheIndexManager() {

--- a/packages/cloud_firestore/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/cloud_firestore_test.dart
@@ -40,34 +40,25 @@ void main() {
       );
     });
 
-    test('databaseId and databaseURL', () {
+    test('databaseId', () {
       final firestore = FirebaseFirestore.instanceFor(
-        // ignore: deprecated_member_use_from_same_package
-        app: Firebase.app(), databaseURL: 'foo',
+        app: Firebase.app(),
+        databaseId: 'foo',
       );
-
-      // ignore: deprecated_member_use_from_same_package
-      expect(firestore.databaseURL, equals('foo'));
 
       expect(firestore.databaseId, equals('foo'));
 
       final firestore2 =
           FirebaseFirestore.instanceFor(app: Firebase.app(), databaseId: 'bar');
 
-      // ignore: deprecated_member_use_from_same_package
-      expect(firestore2.databaseURL, equals('bar'));
-
       expect(firestore2.databaseId, equals('bar'));
 
       final firestore3 = FirebaseFirestore.instanceFor(
-        // ignore: deprecated_member_use_from_same_package
-        app: Firebase.app(), databaseId: 'fire', databaseURL: 'not-this',
+        app: Firebase.app(),
+        databaseId: 'fire',
       );
 
-      // databaseId should take precedence
       expect(firestore3.databaseId, equals('fire'));
-      // ignore: deprecated_member_use_from_same_package
-      expect(firestore3.databaseURL, equals('fire'));
     });
 
     test('returns the correct $FirebaseApp', () {

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_firestore.dart
@@ -145,13 +145,6 @@ class MethodChannelFirebaseFirestore extends FirebaseFirestorePlatform {
   }
 
   @override
-  Future<void> enablePersistence(
-      [PersistenceSettings? persistenceSettings]) async {
-    throw UnimplementedError(
-        'enablePersistence() is only available for Web. Use [Settings.persistenceEnabled] for other platforms.');
-  }
-
-  @override
   CollectionReferencePlatform collection(String collectionPath) {
     return MethodChannelCollectionReference(this, collectionPath, pigeonApp);
   }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_firestore.dart
@@ -99,15 +99,6 @@ abstract class FirebaseFirestorePlatform extends PlatformInterface {
     throw UnimplementedError('clearPersistence() is not implemented');
   }
 
-  /// Enable persistence of Firestore data for web-only. Use [Settings.persistenceEnabled] for non-web platforms.
-  /// If `enablePersistence()` is not called, it defaults to Memory cache.
-  /// If `enablePersistence(const PersistenceSettings(synchronizeTabs: false))` is called, it persists data for a single browser tab.
-  /// If `enablePersistence(const PersistenceSettings(synchronizeTabs: true))` is called, it persists data across multiple browser tabs.
-  Future<void> enablePersistence(
-      [PersistenceSettings? persistenceSettings]) async {
-    throw UnimplementedError('enablePersistence() is not implemented');
-  }
-
   /// Gets a [CollectionReferencePlatform] for the specified Firestore path.
   CollectionReferencePlatform collection(String collectionPath) {
     throw UnimplementedError('collection() is not implemented');

--- a/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
@@ -189,22 +189,6 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
     }
   }
 
-  /// Enable persistence of Firestore data.
-  @override
-  Future<void> enablePersistence([PersistenceSettings? persistenceSettings]) {
-    _settings = _settings.copyWith(persistenceEnabled: true);
-    if (persistenceSettings != null) {
-      firestore_interop.PersistenceSettings interopSettings =
-          firestore_interop.PersistenceSettings(
-              synchronizeTabs: persistenceSettings.synchronizeTabs.toJS);
-
-      return convertWebExceptions(
-          () => _delegate.enablePersistence(interopSettings));
-    }
-
-    return convertWebExceptions(_delegate.enablePersistence);
-  }
-
   @override
   Future<void> terminate() {
     return convertWebExceptions(_delegate.terminate);

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -86,18 +86,6 @@ class Firestore extends JsObjectWrapper<firestore_interop.FirestoreJsImpl> {
   DocumentReference doc(String documentPath) => DocumentReference.getInstance(
       firestore_interop.doc(jsObject as JSAny, documentPath.toJS));
 
-  Future<void> enablePersistence(
-      [firestore_interop.PersistenceSettings? settings]) {
-    if (settings != null && settings.synchronizeTabs.toDart == true) {
-      return firestore_interop
-          .enableMultiTabIndexedDbPersistence(jsObject)
-          .toDart;
-    }
-    return
-        // ignore: deprecated_member_use_from_same_package
-        firestore_interop.enableIndexedDbPersistence(jsObject).toDart;
-  }
-
 // purely for debug mode and tracking listeners to clean up on "hot restart"
   static final Map<String, int> _snapshotInSyncListeners = {};
   String _snapshotInSyncWindowsKey() {

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore_interop.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore_interop.dart
@@ -113,16 +113,6 @@ external FieldPath documentId();
 
 @JS()
 @staticInterop
-@Deprecated(
-  'This function will be removed in a future major release. Instead, set FirestoreSettings.localCache to an instance of PersistentLocalCache to turn on IndexedDb cache.',
-)
-external JSPromise enableIndexedDbPersistence(
-  FirestoreJsImpl firestore, [
-  PersistenceSettings? settings,
-]);
-
-@JS()
-@staticInterop
 external JSPromise enableMultiTabIndexedDbPersistence(
   FirestoreJsImpl firestore,
 );
@@ -743,10 +733,6 @@ abstract class FirestoreSettings {
 }
 
 extension FirestoreSettingsExtension on FirestoreSettings {
-  @Deprecated('Use FirestoreSettings.localCache instead.')
-  //ignore: avoid_setters_without_getters
-  external set cacheSizeBytes(JSNumber i);
-
   //ignore: avoid_setters_without_getters
   external set host(JSString h);
 


### PR DESCRIPTION
## Summary

Removes all deprecated methods from the cloud_firestore package's front-facing API in preparation for a breaking change release.

## Removed Methods

- `databaseURL` parameter/property → Use `databaseId` instead
- `enablePersistence()` method → Use `Settings.persistenceEnabled` instead  
- `setIndexConfiguration()` method → Use `PersistentCacheIndexManager` instead
- `enableIndexedDbPersistence()` function → Use `FirestoreSettings.localCache` instead
- `cacheSizeBytes` setter → Use `FirestoreSettings.localCache` instead

## Migration Guide

```dart
// Before
FirebaseFirestore.instanceFor(app: app, databaseURL: 'db');
await firestore.enablePersistence();
await firestore.setIndexConfiguration(indexes: [...]);

// After  
FirebaseFirestore.instanceFor(app: app, databaseId: 'db');
firestore.settings = const Settings(persistenceEnabled: true);
final indexManager = firestore.persistentCacheIndexManager();
await indexManager?.enableIndexAutoCreation();
```
