### PR TITLE
fix: Fix analyzer infos

### DIFF
--- a/packages/firebase_app_installations/firebase_app_installations/example/lib/main.dart
+++ b/packages/firebase_app_installations/firebase_app_installations/example/lib/main.dart
@@ -72,7 +72,7 @@ class _InstallationsCardState extends State<InstallationsCard> {
   String id = 'None';
   String authToken = 'None';
 
-  init() async {
+  void init() async {
     await getId();
     await getAuthToken();
   }
@@ -101,7 +101,7 @@ class _InstallationsCardState extends State<InstallationsCard> {
     }
   }
 
-  Future<void> getAuthToken([forceRefresh = false]) async {
+  Future<void> getAuthToken([bool forceRefresh = false]) async {
     try {
       final token = await FirebaseInstallations.instance.getToken(forceRefresh);
       setState(() {

--- a/packages/firebase_app_installations/firebase_app_installations_platform_interface/lib/firebase_app_installations_platform_interface.dart
+++ b/packages/firebase_app_installations/firebase_app_installations_platform_interface/lib/firebase_app_installations_platform_interface.dart
@@ -2,6 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-library firebase_app_installations_platform_interface;
+library;
 
 export 'src/platform_interface/firebase_app_installations_platform_interface.dart';

--- a/packages/firebase_app_installations/firebase_app_installations_web/lib/src/interop/installations_interop.dart
+++ b/packages/firebase_app_installations/firebase_app_installations_web/lib/src/interop/installations_interop.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 @JS('firebase_installations')
-library firebase_interop.installations;
+library;
 
 import 'dart:js_interop';
 

--- a/packages/firebase_auth/firebase_auth/example/lib/auth.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/auth.dart
@@ -256,7 +256,9 @@ class _AuthGateState extends State<AuthGate> {
                                             height: 50,
                                             child: SignInButton(
                                               button,
-                                              onPressed: authButtons[button],
+                                              // Null check is required by some versions of Dart.
+                                              // ignore: unnecessary_null_checks
+                                              onPressed: authButtons[button]!,
                                             ),
                                           ),
                                   ),

--- a/packages/firebase_database/firebase_database_web/lib/src/database_reference_web.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/database_reference_web.dart
@@ -73,7 +73,7 @@ class DatabaseReferenceWeb extends QueryWeb
   }
 
   @override
-  Future<void> setPriority(priority) async {
+  Future<void> setPriority(Object? priority) async {
     try {
       await _delegate.setPriority(priority);
     } catch (e, s) {

--- a/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/interop/database.dart
@@ -126,7 +126,7 @@ class DatabaseReference<T extends database_interop.ReferenceJsImpl>
   ///
   /// This method returns [ThenableReference], [DatabaseReference]
   /// with a [Future] property.
-  ThenableReference push([value]) => ThenableReference.fromJsObject(
+  ThenableReference push([Object? value]) => ThenableReference.fromJsObject(
       database_interop.push(jsObject, value?.jsify()));
 
   /// Removes data from actual database location.
@@ -149,8 +149,8 @@ class DatabaseReference<T extends database_interop.ReferenceJsImpl>
   /// Sets a priority for data at actual database location.
   ///
   /// The [priority] must be a [String], [num] or `null`, or the error is thrown.
-  Future setPriority(priority) =>
-      database_interop.setPriority(jsObject, priority).toDart;
+  Future setPriority(Object? priority) =>
+      database_interop.setPriority(jsObject, priority?.jsify()).toDart;
 
   /// Sets data [newVal] at actual database location with provided priority
   /// [newPriority].
@@ -676,12 +676,11 @@ class OnDisconnect
 /// See: <https://firebase.google.com/docs/reference/js/firebase.database.ThenableReference>.
 class ThenableReference
     extends DatabaseReference<database_interop.ThenableReferenceJsImpl> {
-  late final Future<DatabaseReference> _future = jsObject
-      .then(((database_interop.ReferenceJsImpl reference) {
-        DatabaseReference.getInstance(reference);
-      }).toJS)
+  late final Future<DatabaseReference> _future = (jsObject as JSPromise)
       .toDart
-      .then((value) => value as DatabaseReference);
+      .then((value) => DatabaseReference.getInstance(
+            value as database_interop.ReferenceJsImpl,
+          ));
 
   /// Creates a new ThenableReference from a [jsObject].
   ThenableReference.fromJsObject(

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/example/lib/main.dart
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/example/lib/main.dart
@@ -35,7 +35,7 @@ class _MyAppState extends State<MyApp> {
   FirebaseCustomModel? model;
 
   /// Initially get the lcoal model if found, and asynchronously get the latest one in background.
-  initWithLocalModel() async {
+  void initWithLocalModel() async {
     final newModel = await FirebaseModelDownloader.instance.getModel(
         kModelName, FirebaseModelDownloadType.localModelUpdateInBackground);
 

--- a/scripts/generate_versions_gradle.dart
+++ b/scripts/generate_versions_gradle.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: avoid_print
+
 import 'dart:io';
 
 import 'package:cli_util/cli_logging.dart' as logging;
@@ -36,7 +38,7 @@ void main() async {
 
   // Define files using paths
   final globalConfig = File(globalConfigPath);
-  
+
   // Check if the files exist
   if (!globalConfig.existsSync()) {
     throw Exception(
@@ -68,7 +70,7 @@ void main() async {
         print('File copied to: ${copiedConfig.path}');
 
         final gradlePropertiesFilePath = '${package.path}/example/android/gradle.properties';
-        extractAndWriteProperty(
+        await extractAndWriteProperty(
           globalConfig: globalConfig,
           gradlePropertiesFile: File(gradlePropertiesFilePath),
         );
@@ -80,11 +82,10 @@ void main() async {
         final copiedConfig = await globalConfig.copy(
         localConfigGradleFilePath,
         );
-        // ignore: avoid_print
         print('File copied to: ${copiedConfig.path}');
-        
+
         final gradlePropertiesFilePath = '${package.path}/example/android/gradle.properties';
-        extractAndWriteProperty(
+        await extractAndWriteProperty(
           globalConfig: globalConfig,
           gradlePropertiesFile: File(gradlePropertiesFilePath),
         );
@@ -123,7 +124,7 @@ Future<void> extractAndWriteProperty({
 }) async {
 
   const String propertyName = 'androidGradlePluginVersion';
-  if (!await globalConfig.exists()) {
+  if (!globalConfig.existsSync()) {
     print('Global config file not found: ${globalConfig.path}');
     return;
   }
@@ -141,7 +142,7 @@ Future<void> extractAndWriteProperty({
 
   final value = match.group(1);
 
-  final lines = await gradlePropertiesFile.exists()
+  final lines = gradlePropertiesFile.existsSync()
       ? await gradlePropertiesFile.readAsLines()
       : [];
 

--- a/scripts/generate_versions_spm.dart
+++ b/scripts/generate_versions_spm.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: avoid_print
+
 import 'package:melos/melos.dart' as melos;
 import 'package:glob/glob.dart';
 import 'dart:io';
@@ -131,7 +133,11 @@ void updateVersionsPackageSwift(String firebaseiOSVersion) {
 
 void updateLibraryVersionPureSwiftPlugins() {
   // Packages that require updating library versions
-  const packages = ['firebase_ml_model_downloader', 'firebase_app_installations', 'cloud_functions'];
+  const packages = [
+    'firebase_ml_model_downloader',
+    'firebase_app_installations',
+    'cloud_functions',
+  ];
 
   for (final package in packages) {
     final pubspecPath = 'packages/$package/$package/pubspec.yaml';


### PR DESCRIPTION
## Description

This just fixes a number of analyzer info messages so that there aren't any in the repo. It cleans up the "Problems" view in VSCode, and actually could avoid some coding issues.

I looked at the CI, and it appears to already use `dart analyze --fatal-infos`, so I'm not sure why these were missed. Maybe because they haven't been modified since that was turned on?

There should be no change in functionality because of any of these changes, although the added `await`s could cause a change in execution order.

## Related Issues

No issues found for this.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
