### PR TITLE
docs(firebase_core): correct androidClientId docs (iOS-only → Android-only)

### DIFF
--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_options.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_options.dart
@@ -147,10 +147,10 @@ class FirebaseOptions {
   /// The URL scheme used by iOS secondary apps for Dynamic Links.
   final String? deepLinkURLScheme;
 
-  /// The Android client ID from the Firebase Console, for example
+  /// The Android OAuth client ID from the Firebase Console, for example
   /// "12345.apps.googleusercontent.com."
   ///
-  /// This value is used by iOS only.
+  /// This value is used on Android only.
   final String? androidClientId;
 
   /// The iOS client ID from the Firebase Console, for example


### PR DESCRIPTION
This updates the `FirebaseOptions.androidClientId` documentation.

- Fixes a copy/paste mistake that said “This value is used by iOS only”.
- Clarifies it as the Android OAuth client ID and notes “This value is used on Android only”.

This aligns `androidClientId` with `iosClientId` and avoids confusion for developers following the API docs on pub.dev.

Fixes #13519.
