### PR TITLE
fix(messaging, iOS): scope iOS 18 duplicate notification workaround to iOS 18.0 only

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
@@ -353,20 +353,20 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   // See this Apple issue: https://forums.developer.apple.com/forums/thread/761597
   // when it has been resolved, "_foregroundUniqueIdentifier" can be removed (i.e. the commit for
   // this fix)
-  NSString *notificationIdentifier = notification.request.identifier;
+  NSDictionary *userInfo = notification.request.content.userInfo;
+  NSString *messageID = userInfo[@"gcm.message_id"];
 
   BOOL shouldCheckForDuplicate = NO;
 #if !TARGET_OS_OSX
   if (@available(iOS 18.0, *)) {
     if (!@available(iOS 18.1, *)) {
       // Only iOS 18.0 specifically
-      shouldCheckForDuplicate =
-          [notificationIdentifier isEqualToString:_foregroundUniqueIdentifier];
+      shouldCheckForDuplicate = [messageID isEqualToString:_foregroundUniqueIdentifier];
     }
   }
 #endif
 
-  if (notification.request.content.userInfo[@"gcm.message_id"] && !shouldCheckForDuplicate) {
+  if (messageID && !shouldCheckForDuplicate) {
     NSDictionary *notificationDict =
         [FLTFirebaseMessagingPlugin NSDictionaryFromUNNotification:notification];
     [_channel invokeMethod:@"Messaging#onMessage" arguments:notificationDict];
@@ -400,7 +400,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 #if !TARGET_OS_OSX
   if (@available(iOS 18.0, *)) {
     if (!@available(iOS 18.1, *)) {
-      _foregroundUniqueIdentifier = notificationIdentifier;
+      _foregroundUniqueIdentifier = messageID;
     }
   }
 #endif


### PR DESCRIPTION
## Description

PR https://github.com/firebase/flutterfire/pull/13572 introduced a duplicate notification check to work around an iOS 18.0 OS bug where the same notification is delivered twice. However, this check was applied to **all iOS versions** and used `notification.request.identifier` for comparison, which caused legitimate notification updates using `apns-collapse-id` to be suppressed.

When multiple notifications share the same `apns-collapse-id`, iOS maps them to the same `request.identifier`, causing only the first notification to trigger `FirebaseMessaging.onMessage.listen` - subsequent updates were incorrectly filtered as duplicates.

### Solution

- Scope the duplicate check to **iOS 18.0 only** (bug was fixed in iOS 18.1+)

## Related Issues
Fixes https://github.com/firebase/flutterfire/issues/17923

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
