### PR TITLE
feat(firebase_ai): Add support for URL context

### DIFF
--- a/packages/firebase_ai/firebase_ai/lib/firebase_ai.dart
+++ b/packages/firebase_ai/firebase_ai/lib/firebase_ai.dart
@@ -108,4 +108,5 @@ export 'src/tool.dart'
         Tool,
         ToolConfig,
         GoogleSearch,
-        CodeExecution;
+        CodeExecution,
+        UrlContext;

--- a/packages/firebase_ai/firebase_ai/lib/src/api.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/api.dart
@@ -182,13 +182,16 @@ final class PromptFeedback {
 /// Metadata on the generation request's token usage.
 final class UsageMetadata {
   // ignore: public_member_api_docs
-  UsageMetadata._(
-      {this.promptTokenCount,
-      this.candidatesTokenCount,
-      this.totalTokenCount,
-      this.thoughtsTokenCount,
-      this.promptTokensDetails,
-      this.candidatesTokensDetails});
+  UsageMetadata._({
+    this.promptTokenCount,
+    this.candidatesTokenCount,
+    this.totalTokenCount,
+    this.thoughtsTokenCount,
+    this.promptTokensDetails,
+    this.candidatesTokensDetails,
+    this.toolUsePromptTokenCount,
+    this.toolUsePromptTokensDetails,
+  });
 
   /// Number of tokens in the prompt.
   final int? promptTokenCount;
@@ -202,11 +205,18 @@ final class UsageMetadata {
   /// Number of tokens present in thoughts output.
   final int? thoughtsTokenCount;
 
+  /// The number of tokens used by tools.
+  final int? toolUsePromptTokenCount;
+
   /// List of modalities that were processed in the request input.
   final List<ModalityTokenCount>? promptTokensDetails;
 
   /// List of modalities that were returned in the response.
   final List<ModalityTokenCount>? candidatesTokensDetails;
+
+  /// A list of tokens used by tools whose usage was triggered from a prompt,
+  /// broken down by modality.
+  final List<ModalityTokenCount>? toolUsePromptTokensDetails;
 }
 
 /// Response candidate generated from a [GenerativeModel].
@@ -214,7 +224,7 @@ final class Candidate {
   // ignore: public_member_api_docs
   Candidate(this.content, this.safetyRatings, this.citationMetadata,
       this.finishReason, this.finishMessage,
-      {this.groundingMetadata});
+      {this.groundingMetadata, this.urlContextMetadata});
 
   /// Generated content returned from the model.
   final Content content;
@@ -241,6 +251,9 @@ final class Candidate {
 
   /// Metadata returned to the client when grounding is enabled.
   final GroundingMetadata? groundingMetadata;
+
+  /// Metadata returned to the client when the [UrlContext] tool is enabled.
+  final UrlContextMetadata? urlContextMetadata;
 
   /// The concatenation of the text parts of [content], if any.
   ///
@@ -415,6 +428,64 @@ final class GroundingMetadata {
   /// These can be used to allow users to explore the search results
   /// themselves.
   final List<String> webSearchQueries;
+}
+
+/// The status of a URL retrieval.
+enum UrlRetrievalStatus {
+  /// Unspecified retrieval status.
+  unspecified('URL_RETRIEVAL_STATUS_UNSPECIFIED'),
+
+  /// The URL retrieval was successful.
+  success('URL_RETRIEVAL_STATUS_SUCCESS'),
+
+  /// The URL retrieval failed due.
+  error('URL_RETRIEVAL_STATUS_ERROR'),
+
+  /// The URL retrieval failed because the content is behind a paywall.
+  paywall('URL_RETRIEVAL_STATUS_PAYWALL'),
+
+  /// The URL retrieval failed because the content is unsafe.
+  unsafe('URL_RETRIEVAL_STATUS_UNSAFE');
+
+  const UrlRetrievalStatus(this._jsonString);
+  final String _jsonString;
+
+  // ignore: public_member_api_docs
+  String toJson() => _jsonString;
+
+  // ignore: unused_element
+  static UrlRetrievalStatus _parseValue(Object jsonObject) {
+    return switch (jsonObject) {
+      'URL_RETRIEVAL_STATUS_UNSPECIFIED' => UrlRetrievalStatus.unspecified,
+      'URL_RETRIEVAL_STATUS_SUCCESS' => UrlRetrievalStatus.success,
+      'URL_RETRIEVAL_STATUS_ERROR' => UrlRetrievalStatus.error,
+      'URL_RETRIEVAL_STATUS_PAYWALL' => UrlRetrievalStatus.paywall,
+      'URL_RETRIEVAL_STATUS_UNSAFE' => UrlRetrievalStatus.unsafe,
+      _ => UrlRetrievalStatus
+          .unspecified, // Default to unspecified for unknown values.
+    };
+  }
+}
+
+/// Metadata for a single URL retrieved by the [UrlContext] tool.
+final class UrlMetadata {
+  // ignore: public_member_api_docs
+  UrlMetadata({this.retrievedUrl, required this.urlRetrievalStatus});
+
+  /// The retrieved URL.
+  final Uri? retrievedUrl;
+
+  /// The status of the URL retrieval.
+  final UrlRetrievalStatus urlRetrievalStatus;
+}
+
+/// Metadata related to the [UrlContext] tool.
+final class UrlContextMetadata {
+  // ignore: public_member_api_docs
+  UrlContextMetadata({required this.urlMetadata});
+
+  /// List of [UrlMetadata] used to provide context to the Gemini model.
+  final List<UrlMetadata> urlMetadata;
 }
 
 /// Safety rating for a piece of content.
@@ -1280,6 +1351,11 @@ Candidate _parseCandidate(Object? jsonObject) {
         {'groundingMetadata': final Object groundingMetadata} =>
           parseGroundingMetadata(groundingMetadata),
         _ => null
+      },
+      urlContextMetadata: switch (jsonObject) {
+        {'urlContextMetadata': final Object urlContextMetadata} =>
+          parseUrlContextMetadata(urlContextMetadata),
+        _ => null
       });
 }
 
@@ -1328,6 +1404,11 @@ UsageMetadata parseUsageMetadata(Object jsonObject) {
     {'thoughtsTokenCount': final int thoughtsTokenCount} => thoughtsTokenCount,
     _ => null,
   };
+  final toolUsePromptTokenCount = switch (jsonObject) {
+    {'toolUsePromptTokenCount': final int toolUsePromptTokenCount} =>
+      toolUsePromptTokenCount,
+    _ => null,
+  };
   final promptTokensDetails = switch (jsonObject) {
     {'promptTokensDetails': final List<Object?> promptTokensDetails} =>
       promptTokensDetails.map(_parseModalityTokenCount).toList(),
@@ -1338,13 +1419,23 @@ UsageMetadata parseUsageMetadata(Object jsonObject) {
       candidatesTokensDetails.map(_parseModalityTokenCount).toList(),
     _ => null,
   };
+  final toolUsePromptTokensDetails = switch (jsonObject) {
+    {
+      'toolUsePromptTokensDetails': final List<Object?>
+          toolUsePromptTokensDetails
+    } =>
+      toolUsePromptTokensDetails.map(_parseModalityTokenCount).toList(),
+    _ => null,
+  };
   return UsageMetadata._(
     promptTokenCount: promptTokenCount,
     candidatesTokenCount: candidatesTokenCount,
     totalTokenCount: totalTokenCount,
     thoughtsTokenCount: thoughtsTokenCount,
+    toolUsePromptTokenCount: toolUsePromptTokenCount,
     promptTokensDetails: promptTokensDetails,
     candidatesTokensDetails: candidatesTokensDetails,
+    toolUsePromptTokensDetails: toolUsePromptTokensDetails,
   );
 }
 
@@ -1520,6 +1611,33 @@ SearchEntryPoint _parseSearchEntryPoint(Object? jsonObject) {
 
   return SearchEntryPoint(
     renderedContent: renderedContent,
+  );
+}
+
+UrlMetadata _parseUrlMetadata(Object? jsonObject) {
+  if (jsonObject is! Map) {
+    throw unhandledFormat('UrlMetadata', jsonObject);
+  }
+  final uriString = jsonObject['retrievedUrl'] as String?;
+  return UrlMetadata(
+    retrievedUrl: uriString != null ? Uri.parse(uriString) : null,
+    urlRetrievalStatus:
+        UrlRetrievalStatus._parseValue(jsonObject['urlRetrievalStatus']),
+  );
+}
+
+/// Parses a [UrlContextMetadata] from a JSON object.
+///
+/// This function is used internally to convert URL context metadata from the API
+/// response.
+UrlContextMetadata parseUrlContextMetadata(Object? jsonObject) {
+  if (jsonObject is! Map) {
+    throw unhandledFormat('UrlContextMetadata', jsonObject);
+  }
+  return UrlContextMetadata(
+    urlMetadata: (jsonObject['urlMetadata'] as List<Object?>? ?? [])
+        .map(_parseUrlMetadata)
+        .toList(),
   );
 }
 

--- a/packages/firebase_ai/firebase_ai/lib/src/developer/api.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/developer/api.dart
@@ -29,7 +29,8 @@ import '../api.dart'
         SerializationStrategy,
         parseUsageMetadata,
         parseCitationMetadata,
-        parseGroundingMetadata;
+        parseGroundingMetadata,
+        parseUrlContextMetadata;
 import '../content.dart' show Content, parseContent;
 import '../error.dart';
 import '../tool.dart' show Tool, ToolConfig;
@@ -173,6 +174,11 @@ Candidate _parseCandidate(Object? jsonObject) {
     groundingMetadata: switch (jsonObject) {
       {'groundingMetadata': final Object groundingMetadata} =>
         parseGroundingMetadata(groundingMetadata),
+      _ => null
+    },
+    urlContextMetadata: switch (jsonObject) {
+      {'urlContextMetadata': final Object urlContextMetadata} =>
+        parseUrlContextMetadata(urlContextMetadata),
       _ => null
     },
   );

--- a/packages/firebase_ai/firebase_ai/lib/src/tool.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/tool.dart
@@ -21,12 +21,13 @@ import 'schema.dart';
 /// knowledge and scope of the model.
 final class Tool {
   // ignore: public_member_api_docs
-  Tool._(this._functionDeclarations, this._googleSearch, this._codeExecution);
+  Tool._(this._functionDeclarations, this._googleSearch, this._codeExecution,
+      this._urlContext);
 
   /// Returns a [Tool] instance with list of [FunctionDeclaration].
   static Tool functionDeclarations(
       List<FunctionDeclaration> functionDeclarations) {
-    return Tool._(functionDeclarations, null, null);
+    return Tool._(functionDeclarations, null, null, null);
   }
 
   /// Creates a tool that allows the model to use Grounding with Google Search.
@@ -47,13 +48,26 @@ final class Tool {
   ///
   /// Returns a `Tool` configured for Google Search.
   static Tool googleSearch({GoogleSearch googleSearch = const GoogleSearch()}) {
-    return Tool._(null, googleSearch, null);
+    return Tool._(null, googleSearch, null, null);
   }
 
   /// Returns a [Tool] instance that enables the model to use Code Execution.
   static Tool codeExecution(
       {CodeExecution codeExecution = const CodeExecution()}) {
-    return Tool._(null, null, codeExecution);
+    return Tool._(null, null, codeExecution, null);
+  }
+
+  /// Creates a tool that allows you to provide additional context to the models
+  /// in the form of public web URLs.
+  ///
+  /// By including URLs in your request, the Gemini model will access the
+  /// content from those pages to inform and enhance its response.
+  ///
+  /// - [urlContext]: Specifies the URL context configuration.
+  ///
+  /// Returns a `Tool` configured for URL context.
+  static Tool urlContext({UrlContext urlContext = const UrlContext()}) {
+    return Tool._(null, null, null, urlContext);
   }
 
   /// A list of `FunctionDeclarations` available to the model that can be used
@@ -74,6 +88,9 @@ final class Tool {
   /// A tool that allows the model to use Code Execution.
   final CodeExecution? _codeExecution;
 
+  /// A tool that allows providing URL context to the model.
+  final UrlContext? _urlContext;
+
   /// Convert to json object.
   Map<String, Object> toJson() => {
         if (_functionDeclarations case final _functionDeclarations?)
@@ -82,7 +99,9 @@ final class Tool {
         if (_googleSearch case final _googleSearch?)
           'googleSearch': _googleSearch.toJson(),
         if (_codeExecution case final _codeExecution?)
-          'codeExecution': _codeExecution.toJson()
+          'codeExecution': _codeExecution.toJson(),
+        if (_urlContext case final _urlContext?)
+          'urlContext': _urlContext.toJson(),
       };
 }
 
@@ -99,6 +118,18 @@ final class Tool {
 final class GoogleSearch {
   // ignore: public_member_api_docs
   const GoogleSearch();
+
+  /// Convert to json object.
+  Map<String, Object> toJson() => {};
+}
+
+/// A tool that allows you to provide additional context to the models in the
+/// form of public web URLs. By including URLs in your request, the Gemini 
+/// model will access the content from those pages to inform and enhance its 
+/// response.
+final class UrlContext {
+  // ignore: public_member_api_docs
+  const UrlContext();
 
   /// Convert to json object.
   Map<String, Object> toJson() => {};

--- a/packages/firebase_ai/firebase_ai/test/api_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/api_test.dart
@@ -242,14 +242,17 @@ void main() {
         SafetyRating(HarmCategory.harassment, HarmProbability.low)
       ];
       final citationMeta = CitationMetadata([]);
+      final urlContextMetadata = UrlContextMetadata(urlMetadata: []);
       final candidate = Candidate(
-          content, ratings, citationMeta, FinishReason.stop, 'Finished');
+          content, ratings, citationMeta, FinishReason.stop, 'Finished',
+          urlContextMetadata: urlContextMetadata);
 
       expect(candidate.content, same(content));
       expect(candidate.safetyRatings, same(ratings));
       expect(candidate.citationMetadata, same(citationMeta));
       expect(candidate.finishReason, FinishReason.stop);
       expect(candidate.finishMessage, 'Finished');
+      expect(candidate.urlContextMetadata, same(urlContextMetadata));
     });
   });
 
@@ -411,6 +414,25 @@ void main() {
       expect(metadata.groundingChunks.first, same(groundingChunk));
       expect(metadata.groundingSupport.first, same(groundingSupport));
       expect(metadata.webSearchQueries, ['web query']);
+    });
+  });
+
+  group('UrlContextMetadata', () {
+    test('UrlMetadata constructor', () {
+      final uri = Uri.parse('http://example.com/page');
+      final metadata = UrlMetadata(
+          retrievedUrl: uri, urlRetrievalStatus: UrlRetrievalStatus.success);
+      expect(metadata.retrievedUrl, uri);
+      expect(metadata.urlRetrievalStatus, UrlRetrievalStatus.success);
+    });
+
+    test('UrlContextMetadata constructor', () {
+      final urlMetadata = UrlMetadata(
+          retrievedUrl: Uri.parse('http://example.com'),
+          urlRetrievalStatus: UrlRetrievalStatus.success);
+      final contextMetadata = UrlContextMetadata(urlMetadata: [urlMetadata]);
+      expect(contextMetadata.urlMetadata, hasLength(1));
+      expect(contextMetadata.urlMetadata.first, same(urlMetadata));
     });
   });
 
