### PR TITLE
Expose AppleAppAttestProvider without importing platform interface

### DIFF
--- a/packages/firebase_app_check/firebase_app_check/lib/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/firebase_app_check.dart
@@ -17,6 +17,7 @@ export 'package:firebase_app_check_platform_interface/firebase_app_check_platfor
         AppleAppCheckProvider,
         AppleDebugProvider,
         AppleDeviceCheckProvider,
+        AppleAppAttestProvider,
         AppleAppAttestWithDeviceCheckFallbackProvider,
         ReCaptchaEnterpriseProvider,
         ReCaptchaV3Provider;


### PR DESCRIPTION
## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
