### PR TITLE
feat(auth): remove deprecated functions

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/firebase_auth.dart
@@ -48,7 +48,6 @@ export 'package:firebase_auth_platform_interface/firebase_auth_platform_interfac
         YahooAuthProvider,
         YahooAuthCredential,
         MicrosoftAuthProvider,
-        MicrosoftAuthCredential,
         OAuthProvider,
         OAuthCredential,
         PhoneAuthProvider,

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -43,10 +43,6 @@ class FirebaseAuth extends FirebasePluginPlatform {
   /// Returns an instance using a specified [FirebaseApp].
   factory FirebaseAuth.instanceFor({
     required FirebaseApp app,
-    @Deprecated(
-      'Will be removed in future release. Use setPersistence() instead.',
-    )
-    Persistence? persistence,
   }) {
     return _firebaseAuthInstances.putIfAbsent(app.name, () {
       return FirebaseAuth._(app: app);
@@ -236,22 +232,6 @@ class FirebaseAuth extends FirebasePluginPlatform {
   }
 
   /// Returns a list of sign-in methods that can be used to sign in a given
-  /// user (identified by its main email address).
-  ///
-  /// This method is useful when you support multiple authentication mechanisms
-  /// if you want to implement an email-first authentication flow.
-  ///
-  /// An empty `List` is returned if the user could not be found.
-  ///
-  /// A [FirebaseAuthException] maybe thrown with the following error code:
-  /// - **invalid-email**:
-  ///  - Thrown if the email address is not valid.
-  @Deprecated('fetchSignInMethodsForEmail() has been deprecated. '
-      'Migrating off of this method is recommended as a security best-practice. Learn more in the Identity Platform documentation: '
-      ' https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection.')
-  Future<List<String>> fetchSignInMethodsForEmail(String email) {
-    return _delegate.fetchSignInMethodsForEmail(email);
-  }
 
   /// Returns a UserCredential from the redirect-based sign-in flow.
   ///
@@ -473,7 +453,7 @@ class FirebaseAuth extends FirebasePluginPlatform {
   ///  - Thrown if there already exists an account with the email address
   ///    asserted by the credential.
   // ignore: deprecated_member_use_from_same_package
-  ///    Resolve this by calling [fetchSignInMethodsForEmail] and then asking
+  ///    Resolve this by asking
   ///    the user to sign in using one of the returned providers.
   ///    Once the user is signed in, the original credential can be linked to
   ///    the user with [linkWithCredential].

--- a/packages/firebase_auth/firebase_auth/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/user.dart
@@ -163,7 +163,7 @@ class User {
   ///    user, an `email` and `credential` ([AuthCredential]) fields are also
   ///    provided. You have to link the credential to the existing user with
   ///    that email if you wish to continue signing in with that credential. To
-  ///    do so, call [fetchSignInMethodsForEmail], sign in to `email` via one of
+  ///    do so, sign in to `email` via one of
   ///    the providers returned and then [User.linkWithCredential] the original
   ///    credential to that newly signed in user.
   /// - **operation-not-allowed**:
@@ -225,8 +225,8 @@ class User {
   ///    user, an `email` and `credential` ([AuthCredential]) fields are also
   ///    provided. You have to link the credential to the existing user with
   ///    that email if you wish to continue signing in with that credential.
-  ///    To do so, call [fetchSignInMethodsForEmail], sign in to `email` via one
-  ///    of the providers returned and then [User.linkWithCredential] the
+  ///    To do so, sign in to `email` via one
+  ///    of the providers and then [User.linkWithCredential] the
   ///    original credential to that newly signed in user.
   /// - **operation-not-allowed**:
   ///  - Thrown if you have not enabled the provider in the Firebase Console. Go
@@ -392,8 +392,8 @@ class User {
   ///    user, an `email` and `credential` ([AuthCredential]) fields are also
   ///    provided. You have to link the credential to the existing user with
   ///    that email if you wish to continue signing in with that credential.
-  ///    To do so, call [fetchSignInMethodsForEmail], sign in to `email` via one
-  ///    of the providers returned and then [User.linkWithCredential] the
+  ///    To do so, sign in to `email` via one
+  ///    of the providers and then [User.linkWithCredential] the
   ///    original credential to that newly signed in user.
   /// - **operation-not-allowed**:
   ///  - Thrown if you have not enabled the provider in the Firebase Console. Go
@@ -440,8 +440,8 @@ class User {
   ///    user, an `email` and `credential` ([AuthCredential]) fields are also
   ///    provided. You have to link the credential to the existing user with
   ///    that email if you wish to continue signing in with that credential.
-  ///    To do so, call [fetchSignInMethodsForEmail], sign in to `email` via one
-  ///    of the providers returned and then [User.linkWithCredential] the
+  ///    To do so, sign in to `email` via one
+  ///    of the providers and then [User.linkWithCredential] the
   ///    original credential to that newly signed in user.
   /// - **operation-not-allowed**:
   ///  - Thrown if you have not enabled the provider in the Firebase Console. Go
@@ -584,20 +584,6 @@ class User {
   ///   user to have recently signed in. If this requirement isn't met, ask the
   ///   user to authenticate again and then call [User.reauthenticateWithCredential].
   ///
-  /// A [FirebaseAuthException] maybe thrown with the following error code:
-  /// - **invalid-email**:
-  ///  - Thrown if the email used is invalid.
-  /// - **email-already-in-use**:
-  ///  - Thrown if the email is already used by another user.
-  /// - **requires-recent-login**:
-  ///  - Thrown if the user's last sign-in time does not meet the security
-  ///    threshold. Use [User.reauthenticateWithCredential] to resolve. This
-  ///    does not apply if the user is anonymous.
-  @Deprecated(
-      'updateEmail() has been deprecated. Please use verifyBeforeUpdateEmail() instead.')
-  Future<void> updateEmail(String newEmail) async {
-    await _delegate.updateEmail(newEmail);
-  }
 
   /// Updates the user's password.
   ///

--- a/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
@@ -348,17 +348,6 @@ void main() {
       });
     });
 
-    group('fetchSignInMethodsForEmail()', () {
-      test('should call delegate method', () async {
-        // Necessary as we otherwise get a "null is not a Future<void>" error
-        when(mockAuthPlatform.fetchSignInMethodsForEmail(any))
-            .thenAnswer((i) async => []);
-        // ignore: deprecated_member_use_from_same_package
-        await auth.fetchSignInMethodsForEmail(kMockEmail);
-        verify(mockAuthPlatform.fetchSignInMethodsForEmail(kMockEmail));
-      });
-    });
-
     group('getRedirectResult()', () {
       test('should call delegate method', () async {
         // Necessary as we otherwise get a "null is not a Future<void>" error
@@ -1049,15 +1038,6 @@ class MockFirebaseAuth extends Mock
       Invocation.method(#confirmPasswordReset, [code, newPassword]),
       returnValue: neverEndingFuture<void>(),
       returnValueForMissingStub: neverEndingFuture<void>(),
-    );
-  }
-
-  @override
-  Future<List<String>> fetchSignInMethodsForEmail(String? email) {
-    return super.noSuchMethod(
-      Invocation.method(#checkActionCode, [email]),
-      returnValue: neverEndingFuture<List<String>>(),
-      returnValueForMissingStub: neverEndingFuture<List<String>>(),
     );
   }
 

--- a/packages/firebase_auth/firebase_auth/test/user_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/user_test.dart
@@ -247,18 +247,6 @@ void main() {
         verify(mockUserPlatform.unlink(providerId));
       });
     });
-    group('updateEmail()', () {
-      test('should call updateEmail()', () async {
-        // Necessary as we otherwise get a "null is not a Future<void>" error
-        when(mockUserPlatform.updateEmail(any)).thenAnswer((i) async {});
-
-        const String newEmail = 'newEmail';
-        // ignore: deprecated_member_use_from_same_package
-        await auth.currentUser!.updateEmail(newEmail);
-
-        verify(mockUserPlatform.updateEmail(newEmail));
-      });
-    });
 
     group('updatePassword()', () {
       test('should call updatePassword()', () async {
@@ -480,15 +468,6 @@ class MockUserPlatform extends Mock
   Future<void> sendEmailVerification(ActionCodeSettings? actionCodeSettings) {
     return super.noSuchMethod(
       Invocation.method(#sendEmailVerification, [actionCodeSettings]),
-      returnValue: neverEndingFuture<void>(),
-      returnValueForMissingStub: neverEndingFuture<void>(),
-    );
-  }
-
-  @override
-  Future<void> updateEmail(String? newEmail) {
-    return super.noSuchMethod(
-      Invocation.method(#updateEmail, [newEmail]),
       returnValue: neverEndingFuture<void>(),
       returnValueForMissingStub: neverEndingFuture<void>(),
     );

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/action_code_settings.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/action_code_settings.dart
@@ -14,11 +14,6 @@ class ActionCodeSettings {
     this.androidPackageName,
     this.androidMinimumVersion,
     this.androidInstallApp = false,
-    @Deprecated(
-        'Firebase Dynamic Links is deprecated and will be shut down as early as August * 2025. '
-        'Instead, use ActionCodeSettings.linkDomain to set a a custom domain. '
-        'Learn more at: https://firebase.google.com/support/dynamic-links-faq')
-    this.dynamicLinkDomain,
     this.linkDomain,
     this.handleCodeInApp = false,
     this.iOSBundleId,
@@ -42,13 +37,6 @@ class ActionCodeSettings {
   /// The iOS app to open if it is installed on the device.
   final String? iOSBundleId;
 
-  /// Sets an optional Dynamic Link domain.
-  @Deprecated(
-      'Firebase Dynamic Links is deprecated and will be shut down as early as August * 2025. '
-      'Instead, use ActionCodeSettings.linkDomain to set a a custom domain. '
-      'Learn more at: https://firebase.google.com/support/dynamic-links-faq')
-  final String? dynamicLinkDomain;
-
   /// The default is false. When true, the action code link will be sent
   /// as a Universal Link or Android App Link and will be opened by the
   /// app if installed.
@@ -65,8 +53,6 @@ class ActionCodeSettings {
   Map<String, dynamic> asMap() {
     return <String, dynamic>{
       'url': url,
-      // ignore: deprecated_member_use_from_same_package
-      'dynamicLinkDomain': dynamicLinkDomain,
       'linkDomain': linkDomain,
       'handleCodeInApp': handleCodeInApp,
       if (iOSBundleId != null)

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_firebase_auth.dart
@@ -482,8 +482,6 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
                 androidPackageName: actionCodeSettings.androidPackageName,
                 androidInstallApp: actionCodeSettings.androidInstallApp,
                 androidMinimumVersion: actionCodeSettings.androidMinimumVersion,
-                // ignore: deprecated_member_use_from_same_package
-                dynamicLinkDomain: actionCodeSettings.dynamicLinkDomain,
                 linkDomain: actionCodeSettings.linkDomain,
               ),
       );
@@ -509,8 +507,6 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
           androidPackageName: actionCodeSettings.androidPackageName,
           androidInstallApp: actionCodeSettings.androidInstallApp,
           androidMinimumVersion: actionCodeSettings.androidMinimumVersion,
-          // ignore: deprecated_member_use_from_same_package
-          dynamicLinkDomain: actionCodeSettings.dynamicLinkDomain,
         ),
       );
     } catch (e, stack) {

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_user.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_user.dart
@@ -198,8 +198,6 @@ class MethodChannelUser extends UserPlatform {
                 androidPackageName: actionCodeSettings.androidPackageName,
                 androidInstallApp: actionCodeSettings.androidInstallApp,
                 androidMinimumVersion: actionCodeSettings.androidMinimumVersion,
-                // ignore: deprecated_member_use_from_same_package
-                dynamicLinkDomain: actionCodeSettings.dynamicLinkDomain,
                 linkDomain: actionCodeSettings.linkDomain,
               ),
       );
@@ -310,8 +308,6 @@ class MethodChannelUser extends UserPlatform {
                 androidPackageName: actionCodeSettings.androidPackageName,
                 androidInstallApp: actionCodeSettings.androidInstallApp,
                 androidMinimumVersion: actionCodeSettings.androidMinimumVersion,
-                // ignore: deprecated_member_use_from_same_package
-                dynamicLinkDomain: actionCodeSettings.dynamicLinkDomain,
                 linkDomain: actionCodeSettings.linkDomain,
               ),
       );

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/microsoft_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/microsoft_auth.dart
@@ -36,16 +36,6 @@ class MicrosoftAuthProvider extends AuthProvider {
   /// Creates a new instance.
   MicrosoftAuthProvider() : super(_kProviderId);
 
-  /// Create a new [MicrosoftAuthCredential] from a provided [accessToken];
-  @Deprecated(
-    '`credential()` has been deprecated. Sign-in cannot be directly achieved with OAuth access token based credentials for Microsoft. Please use `signInWithProvider(MicrosoftAuthProvider)` instead.',
-  )
-  static OAuthCredential credential(String accessToken) {
-    return MicrosoftAuthCredential._credential(
-      accessToken,
-    );
-  }
-
   /// This corresponds to the sign-in method identifier.
   static String get MICROSOFT_SIGN_IN_METHOD {
     return _kProviderId;
@@ -82,19 +72,5 @@ class MicrosoftAuthProvider extends AuthProvider {
   ) {
     _parameters = customOAuthParameters;
     return this;
-  }
-}
-
-// ignore: deprecated_member_use_from_same_package
-/// [MicrosoftAuthProvider.credential] returns a [MicrosoftAuthCredential] instance.
-class MicrosoftAuthCredential extends OAuthCredential {
-  MicrosoftAuthCredential._({
-    required String accessToken,
-  }) : super(
-            providerId: _kProviderId,
-            signInMethod: _kProviderId,
-            accessToken: accessToken);
-  factory MicrosoftAuthCredential._credential(String accessToken) {
-    return MicrosoftAuthCredential._(accessToken: accessToken);
   }
 }


### PR DESCRIPTION
This PR removes all deprecated methods from the firebase_auth package in preparation for a breaking change release.

## Removed Methods

- `ActionCodeSettings.dynamicLinkDomain` - Firebase Dynamic Links is deprecated and will be shut down
- `MicrosoftAuthProvider.credential()` - Use `signInWithProvider(MicrosoftAuthProvider)` instead
- `FirebaseAuth.instanceFor()` persistence parameter - Use `setPersistence()` instead
- `FirebaseAuth.fetchSignInMethodsForEmail()` - Removed for security best practices
- `User.updateEmail()` - Use `verifyBeforeUpdateEmail()` instead

## Migration Guide

### ActionCodeSettings
```dart
// Before
ActionCodeSettings(
  url: 'https://example.com',
  dynamicLinkDomain: 'example.page.link',
)

// After
ActionCodeSettings(
  url: 'https://example.com',
  linkDomain: 'your-custom-domain.com', // Use custom Firebase Hosting domain
)
```

### Microsoft Authentication
```dart
// Before
final credential = MicrosoftAuthProvider.credential(accessToken);
await FirebaseAuth.instance.signInWithCredential(credential);

// After
final provider = MicrosoftAuthProvider();
await FirebaseAuth.instance.signInWithProvider(provider);
```

### FirebaseAuth Instance
```dart
// Before
FirebaseAuth.instanceFor(app: app, persistence: Persistence.local);

// After
final auth = FirebaseAuth.instanceFor(app: app);
auth.setPersistence(Persistence.local);
```

### Email Updates
```dart
// Before
await user.updateEmail('new@email.com');

// After
await user.verifyBeforeUpdateEmail('new@email.com');
```

### Email Sign-in Methods
The `fetchSignInMethodsForEmail()` method has been removed for security reasons. Consider implementing alternative authentication flows that don't require email enumeration.
