### PR TITLE
chore(ci): implement best practices for CI caching

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -56,9 +56,11 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         continue-on-error: true
         with:
+          # The firebase emulators are pure javascript and java, OS-independent
+          enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
+          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
         with:

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -33,6 +33,10 @@ jobs:
       matrix:
         working_directory:
           ['tests', 'packages/cloud_firestore/cloud_firestore/example']
+    env:
+      AVD_ARCH: x86_64
+      AVD_API_LEVEL: 34
+      AVD_TARGET: google_apis
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
@@ -43,6 +47,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+      - name: 'Install Tools'
+        run: |
+          sudo npm i -g firebase-tools
+          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
@@ -50,7 +58,7 @@ jobs:
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ runner.os }}
+          key: firebase-emulators-v3-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
         with:
@@ -64,9 +72,6 @@ jobs:
           melos-version: '5.3.0'
       - name: 'Bootstrap package'
         run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools
       - name: Start Firebase Emulator
         run: cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
       - name: Enable KVM
@@ -93,13 +98,13 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ runner.os }}
+          key: avd-${{ runner.os }}-${{ env.AVD_API_LEVEL }}-${{ env.AVD_TARGET }}-${{ env.AVD_ARCH }}
       - name: Start AVD then run E2E tests
         uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b
         with:
-          api-level: 34
-          target: google_apis
-          arch: x86_64
+          api-level: ${{ env.AVD_API_LEVEL }}
+          target: ${{ env.AVD_TARGET }}
+          arch: ${{ env.AVD_ARCH }}
           working-directory: ${{ matrix.working_directory }}
           script: |
             flutter test integration_test/e2e_test.dart --ignore-timeouts --dart-define=CI=true -d emulator-5554

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -90,7 +90,7 @@ jobs:
             ~/.android/adb*
           key: avd-${{ runner.os }}
       - name: Start AVD then run E2E tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b
         with:
           api-level: 34
           target: google_apis

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -44,8 +44,10 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Firebase Emulator Cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        id: firebase-emulator-cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
+          # Must match the save path exactly
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-v3-${{ runner.os }}
           restore-keys: firebase-emulators-v3
@@ -82,9 +84,10 @@ jobs:
           remove-docker-images: true
           remove-large-packages: true
       - name: AVD cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         id: avd-cache
         with:
+          # Must match the save path exactly
           path: |
             ~/.android/avd/*
             ~/.android/adb*
@@ -103,3 +106,21 @@ jobs:
       # https://github.com/ReactiveCircus/android-emulator-runner/issues/385
         run: |
           pgrep -f appium && pkill -f appium || echo "No Appium process found"
+      - name: Save Firestore Emulator Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
+          # Must match the restore path exactly
+          path: ~/.cache/firebase/emulators
+      - name: Save Android Emulator Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.avd-cache.outputs.cache-primary-key }}
+          # Must match the restore path exactly
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -46,6 +46,7 @@ jobs:
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
@@ -85,6 +86,7 @@ jobs:
           remove-large-packages: true
       - name: AVD cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         id: avd-cache
         with:
           # Must match the save path exactly

--- a/.github/workflows/e2e_tests_fdc.yaml
+++ b/.github/workflows/e2e_tests_fdc.yaml
@@ -38,8 +38,10 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Firebase Emulator Cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        id: firebase-emulator-cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
+          # Must match the save path exactly
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-v3-fdc-${{ runner.os }}
           restore-keys: firebase-emulators-v3
@@ -80,9 +82,10 @@ jobs:
           remove-docker-images: true
           remove-large-packages: true
       - name: AVD cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         id: avd-cache
         with:
+          # Must match the save path exactly
           path: |
             ~/.android/avd/*
             ~/.android/adb*
@@ -96,6 +99,24 @@ jobs:
           working-directory: 'packages/firebase_data_connect/firebase_data_connect/example'
           script: |
             flutter test integration_test/e2e_test.dart --dart-define=CI=true -d emulator-5554
+      - name: Save Android Emulator Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.avd-cache.outputs.cache-primary-key }}
+          # Must match the restore path exactly
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+      - name: Save Firestore Emulator Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
+          # Must match the restore path exactly
+          path: ~/.cache/firebase/emulators
 
   ios:
     runs-on: macos-15
@@ -121,16 +142,19 @@ jobs:
         with:
           key: xcode-cache-${{ runner.os }}
           max-size: 700M
-      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         name: Pods Cache
         id: pods-cache
         with:
+          # Must match the save path exactly
           path: tests/ios/Pods
           key: ${{ runner.os }}-fdc-pods-v3-${{ hashFiles('tests/ios/Podfile.lock') }}
           restore-keys: ${{ runner.os }}-ios-pods-v2
       - name: Firebase Emulator Cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        id: firebase-emulator-cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
+          # Must match the save path exactly
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-v3-fdc-${{ runner.os }}
           restore-keys: firebase-emulators-v3
@@ -178,6 +202,22 @@ jobs:
           # Uncomment following line to have simulator logs printed out for debugging purposes.
           # xcrun simctl spawn booted log stream --predicate 'eventMessage contains "flutter"' &
           flutter test integration_test/e2e_test.dart -d "$SIMULATOR" --dart-define=CI=true
+      - name: Save Firestore Emulator Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
+          # Must match the restore path exactly
+          path: ~/.cache/firebase/emulators
+      - name: Save Pods Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.pods-cache.outputs.cache-primary-key }}
+          # Must match the restore paths exactly
+          path: tests/ios/Pods
 
   web:
     runs-on: macos-latest
@@ -208,9 +248,11 @@ jobs:
         run: melos bootstrap --scope "firebase_data_connect*"
       - name: 'Install Tools'
         run: sudo npm i -g firebase-tools
-      - name: Cache Firebase Emulator
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      - name: Firebase Emulator Cache
+        id: firebase-emulator-cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
+          # Must match the save path exactly
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-v3-fdc-${{ runner.os }}
           restore-keys: firebase-emulators-v3
@@ -237,3 +279,19 @@ jobs:
           exit 1
           fi
         shell: bash
+      - name: Save Firestore Emulator Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
+          # Must match the restore path exactly
+          path: ~/.cache/firebase/emulators
+      - name: Save Pods Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.pods-cache.outputs.cache-primary-key }}
+          # Must match the restore paths exactly
+          path: tests/ios/Pods

--- a/.github/workflows/e2e_tests_fdc.yaml
+++ b/.github/workflows/e2e_tests_fdc.yaml
@@ -27,6 +27,10 @@ jobs:
     timeout-minutes: 45
     strategy:
       fail-fast: false
+    env:
+      AVD_ARCH: x86_64
+      AVD_API_LEVEL: 34
+      AVD_TARGET: google_apis
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
@@ -37,6 +41,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+      - name: 'Install Tools'
+        run: |
+          sudo npm i -g firebase-tools
+          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
@@ -44,7 +52,7 @@ jobs:
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-fdc-${{ runner.os }}
+          key: firebase-emulators-v3-fdc-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
         with:
@@ -58,9 +66,6 @@ jobs:
           melos-version: '5.3.0'
       - name: 'Bootstrap package'
         run: melos bootstrap --scope "firebase_data_connect*"
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools
       - name: Start Firebase Emulator
         run: |
           cd ./packages/firebase_data_connect/firebase_data_connect/example
@@ -91,13 +96,13 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ runner.os }}
+          key: avd-${{ runner.os }}-${{ env.AVD_API_LEVEL }}-${{ env.AVD_TARGET }}-${{ env.AVD_ARCH }}
       - name: Start AVD then run E2E tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
-          target: google_apis
-          arch: x86_64
+          api-level: ${{ env.AVD_API_LEVEL }}
+          target: ${{ env.AVD_TARGET }}
+          arch: ${{ env.AVD_ARCH }}
           working-directory: 'packages/firebase_data_connect/firebase_data_connect/example'
           script: |
             flutter test integration_test/e2e_test.dart --dart-define=CI=true -d emulator-5554
@@ -155,6 +160,10 @@ jobs:
           path: tests/ios/Pods
           key: ${{ runner.os }}-fdc-pods-v3-${{ hashFiles('tests/ios/Podfile.lock') }}
           restore-keys: ${{ runner.os }}-ios-pods-v2
+      - name: 'Install Tools'
+        run: |
+          sudo npm i -g firebase-tools
+          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
@@ -162,7 +171,7 @@ jobs:
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-fdc-${{ runner.os }}
+          key: firebase-emulators-v3-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
         with:
@@ -174,9 +183,6 @@ jobs:
           melos-version: '5.3.0'
       - name: 'Bootstrap package'
         run: melos bootstrap --scope "firebase_data_connect*"
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools
       - name: 'Build Application'
         working-directory: 'packages/firebase_data_connect/firebase_data_connect/example'
         run: |
@@ -255,15 +261,17 @@ jobs:
       - name: 'Bootstrap package'
         run: melos bootstrap --scope "firebase_data_connect*"
       - name: 'Install Tools'
-        run: sudo npm i -g firebase-tools
-      - name: Firebase Emulator Cache
+        run: |
+          sudo npm i -g firebase-tools
+          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
+     - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         continue-on-error: true
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-fdc-${{ runner.os }}
+          key: firebase-emulators-v3-fdc-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - name: Start Firebase Emulator
         run: |

--- a/.github/workflows/e2e_tests_fdc.yaml
+++ b/.github/workflows/e2e_tests_fdc.yaml
@@ -40,6 +40,7 @@ jobs:
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
@@ -84,6 +85,7 @@ jobs:
       - name: AVD cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         id: avd-cache
+        continue-on-error: true
         with:
           # Must match the save path exactly
           path: |
@@ -103,6 +105,7 @@ jobs:
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           key: ${{ steps.avd-cache.outputs.cache-primary-key }}
           # Must match the restore path exactly
@@ -113,6 +116,7 @@ jobs:
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
           # Must match the restore path exactly
@@ -143,6 +147,7 @@ jobs:
           key: xcode-cache-${{ runner.os }}
           max-size: 700M
       - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         name: Pods Cache
         id: pods-cache
         with:
@@ -153,6 +158,7 @@ jobs:
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
@@ -206,6 +212,7 @@ jobs:
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
           # Must match the restore path exactly
@@ -214,6 +221,7 @@ jobs:
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           key: ${{ steps.pods-cache.outputs.cache-primary-key }}
           # Must match the restore paths exactly
@@ -251,6 +259,7 @@ jobs:
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
@@ -283,6 +292,7 @@ jobs:
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
           # Must match the restore path exactly
@@ -291,6 +301,7 @@ jobs:
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           key: ${{ steps.pods-cache.outputs.cache-primary-key }}
           # Must match the restore paths exactly

--- a/.github/workflows/e2e_tests_fdc.yaml
+++ b/.github/workflows/e2e_tests_fdc.yaml
@@ -50,9 +50,11 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         continue-on-error: true
         with:
+          # The firebase emulators are pure javascript and java, OS-independent
+          enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-fdc-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
+          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
         with:
@@ -169,9 +171,11 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         continue-on-error: true
         with:
+          # The firebase emulators are pure javascript and java, OS-independent
+          enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
+          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
         with:
@@ -269,9 +273,11 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         continue-on-error: true
         with:
+          # The firebase emulators are pure javascript and java, OS-independent
+          enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-fdc-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
+          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - name: Start Firebase Emulator
         run: |

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -59,6 +59,10 @@ jobs:
           path: tests/ios/Pods
           key: pods-v3-${{ runner.os }}-${{ hashFiles('tests/ios/Podfile.lock') }}
           restore-keys: pods-v3-${{ runner.os }}
+      - name: 'Install Tools'
+        run: |
+          sudo npm i -g firebase-tools
+          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
@@ -66,7 +70,7 @@ jobs:
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ runner.os }}
+          key: firebase-emulators-v3-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
         with:
@@ -80,9 +84,6 @@ jobs:
           melos-version: '5.3.0'
       - name: 'Bootstrap package'
         run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools
       - name: 'Free up space'
         run: |
           sudo rm -rf \

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -51,6 +51,7 @@ jobs:
           key: xcode-cache-${{ runner.os }}
           max-size: 700M
       - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         name: Pods Cache
         id: pods-cache
         with:
@@ -61,6 +62,7 @@ jobs:
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
@@ -125,6 +127,7 @@ jobs:
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
           # Must match the restore paths exactly
@@ -133,6 +136,7 @@ jobs:
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           key: ${{ steps.pods-cache.outputs.cache-primary-key }}
           # Must match the restore paths exactly

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -68,9 +68,11 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         continue-on-error: true
         with:
+          # The firebase emulators are pure javascript and java, OS-independent
+          enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
+          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
         with:

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -50,16 +50,19 @@ jobs:
         with:
           key: xcode-cache-${{ runner.os }}
           max-size: 700M
-      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         name: Pods Cache
         id: pods-cache
         with:
+          # Must match the save path exactly
           path: tests/ios/Pods
           key: pods-v3-${{ runner.os }}-${{ hashFiles('tests/ios/Podfile.lock') }}
           restore-keys: pods-v3-${{ runner.os }}
       - name: Firebase Emulator Cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        id: firebase-emulator-cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
+          # Must match the save path exactly
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-v3-${{ runner.os }}
           restore-keys: firebase-emulators-v3
@@ -118,3 +121,19 @@ jobs:
           # Uncomment following line to have simulator logs printed out for debugging purposes.
           # xcrun simctl spawn booted log stream --predicate 'eventMessage contains "flutter"' &
           flutter test integration_test/e2e_test.dart -d "$SIMULATOR" --ignore-timeouts --dart-define=CI=true
+      - name: Save Firestore Emulator Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
+          # Must match the restore paths exactly
+          path: ~/.cache/firebase/emulators
+      - name: Save Pods Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.pods-cache.outputs.cache-primary-key }}
+          # Must match the restore paths exactly
+          path: tests/ios/Pods

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -66,9 +66,11 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         continue-on-error: true
         with:
+          # The firebase emulators are pure javascript and java, OS-independent
+          enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
+          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
         with:

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -57,6 +57,10 @@ jobs:
           path: tests/macos/Pods
           key: pods-v3-${{ runner.os }}-${{ hashFiles('tests/macos/Podfile.lock') }}
           restore-keys: pods-v3-${{ runner.os }}
+      - name: 'Install Tools'
+        run: |
+          sudo npm i -g firebase-tools
+          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
@@ -64,7 +68,7 @@ jobs:
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ runner.os }}
+          key: firebase-emulators-v3-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
         with:
@@ -78,9 +82,6 @@ jobs:
           melos-version: '5.3.0'
       - name: 'Bootstrap package'
         run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools
       - name: 'Build Application'
         working-directory: ${{ matrix.working_directory }}
         run: |

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -49,6 +49,7 @@ jobs:
           key: xcode-cache-${{ runner.os }}
           max-size: 700M
         name: Pods Cache
+        continue-on-error: true
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         id: pods-cache
         with:
@@ -59,6 +60,7 @@ jobs:
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
@@ -102,6 +104,7 @@ jobs:
             --dart-define=CI=true \
             --ignore-timeouts
       - name: Save Firestore Emulator Cache
+        continue-on-error: true
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
@@ -110,6 +113,7 @@ jobs:
           # Must match the restore path exactly
           path: ~/.cache/firebase/emulators
       - name: Save Pods Cache
+        continue-on-error: true
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -48,16 +48,19 @@ jobs:
         with:
           key: xcode-cache-${{ runner.os }}
           max-size: 700M
-      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
         name: Pods Cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         id: pods-cache
         with:
+          # Must match the save path exactly
           path: tests/macos/Pods
           key: pods-v3-${{ runner.os }}-${{ hashFiles('tests/macos/Podfile.lock') }}
           restore-keys: pods-v3-${{ runner.os }}
-      - name: Cache Firebase Emulator
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      - name: Firebase Emulator Cache
+        id: firebase-emulator-cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
+          # Must match the save path exactly
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-v3-${{ runner.os }}
           restore-keys: firebase-emulators-v3
@@ -98,3 +101,19 @@ jobs:
             -d macos \
             --dart-define=CI=true \
             --ignore-timeouts
+      - name: Save Firestore Emulator Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
+          # Must match the restore path exactly
+          path: ~/.cache/firebase/emulators
+      - name: Save Pods Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.pods-cache.outputs.cache-primary-key }}
+          # Must match the restore paths exactly
+          path: tests/ios/Pods

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -64,9 +64,11 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         continue-on-error: true
         with:
+          # The firebase emulators are pure javascript and java, OS-independent
+          enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
+          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - name: Start Firebase Emulator
         run: sudo chown -R 501:20 "/Users/runner/.npm" && cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
@@ -130,9 +132,11 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         continue-on-error: true
         with:
+          # The firebase emulators are pure javascript and java, OS-independent
+          enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
+          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - name: Start Firebase Emulator
         run: sudo chown -R 501:20 "/Users/runner/.npm" && cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
@@ -201,9 +205,11 @@ jobs:
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         continue-on-error: true
         with:
+          # The firebase emulators are pure javascript and java, OS-independent
+          enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
+          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - name: Start Firebase Emulator
         run: sudo chown -R 501:20 "/Users/runner/.npm" && cd ./.github/workflows/scripts && ./start-firebase-emulator.sh

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -56,7 +56,9 @@ jobs:
       - name: 'Bootstrap package'
         run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
       - name: 'Install Tools'
-        run: sudo npm i -g firebase-tools
+        run: |
+          sudo npm i -g firebase-tools
+          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
@@ -64,7 +66,7 @@ jobs:
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ runner.os }}
+          key: firebase-emulators-v3-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - name: Start Firebase Emulator
         run: sudo chown -R 501:20 "/Users/runner/.npm" && cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
@@ -120,7 +122,9 @@ jobs:
       - name: 'Bootstrap package'
         run: melos bootstrap --scope tests
       - name: 'Install Tools'
-        run: sudo npm i -g firebase-tools
+        run: |
+          sudo npm i -g firebase-tools
+          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
@@ -128,7 +132,7 @@ jobs:
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ runner.os }}
+          key: firebase-emulators-v3-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - name: Start Firebase Emulator
         run: sudo chown -R 501:20 "/Users/runner/.npm" && cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
@@ -189,7 +193,9 @@ jobs:
       - name: 'Bootstrap package'
         run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
       - name: 'Install Tools'
-        run: sudo npm i -g firebase-tools
+        run: |
+          sudo npm i -g firebase-tools
+          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
@@ -197,7 +203,7 @@ jobs:
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ runner.os }}
+          key: firebase-emulators-v3-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
           restore-keys: firebase-emulators-v3
       - name: Start Firebase Emulator
         run: sudo chown -R 501:20 "/Users/runner/.npm" && cd ./.github/workflows/scripts && ./start-firebase-emulator.sh

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -57,9 +57,11 @@ jobs:
         run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
       - name: 'Install Tools'
         run: sudo npm i -g firebase-tools
-      - name: Cache Firebase Emulator
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      - name: Firebase Emulator Cache
+        id: firebase-emulator-cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
+          # Must match the save path exactly
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-v3-${{ runner.os }}
           restore-keys: firebase-emulators-v3
@@ -81,6 +83,14 @@ jobs:
           exit 1
           fi
         shell: bash
+      - name: Save Firestore Emulator Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
+          # Must match the restore path exactly
+          path: ~/.cache/firebase/emulators
 
   web-app-check:
     runs-on: macos-latest
@@ -109,9 +119,11 @@ jobs:
         run: melos bootstrap --scope tests
       - name: 'Install Tools'
         run: sudo npm i -g firebase-tools
-      - name: Cache Firebase Emulator
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      - name: Firebase Emulator Cache
+        id: firebase-emulator-cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
+          # Must match the save path exactly
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-v3-${{ runner.os }}
           restore-keys: firebase-emulators-v3
@@ -133,6 +145,14 @@ jobs:
           exit 1
           fi
         shell: bash
+      - name: Save Firestore Emulator Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
+          # Must match the restore path exactly
+          path: ~/.cache/firebase/emulators
 
   web-wasm:
     runs-on: macos-latest
@@ -166,9 +186,11 @@ jobs:
         run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
       - name: 'Install Tools'
         run: sudo npm i -g firebase-tools
-      - name: Cache Firebase Emulator
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      - name: Firebase Emulator Cache
+        id: firebase-emulator-cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
+          # Must match the save path exactly
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-v3-${{ runner.os }}
           restore-keys: firebase-emulators-v3
@@ -191,3 +213,11 @@ jobs:
           exit 1
           fi
         shell: bash
+      - name: Save Firestore Emulator Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
+          # Must match the restore path exactly
+          path: ~/.cache/firebase/emulators

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -60,6 +60,7 @@ jobs:
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
@@ -86,6 +87,7 @@ jobs:
       - name: Save Firestore Emulator Cache
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
+        continue-on-error: true
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
         with:
           key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
@@ -122,6 +124,7 @@ jobs:
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
@@ -149,6 +152,7 @@ jobs:
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
           # Must match the restore path exactly
@@ -189,6 +193,7 @@ jobs:
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
@@ -217,6 +222,7 @@ jobs:
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
         with:
           key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
           # Must match the restore path exactly


### PR DESCRIPTION
## Description

👋  this is based on #17871 from @SelaseKay vs main because Jude was working on that file already and it will likely suffer a conflict otherwise

I worked with Jude on that change in 17871 and while I was in there I noticed that the caching setup for CI in this repo was likely to be subject to severe LRU thrashing and very very low hit rates, with low useful caches even with hits.

In fact when I went to verify that, it was true: https://github.com/firebase/flutterfire/actions/caches?query=sort%3Acreated-asc

The oldest cache is only 4 days old, the majority of the cache storage is taken up with caches only 4 hours old - and those are from a branch which means main builds can't even see them to use them.

Each commit in this series is a fully separate idea to improve things, and each should be reviewed separately by reading the commit message explaining that specific change then checking the diff for that commit

The basic idea is this though:
- caches are not visible from branch to main, or between OSs by rule (so you want to cache main but read-only on branch)
- caches are immutable if the primary key was hit, so key uniqueness is vital, but it must actually change when the cache is known to be stale
- cache failures shouldn't fail a workflow (it happens, it's a useless flake to fail on)
- firestore emulators are truly cross-platform so may be shared

In addition, I pinned the Android Emulator runner to a concrete SHA as is practice in this repo

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