@@ -659,6 +681,7 @@ void main() {
               'candidatesTokenCount': 20,
               'totalTokenCount': 30,
               'thoughtsTokenCount': 5,
+              'toolUsePromptTokenCount': 12
             }
           };
           final response =
@@ -668,6 +691,7 @@ void main() {
           expect(response.usageMetadata!.candidatesTokenCount, 20);
           expect(response.usageMetadata!.totalTokenCount, 30);
           expect(response.usageMetadata!.thoughtsTokenCount, 5);
+          expect(response.usageMetadata!.toolUsePromptTokenCount, 12);
         });
 
         test('parses usageMetadata when thoughtsTokenCount is missing', () {
@@ -998,6 +1022,118 @@ void main() {
         });
       });
 
+      group('UrlContextMetadata parsing', () {
+        test('parses valid response with full url context metadata', () {
+          final jsonResponse = {
+            'candidates': [
+              {
+                'content': {
+                  'parts': [
+                    {'text': 'Some text'}
+                  ]
+                },
+                'finishReason': 'STOP',
+                'urlContextMetadata': {
+                  'urlMetadata': [
+                    {
+                      'retrievedUrl': 'https://example.com',
+                      'urlRetrievalStatus': 'URL_RETRIEVAL_STATUS_SUCCESS'
+                    }
+                  ]
+                }
+              }
+            ]
+          };
+          final response =
+              VertexSerialization().parseGenerateContentResponse(jsonResponse);
+          final urlContextMetadata =
+              response.candidates.first.urlContextMetadata;
+          expect(urlContextMetadata, isNotNull);
+          expect(urlContextMetadata!.urlMetadata, hasLength(1));
+          final urlMetadata = urlContextMetadata.urlMetadata.first;
+          expect(urlMetadata.retrievedUrl, Uri.parse('https://example.com'));
+          expect(urlMetadata.urlRetrievalStatus, UrlRetrievalStatus.success);
+        });
+
+        test('parses response with missing retrievedUrl', () {
+          final jsonResponse = {
+            'candidates': [
+              {
+                'urlContextMetadata': {
+                  'urlMetadata': [
+                    {'urlRetrievalStatus': 'URL_RETRIEVAL_STATUS_ERROR'}
+                  ]
+                }
+              }
+            ]
+          };
+          final response =
+              VertexSerialization().parseGenerateContentResponse(jsonResponse);
+          final urlMetadata =
+              response.candidates.first.urlContextMetadata!.urlMetadata.first;
+          expect(urlMetadata.retrievedUrl, isNull);
+          expect(urlMetadata.urlRetrievalStatus, UrlRetrievalStatus.error);
+        });
+
+        test('handles empty urlMetadata list', () {
+          final jsonResponse = {
+            'candidates': [
+              {
+                'urlContextMetadata': {'urlMetadata': []}
+              }
+            ]
+          };
+          final response =
+              VertexSerialization().parseGenerateContentResponse(jsonResponse);
+          final urlContextMetadata =
+              response.candidates.first.urlContextMetadata;
+          expect(urlContextMetadata, isNotNull);
+          expect(urlContextMetadata!.urlMetadata, isEmpty);
+        });
+
+        test('handles missing urlContextMetadata field', () {
+          final jsonResponse = {
+            'candidates': [
+              {'finishReason': 'STOP'}
+            ]
+          };
+          final response =
+              VertexSerialization().parseGenerateContentResponse(jsonResponse);
+          final candidate = response.candidates.first;
+          expect(candidate.urlContextMetadata, isNull);
+        });
+
+        test('throws for invalid urlContextMetadata structure', () {
+          final jsonResponse = {
+            'candidates': [
+              {'urlContextMetadata': 'not_a_map'}
+            ]
+          };
+          expect(
+              () => VertexSerialization()
+                  .parseGenerateContentResponse(jsonResponse),
+              throwsA(isA<FirebaseAISdkException>().having((e) => e.message,
+                  'message', contains('UrlContextMetadata'))));
+        });
+
+        test('throws for invalid urlMetadata item in list', () {
+          final jsonResponse = {
+            'candidates': [
+              {
+                'urlContextMetadata': {
+                  'urlMetadata': ['not_a_map']
+                }
+              }
+            ]
+          };
+          expect(
+              () => VertexSerialization()
+                  .parseGenerateContentResponse(jsonResponse),
+              throwsA(isA<FirebaseAISdkException>().having(
+                  (e) => e.message, 'message', contains('UrlMetadata'))));
+        });
+      });
+
       test('parses JSON with no candidates (empty list)', () {
         final json = {'candidates': []};
         final response =
@@ -1054,6 +1190,9 @@ void main() {
                 'modality': 'TEXT',
               }
             ],
+            'toolUsePromptTokensDetails': [
+              {'modality': 'TEXT', 'tokenCount': 12}
+            ],
           }
         };
         final response =
