### PR TITLE
fix(remote_config, android): make `onCancel` accept nullable arguments to avoid crash on hot restart

### DIFF
--- a/packages/firebase_remote_config/firebase_remote_config/android/src/main/kotlin/io/flutter/plugins/firebase/firebaseremoteconfig/FirebaseRemoteConfigPlugin.kt
+++ b/packages/firebase_remote_config/firebase_remote_config/android/src/main/kotlin/io/flutter/plugins/firebase/firebaseremoteconfig/FirebaseRemoteConfigPlugin.kt
@@ -206,9 +206,9 @@ class FirebaseRemoteConfigPlugin
       })
   }
 
-  override fun onCancel(arguments: Any) {
+  override fun onCancel(arguments: Any?) {
     // arguments will be null on hot restart, so we will clean up listeners in didReinitializeFirebaseCore()
-    val argumentsMap = arguments as Map<String, Any>
+    val argumentsMap = arguments as? Map<String, Any>
       ?: return
     val appName = Objects.requireNonNull(argumentsMap["appName"]) as String
 


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/firebase/flutterfire/issues/17566

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
