### PR TITLE
feat(firebaseai): add `responseJsonSchema` to `GenerationConfig`

### DIFF
--- a/packages/firebase_ai/firebase_ai/example/lib/main.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/main.dart
@@ -17,16 +17,17 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 
-import 'pages/audio_page.dart';
-import 'pages/bidi_page.dart';
 // Import after file is generated through flutterfire_cli.
 // import 'package:firebase_ai_example/firebase_options.dart';
 
+import 'pages/audio_page.dart';
+import 'pages/bidi_page.dart';
 import 'pages/chat_page.dart';
 import 'pages/document.dart';
 import 'pages/function_calling_page.dart';
 import 'pages/image_prompt_page.dart';
 import 'pages/imagen_page.dart';
+import 'pages/json_schema_page.dart';
 import 'pages/schema_page.dart';
 import 'pages/token_count_page.dart';
 import 'pages/video_page.dart';
@@ -64,11 +65,11 @@ class _GenerativeAISampleState extends State<GenerativeAISample> {
   void _initializeModel(bool useVertexBackend) {
     if (useVertexBackend) {
       final vertexInstance = FirebaseAI.vertexAI(auth: FirebaseAuth.instance);
-      _currentModel = vertexInstance.generativeModel(model: 'gemini-1.5-flash');
+      _currentModel = vertexInstance.generativeModel(model: 'gemini-2.5-flash');
       _currentImagenModel = _initializeImagenModel(vertexInstance);
     } else {
       final googleAI = FirebaseAI.googleAI(auth: FirebaseAuth.instance);
-      _currentModel = googleAI.generativeModel(model: 'gemini-2.0-flash');
+      _currentModel = googleAI.generativeModel(model: 'gemini-2.5-flash');
       _currentImagenModel = _initializeImagenModel(googleAI);
     }
   }
@@ -184,10 +185,12 @@ class _HomeScreenState extends State<HomeScreen> {
       case 6:
         return SchemaPromptPage(title: 'Schema Prompt', model: currentModel);
       case 7:
-        return DocumentPage(title: 'Document Prompt', model: currentModel);
+        return JsonSchemaPage(title: 'JSON Schema', model: currentModel);
       case 8:
-        return VideoPage(title: 'Video Prompt', model: currentModel);
+        return DocumentPage(title: 'Document Prompt', model: currentModel);
       case 9:
+        return VideoPage(title: 'Video Prompt', model: currentModel);
+      case 10:
         return BidiPage(
           title: 'Live Stream',
           model: currentModel,
@@ -301,6 +304,11 @@ class _HomeScreenState extends State<HomeScreen> {
             icon: Icon(Icons.schema),
             label: 'Schema',
             tooltip: 'Schema Prompt',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.data_object),
+            label: 'JSON',
+            tooltip: 'JSON Schema',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.edit_document),

--- a/packages/firebase_ai/firebase_ai/lib/src/api.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/api.dart
@@ -998,8 +998,10 @@ final class GenerationConfig extends BaseGenerationConfig {
     super.responseModalities,
     this.responseMimeType,
     this.responseSchema,
+    this.responseJsonSchema,
     this.thinkingConfig,
-  });
+  }) : assert(responseSchema == null || responseJsonSchema == null,
+            'responseSchema and responseJsonSchema cannot both be set.');
 
   /// The set of character sequences (up to 5) that will stop output generation.
   ///
@@ -1018,7 +1020,27 @@ final class GenerationConfig extends BaseGenerationConfig {
   ///
   /// - Note: This only applies when the [responseMimeType] supports
   ///   a schema; currently this is limited to `application/json`.
+  ///
+  /// Only one of [responseSchema] or [responseJsonSchema] may be specified at
+  /// the same time.
   final Schema? responseSchema;
+
+  /// The response schema as a JSON-compatible map.
+  ///
+  /// - Note: This only applies when the [responseMimeType] supports a schema;
+  ///   currently this is limited to `application/json`.
+  ///
+  /// This schema can include more advanced features of JSON than the [Schema]
+  /// class taken by [responseSchema] supports.  See the [Gemini
+  /// documentation](https://ai.google.dev/api/generate-content#FIELDS.response_json_schema)
+  /// about the limitations of this feature.
+  ///
+  /// Notably, this feature is only supported on Gemini 2.5 and later. Use
+  /// [responseSchema] for earlier models.
+  ///
+  /// Only one of [responseSchema] or [responseJsonSchema] may be specified at
+  /// the same time.
+  final Map<String, Object?>? responseJsonSchema;
 
   /// Config for thinking features.
   ///
@@ -1036,6 +1058,8 @@ final class GenerationConfig extends BaseGenerationConfig {
           'responseMimeType': responseMimeType,
         if (responseSchema case final responseSchema?)
           'responseSchema': responseSchema.toJson(),
+        if (responseJsonSchema case final responseJsonSchema?)
+          'responseJsonSchema': responseJsonSchema,
         if (thinkingConfig case final thinkingConfig?)
           'thinkingConfig': thinkingConfig.toJson(),
       };

--- a/packages/firebase_ai/firebase_ai/test/api_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/api_test.dart
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+import 'dart:convert';
+
 import 'package:firebase_ai/firebase_ai.dart';
 import 'package:firebase_ai/src/api.dart';
 
@@ -440,6 +443,38 @@ void main() {
         'responseSchema': schema.toJson(),
         'thinkingConfig': {'thinkingBudget': 100},
       });
+    });
+
+    test('GenerationConfig toJson with responseJsonSchema', () {
+      final jsonSchema = {
+        'type': 'object',
+        'properties': {
+          'recipeName': {'type': 'string'}
+        },
+        'required': ['recipeName']
+      };
+      final config = GenerationConfig(
+        responseMimeType: 'application/json',
+        responseJsonSchema: jsonSchema,
+      );
+      final json = config.toJson();
+      expect(json['responseMimeType'], 'application/json');
+      final dynamic responseSchema = json['responseJsonSchema'];
+      expect(responseSchema, isA<Map<String, Object?>>());
+      expect(responseSchema, equals(jsonSchema));
+    });
+
+    test(
+        'throws assertion if both responseSchema and responseJsonSchema are provided',
+        () {
+      final schema = Schema.object(properties: {});
+      final jsonSchema =
+          (json.decode('{"type": "string", "title": "MyString"}') as Map)
+              .cast<String, Object?>();
+      expect(
+          () => GenerationConfig(
+              responseSchema: schema, responseJsonSchema: jsonSchema),
+          throwsA(isA<AssertionError>()));
     });
 
     test('GenerationConfig toJson with empty stopSequences (omitted)', () {


### PR DESCRIPTION
## Description

This adds the `responseJsonSchema` field to the GenerationConfig class, which enables more JSON schema features like `$def` and `$ref` along with other advanced JSON schema features that Gemini 2.5 supports.

See [the Gemini docs](https://ai.google.dev/gemini-api/docs/structured-output#json-schema) for more information about what is supported.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17551

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
