### PR TITLE
fix(app-check): token not available on new session

### DIFF
--- a/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
@@ -43,10 +43,19 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
       ensurePluginInitialized: (firebaseApp) async {
         final instance =
             FirebaseAppCheckWeb(app: Firebase.app(firebaseApp.name));
-        final recaptchaType = web.window.sessionStorage
+        var recaptchaType = web.window.localStorage
             .getItem(_sessionKeyRecaptchaType(firebaseApp.name));
-        final recaptchaSiteKey = web.window.sessionStorage
+        var recaptchaSiteKey = web.window.localStorage
             .getItem(_sessionKeyRecaptchaSiteKey(firebaseApp.name));
+
+        // For backwards compatibility, with previously used session storage
+        if (recaptchaType == null || recaptchaSiteKey == null) {
+          recaptchaType = web.window.sessionStorage
+              .getItem(_sessionKeyRecaptchaType(firebaseApp.name));
+          recaptchaSiteKey = web.window.sessionStorage
+              .getItem(_sessionKeyRecaptchaSiteKey(firebaseApp.name));
+        }
+
         if (recaptchaType != null && recaptchaSiteKey != null) {
           final WebProvider provider;
           if (recaptchaType == recaptchaTypeV3) {
@@ -125,9 +134,9 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
       } else {
         throw Exception('Invalid web provider: $webProvider');
       }
-      web.window.sessionStorage
+      web.window.localStorage
           .setItem(_sessionKeyRecaptchaType(app.name), recaptchaType);
-      web.window.sessionStorage
+      web.window.localStorage
           .setItem(_sessionKeyRecaptchaSiteKey(app.name), webProvider.siteKey);
     }
 


### PR DESCRIPTION
## Description

Use `localStorage` to store app check details instead of `sessionStorage` so that the details are available when initializing app check before other plugins inside `firebase_core` in a new session (fresh new tab).

## Related Issues

fixes #17611

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
