### PR TITLE
fix(app_check): Deprecate androidProvider and appleProvider parameters in activate method

### DIFF
--- a/packages/firebase_app_check/firebase_app_check/example/lib/main.dart
+++ b/packages/firebase_app_check/firebase_app_check/example/lib/main.dart
@@ -23,11 +23,9 @@ Future<void> main() async {
   await FirebaseAppCheck.instance
       // Your personal reCaptcha public key goes here:
       .activate(
-    androidProvider: AndroidProvider.debug,
-    appleProvider: AppleProvider.debug,
     providerWeb: ReCaptchaV3Provider(kWebRecaptchaSiteKey),
-    providerAndroid: const AndroidDebugProvider(debugToken: 'androidDebug'),
-    providerApple: const AppleDebugProvider(debugToken: 'appleDebug'),
+    providerAndroid: const AndroidDebugProvider(),
+    providerApple: const AppleDebugProvider(),
   );
 
   runApp(MyApp());

--- a/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
@@ -76,7 +76,15 @@ class FirebaseAppCheck extends FirebasePluginPlatform {
     )
     WebProvider? webProvider,
     WebProvider? providerWeb,
+    @Deprecated(
+      'Use providerAndroid instead. '
+      'This parameter will be removed in a future major release.',
+    )
     AndroidProvider androidProvider = AndroidProvider.playIntegrity,
+    @Deprecated(
+      'Use providerApple instead. '
+      'This parameter will be removed in a future major release.',
+    )
     AppleProvider appleProvider = AppleProvider.deviceCheck,
     AndroidAppCheckProvider providerAndroid =
         const AndroidPlayIntegrityProvider(),

--- a/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
@@ -80,12 +80,12 @@ class FirebaseAppCheck extends FirebasePluginPlatform {
       'Use providerAndroid instead. '
       'This parameter will be removed in a future major release.',
     )
-    AndroidProvider? androidProvider,
+    AndroidProvider androidProvider = AndroidProvider.playIntegrity,
     @Deprecated(
       'Use providerApple instead. '
       'This parameter will be removed in a future major release.',
     )
-    AppleProvider? appleProvider,
+    AppleProvider appleProvider = AppleProvider.deviceCheck,
     AndroidAppCheckProvider providerAndroid =
         const AndroidPlayIntegrityProvider(),
     AppleAppCheckProvider providerApple = const AppleDeviceCheckProvider(),

--- a/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
@@ -80,12 +80,12 @@ class FirebaseAppCheck extends FirebasePluginPlatform {
       'Use providerAndroid instead. '
       'This parameter will be removed in a future major release.',
     )
-    AndroidProvider androidProvider = AndroidProvider.playIntegrity,
+    AndroidProvider? androidProvider,
     @Deprecated(
       'Use providerApple instead. '
       'This parameter will be removed in a future major release.',
     )
-    AppleProvider appleProvider = AppleProvider.deviceCheck,
+    AppleProvider? appleProvider,
     AndroidAppCheckProvider providerAndroid =
         const AndroidPlayIntegrityProvider(),
     AppleAppCheckProvider providerApple = const AppleDeviceCheckProvider(),

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/utils/provider_to_string.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/utils/provider_to_string.dart
@@ -12,12 +12,11 @@ String getAndroidProviderString({
   AndroidProvider? legacyProvider,
   AndroidAppCheckProvider? newProvider,
 }) {
-  // Prefer new provider over legacy provider
-  if (newProvider != null) {
-    return newProvider.type;
+  if (legacyProvider != null) {
+    return getLegacyAndroidProviderString(legacyProvider);
   }
 
-  return getLegacyAndroidProviderString(legacyProvider);
+  return newProvider?.type ?? 'playIntegrity';
 }
 
 /// Converts [AppleAppCheckProvider] to [String] with backwards compatibility
@@ -25,12 +24,11 @@ String getAppleProviderString({
   AppleProvider? legacyProvider,
   AppleAppCheckProvider? newProvider,
 }) {
-  // Prefer new provider over legacy provider
-  if (newProvider != null) {
-    return newProvider.type;
+  if (legacyProvider != null) {
+    return getLegacyAppleProviderString(legacyProvider);
   }
 
-  return getLegacyAppleProviderString(legacyProvider);
+  return newProvider?.type ?? 'deviceCheck';
 }
 
 /// Converts [AndroidProvider] enum to [String]

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/utils/provider_to_string.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/utils/provider_to_string.dart
@@ -12,10 +12,12 @@ String getAndroidProviderString({
   AndroidProvider? legacyProvider,
   AndroidAppCheckProvider? newProvider,
 }) {
-  if (legacyProvider != null) {
-    return getLegacyAndroidProviderString(legacyProvider);
+  if (newProvider != null && legacyProvider != null) {
+    if (legacyProvider != AndroidProvider.playIntegrity) {
+      // Legacy provider is explicitly set to something other than default
+      return getLegacyAndroidProviderString(legacyProvider);
+    }
   }
-
   return newProvider?.type ?? 'playIntegrity';
 }
 
@@ -24,10 +26,12 @@ String getAppleProviderString({
   AppleProvider? legacyProvider,
   AppleAppCheckProvider? newProvider,
 }) {
-  if (legacyProvider != null) {
-    return getLegacyAppleProviderString(legacyProvider);
+  if (newProvider != null && legacyProvider != null) {
+    if (legacyProvider != AppleProvider.deviceCheck) {
+      // Legacy provider is explicitly set to something other than default
+      return getLegacyAppleProviderString(legacyProvider);
+    }
   }
-
   return newProvider?.type ?? 'deviceCheck';
 }
 

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/test/method_channel_tests/utils/provider_to_string_test.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/test/method_channel_tests/utils/provider_to_string_test.dart
@@ -1,0 +1,124 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:firebase_app_check_platform_interface/src/android_provider.dart';
+import 'package:firebase_app_check_platform_interface/src/android_providers.dart';
+import 'package:firebase_app_check_platform_interface/src/apple_provider.dart';
+import 'package:firebase_app_check_platform_interface/src/apple_providers.dart';
+import 'package:firebase_app_check_platform_interface/src/method_channel/utils/provider_to_string.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('getAndroidProviderString', () {
+    test(
+        'returns new provider type when both providers are provided and legacy is default',
+        () {
+      final result = getAndroidProviderString(
+        legacyProvider: AndroidProvider.playIntegrity,
+        newProvider: const AndroidPlayIntegrityProvider(),
+      );
+      expect(result, 'playIntegrity');
+    });
+
+    test(
+        'returns legacy provider when explicitly set to debug and new provider is default',
+        () {
+      final result = getAndroidProviderString(
+        legacyProvider: AndroidProvider.debug,
+        newProvider: const AndroidPlayIntegrityProvider(),
+      );
+      expect(result, 'debug');
+    });
+
+    test(
+        'returns new provider type when only new provider is provided and legacy is default',
+        () {
+      final result = getAndroidProviderString(
+        legacyProvider: AndroidProvider.playIntegrity,
+        newProvider: const AndroidDebugProvider(),
+      );
+      expect(result, 'debug');
+    });
+
+    test('returns default when neither provider is provided', () {
+      final result = getAndroidProviderString();
+      expect(result, 'playIntegrity');
+    });
+  });
+
+  group('getAppleProviderString', () {
+    test('returns default provider when both providers are default', () {
+      final result = getAppleProviderString(
+        legacyProvider: AppleProvider.deviceCheck,
+        newProvider: const AppleDeviceCheckProvider(),
+      );
+      expect(result, 'deviceCheck');
+    });
+
+    test(
+        'returns legacy provider when explicitly set to debug and new provider is default',
+        () {
+      final result = getAppleProviderString(
+        legacyProvider: AppleProvider.debug,
+        newProvider: const AppleDeviceCheckProvider(),
+      );
+      expect(result, 'debug');
+    });
+
+    test(
+        'returns legacy provider when explicitly set to appAttest and new provider is default',
+        () {
+      final result = getAppleProviderString(
+        legacyProvider: AppleProvider.appAttest,
+        newProvider: const AppleDeviceCheckProvider(),
+      );
+      expect(result, 'appAttest');
+    });
+
+    test(
+        'returns legacy provider when explicitly set to appAttestWithDeviceCheckFallback and new provider is default',
+        () {
+      final result = getAppleProviderString(
+        legacyProvider: AppleProvider.appAttestWithDeviceCheckFallback,
+        newProvider: const AppleDeviceCheckProvider(),
+      );
+      expect(result, 'appAttestWithDeviceCheckFallback');
+    });
+
+    test(
+        'returns new provider type when new provider is provided and legacy is default',
+        () {
+      final result = getAppleProviderString(
+        legacyProvider: AppleProvider.deviceCheck,
+        newProvider: const AppleDebugProvider(),
+      );
+      expect(result, 'debug');
+    });
+
+    test(
+        'returns legacy provider when new provider is provided and legacy is default',
+        () {
+      final result = getAppleProviderString(
+        legacyProvider: AppleProvider.deviceCheck,
+        newProvider: const AppleAppAttestProvider(),
+      );
+      expect(result, 'appAttest');
+    });
+
+    test('returns default when neither provider is provided', () {
+      final result = getAppleProviderString();
+      expect(result, 'deviceCheck');
+    });
+
+    test(
+        'returns new provider when explicitly set to appAttestWithDeviceCheckFallback',
+        () {
+      final result = getAppleProviderString(
+        legacyProvider: AppleProvider.deviceCheck,
+        newProvider: const AppleAppAttestWithDeviceCheckFallbackProvider(),
+      );
+      expect(result, 'appAttestWithDeviceCheckFallback');
+    });
+  });
+}

--- a/packages/firebase_data_connect/firebase_data_connect/example/lib/main.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/example/lib/main.dart
@@ -41,14 +41,14 @@ void main() async {
       // 1. Debug provider
       // 2. Safety Net provider
       // 3. Play Integrity provider
-      androidProvider: AndroidProvider.debug,
+      providerAndroid: const AndroidDebugProvider(),
       // Default provider for iOS/macOS is the Device Check provider. You can use the "AppleProvider" enum to choose
       // your preferred provider. Choose from:
       // 1. Debug provider
       // 2. Device Check provider
       // 3. App Attest provider
       // 4. App Attest provider with fallback to Device Check provider (App Attest provider is only available on iOS 14.0+, macOS 14.0+)
-      appleProvider: AppleProvider.appAttest,
+      providerApple: const AppleAppAttestProvider(),
     );
   }
   if (configureEmulator) {

--- a/tests/integration_test/firebase_app_check/firebase_app_check_e2e_test.dart
+++ b/tests/integration_test/firebase_app_check/firebase_app_check_e2e_test.dart
@@ -83,10 +83,7 @@ void main() {
         () async {
           await expectLater(
             FirebaseAppCheck.instance.activate(
-              androidProvider: AndroidProvider.debug,
-              providerAndroid: const AndroidDebugProvider(
-                debugToken: 'debug_token',
-              ),
+              providerAndroid: const AndroidDebugProvider(),
             ),
             completes,
           );
@@ -99,10 +96,7 @@ void main() {
         () async {
           await expectLater(
             FirebaseAppCheck.instance.activate(
-              appleProvider: AppleProvider.debug,
-              providerApple: const AppleDebugProvider(
-                debugToken: 'debug_token',
-              ),
+              providerApple: const AppleDebugProvider(),
             ),
             completes,
           );


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/firebase/flutterfire/issues/17738

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
