### PR TITLE
fix(firebase_core, web): return empty list from apps getter in WASM mode

### DIFF
--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -227,6 +227,11 @@ class FirebaseCoreWeb extends FirebasePlatform {
   /// Returns all created [FirebaseAppPlatform] instances.
   @override
   List<FirebaseAppPlatform> get apps {
+    // Check if Firebase core module is loaded before accessing firebase.apps
+    if (globalContext.getProperty('firebase_core'.toJS) == null) {
+      return [];
+    }
+
     try {
       return firebase.apps.map(_createFromJsApp).toList(growable: false);
     } catch (exception, stackTrace) {

--- a/packages/firebase_core/firebase_core_web/test/firebase_core_web_exceptions_test.dart
+++ b/packages/firebase_core/firebase_core_web/test/firebase_core_web_exceptions_test.dart
@@ -45,9 +45,7 @@ void main() {
       FirebasePlatform.instance = FirebaseCoreWeb();
     });
 
-    test(
-        'should return empty list when Firebase is not initialized',
-        () {
+    test('should return empty list when Firebase is not initialized', () {
       expect(FirebasePlatform.instance.apps, isEmpty);
     });
   });

--- a/packages/firebase_core/firebase_core_web/test/firebase_core_web_exceptions_test.dart
+++ b/packages/firebase_core/firebase_core_web/test/firebase_core_web_exceptions_test.dart
@@ -39,4 +39,16 @@ void main() {
       });
     });
   });
+
+  group('apps getter', () {
+    setUp(() async {
+      FirebasePlatform.instance = FirebaseCoreWeb();
+    });
+
+    test(
+        'should return empty list when Firebase is not initialized',
+        () {
+      expect(FirebasePlatform.instance.apps, isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Adds a proactive check in the `apps` getter to verify if the Firebase core module is loaded before accessing `firebase.apps`
- This avoids triggering a JavaScript exception when Firebase is not initialized, ensuring consistent behavior in both JS and WASM web builds

Fixes #17918

## Changes

### `packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart`
Added a check using the existing pattern from `_initializeCore()`:
```dart
if (globalContext.getProperty('firebase_core'.toJS) == null) {
  return [];
}
```

### `packages/firebase_core/firebase_core_web/test/firebase_core_web_exceptions_test.dart`
Added a test to verify `apps` returns an empty list when Firebase is not initialized.

## Test plan

- [x] Added unit test for the `apps` getter
- [x] All existing tests pass (`flutter test --platform chrome`)
- [x] Manual verification in WASM mode:
  ```bash
  flutter run -d chrome --release --wasm
  # Access Firebase.apps before initializeApp() - should return []
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)