### PR TITLE
feat!(analytics): remove deprecated methods for breaking change release

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
@@ -188,40 +188,6 @@ class FirebaseAnalytics extends FirebasePluginPlatform {
     await _delegate.setUserId(id: id, callOptions: callOptions);
   }
 
-  /// Sets the current [screenName], which specifies the current visual context
-  /// in your app.
-  ///
-  /// This helps identify the areas in your app where users spend their time
-  /// and how they interact with your app.
-  ///
-  /// The class name can optionally be overridden by the [screenClassOverride]
-  /// parameter.
-  ///
-  /// The [screenName] and [screenClassOverride] remain in effect until the
-  /// current `Activity` (in Android) or `UIViewController` (in iOS) changes or
-  /// a new call to [setCurrentScreen] is made.
-  ///
-  /// Setting a null [screenName] clears the current screen name.
-  ///
-  /// See also:
-  ///
-  ///  * https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.html#setCurrentScreen(android.app.Activity, java.lang.String, java.lang.String)
-  ///  * https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Classes/FIRAnalytics#setscreennamescreenclass
-  @Deprecated(
-    'setCurrentScreen() has been deprecated. Please use logScreenView()',
-  )
-  Future<void> setCurrentScreen({
-    required String? screenName,
-    String screenClassOverride = 'Flutter',
-    AnalyticsCallOptions? callOptions,
-  }) async {
-    await _delegate.setCurrentScreen(
-      screenName: screenName,
-      screenClassOverride: screenClassOverride,
-      callOptions: callOptions,
-    );
-  }
-
   static final RegExp _nonAlphaNumeric = RegExp('[^a-zA-Z0-9_]');
   static final RegExp _alpha = RegExp('[a-zA-Z]');
 
@@ -658,26 +624,6 @@ class FirebaseAnalytics extends FirebasePluginPlatform {
         if (parameters != null) ...parameters,
       }),
       callOptions: callOptions,
-    );
-  }
-
-  /// Logs the standard `set_checkout_option` event. This event has been deprecated and is unsupported in updated Enhanced Ecommerce reports.
-  /// See: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event.html#SET_CHECKOUT_OPTION
-  @Deprecated('logSetCheckoutOption() has been deprecated.')
-  Future<void> logSetCheckoutOption({
-    required int checkoutStep,
-    required String checkoutOption,
-    Map<String, Object>? parameters,
-  }) {
-    _assertParameterTypesAreCorrect(parameters);
-
-    return _delegate.logEvent(
-      name: 'set_checkout_option',
-      parameters: filterOutNulls(<String, Object?>{
-        _CHECKOUT_STEP: checkoutStep,
-        _CHECKOUT_OPTION: checkoutOption,
-        if (parameters != null) ...parameters,
-      }),
     );
   }
 

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/lib/src/method_channel/method_channel_firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/lib/src/method_channel/method_channel_firebase_analytics.dart
@@ -134,25 +134,6 @@ class MethodChannelFirebaseAnalytics extends FirebaseAnalyticsPlatform {
   }
 
   @override
