### PR TITLE
fix(fdc): add support Int64 to nativeFromJson

### DIFF
--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/optional.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/optional.dart
@@ -97,6 +97,14 @@ T nativeFromJson<T>(dynamic input) {
       return DateTime.parse(input) as T;
     } else if (T == String) {
       return input as T;
+    } else if (T == int) {
+      // Int64 is transmitted as String.
+      final value = BigInt.parse(input);
+      if (value.isValidInt) {
+        return value.toInt() as T;
+      } else {
+        throw UnsupportedError('BigInt ($input) too large for Dart int');
+      }
     }
   } else if (input is num) {
     if (input is double && T == int) {
@@ -105,7 +113,7 @@ T nativeFromJson<T>(dynamic input) {
       return input.toDouble() as T;
     }
   }
-  throw UnimplementedError('This type is unimplemented: ${T.runtimeType}');
+  throw UnimplementedError('This type is unimplemented: $T');
 }
 
 DynamicDeserializer<List<T>> listDeserializer<T>(

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/optional_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/optional_test.dart
@@ -89,6 +89,13 @@ void main() {
       expect(nativeFromJson<int>(42), equals(42));
       expect(nativeFromJson<bool>(true), equals(true));
       expect(nativeFromJson<String>('Test'), equals('Test'));
+      expect(nativeFromJson<int>('42000000000000'), equals(42000000000000));
+    });
+
+    test('nativeFromJson throws UnsupportedError for bigint’s too big for int',
+        () {
+      expect(() => nativeFromJson<int>('42000000000000000000'),
+          throwsUnsupportedError);
     });
 
     test('nativeToJson correctly serializes null primitive types', () {


### PR DESCRIPTION
## Description

If you used a `Int64` type in the GraphQL schema it cannot be decoded in the generated code. `Int64` is treated as a `BigInt` in Postgres/DataConnect and as such transmitted through gRPC as a `String`. The `firebase_data_connect` package throws `This type is unimplemented: Type`... because the `nativeFromJson` function does not support `input` being a `String` and the output type being an `int`. 

This PR also fixes the incorrect Type display in the error message for the exception.

@maneesht this one's for you.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