@@ -1079,6 +1218,15 @@ void main() {
         expect(
             response.usageMetadata!.candidatesTokensDetails!.first.tokenCount,
             0);
+        expect(
+            response.usageMetadata!.toolUsePromptTokensDetails, hasLength(1));
+        expect(
+            response.usageMetadata!.toolUsePromptTokensDetails!.first.modality,
+            ContentModality.text);
+        expect(
+            response
+                .usageMetadata!.toolUsePromptTokensDetails!.first.tokenCount,
+            12);
       });
 
       test('parses citationMetadata with "citationSources"', () {

--- a/packages/firebase_ai/firebase_ai/test/developer_api_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/developer_api_test.dart
@@ -47,6 +47,9 @@ void main() {
             'candidatesTokensDetails': [
               {'modality': 'TEXT', 'tokenCount': 25}
             ],
+            'toolUsePromptTokensDetails': [
+              {'modality': 'TEXT', 'tokenCount': 12}
+            ],
           }
         };
         final response =
@@ -65,6 +68,13 @@ void main() {
         expect(
             response.usageMetadata!.candidatesTokensDetails!.first.tokenCount,
             25);
+        expect(response.usageMetadata!.toolUsePromptTokensDetails, isNotNull);
+        expect(
+            response.usageMetadata!.toolUsePromptTokensDetails, hasLength(1));
+        expect(
+            response
+                .usageMetadata!.toolUsePromptTokensDetails!.first.tokenCount,
+            12);
       });
 
       test('parses usageMetadata when thoughtsTokenCount is missing', () {
@@ -322,6 +332,118 @@ void main() {
           final validSupport = groundingMetadata.groundingSupport.first;
           expect(validSupport.segment.text, 'Test');
           expect(validSupport.groundingChunkIndices, [0]);
+        });
+      });
+
+      group('UrlContextMetadata parsing', () {
+        test('parses valid response with full url context metadata', () {
+          final jsonResponse = {
+            'candidates': [
+              {
+                'content': {
+                  'parts': [
+                    {'text': 'Some text'}
+                  ]
+                },
+                'finishReason': 'STOP',
+                'urlContextMetadata': {
+                  'urlMetadata': [
+                    {
+                      'retrievedUrl': 'https://example.com',
+                      'urlRetrievalStatus': 'URL_RETRIEVAL_STATUS_SUCCESS'
+                    }
+                  ]
+                }
+              }
+            ]
+          };
+          final response =
+              VertexSerialization().parseGenerateContentResponse(jsonResponse);
+          final urlContextMetadata =
+              response.candidates.first.urlContextMetadata;
+          expect(urlContextMetadata, isNotNull);
+          expect(urlContextMetadata!.urlMetadata, hasLength(1));
+          final urlMetadata = urlContextMetadata.urlMetadata.first;
+          expect(urlMetadata.retrievedUrl, Uri.parse('https://example.com'));
+          expect(urlMetadata.urlRetrievalStatus, UrlRetrievalStatus.success);
+        });
+
+        test('parses response with missing retrievedUrl', () {
+          final jsonResponse = {
+            'candidates': [
+              {
+                'urlContextMetadata': {
+                  'urlMetadata': [
+                    {'urlRetrievalStatus': 'URL_RETRIEVAL_STATUS_ERROR'}
+                  ]
+                }
+              }
+            ]
+          };
+          final response =
+              VertexSerialization().parseGenerateContentResponse(jsonResponse);
+          final urlMetadata =
+              response.candidates.first.urlContextMetadata!.urlMetadata.first;
+          expect(urlMetadata.retrievedUrl, isNull);
+          expect(urlMetadata.urlRetrievalStatus, UrlRetrievalStatus.error);
+        });
+
+        test('handles empty urlMetadata list', () {
+          final jsonResponse = {
+            'candidates': [
+              {
+                'urlContextMetadata': {'urlMetadata': []}
+              }
+            ]
+          };
+          final response =
+              VertexSerialization().parseGenerateContentResponse(jsonResponse);
+          final urlContextMetadata =
+              response.candidates.first.urlContextMetadata;
+          expect(urlContextMetadata, isNotNull);
+          expect(urlContextMetadata!.urlMetadata, isEmpty);
+        });
+
+        test('handles missing urlContextMetadata field', () {
+          final jsonResponse = {
+            'candidates': [
+              {'finishReason': 'STOP'}
+            ]
+          };
+          final response =
+              VertexSerialization().parseGenerateContentResponse(jsonResponse);
+          final candidate = response.candidates.first;
+          expect(candidate.urlContextMetadata, isNull);
+        });
+
+        test('throws for invalid urlContextMetadata structure', () {
+          final jsonResponse = {
+            'candidates': [
+              {'urlContextMetadata': 'not_a_map'}
+            ]
+          };
+          expect(
+              () => VertexSerialization()
+                  .parseGenerateContentResponse(jsonResponse),
+              throwsA(isA<FirebaseAISdkException>().having((e) => e.message,
+                  'message', contains('UrlContextMetadata'))));
+        });
+
+        test('throws for invalid urlMetadata item in list', () {
+          final jsonResponse = {
+            'candidates': [
+              {
+                'urlContextMetadata': {
+                  'urlMetadata': ['not_a_map']
+                }
+              }
+            ]
+          };
+          expect(
+              () => VertexSerialization()
+                  .parseGenerateContentResponse(jsonResponse),
+              throwsA(isA<FirebaseAISdkException>().having(
+                  (e) => e.message, 'message', contains('UrlMetadata'))));
         });
       });
 