-  Future<void> setCurrentScreen({
-    String? screenName,
-    String? screenClassOverride,
-    AnalyticsCallOptions? callOptions,
-  }) {
-    try {
-      return _api.logEvent(<String, Object?>{
-        'eventName': 'screen_view',
-        'parameters': <String, String?>{
-          'screen_name': screenName,
-          'screen_class': screenClassOverride,
-        },
-      });
-    } catch (e, s) {
-      convertPlatformException(e, s);
-    }
-  }
-
-  @override
   Future<void> setUserProperty({
     required String name,
     required String? value,

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/lib/src/platform_interface/platform_interface_firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/lib/src/platform_interface/platform_interface_firebase_analytics.dart
@@ -138,19 +138,6 @@ abstract class FirebaseAnalyticsPlatform extends PlatformInterface {
     throw UnimplementedError('setUserId() is not implemented');
   }
 
-  /// Sets the current screen name, which specifies the current visual context
-  /// in your app.
-  ///
-  /// Setting a null [screenName] clears the current screen name.
-  /// [callOptions] are for web platform only.
-  Future<void> setCurrentScreen({
-    String? screenName,
-    String? screenClassOverride,
-    AnalyticsCallOptions? callOptions,
-  }) {
-    throw UnimplementedError('setCurrentScreen() is not implemented');
-  }
-
   /// Sets a user property to the given value.
   /// Setting a null [value] removes the user property.
   /// [callOptions] are for web platform only.

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/test/platform_interface_tests/platform_interface_analytics_test.dart
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/test/platform_interface_tests/platform_interface_analytics_test.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_analytics_platform_interface/src/platform_interface/platform_interface_firebase_analytics.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -110,21 +110,6 @@ void main() {
             (e) => e.message,
             'message',
             'setUserId() is not implemented',
-          ),
-        ),
-      );
-    });
-
-    test('throws if .setCurrentScreen() not implemented', () async {
-      await expectLater(
-        () => firebaseAnalyticsPlatform.setCurrentScreen(
-          screenName: 'test screen',
-        ),
-        throwsA(
-          isA<UnimplementedError>().having(
-            (e) => e.message,
-            'message',
-            'setCurrentScreen() is not implemented',
           ),
         ),
       );

--- a/packages/firebase_analytics/firebase_analytics_web/lib/firebase_analytics_web.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/firebase_analytics_web.dart
@@ -119,20 +119,6 @@ class FirebaseAnalyticsWeb extends FirebaseAnalyticsPlatform {
   }
 
   @override
-  Future<void> setCurrentScreen({
-    String? screenName,
-    String? screenClassOverride,
-    AnalyticsCallOptions? callOptions,
-  }) async {
-    return convertWebExceptions(() {
-      return _delegate.setCurrentScreen(
-        screenName: screenName,
-        callOptions: callOptions,
-      );
-    });
-  }
-
-  @override
   Future<void> resetAnalyticsData() async {
     throw UnimplementedError('resetAnalyticsData() is not supported on Web.');
   }

--- a/packages/firebase_analytics/firebase_analytics_web/lib/interop/analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/interop/analytics.dart
@@ -102,18 +102,6 @@ class Analytics extends JsObjectWrapper<analytics_interop.AnalyticsJsImpl> {
     );
   }
 
-  void setCurrentScreen({
-    String? screenName,
-    AnalyticsCallOptions? callOptions,
-  }) {
-    return analytics_interop.logEvent(
-      jsObject,
-      'screen_view'.toJS,
-      {'firebase_screen': screenName}.jsify(),
-      callOptions?.asMap().jsify() as JSObject?,
-    );
-  }
-
   void setUserId({
     String? id,
     AnalyticsCallOptions? callOptions,

--- a/packages/firebase_analytics/firebase_analytics_web/test/firebase_analytics_web_test.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/test/firebase_analytics_web_test.dart
@@ -42,16 +42,6 @@ void main() {
       verifyNoMoreInteractions(analytics);
     });
 
-    test('setCurrentScreen', () {
-      const screenName = 'screenName';
-      // screenClassOverride is discarded in web.
-      analytics.setCurrentScreen(
-        screenName: screenName,
-      );
-      verify(analytics.setCurrentScreen(screenName: screenName));
-      verifyNoMoreInteractions(analytics);
-    });
-
     test('setAnalyticsCollectionEnabled', () {
       analytics.setAnalyticsCollectionEnabled(true);
       verify(analytics.setAnalyticsCollectionEnabled(true));

--- a/packages/firebase_analytics/firebase_analytics_web/test/firebase_analytics_web_test.mocks.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/test/firebase_analytics_web_test.mocks.dart
@@ -215,26 +215,6 @@ class MockFirebaseAnalyticsWeb extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setCurrentScreen({
-    String? screenName,
-    String? screenClassOverride,
-    _i3.AnalyticsCallOptions? callOptions,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #setCurrentScreen,
-          [],
-          {
-            #screenName: screenName,
-            #screenClassOverride: screenClassOverride,
-            #callOptions: callOptions,
-          },
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
   _i5.Future<void> resetAnalyticsData() => (super.noSuchMethod(
         Invocation.method(
           #resetAnalyticsData,

--- a/tests/integration_test/firebase_analytics/firebase_analytics_e2e_test.dart
+++ b/tests/integration_test/firebase_analytics/firebase_analytics_e2e_test.dart
@@ -177,10 +177,12 @@ void main() {
       );
     });
 
-    test('setCurrentScreen', () async {
+    test('logScreenView', () async {
       await expectLater(
-        // ignore: deprecated_member_use
-        FirebaseAnalytics.instance.setCurrentScreen(screenName: 'screen-name'),
+        FirebaseAnalytics.instance.logScreenView(
+          screenName: 'screen-name',
+          screenClass: 'TestScreen',
+        ),
         completes,
       );
     });


### PR DESCRIPTION
BREAKING CHANGE: Removes deprecated methods from firebase_analytics package

- Removed `setCurrentScreen()` method (deprecated in favor of `logScreenView()`)
- Removed `logSetCheckoutOption()` method (deprecated and unsupported in Enhanced Ecommerce reports)

## Migration Guide

### Replace `setCurrentScreen()` with `logScreenView()`

**Before:**
```dart
await FirebaseAnalytics.instance.setCurrentScreen(
  screenName: 'home_screen',
  screenClassOverride: 'HomeScreen',
);
```

**After:**
```dart
await FirebaseAnalytics.instance.logScreenView(
  screenName: 'home_screen',
  screenClass: 'HomeScreen',
);
```

### Remove `logSetCheckoutOption()` calls

The `logSetCheckoutOption()` method has been completely removed as it's unsupported in updated Enhanced Ecommerce reports. If you were using this method, consider using alternative ecommerce tracking methods or consult the Firebase Analytics documentation for current best practices.
