### PR TITLE
fix(firebase_messaging): fix null apple notification when sound is of type String

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
@@ -992,7 +992,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     if (apsDict[@"sound"] != nil) {
       if ([apsDict[@"sound"] isKindOfClass:[NSString class]]) {
         // message.notification.apple.sound
-        notification[@"sound"] = @{
+        notificationIOS[@"sound"] = @{
           @"name" : apsDict[@"sound"],
           @"critical" : @NO,
           @"volume" : @1,


### PR DESCRIPTION
fixed notification sound being null in notification.apple.sound of onMessage stream

## Description

If a notification is sent from backend with a sound file String, the sound value in RemoteMessage.notification.apple.sound is being received as null in FirebaseMessaging.onMessage stream of Flutter interface. That was because sound was incorrectly being assigned to notification instead of notificationIOS in FLTFirebaseMessagingPlugin implementation of iOS.

## Related Issues

None

## Checklist

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ x] All existing and new tests are passing.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ x] I read and followed the [Flutter Style Guide].
- [ x] I signed the [CLA].
- [ x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
