### PR TITLE
test(ci): cache key names must include enough information to expire correctly

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -28,6 +28,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           melos-version: '5.3.0'
@@ -46,6 +48,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           melos-version: '5.3.0'
@@ -63,6 +67,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           melos-version: '5.3.0'
@@ -81,6 +87,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           melos-version: '5.3.0'
@@ -115,6 +123,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           melos-version: '5.3.0'
@@ -133,6 +143,9 @@ jobs:
       - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
         with:
           channel: 'stable'
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - name: Xcode
         run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
       - name: Setup firebase_core example app to test Swift integration
@@ -158,6 +171,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           melos-version: '5.3.0'

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -66,8 +66,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
-          cache-key: flutter-${{ runner.os }}
-          pub-cache-key: pub-${{ runner.os }}
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           run-bootstrap: false

--- a/.github/workflows/e2e_tests_fdc.yaml
+++ b/.github/workflows/e2e_tests_fdc.yaml
@@ -166,8 +166,8 @@ jobs:
         with:
           # Must match the save path exactly
           path: tests/ios/Pods
-          key: ${{ runner.os }}-fdc-pods-v3-${{ hashFiles('tests/ios/Podfile.lock') }}
-          restore-keys: ${{ runner.os }}-ios-pods-v2
+          key: ${{ runner.os }}-fdc-pods-${{ hashFiles('tests/pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-fdc-pods
       - name: 'Install Tools'
         run: |
           sudo npm i -g firebase-tools
@@ -325,12 +325,3 @@ jobs:
           key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
           # Must match the restore path exactly
           path: ~/.cache/firebase/emulators
-      - name: Save Pods Cache
-        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
-        continue-on-error: true
-        with:
-          key: ${{ steps.pods-cache.outputs.cache-primary-key }}
-          # Must match the restore paths exactly
-          path: tests/ios/Pods

--- a/.github/workflows/e2e_tests_fdc.yaml
+++ b/.github/workflows/e2e_tests_fdc.yaml
@@ -60,6 +60,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - name: Setup PostgreSQL for Linux/macOS/Windows
         uses: ikalnytskyi/action-setup-postgres@v7
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
@@ -185,6 +187,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           run-bootstrap: false
@@ -264,6 +268,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           run-bootstrap: false

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -79,8 +79,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
-          cache-key: flutter-${{ runner.os }}
-          pub-cache-key: pub-${{ runner.os }}
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           run-bootstrap: false

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -58,8 +58,8 @@ jobs:
         with:
           # Must match the save path exactly
           path: tests/ios/Pods
-          key: pods-v3-${{ runner.os }}-${{ hashFiles('tests/ios/Podfile.lock') }}
-          restore-keys: pods-v3-${{ runner.os }}
+          key: pods-v3-${{ runner.os }}-ios-${{ hashFiles('tests/pubspec.lock') }}
+          restore-keys: pods-v3-${{ runner.os }}-ios
       - name: 'Install Tools'
         run: |
           sudo npm i -g firebase-tools

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -56,8 +56,8 @@ jobs:
         with:
           # Must match the save path exactly
           path: tests/macos/Pods
-          key: pods-v3-${{ runner.os }}-${{ hashFiles('tests/macos/Podfile.lock') }}
-          restore-keys: pods-v3-${{ runner.os }}
+          key: pods-v3-${{ runner.os }}-macos-${{ hashFiles('tests/pubspec.lock') }}
+          restore-keys: pods-v3-${{ runner.os }}-macos
       - name: 'Install Tools'
         run: |
           sudo npm i -g firebase-tools
@@ -126,4 +126,4 @@ jobs:
         with:
           key: ${{ steps.pods-cache.outputs.cache-primary-key }}
           # Must match the restore paths exactly
-          path: tests/ios/Pods
+          path: tests/macos/Pods

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -77,8 +77,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
-          cache-key: flutter-${{ runner.os }}
-          pub-cache-key: pub-${{ runner.os }}
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           run-bootstrap: false

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -47,8 +47,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
-          cache-key: flutter-${{ runner.os }}
-          pub-cache-key: pub-${{ runner.os }}
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           run-bootstrap: false
@@ -117,8 +117,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
-          cache-key: flutter-${{ runner.os }}
-          pub-cache-key: pub-${{ runner.os }}
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           run-bootstrap: false
@@ -192,8 +192,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
-          cache-key: flutter-${{ runner.os }}
-          pub-cache-key: pub-${{ runner.os }}
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           run-bootstrap: false

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -42,8 +42,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
-          cache-key: flutter-${{ runner.os }}
-          pub-cache-key: pub-${{ runner.os }}
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           run-bootstrap: false
@@ -74,8 +74,8 @@ jobs:
         with:
           channel: 'stable'
           cache: true
-          cache-key: flutter-${{ runner.os }}
-          pub-cache-key: pub-${{ runner.os }}
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
         with:
           run-bootstrap: false


### PR DESCRIPTION
## Description

After the initial CI caching best practices PR merged I noticed a problem that was hidden by the LRU thrashing before

https://github.com/firebase/flutterfire/actions/caches?query=sort%3Acreated-asc

See the flutter- and pub- caches? They are not unique keys, they will never update.

The same problem was present for the Pods caches - but for a different reason, in that case the Podfile.lock files don't exist so they cannot be used to generate a cache key name part. I deferred to the pubspec.lock file as it drives the Pods dependencies anyway

----

the flutter action caches things by default with a cache key name that is not specific enough that it will expire if a new version comes out

alter the key naming to include all pertinent details about the flutter version (or pub version) being cached so that new versions will get a fresh cache

see https://github.com/subosito/flutter-action?tab=readme-ov-file#caching in combination with knowledge that github actions/cache produces *immutable* caches so they will never update meaning you must make a new cache if a new version comes out

## Related Issues

- #17930 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
