### PR TITLE
fix(auth, apple): Move FirebaseAuth imports to implementation files

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTPhoneNumberVerificationStreamHandler.m
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTPhoneNumberVerificationStreamHandler.m
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+@import FirebaseAuth;
+
 #import "include/Private/FLTPhoneNumberVerificationStreamHandler.h"
 #import "include/Public/FLTFirebaseAuthPlugin.h"
 

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/include/Private/FLTAuthStateChannelStreamHandler.h
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/include/Private/FLTAuthStateChannelStreamHandler.h
@@ -5,15 +5,15 @@
 #import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
-#import <FirebaseAuth/FirebaseAuth.h>
 #import <FlutterMacOS/FlutterMacOS.h>
 #else
 #import <Flutter/Flutter.h>
-@import FirebaseAuth;
 #endif
 
 #import <Foundation/Foundation.h>
 #import "../Public/CustomPigeonHeader.h"
+
+@class FIRAuth;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/include/Private/FLTIdTokenChannelStreamHandler.h
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/include/Private/FLTIdTokenChannelStreamHandler.h
@@ -5,16 +5,16 @@
 #import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
-#import <FirebaseAuth/FirebaseAuth.h>
 #import <FlutterMacOS/FlutterMacOS.h>
 #else
 #import <Flutter/Flutter.h>
-@import FirebaseAuth;
 #endif
 
 #import "../Public/CustomPigeonHeader.h"
 
 #import <Foundation/Foundation.h>
+
+@class FIRAuth;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/include/Private/FLTPhoneNumberVerificationStreamHandler.h
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/include/Private/FLTPhoneNumberVerificationStreamHandler.h
@@ -5,16 +5,18 @@
 #import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
-#import <FirebaseAuth/FirebaseAuth.h>
 #import <FlutterMacOS/FlutterMacOS.h>
 #else
 #import <Flutter/Flutter.h>
-@import FirebaseAuth;
 #endif
 
 #import "../Public/firebase_auth_messages.g.h"
 
 #import <Foundation/Foundation.h>
+
+@class FIRAuth;
+@class FIRMultiFactorSession;
+@class FIRPhoneMultiFactorInfo;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/include/Private/PigeonParser.h
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/include/Private/PigeonParser.h
@@ -4,14 +4,15 @@
  * BSD-style license that can be found in the LICENSE file.
  */
 
-#if TARGET_OS_OSX
-#import <FirebaseAuth/FirebaseAuth.h>
-#else
-@import FirebaseAuth;
-#endif
-
 #import <Foundation/Foundation.h>
 #import "../Public/firebase_auth_messages.g.h"
+
+@class FIRAuthDataResult;
+@class FIRUser;
+@class FIRActionCodeSettings;
+@class FIRAuthTokenResult;
+@class FIRTOTPSecret;
+@class FIRAuthCredential;
 
 @interface PigeonParser : NSObject
 


### PR DESCRIPTION
## Description

Changed are non-public headers that import the firebase-ios-sdk's FirebaseAuth module (a Swift module). Importing Swift modules into an Objective-C header is not really supported (e.g. https://forums.swift.org/t/swift-cant-see-objc-methods-that-include-package-symbols/65732). 

## Related Issues

* fixes https://github.com/firebase/flutterfire/issues/17552

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