--- a/packages/firebase_ai/firebase_ai/test/google_ai_generative_model_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/google_ai_generative_model_test.dart
@@ -336,6 +336,22 @@ void main() {
         );
       });
 
+      test('can pass a url context tool', () async {
+        final (client, model) = createModel(
+          tools: [Tool.urlContext()],
+        );
+        const prompt = 'Some prompt';
+        await client.checkRequest(
+          () => model.generateContent([Content.text(prompt)]),
+          verifyRequest: (_, request) {
+            expect(request['tools'], [
+              {'urlContext': {}},
+            ]);
+          },
+          response: arbitraryGenerateContentResponse,
+        );
+      });
+
       test('can enable code execution', () async {
         final (client, model) = createModel(tools: [
           // Tool(codeExecution: CodeExecution()),

--- a/packages/firebase_ai/firebase_ai/test/google_ai_response_parsing_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/google_ai_response_parsing_test.dart
@@ -15,6 +15,7 @@
 import 'dart:convert';
 
 import 'package:firebase_ai/firebase_ai.dart';
+import 'package:firebase_ai/src/api.dart';
 import 'package:firebase_ai/src/developer/api.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -626,6 +627,241 @@ void main() {
         ),
       );
     }, skip: 'Code Execution Unsupported');
+
+    test('url context', () {
+      const response = '''
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "text": "The Berkshire Hathaway Inc. website serves as the official homepage for the company, providing a message from Warren E. Buffett and various corporate information. It includes annual and interim reports, news releases, SEC filings, and information about the annual meeting. The site also features letters from Warren Buffett and Charlie Munger, details on corporate governance and sustainability, and links to Berkshire Hathaway's operating companies. It also warns about fraudulent claims regarding Mr. Buffett's endorsements and provides information on common stock."
+          }
+        ]
+      },
+      "finishReason": "STOP",
+      "groundingMetadata": {
+        "groundingChunks": [
+          {
+            "web": {
+              "uri": "https://berkshirehathaway.com",
+              "title": "BERKSHIRE HATHAWAY INC."
+            }
+          }
+        ],
+        "groundingSupports": [
+          {
+            "segment": {
+              "startIndex": 273,
+              "endIndex": 450,
+              "text": "The site also features letters from Warren Buffett and Charlie Munger, details on corporate governance and sustainability, and links to Berkshire Hathaway's operating companies."
+            },
+            "groundingChunkIndices": [
+              0
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 503,
+              "endIndex": 567,
+              "text": "Buffett's endorsements and provides information on common stock."
+            },
+            "groundingChunkIndices": [
+              0
+            ]
+          }
+        ]
+      },
+      "urlContextMetadata": {
+        "urlMetadata": [
+          {
+            "retrievedUrl": "https://berkshirehathaway.com",
+            "urlRetrievalStatus": "URL_RETRIEVAL_STATUS_SUCCESS"
+          }
+        ]
+      }
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 13,
+    "candidatesTokenCount": 98,
+    "totalTokenCount": 181,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 13
+      }
+    ],
+    "candidatesTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 98
+      }
+    ],
+    "toolUsePromptTokenCount": 34,
+    "thoughtsTokenCount": 36
+  }
+}
+''';
+      final decoded = jsonDecode(response) as Object;
+      final generateContentResponse =
+          DeveloperSerialization().parseGenerateContentResponse(decoded);
+      final candidate = generateContentResponse.candidates.first;
+      final urlContextMetadata = candidate.urlContextMetadata;
+      expect(urlContextMetadata, isNotNull);
+      expect(urlContextMetadata!.urlMetadata, hasLength(1));
+      expect(urlContextMetadata.urlMetadata.first.retrievedUrl,
+          Uri.parse('https://berkshirehathaway.com'));
+      expect(urlContextMetadata.urlMetadata.first.urlRetrievalStatus,
+          UrlRetrievalStatus.success);
+      final usageMetadata = generateContentResponse.usageMetadata;
+      expect(usageMetadata, isNotNull);
+      expect(usageMetadata!.toolUsePromptTokenCount, 34);
+    });
+
+    test('url context mixed validity', () {
+      const response = '''
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "text": "The `browse` tool output shows the following:1.  **Valid Page (`https://ai.google.dev`)**: The tool successfully accessed this URL. It returned a `title` (Gemini Developer API | Gemma open models | Google AI for ...) and extensive `content`, indicating that the page is publicly accessible and rendered correctly.2.  **Broken Page (`https://a-completely-non-existent-url-for-testing.org`)**: The tool reported that it was not able to access the website(s). This indicates that the URL likely does not exist or is unreachable, confirming its broken status.3.  **Paywalled Page (`https://www.nytimes.com/2023/06/25/realestate/barbiecore-home-decor-interior-design.html?...`)**: Similar to the broken page, the tool also reported being not able to access the website(s) for this URL, explicitly mentioning paywalls, login requirements or sensitive information as common reasons. This suggests that the content is behind a paywall or requires authentication, making it inaccessible to the browsing tool.In summary, the `browse` tool successfully retrieved content from the valid page, while it was unable to access both the non-existent URL and the paywalled New York Times article, with specific reasons provided for the latter.The `browse` tool successfully retrieved the content and title from `https://ai.google.dev`, indicating it is a valid and accessible page.For `https://a-completely-non-existent-url-for-testing.org`, the tool reported that it was not able to access the website(s), which confirms it as a broken or non-existent page.Similarly, for `https://www.nytimes.com/2023/06/25/realestate/barbiecore-home-decor-interior-design.html?...`, the tool also stated it was not able to access the website(s), citing paywalls, login requirements or sensitive information as common reasons, confirming its paywalled status."
+          }
+        ]
+      },
+      "finishReason": "STOP",
+      "groundingMetadata": {
+        "groundingChunks": [
+          {
+            "web": {
+              "uri": "https://ai.google.dev",
+              "title": "Gemini Developer API | Gemma open models | Google AI for ..."
+            }
+          }
+        ],
+        "groundingSupports": [
+          {
+            "segment": {
+              "startIndex": 134,
+              "endIndex": 317,
+              "text": "It returned a `title` (Gemini Developer API | Gemma open models | Google AI for ...) and extensive `content`, indicating that the page is publicly accessible and rendered correctly."
+            },
+            "groundingChunkIndices": [
+              0
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 465,
+              "endIndex": 565,
+              "text": "This indicates that the URL likely does not exist or is unreachable, confirming its broken status."
+            },
+            "groundingChunkIndices": [
+              1
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 892,
+              "endIndex": 1015,
+              "text": "This suggests that the content is behind a paywall or requires authentication, making it inaccessible to the browsing tool."
+            },
+            "groundingChunkIndices": [
+              2
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 1244,
+              "endIndex": 1382,
+              "text": "The `browse` tool successfully retrieved the content and title from `https://ai.google.dev`, indicating it is a valid and accessible page."
+            },
+            "groundingChunkIndices": [
+              0
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 1384,
+              "endIndex": 1563,
+              "text": "For `https://a-completely-non-existent-url-for-testing.org`, the tool reported that it was not able to access the website(s), which confirms it as a broken or non-existent page."
+            },
+            "groundingChunkIndices": [
+              1
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 1565,
+              "endIndex": 1855,
+              "text": "Similarly, for `https://www.nytimes.com/2023/06/25/realestate/barbiecore-home-decor-interior-design.html?...`, the tool also stated it was not able to access the website(s), citing paywalls, login requirements or sensitive information as common reasons, confirming its paywalled status."
+            },
+            "groundingChunkIndices": [
+              2
+            ]
+          }
+        ]
+      },
+      "urlContextMetadata": {
+        "urlMetadata": [
+          {
+            "retrievedUrl": "https://www.nytimes.com/2023/06/25/realestate/barbiecore-home-decor-interior-design.html?action=click&contentCollection=undefined&region=Footer&module=WhatsNext&version=WhatsNext&contentID=WhatsNext&moduleDetail=most-emailed-0&pgtype=undefinedl",
+            "urlRetrievalStatus": "URL_RETRIEVAL_STATUS_ERROR"
+          },
+          {
+            "retrievedUrl": "https://ai.google.dev",
+            "urlRetrievalStatus": "URL_RETRIEVAL_STATUS_SUCCESS"
+          },
+          {
+            "retrievedUrl": "https://a-completely-non-existent-url-for-testing.org",
+            "urlRetrievalStatus": "URL_RETRIEVAL_STATUS_ERROR"
+          }
+        ]
+      }
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 116,
+    "candidatesTokenCount": 446,
+    "totalTokenCount": 918,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 116
+      }
+    ],
+    "candidatesTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 446
+      }
+    ],
+    "toolUsePromptTokenCount": 177,
+    "thoughtsTokenCount": 179
+  }
+}
+''';
+      final decoded = jsonDecode(response) as Object;
+      final generateContentResponse =
+          DeveloperSerialization().parseGenerateContentResponse(decoded);
+      final urlContextMetadata =
+          generateContentResponse.candidates.first.urlContextMetadata;
+      expect(urlContextMetadata, isNotNull);
+      expect(urlContextMetadata!.urlMetadata, hasLength(3));
+      expect(urlContextMetadata.urlMetadata[2].retrievedUrl,
+          Uri.parse('https://a-completely-non-existent-url-for-testing.org'));
+      expect(urlContextMetadata.urlMetadata[2].urlRetrievalStatus,
+          UrlRetrievalStatus.error);
+      expect(urlContextMetadata.urlMetadata[1].retrievedUrl,
+          Uri.parse('https://ai.google.dev'));
+      expect(urlContextMetadata.urlMetadata[1].urlRetrievalStatus,
+          UrlRetrievalStatus.success);
+    });
 
     test('allows missing content', () async {
       const response = '''

--- a/packages/firebase_ai/firebase_ai/test/model_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/model_test.dart
@@ -284,6 +284,22 @@ void main() {
         );
       });
 
+      test('can pass a url context tool', () async {
+        final (client, model) = createModel(
+          tools: [Tool.urlContext()],
+        );
+        const prompt = 'Some prompt';
+        await client.checkRequest(
+          () => model.generateContent([Content.text(prompt)]),
+          verifyRequest: (_, request) {
+            expect(request['tools'], [
+              {'urlContext': {}},
+            ]);
+          },
+          response: arbitraryGenerateContentResponse,
+        );
+      });
+
       test('can override tools and function calling config', () async {
         final (client, model) = createModel();
         const prompt = 'Some prompt';

--- a/packages/firebase_ai/firebase_ai/test/response_parsing_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/response_parsing_test.dart
@@ -685,7 +685,8 @@ void main() {
     "candidatesTokensDetails": [{
       "modality": "TEXT",
       "tokenCount": 76
-    }]
+    }],
+    "toolUsePromptTokenCount": 5
   }
 }
         ''';
@@ -695,6 +696,7 @@ void main() {
       expect(
           generateContentResponse.text, 'Here is a description of the image:');
       expect(generateContentResponse.usageMetadata?.totalTokenCount, 1913);
+      expect(generateContentResponse.usageMetadata?.toolUsePromptTokenCount, 5);
       expect(
           generateContentResponse
               .usageMetadata?.promptTokensDetails?[1].modality,
@@ -767,6 +769,311 @@ void main() {
       expect(generateContentResponse.text, 'Initial text And more text');
       expect(generateContentResponse.candidates.single.text,
           'Initial text And more text');
+    });
+
+    test('url context', () {
+      const response = '''
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "text": "The Berkshire Hathaway Inc. website serves as the official homepage for the company, providing a message from Warren E. Buffett and various corporate information. It includes annual and interim reports, news releases, SEC filings, and information about the annual meeting. The site also features letters from Warren Buffett and Charlie Munger, details on corporate governance and sustainability, and links to Berkshire Hathaway's operating companies. It also warns about fraudulent claims regarding Mr. Buffett's endorsements and provides information on common stock."
+          }
+        ]
+      },
+      "finishReason": "STOP",
+      "groundingMetadata": {
+        "groundingChunks": [
+          {
+            "web": {
+              "uri": "https://berkshirehathaway.com",
+              "title": "BERKSHIRE HATHAWAY INC."
+            }
+          }
+        ],
+        "groundingSupports": [
+          {
+            "segment": {
+              "startIndex": 273,
+              "endIndex": 450,
+              "text": "The site also features letters from Warren Buffett and Charlie Munger, details on corporate governance and sustainability, and links to Berkshire Hathaway's operating companies."
+            },
+            "groundingChunkIndices": [
+              0
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 503,
+              "endIndex": 567,
+              "text": "Buffett's endorsements and provides information on common stock."
+            },
+            "groundingChunkIndices": [
+              0
+            ]
+          }
+        ]
+      },
+      "urlContextMetadata": {
+        "urlMetadata": [
+          {
+            "retrievedUrl": "https://berkshirehathaway.com",
+            "urlRetrievalStatus": "URL_RETRIEVAL_STATUS_SUCCESS"
+          }
+        ]
+      }
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 13,
+    "candidatesTokenCount": 98,
+    "totalTokenCount": 181,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 13
+      }
+    ],
+    "candidatesTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 98
+      }
+    ],
+    "toolUsePromptTokenCount": 34,
+    "thoughtsTokenCount": 36
+  }
+}
+''';
+      final decoded = jsonDecode(response) as Object;
+      final generateContentResponse =
+          VertexSerialization().parseGenerateContentResponse(decoded);
+      final candidate = generateContentResponse.candidates.first;
+      final urlContextMetadata = candidate.urlContextMetadata;
+      expect(urlContextMetadata, isNotNull);
+      expect(urlContextMetadata!.urlMetadata, hasLength(1));
+      expect(urlContextMetadata.urlMetadata.first.retrievedUrl,
+          Uri.parse('https://berkshirehathaway.com'));
+      expect(urlContextMetadata.urlMetadata.first.urlRetrievalStatus,
+          UrlRetrievalStatus.success);
+      final usageMetadata = generateContentResponse.usageMetadata;
+      expect(usageMetadata, isNotNull);
+      expect(usageMetadata!.toolUsePromptTokenCount, 34);
+    });
+
+    test('url context mixed validity', () {
+      const response = '''
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "text": "The `browse` tool output shows the following:1.  **Valid Page (`https://ai.google.dev`)**: The tool successfully accessed this URL. It returned a `title` (Gemini Developer API | Gemma open models | Google AI for ...) and extensive `content`, indicating that the page is publicly accessible and rendered correctly.2.  **Broken Page (`https://a-completely-non-existent-url-for-testing.org`)**: The tool reported that it was not able to access the website(s). This indicates that the URL likely does not exist or is unreachable, confirming its broken status.3.  **Paywalled Page (`https://www.nytimes.com/2023/06/25/realestate/barbiecore-home-decor-interior-design.html?...`)**: Similar to the broken page, the tool also reported being not able to access the website(s) for this URL, explicitly mentioning paywalls, login requirements or sensitive information as common reasons. This suggests that the content is behind a paywall or requires authentication, making it inaccessible to the browsing tool.In summary, the `browse` tool successfully retrieved content from the valid page, while it was unable to access both the non-existent URL and the paywalled New York Times article, with specific reasons provided for the latter.The `browse` tool successfully retrieved the content and title from `https://ai.google.dev`, indicating it is a valid and accessible page.For `https://a-completely-non-existent-url-for-testing.org`, the tool reported that it was not able to access the website(s), which confirms it as a broken or non-existent page.Similarly, for `https://www.nytimes.com/2023/06/25/realestate/barbiecore-home-decor-interior-design.html?...`, the tool also stated it was not able to access the website(s), citing paywalls, login requirements or sensitive information as common reasons, confirming its paywalled status."
+          }
+        ]
+      },
+      "finishReason": "STOP",
+      "groundingMetadata": {
+        "groundingChunks": [
+          {
+            "web": {
+              "uri": "https://ai.google.dev",
+              "title": "Gemini Developer API | Gemma open models | Google AI for ..."
+            }
+          }
+        ],
+        "groundingSupports": [
+          {
+            "segment": {
+              "startIndex": 134,
+              "endIndex": 317,
+              "text": "It returned a `title` (Gemini Developer API | Gemma open models | Google AI for ...) and extensive `content`, indicating that the page is publicly accessible and rendered correctly."
+            },
+            "groundingChunkIndices": [
+              0
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 465,
+              "endIndex": 565,
+              "text": "This indicates that the URL likely does not exist or is unreachable, confirming its broken status."
+            },
+            "groundingChunkIndices": [
+              1
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 892,
+              "endIndex": 1015,
+              "text": "This suggests that the content is behind a paywall or requires authentication, making it inaccessible to the browsing tool."
+            },
+            "groundingChunkIndices": [
+              2
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 1244,
+              "endIndex": 1382,
+              "text": "The `browse` tool successfully retrieved the content and title from `https://ai.google.dev`, indicating it is a valid and accessible page."
+            },
+            "groundingChunkIndices": [
+              0
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 1384,
+              "endIndex": 1563,
+              "text": "For `https://a-completely-non-existent-url-for-testing.org`, the tool reported that it was not able to access the website(s), which confirms it as a broken or non-existent page."
+            },
+            "groundingChunkIndices": [
+              1
+            ]
+          },
+          {
+            "segment": {
+              "startIndex": 1565,
+              "endIndex": 1855,
+              "text": "Similarly, for `https://www.nytimes.com/2023/06/25/realestate/barbiecore-home-decor-interior-design.html?...`, the tool also stated it was not able to access the website(s), citing paywalls, login requirements or sensitive information as common reasons, confirming its paywalled status."
+            },
+            "groundingChunkIndices": [
+              2
+            ]
+          }
+        ]
+      },
+      "urlContextMetadata": {
+        "urlMetadata": [
+          {
+            "retrievedUrl": "https://www.nytimes.com/2023/06/25/realestate/barbiecore-home-decor-interior-design.html?action=click&contentCollection=undefined&region=Footer&module=WhatsNext&version=WhatsNext&contentID=WhatsNext&moduleDetail=most-emailed-0&pgtype=undefinedl",
+            "urlRetrievalStatus": "URL_RETRIEVAL_STATUS_ERROR"
+          },
+          {
+            "retrievedUrl": "https://ai.google.dev",
+            "urlRetrievalStatus": "URL_RETRIEVAL_STATUS_SUCCESS"
+          },
+          {
+            "retrievedUrl": "https://a-completely-non-existent-url-for-testing.org",
+            "urlRetrievalStatus": "URL_RETRIEVAL_STATUS_ERROR"
+          }
+        ]
+      }
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 116,
+    "candidatesTokenCount": 446,
+    "totalTokenCount": 918,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 116
+      }
+    ],
+    "candidatesTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 446
+      }
+    ],
+    "toolUsePromptTokenCount": 177,
+    "thoughtsTokenCount": 179
+  }
+}
+''';
+      final decoded = jsonDecode(response) as Object;
+      final generateContentResponse =
+          VertexSerialization().parseGenerateContentResponse(decoded);
+      final urlContextMetadata =
+          generateContentResponse.candidates.first.urlContextMetadata;
+      expect(urlContextMetadata, isNotNull);
+      expect(urlContextMetadata!.urlMetadata, hasLength(3));
+      expect(urlContextMetadata.urlMetadata[2].retrievedUrl,
+          Uri.parse('https://a-completely-non-existent-url-for-testing.org'));
+      expect(urlContextMetadata.urlMetadata[2].urlRetrievalStatus,
+          UrlRetrievalStatus.error);
+      expect(urlContextMetadata.urlMetadata[1].retrievedUrl,
+          Uri.parse('https://ai.google.dev'));
+      expect(urlContextMetadata.urlMetadata[1].urlRetrievalStatus,
+          UrlRetrievalStatus.success);
+    });
+
+    test('url context missing retrievedUrl', () {
+      const response = '''
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "text": "I attempted to access the provided URLs, but I was unable to retrieve any content from them. The error message indicated that the websites could not be accessed, possibly due to reasons such as paywalls, login requirements, sensitive information, or other access restrictions. This suggests that these pages are not real in the sense of being publicly accessible or existing web pages. The `example.com` domain is typically used for illustrative purposes and not for actual active websites."
+          }
+        ]
+      },
+      "finishReason": "STOP",
+      "groundingMetadata": {
+        "groundingSupports": [
+          {
+            "segment": {
+              "startIndex": 93,
+              "endIndex": 275,
+              "text": "The error message indicated that the websites could not be accessed, possibly due to reasons such as paywalls, login requirements, sensitive information, or other access restrictions"
+            },
+            "groundingChunkIndices": [
+              0
+            ]
+          }
+        ]
+      },
+      "urlContextMetadata": {
+        "urlMetadata": [
+          {
+            "urlRetrievalStatus": "URL_RETRIEVAL_STATUS_ERROR"
+          }
+        ]
+      }
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 175,
+    "candidatesTokenCount": 93,
+    "totalTokenCount": 564,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 175
+      }
+    ],
+    "candidatesTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 93
+      }
+    ],
+    "toolUsePromptTokenCount": 60,
+    "thoughtsTokenCount": 236
+  }
+}
+''';
+      final decoded = jsonDecode(response) as Object;
+      final generateContentResponse =
+          VertexSerialization().parseGenerateContentResponse(decoded);
+      final urlContextMetadata =
+          generateContentResponse.candidates.first.urlContextMetadata;
+      expect(urlContextMetadata, isNotNull);
+      expect(urlContextMetadata!.urlMetadata, hasLength(1));
+      expect(urlContextMetadata.urlMetadata[0].retrievedUrl, isNull);
+      expect(urlContextMetadata.urlMetadata[0].urlRetrievalStatus,
+          UrlRetrievalStatus.error);
     });
   });
 


### PR DESCRIPTION
Adds support for the URL context tool.

API Proposal: [go/alf-urlcontext-api](http://go/alf-urlcontext-api) (internal)