### PR TITLE
fix(messaging, iOS): refactor notification handling in scene delegate methods

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/example/ios/Runner/AppDelegate.h
+++ b/packages/firebase_messaging/firebase_messaging/example/ios/Runner/AppDelegate.h
@@ -1,6 +1,6 @@
 #import <Flutter/Flutter.h>
 #import <UIKit/UIKit.h>
 
-@interface AppDelegate : FlutterAppDelegate
+@interface AppDelegate : FlutterAppDelegate <FlutterImplicitEngineDelegate>
 
 @end

--- a/packages/firebase_messaging/firebase_messaging/example/ios/Runner/AppDelegate.m
+++ b/packages/firebase_messaging/firebase_messaging/example/ios/Runner/AppDelegate.m
@@ -5,9 +5,13 @@
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  [GeneratedPluginRegistrant registerWithRegistry:self];
+  // [GeneratedPluginRegistrant registerWithRegistry:self];
   // Override point for customization after application launch.
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
+}
+
+- (void)didInitializeImplicitFlutterEngine:(NSObject<FlutterImplicitEngineBridge> *)engineBridge {
+  [GeneratedPluginRegistrant registerWithRegistry:engineBridge.pluginRegistry];
 }
 
 @end

--- a/packages/firebase_messaging/firebase_messaging/example/ios/Runner/AppDelegate.m
+++ b/packages/firebase_messaging/firebase_messaging/example/ios/Runner/AppDelegate.m
@@ -5,7 +5,6 @@
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  // [GeneratedPluginRegistrant registerWithRegistry:self];
   // Override point for customization after application launch.
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }

