### PR TITLE
fix(firestore, android): avoid ConcurrentModificationException by collecting Firestore instances before termination

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -207,15 +207,17 @@ public class FlutterFirebaseFirestorePlugin
         () -> {
           try {
             // Context is ignored by API so we don't send it over even though annotated non-null.
+            List<FirebaseFirestore> firestoresToTerminate;
             synchronized (firestoreInstanceCache) {
-              for (Map.Entry<FirebaseFirestore, FlutterFirebaseFirestoreExtension> entry :
-                  firestoreInstanceCache.entrySet()) {
-                FirebaseFirestore firestore = entry.getKey();
+              // Collect all firestore instances first to avoid ConcurrentModificationException
+              firestoresToTerminate = new ArrayList<>(firestoreInstanceCache.keySet());
+              for (FirebaseFirestore firestore : firestoresToTerminate) {
                 Tasks.await(firestore.terminate());
                 FlutterFirebaseFirestorePlugin.destroyCachedFirebaseFirestoreInstanceForKey(
                     firestore);
               }
             }
+
             removeEventListeners();
 
             taskCompletionSource.setResult(null);


### PR DESCRIPTION
## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues
Fixes https://github.com/firebase/flutterfire/issues/17954

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
