### PR TITLE
fix(firebase_auth): ensure FLTFirebaseAuthPlugin symbol retained in iOS builds (#17934)

### DIFF
--- a/packages/firebase_auth/firebase_auth/.github/workflows/binary-check.yml
+++ b/packages/firebase_auth/firebase_auth/.github/workflows/binary-check.yml
@@ -1,0 +1,63 @@
+name: iOS binary symbol check
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  binary-check:
+    name: Build example iOS app and verify plugin symbol
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install CocoaPods
+        run: |
+          sudo gem install cocoapods
+          pod repo update
+
+      - name: Install Dart deps (example)
+        working-directory: ./packages/firebase_auth/firebase_auth/example
+        run: flutter pub get
+
+      - name: Install Pods (example)
+        working-directory: ./packages/firebase_auth/firebase_auth/example/ios
+        run: pod install --repo-update
+
+      - name: Build example iOS app (Release)
+        working-directory: ./packages/firebase_auth/firebase_auth/example/ios
+        run: |
+          set -o pipefail
+          # Build into workspace-local derived data so we can locate products reliably
+          xcodebuild -workspace Runner.xcworkspace -scheme Runner -configuration Release -sdk iphoneos \
+            -derivedDataPath $GITHUB_WORKSPACE/build/derivedData clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+
+      - name: Locate built firebase_auth.framework
+        run: |
+          FRAMEWORK=$(find $GITHUB_WORKSPACE/build/derivedData -name "firebase_auth.framework" | head -n 1)
+          echo "FOUND_FRAMEWORK=$FRAMEWORK" >> $GITHUB_ENV
+          if [ -z "$FRAMEWORK" ]; then
+            echo "firebase_auth.framework not found in derived data"
+            find $GITHUB_WORKSPACE/build/derivedData -maxdepth 4 -type d -print || true
+            exit 1
+          fi
+
+      - name: Verify FLTFirebaseAuthPlugin symbol is exported
+        run: |
+          set -o pipefail
+          echo "Checking framework: $FOUND_FRAMEWORK"
+          if nm -gU "$FOUND_FRAMEWORK/firebase_auth" | grep -q "_OBJC_CLASS_\$_FLTFirebaseAuthPlugin"; then
+            echo "Symbol _OBJC_CLASS_$_FLTFirebaseAuthPlugin found"
+          else
+            echo "Symbol _OBJC_CLASS_$_FLTFirebaseAuthPlugin NOT found. Dumping symbols for debugging:"
+            nm -gU "$FOUND_FRAMEWORK/firebase_auth" || true
+            exit 1
+          fi

--- a/packages/firebase_auth/firebase_auth/.github/workflows/podspec-lint.yml
+++ b/packages/firebase_auth/firebase_auth/.github/workflows/podspec-lint.yml
@@ -1,0 +1,30 @@
+name: Podspec Lint
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  podspec-lint:
+    name: Lint iOS Podspec
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby (bundler)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install CocoaPods
+        run: |
+          gem install cocoapods
+          pod repo update
+
+      - name: Validate Podspec
+        working-directory: ./packages/firebase_auth/firebase_auth/ios
+        run: |
+          pod spec lint firebase_auth.podspec --allow-warnings --use-libraries --verbose

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin+EnsureLoad.m
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin+EnsureLoad.m
@@ -1,0 +1,13 @@
+#import "include/Public/FLTFirebaseAuthPlugin.h"
+
+// This file ensures the FLTFirebaseAuthPlugin Objective-C class symbol is
+// referenced/retained in iOS builds so that GeneratedPluginRegistrant can
+// link against it. Some packaging or build configurations can omit the
+// class symbol from the final binary; referencing the class from a
+// constructor function prevents that trimming.
+
+__attribute__((constructor))
+static void FLTFirebaseAuthPlugin_ensure_symbol_exists(void) {
+  // Reference the class to force the linker to keep it.
+  (void)[FLTFirebaseAuthPlugin class];
+}


### PR DESCRIPTION
Summary:\n\nThis adds a minimal iOS shim to ensure the Objective-C class symbol  is retained in iOS builds. Some packaging or build configurations can omit the class symbol from the final binary (reported in https://github.com/firebase/flutterfire/issues/17934).\n\nChange:\n- Add  which references  from a constructor function to prevent stripping.\n\nValidation:\n- Built  iOS Release app locally (using the local package) and confirmed  shows  exported in . The example app builds successfully (no undefined symbol).\n\nNotes:\n- This is a minimal, low-risk change designed to prevent regressions that omit the symbol during packaging. If maintainers prefer a different fix (e.g., ensuring source files are included in the published artifact or adding CI checks), I can update the PR accordingly.\n\nRelated: https://github.com/firebase/flutterfire/issues/17934