--- a/packages/firebase_messaging/firebase_messaging/example/ios/Runner/Info.plist
+++ b/packages/firebase_messaging/firebase_messaging/example/ios/Runner/Info.plist
@@ -50,5 +50,26 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
@@ -93,6 +93,7 @@ Future<void> setupFlutterNotifications() async {
 }
 
 void showFlutterNotification(RemoteMessage message) {
+  print('foreground message received: ${message.messageId}');
   RemoteNotification? notification = message.notification;
   AndroidNotification? android = message.notification?.android;
   if (notification != null && android != null && !kIsWeb) {
@@ -179,14 +180,17 @@ class _Application extends State<Application> {
   void initState() {
     super.initState();
 
-    FirebaseMessaging.instance.getInitialMessage().then(
-          (value) => setState(
-            () {
-              _resolved = true;
-              initialMessage = value?.data.toString();
-            },
-          ),
-        );
+    // Delay getInitialMessage call by 3 seconds
+    Future.delayed(const Duration(seconds: 3), () {
+      FirebaseMessaging.instance.getInitialMessage().then(
+            (value) => setState(
+              () {
+                _resolved = true;
+                initialMessage = value?.data.toString();
+              },
+            ),
+          );
+    });
 
     FirebaseMessaging.onMessage.listen(showFlutterNotification);
 

--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
@@ -40,6 +40,9 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   NSString *_notificationOpenedAppID;
   NSString *_foregroundUniqueIdentifier;
 
+  // Track if scene delegate connected (for iOS 13+ scene delegate support)
+  BOOL _sceneDidConnect;
+
 #ifdef __FF_NOTIFICATIONS_SUPPORTED_PLATFORM
   API_AVAILABLE(ios(10), macosx(10.14))
   __weak id<UNUserNotificationCenterDelegate> _originalNotificationCenterDelegate;
@@ -59,6 +62,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   self = [super init];
   if (self) {
     _initialNotificationGathered = NO;
+    _sceneDidConnect = NO;
     _channel = channel;
     _registrar = registrar;
     // Application
@@ -223,9 +227,24 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     _initialNotification =
         [FLTFirebaseMessagingPlugin remoteMessageUserInfoToDict:remoteNotification];
     _initialNotificationID = remoteNotification[@"gcm.message_id"];
+    _initialNotificationGathered = YES;
+    [self initialNotificationCallback];
+  } else if (_sceneDidConnect) {
+    // For scene delegates, if no notification was found in connectionOptions,
+    // delay marking as gathered to allow didReceiveRemoteNotification to fire first
+    // for contentAvailable notifications that caused the app to launch
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+                     if (!self->_initialNotificationGathered) {
+                       self->_initialNotificationGathered = YES;
+                       [self initialNotificationCallback];
+                     }
+                   });
+  } else {
+    // For non-scene delegate apps, mark as gathered immediately
+    _initialNotificationGathered = YES;
+    [self initialNotificationCallback];
   }
-  _initialNotificationGathered = YES;
-  [self initialNotificationCallback];
 
   [GULAppDelegateSwizzler registerAppDelegateInterceptor:self];
   [GULAppDelegateSwizzler proxyOriginalDelegateIncludingAPNSMethods];
@@ -478,6 +497,15 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
       [FLTFirebaseMessagingPlugin remoteMessageUserInfoToDict:userInfo];
   // Only handle notifications from FCM.
   if (userInfo[@"gcm.message_id"]) {
+    // For scene delegate apps: if this notification arrives during cold launch
+    // (before initial notification gathering is complete) and no notification was found
+    // in connectionOptions, this is the notification that caused the launch.
+    if (_sceneDidConnect && !_initialNotificationGathered && _initialNotification == nil) {
+      _initialNotification = notificationDict;
+      _initialNotificationID = userInfo[@"gcm.message_id"];
+      _initialNotificationGathered = YES;
+      [self initialNotificationCallback];
+    }
     if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground) {
       __block BOOL completed = NO;
 
@@ -548,6 +576,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
                  options:(UISceneConnectionOptions *)connectionOptions {
   // Handle launch notification if present
   // With scene delegates, the notification can be in notificationResponse if user tapped it
+  _sceneDidConnect = YES;
 
   NSDictionary *remoteNotification = nil;
   if (connectionOptions.notificationResponse != nil) {

--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
@@ -542,8 +542,14 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     willConnectToSession:(UISceneSession *)session
                  options:(UISceneConnectionOptions *)connectionOptions {
   // Handle launch notification if present
-  NSDictionary *remoteNotification =
-      connectionOptions.notificationResponse.notification.request.content.userInfo;
+  // With scene delegates, the notification can be in notificationResponse if user tapped it
+
+  NSDictionary *remoteNotification = nil;
+  if (connectionOptions.notificationResponse != nil) {
+    remoteNotification =
+        connectionOptions.notificationResponse.notification.request.content.userInfo;
+  }
+
   if (remoteNotification != nil) {
     // If remoteNotification exists, it is the notification that opened the app.
     _initialNotification =
@@ -551,11 +557,82 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     _initialNotificationID = remoteNotification[@"gcm.message_id"];
   }
 
+  // Mark that initial notification has been gathered (even if nil)
+  _initialNotificationGathered = YES;
+  [self initialNotificationCallback];
+
+  [GULAppDelegateSwizzler registerAppDelegateInterceptor:self];
+  [GULAppDelegateSwizzler proxyOriginalDelegateIncludingAPNSMethods];
+
+  SEL didReceiveRemoteNotificationWithCompletionSEL =
+      NSSelectorFromString(@"application:didReceiveRemoteNotification:fetchCompletionHandler:");
+  if ([[GULAppDelegateSwizzler sharedApplication].delegate
+          respondsToSelector:didReceiveRemoteNotificationWithCompletionSEL]) {
+    // noop - user has own implementation of this method in their AppDelegate, this
+    // means GULAppDelegateSwizzler will have already replaced it with a donor method
+  } else {
+    // add our own donor implementation of
+    // application:didReceiveRemoteNotification:fetchCompletionHandler:
+    Method donorMethod = class_getInstanceMethod(object_getClass(self),
+                                                 didReceiveRemoteNotificationWithCompletionSEL);
+    class_addMethod(object_getClass([GULAppDelegateSwizzler sharedApplication].delegate),
+                    didReceiveRemoteNotificationWithCompletionSEL,
+                    method_getImplementation(donorMethod), method_getTypeEncoding(donorMethod));
+  }
+
+#if !TARGET_OS_OSX
+  // `[_registrar addApplicationDelegate:self];` alone doesn't work for notifications to be received
+  // without the above swizzling This commit:
+  // https://github.com/google/GoogleUtilities/pull/162/files#diff-6bb6d1c46632fc66405a524071cc4baca5fc6a1a6c0eefef81d8c3e2c89cbc13L520-L533
+  // broke notifications which was released with firebase-ios-sdk v11.0.0
+  [_registrar addApplicationDelegate:self];
+#endif
+
+  // Ensure UNUserNotificationCenter delegate is set up for scene delegates
+  // This is critical for foreground notifications to work with scene delegates
+  if (@available(iOS 10.0, *)) {
+    BOOL shouldReplaceDelegate = YES;
+    UNUserNotificationCenter *notificationCenter =
+        [UNUserNotificationCenter currentNotificationCenter];
+
+    if (notificationCenter.delegate != nil) {
+      // If a UNUserNotificationCenterDelegate is set and it conforms to
+      // FlutterAppLifeCycleProvider then we don't want to replace it on iOS as the earlier
+      // call to `[_registrar addApplicationDelegate:self];` will automatically delegate calls
+      // to this plugin. If we replace it, it will cause a stack overflow. See
+      // https://github.com/firebasefire/issues/4026.
+      if ([notificationCenter.delegate conformsToProtocol:@protocol(FlutterAppLifeCycleProvider)]) {
+        // Note this one only executes if Firebase swizzling is **enabled**.
+        shouldReplaceDelegate = NO;
+      }
+
+      if (shouldReplaceDelegate && _originalNotificationCenterDelegate == nil) {
+        // Preserve original delegate if it exists
+        _originalNotificationCenterDelegate = notificationCenter.delegate;
+        _originalNotificationCenterDelegateRespondsTo.openSettingsForNotification =
+            (unsigned int)[_originalNotificationCenterDelegate
+                respondsToSelector:@selector(userNotificationCenter:openSettingsForNotification:)];
+        _originalNotificationCenterDelegateRespondsTo.willPresentNotification =
+            (unsigned int)[_originalNotificationCenterDelegate
+                respondsToSelector:@selector(userNotificationCenter:
+                                            willPresentNotification:withCompletionHandler:)];
+        _originalNotificationCenterDelegateRespondsTo.didReceiveNotificationResponse =
+            (unsigned int)[_originalNotificationCenterDelegate
+                respondsToSelector:@selector(userNotificationCenter:
+                                       didReceiveNotificationResponse:withCompletionHandler:)];
+      }
+    }
+
+    if (shouldReplaceDelegate && notificationCenter.delegate != self) {
+      // Set our delegate
+      __strong FLTFirebasePlugin<UNUserNotificationCenterDelegate> *strongSelf = self;
+      notificationCenter.delegate = strongSelf;
+    }
+  }
+
   // Register for remote notifications in scene delegate
   // This is critical for getting APNS token when using UISceneDelegate
   [[UIApplication sharedApplication] registerForRemoteNotifications];
-
-  return YES;
 }
 #endif
 


### PR DESCRIPTION
## Description
On `firebase_messaging` to support `UISceneDelegates`, the various callbacks(`onMessage` and `onBackgroundMessage`) weren't getting invoked for background/foreground notifications. This PR resolves this issue. 

The PR is still in progress to address the issue where `getInitialMessage` always returns null in relation to the migration. 

## Related Issues
Fixes https://github.com/firebase/flutterfire/issues/17854

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
