### PR TITLE
chore(firebaseai): remove `generateContent` call from count tokens page

### DIFF
--- a/packages/firebase_ai/firebase_ai/example/lib/pages/token_count_page.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/pages/token_count_page.dart
@@ -87,17 +87,9 @@ class _TokenCountPageState extends State<TokenCountPage> {
     const prompt = 'tell a short story';
     final content = Content.text(prompt);
     final tokenResponse = await widget.model.countTokens([content]);
-    final tokenResult = 'Count token: ${tokenResponse.totalTokens}';
+    final tokenResult = 'Token Count: ${tokenResponse.totalTokens}';
     _messages.add(MessageData(text: tokenResult, fromUser: false));
 
-    final contentResponse = await widget.model.generateContent([content]);
-    final contentMetaData = 'result metadata, promptTokenCount:'
-        '${contentResponse.usageMetadata!.promptTokenCount}, '
-        'candidatesTokenCount:'
-        '${contentResponse.usageMetadata!.candidatesTokenCount}, '
-        'totalTokenCount:'
-        '${contentResponse.usageMetadata!.totalTokenCount}';
-    _messages.add(MessageData(text: contentMetaData, fromUser: false));
     setState(() {
       _loading = false;
     });


### PR DESCRIPTION
## Description

This isn't clear in the sample UI why this is happening, and ends up using more tokens than necessary.


## Related Issues

Internal bug report.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
