### PR TITLE
refactor(fdc): Support for entityId path extensions and hardening

### DIFF
--- a/packages/firebase_data_connect/firebase_data_connect/generate_proto.sh
+++ b/packages/firebase_data_connect/firebase_data_connect/generate_proto.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# Uses dart protoc_plugin version 21.1.2. There are compilation issues with newer plugin versions.
+# https://github.com/google/protobuf.dart/releases/tag/protoc_plugin-v21.1.2
+# Run `pub global activate protoc_plugin 21.1.2`
+
 rm -rf lib/src/generated
 mkdir lib/src/generated
-protoc --dart_out=grpc:lib/src/generated -I./protos/firebase -I./protos/google  connector_service.proto google/protobuf/struct.proto graphql_error.proto --proto_path=./protos
+protoc --dart_out=grpc:lib/src/generated -I./protos/firebase -I./protos/google  connector_service.proto google/protobuf/struct.proto google/protobuf/duration.proto graphql_error.proto graphql_response_extensions.proto --proto_path=./protos

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache.dart
@@ -50,9 +50,13 @@ class Cache {
   Stream<Set<String>> get impactedQueries => _impactedQueryController.stream;
 
   String _constructCacheIdentifier() {
-    final rawIdentifier =
-        '${_settings.storage}-${dataConnect.app.options.projectId}-${dataConnect.app.name}-${dataConnect.connectorConfig.serviceId}-${dataConnect.connectorConfig.connector}-${dataConnect.connectorConfig.location}-${dataConnect.auth?.currentUser?.uid ?? 'anon'}-${dataConnect.transport.transportOptions.host}';
-    return convertToSha256(rawIdentifier);
+    final rawPrefix =
+        '${_settings.storage}-${dataConnect.app.options.projectId}-${dataConnect.app.name}-${dataConnect.connectorConfig.serviceId}-${dataConnect.connectorConfig.connector}-${dataConnect.connectorConfig.location}-${dataConnect.transport.transportOptions.host}';
+    final prefixSha = convertToSha256(rawPrefix);
+    final rawSuffix = dataConnect.auth?.currentUser?.uid ?? 'anon';
+    final suffixSha = convertToSha256(rawSuffix);
+
+    return '$prefixSha-$suffixSha';
   }
 
   void _initializeProvider() {

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache.dart
@@ -151,8 +151,10 @@ class Cache {
 
       EntityNode rootNode =
           EntityNode.fromJson(resultTree.data, _cacheProvider!);
+
       Map<String, dynamic> hydratedJson =
-          rootNode.toJson(); //default mode for toJson is hydrate
+          await _resultTreeProcessor.hydrateResults(rootNode, _cacheProvider!);
+
       return hydratedJson;
     }
 

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache.dart
@@ -97,8 +97,9 @@ class Cache {
             ? ExtensionResponse.fromJson(serverResponse.extensions!)
                 .flattenPathMetadata()
             : {};
-
-    final dehydrationResult = await _resultTreeProcessor.dehydrate(
+    print("flattenedPaths ${paths}");
+    
+    final dehydrationResult = await _resultTreeProcessor.dehydrateResults(
         queryId, serverResponse.data, _cacheProvider!, paths);
 
     EntityNode rootNode = dehydrationResult.dehydratedTree;
@@ -117,7 +118,7 @@ class Cache {
         cachedAt: DateTime.now(),
         lastAccessed: DateTime.now());
 
-    _cacheProvider!.saveResultTree(queryId, resultTree);
+    _cacheProvider!.setResultTree(queryId, resultTree);
 
     Set<String> impactedQueryIds = dehydrationResult.impactedQueryIds;
     impactedQueryIds.remove(queryId); // remove query being cached
@@ -125,7 +126,7 @@ class Cache {
   }
 
   /// Fetches a cached result.
-  Future<Map<String, dynamic>?> get(String queryId, bool allowStale) async {
+  Future<Map<String, dynamic>?> resultTree(String queryId, bool allowStale) async {
     if (_cacheProvider == null) {
       return null;
     }
@@ -146,7 +147,7 @@ class Cache {
       }
 
       resultTree.lastAccessed = DateTime.now();
-      _cacheProvider!.saveResultTree(queryId, resultTree);
+      _cacheProvider!.setResultTree(queryId, resultTree);
 
       EntityNode rootNode =
           EntityNode.fromJson(resultTree.data, _cacheProvider!);
@@ -156,11 +157,6 @@ class Cache {
     }
 
     return null;
-  }
-
-  /// Invalidates the cache.
-  Future<void> invalidate() async {
-    _cacheProvider?.clear();
   }
 
   void dispose() {

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache.dart
@@ -97,8 +97,7 @@ class Cache {
             ? ExtensionResponse.fromJson(serverResponse.extensions!)
                 .flattenPathMetadata()
             : {};
-    print("flattenedPaths ${paths}");
-    
+
     final dehydrationResult = await _resultTreeProcessor.dehydrateResults(
         queryId, serverResponse.data, _cacheProvider!, paths);
 
@@ -126,7 +125,8 @@ class Cache {
   }
 
   /// Fetches a cached result.
-  Future<Map<String, dynamic>?> resultTree(String queryId, bool allowStale) async {
+  Future<Map<String, dynamic>?> resultTree(
+      String queryId, bool allowStale) async {
     if (_cacheProvider == null) {
       return null;
     }

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache_data_types.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache_data_types.dart
@@ -58,7 +58,7 @@ class PathMetadata {
 
   @override
   String toString() {
-    return '$path : ${entityId ?? "nil"}';
+    return '$path : ${entityId ?? "null"}';
   }
 }
 

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache_data_types.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache_data_types.dart
@@ -98,10 +98,11 @@ class ExtensionResponse {
 
   factory ExtensionResponse.fromJson(Map<String, dynamic> json) {
     return ExtensionResponse(
-      maxAge: json['ttl'] != null ? Duration(seconds: json['ttl'] as int) : null,
+      maxAge:
+          json['ttl'] != null ? Duration(seconds: json['ttl'] as int) : null,
       dataConnect: (json['dataConnect'] as List?)
-              ?.map(
-                  (e) => PathMetadataResponse.fromJson(e as Map<String, dynamic>))
+              ?.map((e) =>
+                  PathMetadataResponse.fromJson(e as Map<String, dynamic>))
               .toList() ??
           [],
     );
@@ -111,8 +112,8 @@ class ExtensionResponse {
     final Map<DataConnectPath, PathMetadata> result = {};
     for (final pmr in dataConnect) {
       if (pmr.entityId != null) {
-        final pm =
-            PathMetadata(path: DataConnectPath(pmr.path), entityId: pmr.entityId);
+        final pm = PathMetadata(
+            path: DataConnectPath(pmr.path), entityId: pmr.entityId);
         result[pm.path] = pm;
       }
 
@@ -147,7 +148,6 @@ class CacheSettings {
   // Factory constructor to handle the logic
   factory CacheSettings({
     CacheStorage? storage,
-    int? maxSizeBytes,
     Duration maxAge = Duration.zero,
   }) {
     return CacheSettings._internal(

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache_data_types.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache_data_types.dart
@@ -72,7 +72,7 @@ class PathMetadataResponse {
 
   factory PathMetadataResponse.fromJson(Map<String, dynamic> json) {
     return PathMetadataResponse(
-      path: (json['path'] as List).map((e) => _parsePathSegment(e)).toList(),
+      path: (json['path'] as List).map(_parsePathSegment).toList(),
       entityId: json['entityId'] as String?,
       entityIds: (json['entityIds'] as List?)?.cast<String>(),
     );

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache_manager.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache_manager.dart
@@ -92,6 +92,17 @@ class Cache {
       return;
     }
 
+    if (_cacheProvider == null) {
+      return;
+    }
+
+    // we have a provider lets ensure its initialized
+    bool? initialized = await providerInitialization;
+    if (initialized == null || initialized == false) {
+      developer.log('CacheProvider not initialized. Cache not functional');
+      return;
+    }
+
     final dehydrationResult = await _resultTreeProcessor.dehydrate(
         queryId, serverResponse.data, _cacheProvider!);
 

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache_provider.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/cache_provider.dart
@@ -25,19 +25,16 @@ abstract class CacheProvider {
   Future<bool> initialize();
 
   /// Stores a `ResultTree` object.
-  void saveResultTree(String queryId, ResultTree resultTree);
+  void setResultTree(String queryId, ResultTree resultTree);
 
   /// Retrieves a `ResultTree` object.
   ResultTree? getResultTree(String queryId);
 
   /// Stores an `EntityDataObject` object.
-  void saveEntityDataObject(EntityDataObject edo);
+  void updateEntityData(EntityDataObject edo);
 
   /// Retrieves an `EntityDataObject` object.
-  EntityDataObject getEntityDataObject(String guid);
-
-  /// Manages the cache size and eviction policies.
-  void manageCacheSize();
+  EntityDataObject getEntityData(String guid);
 
   /// Clears all data from the cache.
   void clear();

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/in_memory_cache_provider.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/in_memory_cache_provider.dart
@@ -16,6 +16,7 @@ import 'cache_data_types.dart';
 import 'cache_provider.dart';
 
 /// An in-memory implementation of the `CacheProvider`.
+/// This is used for the web platform
 class InMemoryCacheProvider implements CacheProvider {
   final Map<String, ResultTree> _resultTrees = {};
   final Map<String, EntityDataObject> _edos = {};
@@ -36,7 +37,7 @@ class InMemoryCacheProvider implements CacheProvider {
   }
 
   @override
-  void saveResultTree(String queryId, ResultTree resultTree) {
+  void setResultTree(String queryId, ResultTree resultTree) {
     _resultTrees[queryId] = resultTree;
   }
 
@@ -46,18 +47,13 @@ class InMemoryCacheProvider implements CacheProvider {
   }
 
   @override
-  void saveEntityDataObject(EntityDataObject edo) {
+  void updateEntityData(EntityDataObject edo) {
     _edos[edo.guid] = edo;
   }
 
   @override
-  EntityDataObject getEntityDataObject(String guid) {
+  EntityDataObject getEntityData(String guid) {
     return _edos.putIfAbsent(guid, () => EntityDataObject(guid: guid));
-  }
-
-  @override
-  void manageCacheSize() {
-    // In-memory cache doesn't have a size limit in this implementation.
   }
 
   @override

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/in_memory_cache_provider.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/in_memory_cache_provider.dart
@@ -31,7 +31,7 @@ class InMemoryCacheProvider implements CacheProvider {
 
   @override
   Future<bool> initialize() async {
-    // nothing to be intialized.
+    // nothing to be intialized
     return true;
   }
 

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/result_tree_processor.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/result_tree_processor.dart
@@ -53,7 +53,7 @@ class ResultTreeProcessor {
       Set<String> impactedQueryIds,
       DataConnectPath path,
       Map<DataConnectPath, PathMetadata> paths) {
-        developer.log('dehydrating for path $path');
+    developer.log('dehydrating for path $path');
     if (data is Map<String, dynamic>) {
       // Look up entityId for current path
       String? guid;
@@ -104,16 +104,18 @@ class ResultTreeProcessor {
           // we don't normalize mixed lists. We store them as-is for reconstruction from cache.
           if (nodeList.isNotEmpty && scalarValueList.isNotEmpty) {
             // mixed type array - we directly store the json as-is
-            developer.log('detected mixed type array for key $key. storing as-is');
-            scalarValues[key] = value; 
+            developer
+                .log('detected mixed type array for key $key. storing as-is');
+            scalarValues[key] = value;
           } else if (nodeList.isNotEmpty) {
             nestedObjectLists[key] = nodeList;
           } else if (scalarValueList.isNotEmpty) {
             scalarValues[key] = scalarValueList;
           } else {
             // we have empty array. save key as scalar since we can't determine type
-            developer.log('detected empty array for key $key. storing as scalar');
-             scalarValues[key] = value;
+            developer
+                .log('detected empty array for key $key. storing as scalar');
+            scalarValues[key] = value;
           }
           // end list handling
         } else {
@@ -122,7 +124,8 @@ class ResultTreeProcessor {
         }
       }
 
-      developer.log('Returning EntityNode for $path guid $guid values \nscalars: $scalarValues \nnestedObjects: $nestedObjectLists \nnestedObjectLists: $nestedObjectLists');
+      developer.log(
+          'Returning EntityNode for $path guid $guid values \nscalars: $scalarValues \nnestedObjects: $nestedObjectLists \nnestedObjectLists: $nestedObjectLists');
       if (guid != null) {
         final existingEdo = cacheProvider.getEntityData(guid);
         existingEdo.setServerValues(scalarValues, queryId);

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/result_tree_processor.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/result_tree_processor.dart
@@ -151,38 +151,6 @@ class ResultTreeProcessor {
   /// from the `CacheProvider`, and reconstructs the original data structure.
   Future<Map<String, dynamic>> hydrateResults(
       EntityNode dehydratedTree, CacheProvider cacheProvider) async {
-    return await _hydrateNode(dehydratedTree, cacheProvider)
-        as Map<String, dynamic>;
-  }
-
-  Future<dynamic> _hydrateNode(
-      EntityNode node, CacheProvider cacheProvider) async {
-    final Map<String, dynamic> data = {};
-    if (node.entity != null) {
-      final edo = cacheProvider.getEntityData(node.entity!.guid);
-      data.addAll(edo.fields());
-    }
-
-    if (node.scalarValues != null) {
-      data.addAll(node.scalarValues!);
-    }
-
-    if (node.nestedObjects != null) {
-      for (final entry in node.nestedObjects!.entries) {
-        data[entry.key] = await _hydrateNode(entry.value, cacheProvider);
-      }
-    }
-
-    if (node.nestedObjectLists != null) {
-      for (final entry in node.nestedObjectLists!.entries) {
-        final list = <dynamic>[];
-        for (final item in entry.value) {
-          list.add(await _hydrateNode(item, cacheProvider));
-        }
-        data[entry.key] = list;
-      }
-    }
-
-    return data;
+    return dehydratedTree.toJson(); //default mode for toJson is hydrate
   }
 }

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/result_tree_processor.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/result_tree_processor.dart
@@ -53,7 +53,6 @@ class ResultTreeProcessor {
       Set<String> impactedQueryIds,
       DataConnectPath path,
       Map<DataConnectPath, PathMetadata> paths) {
-    developer.log('dehydrating for path $path');
     if (data is Map<String, dynamic>) {
       // Look up entityId for current path
       String? guid;
@@ -68,7 +67,6 @@ class ResultTreeProcessor {
       for (final entry in data.entries) {
         final key = entry.key;
         final value = entry.value;
-        developer.log('processing $key for value type ${value.runtimeType}');
         if (value is Map<String, dynamic>) {
           //developer.log('detected Map for $key');
           EntityNode en = _dehydrateNode(
@@ -113,8 +111,6 @@ class ResultTreeProcessor {
             scalarValues[key] = scalarValueList;
           } else {
             // we have empty array. save key as scalar since we can't determine type
-            developer
-                .log('detected empty array for key $key. storing as scalar');
             scalarValues[key] = value;
           }
           // end list handling
@@ -124,8 +120,6 @@ class ResultTreeProcessor {
         }
       }
 
-      developer.log(
-          'Returning EntityNode for $path guid $guid values \nscalars: $scalarValues \nnestedObjects: $nestedObjectLists \nnestedObjectLists: $nestedObjectLists');
       if (guid != null) {
         final existingEdo = cacheProvider.getEntityData(guid);
         existingEdo.setServerValues(scalarValues, queryId);

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/sqlite_cache_provider.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/sqlite_cache_provider.dart
@@ -46,7 +46,8 @@ class SQLite3CacheProvider implements CacheProvider {
       } else {
         int major = curVersion ~/ 1000000;
         if (major != 1) {
-          developer.log('Unsupported schema major version $major detected. Expected 1');
+          developer.log(
+              'Unsupported schema major version $major detected. Expected 1');
           return false;
         }
       }

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/sqlite_cache_provider.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/sqlite_cache_provider.dart
@@ -117,9 +117,8 @@ class SQLite3CacheProvider implements CacheProvider {
       [guid],
     );
     if (resultSet.isEmpty) {
-      // not found lets create an empty one and save it.
+      // not found lets create an empty one
       EntityDataObject edo = EntityDataObject(guid: guid);
-      updateEntityData(edo);
       return edo;
     }
     return EntityDataObject.fromRawJson(resultSet.first['data'] as String);

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/sqlite_cache_provider.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/cache/sqlite_cache_provider.dart
@@ -39,7 +39,18 @@ class SQLite3CacheProvider implements CacheProvider {
         final path = join(dbPath.path, '$_identifier.db');
         _db = sqlite3.open(path);
       }
-      _createTables();
+
+      int curVersion = _getDatabaseVersion();
+      if (curVersion == 0) {
+        _createTables();
+      } else {
+        int major = curVersion ~/ 1000000;
+        if (major != 1) {
+          developer.log('Unsupported schema major version $major detected. Expected 1');
+          return false;
+        }
+      }
+
       return true;
     } catch (e) {
       developer.log('Error initializing SQLiteProvider $e');
@@ -47,19 +58,37 @@ class SQLite3CacheProvider implements CacheProvider {
     }
   }
 
+  int _getDatabaseVersion() {
+    final resultSet = _db.select('PRAGMA user_version;');
+    return resultSet.first.columnAt(0) as int;
+  }
+
+  void _setDatabaseVersion(int version) {
+    _db.execute('PRAGMA user_version = $version;');
+  }
+
   void _createTables() {
-    _db.execute('''
-      CREATE TABLE IF NOT EXISTS $resultTreeTable (
-        query_id TEXT PRIMARY KEY,
-        result_tree TEXT
-      );
-    ''');
-    _db.execute('''
-      CREATE TABLE IF NOT EXISTS $entityDataTable (
-        guid TEXT PRIMARY KEY,
-        entity_data_object TEXT
-      );
-    ''');
+    _db.execute('BEGIN TRANSACTION');
+    try {
+      _db.execute('''
+        CREATE TABLE IF NOT EXISTS $resultTreeTable (
+          query_id TEXT PRIMARY KEY NOT NULL,
+          last_accessed REAL NOT NULL,
+          data TEXT NOT NULL
+        );
+      ''');
+      _db.execute('''
+        CREATE TABLE IF NOT EXISTS $entityDataTable (
+          entity_guid TEXT PRIMARY KEY NOT NULL,
+          data TEXT NOT NULL
+        );
+      ''');
+      _setDatabaseVersion(1000000); // 1.0.0
+      _db.execute('COMMIT');
+    } catch (_) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
   }
 
   @override
@@ -69,57 +98,85 @@ class SQLite3CacheProvider implements CacheProvider {
 
   @override
   void clear() {
-    _db.execute('DELETE FROM $resultTreeTable');
-    _db.execute('DELETE FROM $entityDataTable');
+    _db.execute('BEGIN TRANSACTION');
+    try {
+      _db.execute('DELETE FROM $resultTreeTable');
+      _db.execute('DELETE FROM $entityDataTable');
+      _db.execute('COMMIT');
+    } catch (_) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
   }
 
   @override
-  EntityDataObject getEntityDataObject(String guid) {
+  EntityDataObject getEntityData(String guid) {
     final resultSet = _db.select(
-      'SELECT entity_data_object FROM $entityDataTable WHERE guid = ?',
+      'SELECT data FROM $entityDataTable WHERE entity_guid = ?',
       [guid],
     );
     if (resultSet.isEmpty) {
-      // not found lets create an empty one.
+      // not found lets create an empty one and save it.
       EntityDataObject edo = EntityDataObject(guid: guid);
+      updateEntityData(edo);
       return edo;
     }
-    return EntityDataObject.fromRawJson(
-        resultSet.first['entity_data_object'] as String);
+    return EntityDataObject.fromRawJson(resultSet.first['data'] as String);
   }
 
   @override
   ResultTree? getResultTree(String queryId) {
     final resultSet = _db.select(
-      'SELECT result_tree FROM $resultTreeTable WHERE query_id = ?',
+      'SELECT data FROM $resultTreeTable WHERE query_id = ?',
       [queryId],
     );
     if (resultSet.isEmpty) {
       return null;
     }
-    return ResultTree.fromRawJson(resultSet.first['result_tree'] as String);
+    _updateLastAccessedTime(queryId);
+    return ResultTree.fromRawJson(resultSet.first['data'] as String);
+  }
+
+  void _updateLastAccessedTime(String queryId) {
+    _db.execute(
+      'UPDATE $resultTreeTable SET last_accessed = ? WHERE query_id = ?',
+      [DateTime.now().millisecondsSinceEpoch / 1000.0, queryId],
+    );
   }
 
   @override
-  void manageCacheSize() {
-    // TODO: implement manageCacheSize
-  }
-
-  @override
-  void saveEntityDataObject(EntityDataObject edo) {
+  void updateEntityData(EntityDataObject edo) {
     String rawJson = edo.toRawJson();
-    _db.execute(
-      'INSERT OR REPLACE INTO $entityDataTable (guid, entity_data_object) VALUES (?, ?)',
-      [edo.guid, rawJson],
-    );
+    _db.execute('BEGIN TRANSACTION');
+    try {
+      _db.execute(
+        'INSERT OR REPLACE INTO $entityDataTable (entity_guid, data) VALUES (?, ?)',
+        [edo.guid, rawJson],
+      );
+      _db.execute('COMMIT');
+    } catch (_) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
   }
 
   @override
-  void saveResultTree(String queryId, ResultTree resultTree) {
-    _db.execute(
-      'INSERT OR REPLACE INTO $resultTreeTable (query_id, result_tree) VALUES (?, ?)',
-      [queryId, resultTree.toRawJson()],
-    );
+  void setResultTree(String queryId, ResultTree resultTree) {
+    _db.execute('BEGIN TRANSACTION');
+    try {
+      _db.execute(
+        'INSERT OR REPLACE INTO $resultTreeTable (query_id, last_accessed, data) VALUES (?, ?, ?)',
+        [
+          queryId,
+          DateTime.now().millisecondsSinceEpoch / 1000.0,
+          resultTree.toRawJson()
+        ],
+      );
+      _db.execute('COMMIT');
+    } catch (_) {
+      _db.execute('ROLLBACK');
+      rethrow;
+    }
   }
 }
 

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/common/common_library.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/common/common_library.dart
@@ -64,8 +64,9 @@ class TransportOptions {
 class ServerResponse {
   final Map<String, dynamic> data;
   Duration? ttl;
+  final Map<String, dynamic>? extensions;
 
-  ServerResponse(this.data);
+  ServerResponse(this.data, {this.extensions});
 }
 
 /// Interface for transports connecting to the DataConnect backend.

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/common/common_library.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/common/common_library.dart
@@ -61,9 +61,15 @@ class TransportOptions {
   bool? isSecure;
 }
 
+/// Encapsulates the response from server
 class ServerResponse {
+  /// Data returned from server
   final Map<String, dynamic> data;
+
+  /// duration for which the results are considered not stale
   Duration? ttl;
+
+  /// Additional data provided in extensions
   final Map<String, dynamic>? extensions;
 
   ServerResponse(this.data, {this.extensions});

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/common/dataconnect_error.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/common/dataconnect_error.dart
@@ -63,11 +63,37 @@ sealed class DataConnectPathSegment {}
 class DataConnectFieldPathSegment extends DataConnectPathSegment {
   final String field;
   DataConnectFieldPathSegment(this.field);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DataConnectFieldPathSegment &&
+          runtimeType == other.runtimeType &&
+          field == other.field;
+
+  @override
+  int get hashCode => field.hashCode;
+
+  @override
+  String toString() => field;
 }
 
 class DataConnectListIndexPathSegment extends DataConnectPathSegment {
   final int index;
   DataConnectListIndexPathSegment(this.index);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DataConnectListIndexPathSegment &&
+          runtimeType == other.runtimeType &&
+          index == other.index;
+
+  @override
+  int get hashCode => index.hashCode;
+
+  @override
+  String toString() => index.toString();
 }
 
 typedef Serializer<Variables> = String Function(Variables vars);

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/common/dataconnect_error.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/common/dataconnect_error.dart
@@ -58,6 +58,7 @@ class DataConnectOperationFailureResponseErrorInfo {
 }
 
 /// Path where error occurred.
+@immutable
 sealed class DataConnectPathSegment {}
 
 class DataConnectFieldPathSegment extends DataConnectPathSegment {

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/core/ref.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/core/ref.dart
@@ -251,7 +251,7 @@ class QueryRef<Data, Variables> extends OperationRef<Data, Variables> {
     final cacheManager = dataConnect.cacheManager!;
     bool allowStale = fetchPolicy ==
         QueryFetchPolicy.cacheOnly; //if its cache only, we always allow stale
-    final cachedData = await cacheManager.get(_queryId, allowStale);
+    final cachedData = await cacheManager.resultTree(_queryId, allowStale);
 
     if (cachedData != null) {
       try {

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
@@ -25,7 +25,7 @@ import './network/transport_library.dart'
     if (dart.library.html) './network/rest_library.dart';
 
 import 'cache/cache_data_types.dart';
-import 'cache/cache_manager.dart';
+import 'cache/cache.dart';
 
 /// DataConnect class
 class FirebaseDataConnect extends FirebasePluginPlatform {

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pb.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pb.dart
@@ -37,35 +37,45 @@ class ExecuteQueryRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ExecuteQueryRequest._() : super();
-  factory ExecuteQueryRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ExecuteQueryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory ExecuteQueryRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ExecuteQueryRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ExecuteQueryRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ExecuteQueryRequest',
+      package: const $pb.PackageName(
+          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOS(2, _omitFieldNames ? '' : 'operationName')
-    ..aOM<$1.Struct>(3, _omitFieldNames ? '' : 'variables', subBuilder: $1.Struct.create)
-    ..hasRequiredFields = false
-  ;
+    ..aOM<$1.Struct>(3, _omitFieldNames ? '' : 'variables',
+        subBuilder: $1.Struct.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ExecuteQueryRequest clone() => ExecuteQueryRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ExecuteQueryRequest copyWith(void Function(ExecuteQueryRequest) updates) => super.copyWith((message) => updates(message as ExecuteQueryRequest)) as ExecuteQueryRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ExecuteQueryRequest copyWith(void Function(ExecuteQueryRequest) updates) =>
+      super.copyWith((message) => updates(message as ExecuteQueryRequest))
+          as ExecuteQueryRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static ExecuteQueryRequest create() => ExecuteQueryRequest._();
   ExecuteQueryRequest createEmptyInstance() => create();
-  static $pb.PbList<ExecuteQueryRequest> createRepeated() => $pb.PbList<ExecuteQueryRequest>();
+  static $pb.PbList<ExecuteQueryRequest> createRepeated() =>
+      $pb.PbList<ExecuteQueryRequest>();
   @$core.pragma('dart2js:noInline')
-  static ExecuteQueryRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ExecuteQueryRequest>(create);
+  static ExecuteQueryRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ExecuteQueryRequest>(create);
   static ExecuteQueryRequest? _defaultInstance;
 
   /// The resource name of the connector to find the predefined query, in
@@ -76,7 +86,10 @@ class ExecuteQueryRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) { $_setString(0, v); }
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -90,7 +103,10 @@ class ExecuteQueryRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get operationName => $_getSZ(1);
   @$pb.TagNumber(2)
-  set operationName($core.String v) { $_setString(1, v); }
+  set operationName($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasOperationName() => $_has(1);
   @$pb.TagNumber(2)
@@ -100,7 +116,10 @@ class ExecuteQueryRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $1.Struct get variables => $_getN(2);
   @$pb.TagNumber(3)
-  set variables($1.Struct v) { setField(3, v); }
+  set variables($1.Struct v) {
+    setField(3, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasVariables() => $_has(2);
   @$pb.TagNumber(3)
@@ -129,35 +148,47 @@ class ExecuteMutationRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ExecuteMutationRequest._() : super();
-  factory ExecuteMutationRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ExecuteMutationRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory ExecuteMutationRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ExecuteMutationRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ExecuteMutationRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ExecuteMutationRequest',
+      package: const $pb.PackageName(
+          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOS(2, _omitFieldNames ? '' : 'operationName')
-    ..aOM<$1.Struct>(3, _omitFieldNames ? '' : 'variables', subBuilder: $1.Struct.create)
-    ..hasRequiredFields = false
-  ;
+    ..aOM<$1.Struct>(3, _omitFieldNames ? '' : 'variables',
+        subBuilder: $1.Struct.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  ExecuteMutationRequest clone() => ExecuteMutationRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ExecuteMutationRequest copyWith(void Function(ExecuteMutationRequest) updates) => super.copyWith((message) => updates(message as ExecuteMutationRequest)) as ExecuteMutationRequest;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  ExecuteMutationRequest clone() =>
+      ExecuteMutationRequest()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ExecuteMutationRequest copyWith(
+          void Function(ExecuteMutationRequest) updates) =>
+      super.copyWith((message) => updates(message as ExecuteMutationRequest))
+          as ExecuteMutationRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static ExecuteMutationRequest create() => ExecuteMutationRequest._();
   ExecuteMutationRequest createEmptyInstance() => create();
-  static $pb.PbList<ExecuteMutationRequest> createRepeated() => $pb.PbList<ExecuteMutationRequest>();
+  static $pb.PbList<ExecuteMutationRequest> createRepeated() =>
+      $pb.PbList<ExecuteMutationRequest>();
   @$core.pragma('dart2js:noInline')
-  static ExecuteMutationRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ExecuteMutationRequest>(create);
+  static ExecuteMutationRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ExecuteMutationRequest>(create);
   static ExecuteMutationRequest? _defaultInstance;
 
   /// The resource name of the connector to find the predefined mutation, in
@@ -168,7 +199,10 @@ class ExecuteMutationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) { $_setString(0, v); }
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -182,7 +216,10 @@ class ExecuteMutationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get operationName => $_getSZ(1);
   @$pb.TagNumber(2)
-  set operationName($core.String v) { $_setString(1, v); }
+  set operationName($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasOperationName() => $_has(1);
   @$pb.TagNumber(2)
@@ -192,7 +229,10 @@ class ExecuteMutationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $1.Struct get variables => $_getN(2);
   @$pb.TagNumber(3)
-  set variables($1.Struct v) { setField(3, v); }
+  set variables($1.Struct v) {
+    setField(3, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasVariables() => $_has(2);
   @$pb.TagNumber(3)
@@ -221,42 +261,59 @@ class ExecuteQueryResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ExecuteQueryResponse._() : super();
-  factory ExecuteQueryResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ExecuteQueryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory ExecuteQueryResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ExecuteQueryResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ExecuteQueryResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
-    ..aOM<$1.Struct>(1, _omitFieldNames ? '' : 'data', subBuilder: $1.Struct.create)
-    ..pc<$3.GraphqlError>(2, _omitFieldNames ? '' : 'errors', $pb.PbFieldType.PM, subBuilder: $3.GraphqlError.create)
-    ..aOM<$4.GraphqlResponseExtensions>(3, _omitFieldNames ? '' : 'extensions', subBuilder: $4.GraphqlResponseExtensions.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ExecuteQueryResponse',
+      package: const $pb.PackageName(
+          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
+      createEmptyInstance: create)
+    ..aOM<$1.Struct>(1, _omitFieldNames ? '' : 'data',
+        subBuilder: $1.Struct.create)
+    ..pc<$3.GraphqlError>(
+        2, _omitFieldNames ? '' : 'errors', $pb.PbFieldType.PM,
+        subBuilder: $3.GraphqlError.create)
+    ..aOM<$4.GraphqlResponseExtensions>(3, _omitFieldNames ? '' : 'extensions',
+        subBuilder: $4.GraphqlResponseExtensions.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  ExecuteQueryResponse clone() => ExecuteQueryResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ExecuteQueryResponse copyWith(void Function(ExecuteQueryResponse) updates) => super.copyWith((message) => updates(message as ExecuteQueryResponse)) as ExecuteQueryResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  ExecuteQueryResponse clone() =>
+      ExecuteQueryResponse()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ExecuteQueryResponse copyWith(void Function(ExecuteQueryResponse) updates) =>
+      super.copyWith((message) => updates(message as ExecuteQueryResponse))
+          as ExecuteQueryResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static ExecuteQueryResponse create() => ExecuteQueryResponse._();
   ExecuteQueryResponse createEmptyInstance() => create();
-  static $pb.PbList<ExecuteQueryResponse> createRepeated() => $pb.PbList<ExecuteQueryResponse>();
+  static $pb.PbList<ExecuteQueryResponse> createRepeated() =>
+      $pb.PbList<ExecuteQueryResponse>();
   @$core.pragma('dart2js:noInline')
-  static ExecuteQueryResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ExecuteQueryResponse>(create);
+  static ExecuteQueryResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ExecuteQueryResponse>(create);
   static ExecuteQueryResponse? _defaultInstance;
 
   /// The result of executing the requested operation.
   @$pb.TagNumber(1)
   $1.Struct get data => $_getN(0);
   @$pb.TagNumber(1)
-  set data($1.Struct v) { setField(1, v); }
+  set data($1.Struct v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasData() => $_has(0);
   @$pb.TagNumber(1)
@@ -272,7 +329,10 @@ class ExecuteQueryResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $4.GraphqlResponseExtensions get extensions => $_getN(2);
   @$pb.TagNumber(3)
-  set extensions($4.GraphqlResponseExtensions v) { setField(3, v); }
+  set extensions($4.GraphqlResponseExtensions v) {
+    setField(3, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasExtensions() => $_has(2);
   @$pb.TagNumber(3)
@@ -301,42 +361,60 @@ class ExecuteMutationResponse extends $pb.GeneratedMessage {
     return $result;
   }
   ExecuteMutationResponse._() : super();
-  factory ExecuteMutationResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ExecuteMutationResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory ExecuteMutationResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ExecuteMutationResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ExecuteMutationResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
-    ..aOM<$1.Struct>(1, _omitFieldNames ? '' : 'data', subBuilder: $1.Struct.create)
-    ..pc<$3.GraphqlError>(2, _omitFieldNames ? '' : 'errors', $pb.PbFieldType.PM, subBuilder: $3.GraphqlError.create)
-    ..aOM<$4.GraphqlResponseExtensions>(3, _omitFieldNames ? '' : 'extensions', subBuilder: $4.GraphqlResponseExtensions.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ExecuteMutationResponse',
+      package: const $pb.PackageName(
+          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
+      createEmptyInstance: create)
+    ..aOM<$1.Struct>(1, _omitFieldNames ? '' : 'data',
+        subBuilder: $1.Struct.create)
+    ..pc<$3.GraphqlError>(
+        2, _omitFieldNames ? '' : 'errors', $pb.PbFieldType.PM,
+        subBuilder: $3.GraphqlError.create)
+    ..aOM<$4.GraphqlResponseExtensions>(3, _omitFieldNames ? '' : 'extensions',
+        subBuilder: $4.GraphqlResponseExtensions.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  ExecuteMutationResponse clone() => ExecuteMutationResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ExecuteMutationResponse copyWith(void Function(ExecuteMutationResponse) updates) => super.copyWith((message) => updates(message as ExecuteMutationResponse)) as ExecuteMutationResponse;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  ExecuteMutationResponse clone() =>
+      ExecuteMutationResponse()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ExecuteMutationResponse copyWith(
+          void Function(ExecuteMutationResponse) updates) =>
+      super.copyWith((message) => updates(message as ExecuteMutationResponse))
+          as ExecuteMutationResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static ExecuteMutationResponse create() => ExecuteMutationResponse._();
   ExecuteMutationResponse createEmptyInstance() => create();
-  static $pb.PbList<ExecuteMutationResponse> createRepeated() => $pb.PbList<ExecuteMutationResponse>();
+  static $pb.PbList<ExecuteMutationResponse> createRepeated() =>
+      $pb.PbList<ExecuteMutationResponse>();
   @$core.pragma('dart2js:noInline')
-  static ExecuteMutationResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ExecuteMutationResponse>(create);
+  static ExecuteMutationResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ExecuteMutationResponse>(create);
   static ExecuteMutationResponse? _defaultInstance;
 
   /// The result of executing the requested operation.
   @$pb.TagNumber(1)
   $1.Struct get data => $_getN(0);
   @$pb.TagNumber(1)
-  set data($1.Struct v) { setField(1, v); }
+  set data($1.Struct v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasData() => $_has(0);
   @$pb.TagNumber(1)
@@ -352,7 +430,10 @@ class ExecuteMutationResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $4.GraphqlResponseExtensions get extensions => $_getN(2);
   @$pb.TagNumber(3)
-  set extensions($4.GraphqlResponseExtensions v) { setField(3, v); }
+  set extensions($4.GraphqlResponseExtensions v) {
+    setField(3, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasExtensions() => $_has(2);
   @$pb.TagNumber(3)
@@ -361,6 +442,6 @@ class ExecuteMutationResponse extends $pb.GeneratedMessage {
   $4.GraphqlResponseExtensions ensureExtensions() => $_ensure(2);
 }
 
-
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');
+const _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pb.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pb.dart
@@ -1,16 +1,3 @@
-// Copyright 2024 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 //
 //  Generated code. Do not modify.
 //  source: connector_service.proto
@@ -27,7 +14,8 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 import 'google/protobuf/struct.pb.dart' as $1;
-import 'graphql_error.pb.dart' as $2;
+import 'graphql_error.pb.dart' as $3;
+import 'graphql_response_extensions.pb.dart' as $4;
 
 /// The ExecuteQuery request to Firebase Data Connect.
 class ExecuteQueryRequest extends $pb.GeneratedMessage {
@@ -49,45 +37,35 @@ class ExecuteQueryRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ExecuteQueryRequest._() : super();
-  factory ExecuteQueryRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ExecuteQueryRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ExecuteQueryRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ExecuteQueryRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'ExecuteQueryRequest',
-      package: const $pb.PackageName(
-          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ExecuteQueryRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOS(2, _omitFieldNames ? '' : 'operationName')
-    ..aOM<$1.Struct>(3, _omitFieldNames ? '' : 'variables',
-        subBuilder: $1.Struct.create)
-    ..hasRequiredFields = false;
+    ..aOM<$1.Struct>(3, _omitFieldNames ? '' : 'variables', subBuilder: $1.Struct.create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ExecuteQueryRequest clone() => ExecuteQueryRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ExecuteQueryRequest copyWith(void Function(ExecuteQueryRequest) updates) =>
-      super.copyWith((message) => updates(message as ExecuteQueryRequest))
-          as ExecuteQueryRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ExecuteQueryRequest copyWith(void Function(ExecuteQueryRequest) updates) => super.copyWith((message) => updates(message as ExecuteQueryRequest)) as ExecuteQueryRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static ExecuteQueryRequest create() => ExecuteQueryRequest._();
   ExecuteQueryRequest createEmptyInstance() => create();
-  static $pb.PbList<ExecuteQueryRequest> createRepeated() =>
-      $pb.PbList<ExecuteQueryRequest>();
+  static $pb.PbList<ExecuteQueryRequest> createRepeated() => $pb.PbList<ExecuteQueryRequest>();
   @$core.pragma('dart2js:noInline')
-  static ExecuteQueryRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ExecuteQueryRequest>(create);
+  static ExecuteQueryRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ExecuteQueryRequest>(create);
   static ExecuteQueryRequest? _defaultInstance;
 
   /// The resource name of the connector to find the predefined query, in
@@ -98,10 +76,7 @@ class ExecuteQueryRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -115,10 +90,7 @@ class ExecuteQueryRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get operationName => $_getSZ(1);
   @$pb.TagNumber(2)
-  set operationName($core.String v) {
-    $_setString(1, v);
-  }
-
+  set operationName($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasOperationName() => $_has(1);
   @$pb.TagNumber(2)
@@ -128,10 +100,7 @@ class ExecuteQueryRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $1.Struct get variables => $_getN(2);
   @$pb.TagNumber(3)
-  set variables($1.Struct v) {
-    setField(3, v);
-  }
-
+  set variables($1.Struct v) { setField(3, v); }
   @$pb.TagNumber(3)
   $core.bool hasVariables() => $_has(2);
   @$pb.TagNumber(3)
@@ -160,47 +129,35 @@ class ExecuteMutationRequest extends $pb.GeneratedMessage {
     return $result;
   }
   ExecuteMutationRequest._() : super();
-  factory ExecuteMutationRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ExecuteMutationRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ExecuteMutationRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ExecuteMutationRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'ExecuteMutationRequest',
-      package: const $pb.PackageName(
-          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ExecuteMutationRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'name')
     ..aOS(2, _omitFieldNames ? '' : 'operationName')
-    ..aOM<$1.Struct>(3, _omitFieldNames ? '' : 'variables',
-        subBuilder: $1.Struct.create)
-    ..hasRequiredFields = false;
+    ..aOM<$1.Struct>(3, _omitFieldNames ? '' : 'variables', subBuilder: $1.Struct.create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ExecuteMutationRequest clone() =>
-      ExecuteMutationRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ExecuteMutationRequest copyWith(
-          void Function(ExecuteMutationRequest) updates) =>
-      super.copyWith((message) => updates(message as ExecuteMutationRequest))
-          as ExecuteMutationRequest;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ExecuteMutationRequest clone() => ExecuteMutationRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ExecuteMutationRequest copyWith(void Function(ExecuteMutationRequest) updates) => super.copyWith((message) => updates(message as ExecuteMutationRequest)) as ExecuteMutationRequest;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static ExecuteMutationRequest create() => ExecuteMutationRequest._();
   ExecuteMutationRequest createEmptyInstance() => create();
-  static $pb.PbList<ExecuteMutationRequest> createRepeated() =>
-      $pb.PbList<ExecuteMutationRequest>();
+  static $pb.PbList<ExecuteMutationRequest> createRepeated() => $pb.PbList<ExecuteMutationRequest>();
   @$core.pragma('dart2js:noInline')
-  static ExecuteMutationRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ExecuteMutationRequest>(create);
+  static ExecuteMutationRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ExecuteMutationRequest>(create);
   static ExecuteMutationRequest? _defaultInstance;
 
   /// The resource name of the connector to find the predefined mutation, in
@@ -211,10 +168,7 @@ class ExecuteMutationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -228,10 +182,7 @@ class ExecuteMutationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get operationName => $_getSZ(1);
   @$pb.TagNumber(2)
-  set operationName($core.String v) {
-    $_setString(1, v);
-  }
-
+  set operationName($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasOperationName() => $_has(1);
   @$pb.TagNumber(2)
@@ -241,10 +192,7 @@ class ExecuteMutationRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $1.Struct get variables => $_getN(2);
   @$pb.TagNumber(3)
-  set variables($1.Struct v) {
-    setField(3, v);
-  }
-
+  set variables($1.Struct v) { setField(3, v); }
   @$pb.TagNumber(3)
   $core.bool hasVariables() => $_has(2);
   @$pb.TagNumber(3)
@@ -257,7 +205,8 @@ class ExecuteMutationRequest extends $pb.GeneratedMessage {
 class ExecuteQueryResponse extends $pb.GeneratedMessage {
   factory ExecuteQueryResponse({
     $1.Struct? data,
-    $core.Iterable<$2.GraphqlError>? errors,
+    $core.Iterable<$3.GraphqlError>? errors,
+    $4.GraphqlResponseExtensions? extensions,
   }) {
     final $result = create();
     if (data != null) {
@@ -266,60 +215,48 @@ class ExecuteQueryResponse extends $pb.GeneratedMessage {
     if (errors != null) {
       $result.errors.addAll(errors);
     }
+    if (extensions != null) {
+      $result.extensions = extensions;
+    }
     return $result;
   }
   ExecuteQueryResponse._() : super();
-  factory ExecuteQueryResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ExecuteQueryResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ExecuteQueryResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ExecuteQueryResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'ExecuteQueryResponse',
-      package: const $pb.PackageName(
-          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
-      createEmptyInstance: create)
-    ..aOM<$1.Struct>(1, _omitFieldNames ? '' : 'data',
-        subBuilder: $1.Struct.create)
-    ..pc<$2.GraphqlError>(
-        2, _omitFieldNames ? '' : 'errors', $pb.PbFieldType.PM,
-        subBuilder: $2.GraphqlError.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ExecuteQueryResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
+    ..aOM<$1.Struct>(1, _omitFieldNames ? '' : 'data', subBuilder: $1.Struct.create)
+    ..pc<$3.GraphqlError>(2, _omitFieldNames ? '' : 'errors', $pb.PbFieldType.PM, subBuilder: $3.GraphqlError.create)
+    ..aOM<$4.GraphqlResponseExtensions>(3, _omitFieldNames ? '' : 'extensions', subBuilder: $4.GraphqlResponseExtensions.create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ExecuteQueryResponse clone() =>
-      ExecuteQueryResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ExecuteQueryResponse copyWith(void Function(ExecuteQueryResponse) updates) =>
-      super.copyWith((message) => updates(message as ExecuteQueryResponse))
-          as ExecuteQueryResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ExecuteQueryResponse clone() => ExecuteQueryResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ExecuteQueryResponse copyWith(void Function(ExecuteQueryResponse) updates) => super.copyWith((message) => updates(message as ExecuteQueryResponse)) as ExecuteQueryResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static ExecuteQueryResponse create() => ExecuteQueryResponse._();
   ExecuteQueryResponse createEmptyInstance() => create();
-  static $pb.PbList<ExecuteQueryResponse> createRepeated() =>
-      $pb.PbList<ExecuteQueryResponse>();
+  static $pb.PbList<ExecuteQueryResponse> createRepeated() => $pb.PbList<ExecuteQueryResponse>();
   @$core.pragma('dart2js:noInline')
-  static ExecuteQueryResponse getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ExecuteQueryResponse>(create);
+  static ExecuteQueryResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ExecuteQueryResponse>(create);
   static ExecuteQueryResponse? _defaultInstance;
 
   /// The result of executing the requested operation.
   @$pb.TagNumber(1)
   $1.Struct get data => $_getN(0);
   @$pb.TagNumber(1)
-  set data($1.Struct v) {
-    setField(1, v);
-  }
-
+  set data($1.Struct v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasData() => $_has(0);
   @$pb.TagNumber(1)
@@ -329,14 +266,27 @@ class ExecuteQueryResponse extends $pb.GeneratedMessage {
 
   /// Errors of this response.
   @$pb.TagNumber(2)
-  $core.List<$2.GraphqlError> get errors => $_getList(1);
+  $core.List<$3.GraphqlError> get errors => $_getList(1);
+
+  /// Additional response information.
+  @$pb.TagNumber(3)
+  $4.GraphqlResponseExtensions get extensions => $_getN(2);
+  @$pb.TagNumber(3)
+  set extensions($4.GraphqlResponseExtensions v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasExtensions() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearExtensions() => clearField(3);
+  @$pb.TagNumber(3)
+  $4.GraphqlResponseExtensions ensureExtensions() => $_ensure(2);
 }
 
 /// The ExecuteMutation response from Firebase Data Connect.
 class ExecuteMutationResponse extends $pb.GeneratedMessage {
   factory ExecuteMutationResponse({
     $1.Struct? data,
-    $core.Iterable<$2.GraphqlError>? errors,
+    $core.Iterable<$3.GraphqlError>? errors,
+    $4.GraphqlResponseExtensions? extensions,
   }) {
     final $result = create();
     if (data != null) {
@@ -345,61 +295,48 @@ class ExecuteMutationResponse extends $pb.GeneratedMessage {
     if (errors != null) {
       $result.errors.addAll(errors);
     }
+    if (extensions != null) {
+      $result.extensions = extensions;
+    }
     return $result;
   }
   ExecuteMutationResponse._() : super();
-  factory ExecuteMutationResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ExecuteMutationResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ExecuteMutationResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ExecuteMutationResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'ExecuteMutationResponse',
-      package: const $pb.PackageName(
-          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
-      createEmptyInstance: create)
-    ..aOM<$1.Struct>(1, _omitFieldNames ? '' : 'data',
-        subBuilder: $1.Struct.create)
-    ..pc<$2.GraphqlError>(
-        2, _omitFieldNames ? '' : 'errors', $pb.PbFieldType.PM,
-        subBuilder: $2.GraphqlError.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ExecuteMutationResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
+    ..aOM<$1.Struct>(1, _omitFieldNames ? '' : 'data', subBuilder: $1.Struct.create)
+    ..pc<$3.GraphqlError>(2, _omitFieldNames ? '' : 'errors', $pb.PbFieldType.PM, subBuilder: $3.GraphqlError.create)
+    ..aOM<$4.GraphqlResponseExtensions>(3, _omitFieldNames ? '' : 'extensions', subBuilder: $4.GraphqlResponseExtensions.create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ExecuteMutationResponse clone() =>
-      ExecuteMutationResponse()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ExecuteMutationResponse copyWith(
-          void Function(ExecuteMutationResponse) updates) =>
-      super.copyWith((message) => updates(message as ExecuteMutationResponse))
-          as ExecuteMutationResponse;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ExecuteMutationResponse clone() => ExecuteMutationResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ExecuteMutationResponse copyWith(void Function(ExecuteMutationResponse) updates) => super.copyWith((message) => updates(message as ExecuteMutationResponse)) as ExecuteMutationResponse;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static ExecuteMutationResponse create() => ExecuteMutationResponse._();
   ExecuteMutationResponse createEmptyInstance() => create();
-  static $pb.PbList<ExecuteMutationResponse> createRepeated() =>
-      $pb.PbList<ExecuteMutationResponse>();
+  static $pb.PbList<ExecuteMutationResponse> createRepeated() => $pb.PbList<ExecuteMutationResponse>();
   @$core.pragma('dart2js:noInline')
-  static ExecuteMutationResponse getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ExecuteMutationResponse>(create);
+  static ExecuteMutationResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ExecuteMutationResponse>(create);
   static ExecuteMutationResponse? _defaultInstance;
 
   /// The result of executing the requested operation.
   @$pb.TagNumber(1)
   $1.Struct get data => $_getN(0);
   @$pb.TagNumber(1)
-  set data($1.Struct v) {
-    setField(1, v);
-  }
-
+  set data($1.Struct v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasData() => $_has(0);
   @$pb.TagNumber(1)
@@ -409,9 +346,21 @@ class ExecuteMutationResponse extends $pb.GeneratedMessage {
 
   /// Errors of this response.
   @$pb.TagNumber(2)
-  $core.List<$2.GraphqlError> get errors => $_getList(1);
+  $core.List<$3.GraphqlError> get errors => $_getList(1);
+
+  /// Additional response information.
+  @$pb.TagNumber(3)
+  $4.GraphqlResponseExtensions get extensions => $_getN(2);
+  @$pb.TagNumber(3)
+  set extensions($4.GraphqlResponseExtensions v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasExtensions() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearExtensions() => clearField(3);
+  @$pb.TagNumber(3)
+  $4.GraphqlResponseExtensions ensureExtensions() => $_ensure(2);
 }
 
+
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames =
-    $core.bool.fromEnvironment('protobuf.omit_message_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pbenum.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pbenum.dart
@@ -8,4 +8,3 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pbenum.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pbenum.dart
@@ -1,16 +1,3 @@
-// Copyright 2024 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 //
 //  Generated code. Do not modify.
 //  source: connector_service.proto
@@ -21,3 +8,4 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pbgrpc.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pbgrpc.dart
@@ -1,16 +1,3 @@
-// Copyright 2024 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 //
 //  Generated code. Do not modify.
 //  source: connector_service.proto
@@ -34,33 +21,26 @@ export 'connector_service.pb.dart';
 
 @$pb.GrpcServiceName('google.firebase.dataconnect.v1.ConnectorService')
 class ConnectorServiceClient extends $grpc.Client {
-  static final _$executeQuery =
-      $grpc.ClientMethod<$0.ExecuteQueryRequest, $0.ExecuteQueryResponse>(
-          '/google.firebase.dataconnect.v1.ConnectorService/ExecuteQuery',
-          ($0.ExecuteQueryRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.ExecuteQueryResponse.fromBuffer(value));
-  static final _$executeMutation =
-      $grpc.ClientMethod<$0.ExecuteMutationRequest, $0.ExecuteMutationResponse>(
-          '/google.firebase.dataconnect.v1.ConnectorService/ExecuteMutation',
-          ($0.ExecuteMutationRequest value) => value.writeToBuffer(),
-          ($core.List<$core.int> value) =>
-              $0.ExecuteMutationResponse.fromBuffer(value));
+  static final _$executeQuery = $grpc.ClientMethod<$0.ExecuteQueryRequest, $0.ExecuteQueryResponse>(
+      '/google.firebase.dataconnect.v1.ConnectorService/ExecuteQuery',
+      ($0.ExecuteQueryRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.ExecuteQueryResponse.fromBuffer(value));
+  static final _$executeMutation = $grpc.ClientMethod<$0.ExecuteMutationRequest, $0.ExecuteMutationResponse>(
+      '/google.firebase.dataconnect.v1.ConnectorService/ExecuteMutation',
+      ($0.ExecuteMutationRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.ExecuteMutationResponse.fromBuffer(value));
 
   ConnectorServiceClient($grpc.ClientChannel channel,
       {$grpc.CallOptions? options,
       $core.Iterable<$grpc.ClientInterceptor>? interceptors})
-      : super(channel, options: options, interceptors: interceptors);
+      : super(channel, options: options,
+        interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.ExecuteQueryResponse> executeQuery(
-      $0.ExecuteQueryRequest request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.ExecuteQueryResponse> executeQuery($0.ExecuteQueryRequest request, {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$executeQuery, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.ExecuteMutationResponse> executeMutation(
-      $0.ExecuteMutationRequest request,
-      {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.ExecuteMutationResponse> executeMutation($0.ExecuteMutationRequest request, {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$executeMutation, request, options: options);
   }
 }
@@ -70,40 +50,30 @@ abstract class ConnectorServiceBase extends $grpc.Service {
   $core.String get $name => 'google.firebase.dataconnect.v1.ConnectorService';
 
   ConnectorServiceBase() {
-    $addMethod(
-        $grpc.ServiceMethod<$0.ExecuteQueryRequest, $0.ExecuteQueryResponse>(
-            'ExecuteQuery',
-            executeQuery_Pre,
-            false,
-            false,
-            ($core.List<$core.int> value) =>
-                $0.ExecuteQueryRequest.fromBuffer(value),
-            ($0.ExecuteQueryResponse value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.ExecuteMutationRequest,
-            $0.ExecuteMutationResponse>(
+    $addMethod($grpc.ServiceMethod<$0.ExecuteQueryRequest, $0.ExecuteQueryResponse>(
+        'ExecuteQuery',
+        executeQuery_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.ExecuteQueryRequest.fromBuffer(value),
+        ($0.ExecuteQueryResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.ExecuteMutationRequest, $0.ExecuteMutationResponse>(
         'ExecuteMutation',
         executeMutation_Pre,
         false,
         false,
-        ($core.List<$core.int> value) =>
-            $0.ExecuteMutationRequest.fromBuffer(value),
+        ($core.List<$core.int> value) => $0.ExecuteMutationRequest.fromBuffer(value),
         ($0.ExecuteMutationResponse value) => value.writeToBuffer()));
   }
 
-  $async.Future<$0.ExecuteQueryResponse> executeQuery_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ExecuteQueryRequest> request) async {
+  $async.Future<$0.ExecuteQueryResponse> executeQuery_Pre($grpc.ServiceCall call, $async.Future<$0.ExecuteQueryRequest> request) async {
     return executeQuery(call, await request);
   }
 
-  $async.Future<$0.ExecuteMutationResponse> executeMutation_Pre(
-      $grpc.ServiceCall call,
-      $async.Future<$0.ExecuteMutationRequest> request) async {
+  $async.Future<$0.ExecuteMutationResponse> executeMutation_Pre($grpc.ServiceCall call, $async.Future<$0.ExecuteMutationRequest> request) async {
     return executeMutation(call, await request);
   }
 
-  $async.Future<$0.ExecuteQueryResponse> executeQuery(
-      $grpc.ServiceCall call, $0.ExecuteQueryRequest request);
-  $async.Future<$0.ExecuteMutationResponse> executeMutation(
-      $grpc.ServiceCall call, $0.ExecuteMutationRequest request);
+  $async.Future<$0.ExecuteQueryResponse> executeQuery($grpc.ServiceCall call, $0.ExecuteQueryRequest request);
+  $async.Future<$0.ExecuteMutationResponse> executeMutation($grpc.ServiceCall call, $0.ExecuteMutationRequest request);
 }

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pbgrpc.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pbgrpc.dart
@@ -21,26 +21,33 @@ export 'connector_service.pb.dart';
 
 @$pb.GrpcServiceName('google.firebase.dataconnect.v1.ConnectorService')
 class ConnectorServiceClient extends $grpc.Client {
-  static final _$executeQuery = $grpc.ClientMethod<$0.ExecuteQueryRequest, $0.ExecuteQueryResponse>(
-      '/google.firebase.dataconnect.v1.ConnectorService/ExecuteQuery',
-      ($0.ExecuteQueryRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.ExecuteQueryResponse.fromBuffer(value));
-  static final _$executeMutation = $grpc.ClientMethod<$0.ExecuteMutationRequest, $0.ExecuteMutationResponse>(
-      '/google.firebase.dataconnect.v1.ConnectorService/ExecuteMutation',
-      ($0.ExecuteMutationRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.ExecuteMutationResponse.fromBuffer(value));
+  static final _$executeQuery =
+      $grpc.ClientMethod<$0.ExecuteQueryRequest, $0.ExecuteQueryResponse>(
+          '/google.firebase.dataconnect.v1.ConnectorService/ExecuteQuery',
+          ($0.ExecuteQueryRequest value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) =>
+              $0.ExecuteQueryResponse.fromBuffer(value));
+  static final _$executeMutation =
+      $grpc.ClientMethod<$0.ExecuteMutationRequest, $0.ExecuteMutationResponse>(
+          '/google.firebase.dataconnect.v1.ConnectorService/ExecuteMutation',
+          ($0.ExecuteMutationRequest value) => value.writeToBuffer(),
+          ($core.List<$core.int> value) =>
+              $0.ExecuteMutationResponse.fromBuffer(value));
 
   ConnectorServiceClient($grpc.ClientChannel channel,
       {$grpc.CallOptions? options,
       $core.Iterable<$grpc.ClientInterceptor>? interceptors})
-      : super(channel, options: options,
-        interceptors: interceptors);
+      : super(channel, options: options, interceptors: interceptors);
 
-  $grpc.ResponseFuture<$0.ExecuteQueryResponse> executeQuery($0.ExecuteQueryRequest request, {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.ExecuteQueryResponse> executeQuery(
+      $0.ExecuteQueryRequest request,
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$executeQuery, request, options: options);
   }
 
-  $grpc.ResponseFuture<$0.ExecuteMutationResponse> executeMutation($0.ExecuteMutationRequest request, {$grpc.CallOptions? options}) {
+  $grpc.ResponseFuture<$0.ExecuteMutationResponse> executeMutation(
+      $0.ExecuteMutationRequest request,
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$executeMutation, request, options: options);
   }
 }
@@ -50,30 +57,40 @@ abstract class ConnectorServiceBase extends $grpc.Service {
   $core.String get $name => 'google.firebase.dataconnect.v1.ConnectorService';
 
   ConnectorServiceBase() {
-    $addMethod($grpc.ServiceMethod<$0.ExecuteQueryRequest, $0.ExecuteQueryResponse>(
-        'ExecuteQuery',
-        executeQuery_Pre,
-        false,
-        false,
-        ($core.List<$core.int> value) => $0.ExecuteQueryRequest.fromBuffer(value),
-        ($0.ExecuteQueryResponse value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<$0.ExecuteMutationRequest, $0.ExecuteMutationResponse>(
+    $addMethod(
+        $grpc.ServiceMethod<$0.ExecuteQueryRequest, $0.ExecuteQueryResponse>(
+            'ExecuteQuery',
+            executeQuery_Pre,
+            false,
+            false,
+            ($core.List<$core.int> value) =>
+                $0.ExecuteQueryRequest.fromBuffer(value),
+            ($0.ExecuteQueryResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.ExecuteMutationRequest,
+            $0.ExecuteMutationResponse>(
         'ExecuteMutation',
         executeMutation_Pre,
         false,
         false,
-        ($core.List<$core.int> value) => $0.ExecuteMutationRequest.fromBuffer(value),
+        ($core.List<$core.int> value) =>
+            $0.ExecuteMutationRequest.fromBuffer(value),
         ($0.ExecuteMutationResponse value) => value.writeToBuffer()));
   }
 
-  $async.Future<$0.ExecuteQueryResponse> executeQuery_Pre($grpc.ServiceCall call, $async.Future<$0.ExecuteQueryRequest> request) async {
+  $async.Future<$0.ExecuteQueryResponse> executeQuery_Pre(
+      $grpc.ServiceCall call,
+      $async.Future<$0.ExecuteQueryRequest> request) async {
     return executeQuery(call, await request);
   }
 
-  $async.Future<$0.ExecuteMutationResponse> executeMutation_Pre($grpc.ServiceCall call, $async.Future<$0.ExecuteMutationRequest> request) async {
+  $async.Future<$0.ExecuteMutationResponse> executeMutation_Pre(
+      $grpc.ServiceCall call,
+      $async.Future<$0.ExecuteMutationRequest> request) async {
     return executeMutation(call, await request);
   }
 
-  $async.Future<$0.ExecuteQueryResponse> executeQuery($grpc.ServiceCall call, $0.ExecuteQueryRequest request);
-  $async.Future<$0.ExecuteMutationResponse> executeMutation($grpc.ServiceCall call, $0.ExecuteMutationRequest request);
+  $async.Future<$0.ExecuteQueryResponse> executeQuery(
+      $grpc.ServiceCall call, $0.ExecuteQueryRequest request);
+  $async.Future<$0.ExecuteMutationResponse> executeMutation(
+      $grpc.ServiceCall call, $0.ExecuteMutationRequest request);
 }

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pbjson.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pbjson.dart
@@ -18,8 +18,23 @@ const ExecuteQueryRequest$json = {
   '1': 'ExecuteQueryRequest',
   '2': [
     {'1': 'name', '3': 1, '4': 1, '5': 9, '8': {}, '10': 'name'},
-    {'1': 'operation_name', '3': 2, '4': 1, '5': 9, '8': {}, '10': 'operationName'},
-    {'1': 'variables', '3': 3, '4': 1, '5': 11, '6': '.google.protobuf.Struct', '8': {}, '10': 'variables'},
+    {
+      '1': 'operation_name',
+      '3': 2,
+      '4': 1,
+      '5': 9,
+      '8': {},
+      '10': 'operationName'
+    },
+    {
+      '1': 'variables',
+      '3': 3,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Struct',
+      '8': {},
+      '10': 'variables'
+    },
   ],
 };
 
@@ -34,8 +49,23 @@ const ExecuteMutationRequest$json = {
   '1': 'ExecuteMutationRequest',
   '2': [
     {'1': 'name', '3': 1, '4': 1, '5': 9, '8': {}, '10': 'name'},
-    {'1': 'operation_name', '3': 2, '4': 1, '5': 9, '8': {}, '10': 'operationName'},
-    {'1': 'variables', '3': 3, '4': 1, '5': 11, '6': '.google.protobuf.Struct', '8': {}, '10': 'variables'},
+    {
+      '1': 'operation_name',
+      '3': 2,
+      '4': 1,
+      '5': 9,
+      '8': {},
+      '10': 'operationName'
+    },
+    {
+      '1': 'variables',
+      '3': 3,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Struct',
+      '8': {},
+      '10': 'variables'
+    },
   ],
 };
 
@@ -49,9 +79,30 @@ final $typed_data.Uint8List executeMutationRequestDescriptor = $convert.base64De
 const ExecuteQueryResponse$json = {
   '1': 'ExecuteQueryResponse',
   '2': [
-    {'1': 'data', '3': 1, '4': 1, '5': 11, '6': '.google.protobuf.Struct', '10': 'data'},
-    {'1': 'errors', '3': 2, '4': 3, '5': 11, '6': '.google.firebase.dataconnect.v1.GraphqlError', '10': 'errors'},
-    {'1': 'extensions', '3': 3, '4': 1, '5': 11, '6': '.google.firebase.dataconnect.v1.GraphqlResponseExtensions', '10': 'extensions'},
+    {
+      '1': 'data',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Struct',
+      '10': 'data'
+    },
+    {
+      '1': 'errors',
+      '3': 2,
+      '4': 3,
+      '5': 11,
+      '6': '.google.firebase.dataconnect.v1.GraphqlError',
+      '10': 'errors'
+    },
+    {
+      '1': 'extensions',
+      '3': 3,
+      '4': 1,
+      '5': 11,
+      '6': '.google.firebase.dataconnect.v1.GraphqlResponseExtensions',
+      '10': 'extensions'
+    },
   ],
 };
 
@@ -67,9 +118,30 @@ final $typed_data.Uint8List executeQueryResponseDescriptor = $convert.base64Deco
 const ExecuteMutationResponse$json = {
   '1': 'ExecuteMutationResponse',
   '2': [
-    {'1': 'data', '3': 1, '4': 1, '5': 11, '6': '.google.protobuf.Struct', '10': 'data'},
-    {'1': 'errors', '3': 2, '4': 3, '5': 11, '6': '.google.firebase.dataconnect.v1.GraphqlError', '10': 'errors'},
-    {'1': 'extensions', '3': 3, '4': 1, '5': 11, '6': '.google.firebase.dataconnect.v1.GraphqlResponseExtensions', '10': 'extensions'},
+    {
+      '1': 'data',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Struct',
+      '10': 'data'
+    },
+    {
+      '1': 'errors',
+      '3': 2,
+      '4': 3,
+      '5': 11,
+      '6': '.google.firebase.dataconnect.v1.GraphqlError',
+      '10': 'errors'
+    },
+    {
+      '1': 'extensions',
+      '3': 3,
+      '4': 1,
+      '5': 11,
+      '6': '.google.firebase.dataconnect.v1.GraphqlResponseExtensions',
+      '10': 'extensions'
+    },
   ],
 };
 
@@ -80,4 +152,3 @@ final $typed_data.Uint8List executeMutationResponseDescriptor = $convert.base64D
     'bm5lY3QudjEuR3JhcGhxbEVycm9yUgZlcnJvcnMSWQoKZXh0ZW5zaW9ucxgDIAEoCzI5Lmdvb2'
     'dsZS5maXJlYmFzZS5kYXRhY29ubmVjdC52MS5HcmFwaHFsUmVzcG9uc2VFeHRlbnNpb25zUgpl'
     'eHRlbnNpb25z');
-

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pbjson.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/connector_service.pbjson.dart
@@ -1,16 +1,3 @@
-// Copyright 2024 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 //
 //  Generated code. Do not modify.
 //  source: connector_service.proto
@@ -31,23 +18,8 @@ const ExecuteQueryRequest$json = {
   '1': 'ExecuteQueryRequest',
   '2': [
     {'1': 'name', '3': 1, '4': 1, '5': 9, '8': {}, '10': 'name'},
-    {
-      '1': 'operation_name',
-      '3': 2,
-      '4': 1,
-      '5': 9,
-      '8': {},
-      '10': 'operationName'
-    },
-    {
-      '1': 'variables',
-      '3': 3,
-      '4': 1,
-      '5': 11,
-      '6': '.google.protobuf.Struct',
-      '8': {},
-      '10': 'variables'
-    },
+    {'1': 'operation_name', '3': 2, '4': 1, '5': 9, '8': {}, '10': 'operationName'},
+    {'1': 'variables', '3': 3, '4': 1, '5': 11, '6': '.google.protobuf.Struct', '8': {}, '10': 'variables'},
   ],
 };
 
@@ -62,23 +34,8 @@ const ExecuteMutationRequest$json = {
   '1': 'ExecuteMutationRequest',
   '2': [
     {'1': 'name', '3': 1, '4': 1, '5': 9, '8': {}, '10': 'name'},
-    {
-      '1': 'operation_name',
-      '3': 2,
-      '4': 1,
-      '5': 9,
-      '8': {},
-      '10': 'operationName'
-    },
-    {
-      '1': 'variables',
-      '3': 3,
-      '4': 1,
-      '5': 11,
-      '6': '.google.protobuf.Struct',
-      '8': {},
-      '10': 'variables'
-    },
+    {'1': 'operation_name', '3': 2, '4': 1, '5': 9, '8': {}, '10': 'operationName'},
+    {'1': 'variables', '3': 3, '4': 1, '5': 11, '6': '.google.protobuf.Struct', '8': {}, '10': 'variables'},
   ],
 };
 
@@ -92,22 +49,9 @@ final $typed_data.Uint8List executeMutationRequestDescriptor = $convert.base64De
 const ExecuteQueryResponse$json = {
   '1': 'ExecuteQueryResponse',
   '2': [
-    {
-      '1': 'data',
-      '3': 1,
-      '4': 1,
-      '5': 11,
-      '6': '.google.protobuf.Struct',
-      '10': 'data'
-    },
-    {
-      '1': 'errors',
-      '3': 2,
-      '4': 3,
-      '5': 11,
-      '6': '.google.firebase.dataconnect.v1.GraphqlError',
-      '10': 'errors'
-    },
+    {'1': 'data', '3': 1, '4': 1, '5': 11, '6': '.google.protobuf.Struct', '10': 'data'},
+    {'1': 'errors', '3': 2, '4': 3, '5': 11, '6': '.google.firebase.dataconnect.v1.GraphqlError', '10': 'errors'},
+    {'1': 'extensions', '3': 3, '4': 1, '5': 11, '6': '.google.firebase.dataconnect.v1.GraphqlResponseExtensions', '10': 'extensions'},
   ],
 };
 
@@ -115,28 +59,17 @@ const ExecuteQueryResponse$json = {
 final $typed_data.Uint8List executeQueryResponseDescriptor = $convert.base64Decode(
     'ChRFeGVjdXRlUXVlcnlSZXNwb25zZRIrCgRkYXRhGAEgASgLMhcuZ29vZ2xlLnByb3RvYnVmLl'
     'N0cnVjdFIEZGF0YRJECgZlcnJvcnMYAiADKAsyLC5nb29nbGUuZmlyZWJhc2UuZGF0YWNvbm5l'
-    'Y3QudjEuR3JhcGhxbEVycm9yUgZlcnJvcnM=');
+    'Y3QudjEuR3JhcGhxbEVycm9yUgZlcnJvcnMSWQoKZXh0ZW5zaW9ucxgDIAEoCzI5Lmdvb2dsZS'
+    '5maXJlYmFzZS5kYXRhY29ubmVjdC52MS5HcmFwaHFsUmVzcG9uc2VFeHRlbnNpb25zUgpleHRl'
+    'bnNpb25z');
 
 @$core.Deprecated('Use executeMutationResponseDescriptor instead')
 const ExecuteMutationResponse$json = {
   '1': 'ExecuteMutationResponse',
   '2': [
-    {
-      '1': 'data',
-      '3': 1,
-      '4': 1,
-      '5': 11,
-      '6': '.google.protobuf.Struct',
-      '10': 'data'
-    },
-    {
-      '1': 'errors',
-      '3': 2,
-      '4': 3,
-      '5': 11,
-      '6': '.google.firebase.dataconnect.v1.GraphqlError',
-      '10': 'errors'
-    },
+    {'1': 'data', '3': 1, '4': 1, '5': 11, '6': '.google.protobuf.Struct', '10': 'data'},
+    {'1': 'errors', '3': 2, '4': 3, '5': 11, '6': '.google.firebase.dataconnect.v1.GraphqlError', '10': 'errors'},
+    {'1': 'extensions', '3': 3, '4': 1, '5': 11, '6': '.google.firebase.dataconnect.v1.GraphqlResponseExtensions', '10': 'extensions'},
   ],
 };
 
@@ -144,4 +77,7 @@ const ExecuteMutationResponse$json = {
 final $typed_data.Uint8List executeMutationResponseDescriptor = $convert.base64Decode(
     'ChdFeGVjdXRlTXV0YXRpb25SZXNwb25zZRIrCgRkYXRhGAEgASgLMhcuZ29vZ2xlLnByb3RvYn'
     'VmLlN0cnVjdFIEZGF0YRJECgZlcnJvcnMYAiADKAsyLC5nb29nbGUuZmlyZWJhc2UuZGF0YWNv'
-    'bm5lY3QudjEuR3JhcGhxbEVycm9yUgZlcnJvcnM=');
+    'bm5lY3QudjEuR3JhcGhxbEVycm9yUgZlcnJvcnMSWQoKZXh0ZW5zaW9ucxgDIAEoCzI5Lmdvb2'
+    'dsZS5maXJlYmFzZS5kYXRhY29ubmVjdC52MS5HcmFwaHFsUmVzcG9uc2VFeHRlbnNpb25zUgpl'
+    'eHRlbnNpb25z');
+

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/duration.pb.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/duration.pb.dart
@@ -1,0 +1,151 @@
+//
+//  Generated code. Do not modify.
+//  source: google/protobuf/duration.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:fixnum/fixnum.dart' as $fixnum;
+import 'package:protobuf/protobuf.dart' as $pb;
+import 'package:protobuf/src/protobuf/mixins/well_known.dart' as $mixin;
+
+///  A Duration represents a signed, fixed-length span of time represented
+///  as a count of seconds and fractions of seconds at nanosecond
+///  resolution. It is independent of any calendar and concepts like "day"
+///  or "month". It is related to Timestamp in that the difference between
+///  two Timestamp values is a Duration and it can be added or subtracted
+///  from a Timestamp. Range is approximately +-10,000 years.
+///
+///  # Examples
+///
+///  Example 1: Compute Duration from two Timestamps in pseudo code.
+///
+///      Timestamp start = ...;
+///      Timestamp end = ...;
+///      Duration duration = ...;
+///
+///      duration.seconds = end.seconds - start.seconds;
+///      duration.nanos = end.nanos - start.nanos;
+///
+///      if (duration.seconds < 0 && duration.nanos > 0) {
+///        duration.seconds += 1;
+///        duration.nanos -= 1000000000;
+///      } else if (duration.seconds > 0 && duration.nanos < 0) {
+///        duration.seconds -= 1;
+///        duration.nanos += 1000000000;
+///      }
+///
+///  Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
+///
+///      Timestamp start = ...;
+///      Duration duration = ...;
+///      Timestamp end = ...;
+///
+///      end.seconds = start.seconds + duration.seconds;
+///      end.nanos = start.nanos + duration.nanos;
+///
+///      if (end.nanos < 0) {
+///        end.seconds -= 1;
+///        end.nanos += 1000000000;
+///      } else if (end.nanos >= 1000000000) {
+///        end.seconds += 1;
+///        end.nanos -= 1000000000;
+///      }
+///
+///  Example 3: Compute Duration from datetime.timedelta in Python.
+///
+///      td = datetime.timedelta(days=3, minutes=10)
+///      duration = Duration()
+///      duration.FromTimedelta(td)
+///
+///  # JSON Mapping
+///
+///  In JSON format, the Duration type is encoded as a string rather than an
+///  object, where the string ends in the suffix "s" (indicating seconds) and
+///  is preceded by the number of seconds, with nanoseconds expressed as
+///  fractional seconds. For example, 3 seconds with 0 nanoseconds should be
+///  encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
+///  be expressed in JSON format as "3.000000001s", and 3 seconds and 1
+///  microsecond should be expressed in JSON format as "3.000001s".
+class Duration extends $pb.GeneratedMessage with $mixin.DurationMixin {
+  factory Duration({
+    $fixnum.Int64? seconds,
+    $core.int? nanos,
+  }) {
+    final $result = create();
+    if (seconds != null) {
+      $result.seconds = seconds;
+    }
+    if (nanos != null) {
+      $result.nanos = nanos;
+    }
+    return $result;
+  }
+  Duration._() : super();
+  factory Duration.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Duration.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Duration', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.DurationMixin.toProto3JsonHelper, fromProto3Json: $mixin.DurationMixin.fromProto3JsonHelper)
+    ..aInt64(1, _omitFieldNames ? '' : 'seconds')
+    ..a<$core.int>(2, _omitFieldNames ? '' : 'nanos', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Duration clone() => Duration()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Duration copyWith(void Function(Duration) updates) => super.copyWith((message) => updates(message as Duration)) as Duration;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Duration create() => Duration._();
+  Duration createEmptyInstance() => create();
+  static $pb.PbList<Duration> createRepeated() => $pb.PbList<Duration>();
+  @$core.pragma('dart2js:noInline')
+  static Duration getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Duration>(create);
+  static Duration? _defaultInstance;
+
+  /// Signed seconds of the span of time. Must be from -315,576,000,000
+  /// to +315,576,000,000 inclusive. Note: these bounds are computed from:
+  /// 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+  @$pb.TagNumber(1)
+  $fixnum.Int64 get seconds => $_getI64(0);
+  @$pb.TagNumber(1)
+  set seconds($fixnum.Int64 v) { $_setInt64(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSeconds() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSeconds() => clearField(1);
+
+  /// Signed fractions of a second at nanosecond resolution of the span
+  /// of time. Durations less than one second are represented with a 0
+  /// `seconds` field and a positive or negative `nanos` field. For durations
+  /// of one second or more, a non-zero value for the `nanos` field must be
+  /// of the same sign as the `seconds` field. Must be from -999,999,999
+  /// to +999,999,999 inclusive.
+  @$pb.TagNumber(2)
+  $core.int get nanos => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set nanos($core.int v) { $_setSignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasNanos() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNanos() => clearField(2);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/duration.pb.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/duration.pb.dart
@@ -88,25 +88,33 @@ class Duration extends $pb.GeneratedMessage with $mixin.DurationMixin {
     return $result;
   }
   Duration._() : super();
-  factory Duration.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Duration.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory Duration.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Duration.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Duration', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.DurationMixin.toProto3JsonHelper, fromProto3Json: $mixin.DurationMixin.fromProto3JsonHelper)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Duration',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      toProto3Json: $mixin.DurationMixin.toProto3JsonHelper,
+      fromProto3Json: $mixin.DurationMixin.fromProto3JsonHelper)
     ..aInt64(1, _omitFieldNames ? '' : 'seconds')
     ..a<$core.int>(2, _omitFieldNames ? '' : 'nanos', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Duration clone() => Duration()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Duration copyWith(void Function(Duration) updates) => super.copyWith((message) => updates(message as Duration)) as Duration;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Duration copyWith(void Function(Duration) updates) =>
+      super.copyWith((message) => updates(message as Duration)) as Duration;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -115,7 +123,8 @@ class Duration extends $pb.GeneratedMessage with $mixin.DurationMixin {
   Duration createEmptyInstance() => create();
   static $pb.PbList<Duration> createRepeated() => $pb.PbList<Duration>();
   @$core.pragma('dart2js:noInline')
-  static Duration getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Duration>(create);
+  static Duration getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Duration>(create);
   static Duration? _defaultInstance;
 
   /// Signed seconds of the span of time. Must be from -315,576,000,000
@@ -124,7 +133,10 @@ class Duration extends $pb.GeneratedMessage with $mixin.DurationMixin {
   @$pb.TagNumber(1)
   $fixnum.Int64 get seconds => $_getI64(0);
   @$pb.TagNumber(1)
-  set seconds($fixnum.Int64 v) { $_setInt64(0, v); }
+  set seconds($fixnum.Int64 v) {
+    $_setInt64(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSeconds() => $_has(0);
   @$pb.TagNumber(1)
@@ -139,13 +151,16 @@ class Duration extends $pb.GeneratedMessage with $mixin.DurationMixin {
   @$pb.TagNumber(2)
   $core.int get nanos => $_getIZ(1);
   @$pb.TagNumber(2)
-  set nanos($core.int v) { $_setSignedInt32(1, v); }
+  set nanos($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasNanos() => $_has(1);
   @$pb.TagNumber(2)
   void clearNanos() => clearField(2);
 }
 
-
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');
+const _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/duration.pbenum.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/duration.pbenum.dart
@@ -8,4 +8,3 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/duration.pbenum.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/duration.pbenum.dart
@@ -1,6 +1,6 @@
 //
 //  Generated code. Do not modify.
-//  source: graphql_error.proto
+//  source: google/protobuf/duration.proto
 //
 // @dart = 2.12
 

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/duration.pbjson.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/duration.pbjson.dart
@@ -1,0 +1,29 @@
+//
+//  Generated code. Do not modify.
+//  source: google/protobuf/duration.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use durationDescriptor instead')
+const Duration$json = {
+  '1': 'Duration',
+  '2': [
+    {'1': 'seconds', '3': 1, '4': 1, '5': 3, '10': 'seconds'},
+    {'1': 'nanos', '3': 2, '4': 1, '5': 5, '10': 'nanos'},
+  ],
+};
+
+/// Descriptor for `Duration`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List durationDescriptor = $convert.base64Decode(
+    'CghEdXJhdGlvbhIYCgdzZWNvbmRzGAEgASgDUgdzZWNvbmRzEhQKBW5hbm9zGAIgASgFUgVuYW'
+    '5vcw==');
+

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/duration.pbjson.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/duration.pbjson.dart
@@ -26,4 +26,3 @@ const Duration$json = {
 final $typed_data.Uint8List durationDescriptor = $convert.base64Decode(
     'CghEdXJhdGlvbhIYCgdzZWNvbmRzGAEgASgDUgdzZWNvbmRzEhQKBW5hbm9zGAIgASgFUgVuYW'
     '5vcw==');
-

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/struct.pb.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/struct.pb.dart
@@ -37,24 +37,38 @@ class Struct extends $pb.GeneratedMessage with $mixin.StructMixin {
     return $result;
   }
   Struct._() : super();
-  factory Struct.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Struct.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory Struct.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Struct.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Struct', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.StructMixin.toProto3JsonHelper, fromProto3Json: $mixin.StructMixin.fromProto3JsonHelper)
-    ..m<$core.String, Value>(1, _omitFieldNames ? '' : 'fields', entryClassName: 'Struct.FieldsEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OM, valueCreator: Value.create, valueDefaultOrMaker: Value.getDefault, packageName: const $pb.PackageName('google.protobuf'))
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Struct',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      toProto3Json: $mixin.StructMixin.toProto3JsonHelper,
+      fromProto3Json: $mixin.StructMixin.fromProto3JsonHelper)
+    ..m<$core.String, Value>(1, _omitFieldNames ? '' : 'fields',
+        entryClassName: 'Struct.FieldsEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OM,
+        valueCreator: Value.create,
+        valueDefaultOrMaker: Value.getDefault,
+        packageName: const $pb.PackageName('google.protobuf'))
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Struct clone() => Struct()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Struct copyWith(void Function(Struct) updates) => super.copyWith((message) => updates(message as Struct)) as Struct;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Struct copyWith(void Function(Struct) updates) =>
+      super.copyWith((message) => updates(message as Struct)) as Struct;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -63,7 +77,8 @@ class Struct extends $pb.GeneratedMessage with $mixin.StructMixin {
   Struct createEmptyInstance() => create();
   static $pb.PbList<Struct> createRepeated() => $pb.PbList<Struct>();
   @$core.pragma('dart2js:noInline')
-  static Struct getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Struct>(create);
+  static Struct getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Struct>(create);
   static Struct? _defaultInstance;
 
   /// Unordered map of dynamically typed values.
@@ -72,12 +87,12 @@ class Struct extends $pb.GeneratedMessage with $mixin.StructMixin {
 }
 
 enum Value_Kind {
-  nullValue, 
-  numberValue, 
-  stringValue, 
-  boolValue, 
-  structValue, 
-  listValue, 
+  nullValue,
+  numberValue,
+  stringValue,
+  boolValue,
+  structValue,
+  listValue,
   notSet
 }
 
@@ -118,39 +133,53 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
     return $result;
   }
   Value._() : super();
-  factory Value.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Value.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory Value.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Value.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
   static const $core.Map<$core.int, Value_Kind> _Value_KindByTag = {
-    1 : Value_Kind.nullValue,
-    2 : Value_Kind.numberValue,
-    3 : Value_Kind.stringValue,
-    4 : Value_Kind.boolValue,
-    5 : Value_Kind.structValue,
-    6 : Value_Kind.listValue,
-    0 : Value_Kind.notSet
+    1: Value_Kind.nullValue,
+    2: Value_Kind.numberValue,
+    3: Value_Kind.stringValue,
+    4: Value_Kind.boolValue,
+    5: Value_Kind.structValue,
+    6: Value_Kind.listValue,
+    0: Value_Kind.notSet
   };
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Value', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.ValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.ValueMixin.fromProto3JsonHelper)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'Value',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      toProto3Json: $mixin.ValueMixin.toProto3JsonHelper,
+      fromProto3Json: $mixin.ValueMixin.fromProto3JsonHelper)
     ..oo(0, [1, 2, 3, 4, 5, 6])
-    ..e<NullValue>(1, _omitFieldNames ? '' : 'nullValue', $pb.PbFieldType.OE, defaultOrMaker: NullValue.NULL_VALUE, valueOf: NullValue.valueOf, enumValues: NullValue.values)
-    ..a<$core.double>(2, _omitFieldNames ? '' : 'numberValue', $pb.PbFieldType.OD)
+    ..e<NullValue>(1, _omitFieldNames ? '' : 'nullValue', $pb.PbFieldType.OE,
+        defaultOrMaker: NullValue.NULL_VALUE,
+        valueOf: NullValue.valueOf,
+        enumValues: NullValue.values)
+    ..a<$core.double>(
+        2, _omitFieldNames ? '' : 'numberValue', $pb.PbFieldType.OD)
     ..aOS(3, _omitFieldNames ? '' : 'stringValue')
     ..aOB(4, _omitFieldNames ? '' : 'boolValue')
-    ..aOM<Struct>(5, _omitFieldNames ? '' : 'structValue', subBuilder: Struct.create)
-    ..aOM<ListValue>(6, _omitFieldNames ? '' : 'listValue', subBuilder: ListValue.create)
-    ..hasRequiredFields = false
-  ;
+    ..aOM<Struct>(5, _omitFieldNames ? '' : 'structValue',
+        subBuilder: Struct.create)
+    ..aOM<ListValue>(6, _omitFieldNames ? '' : 'listValue',
+        subBuilder: ListValue.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Value clone() => Value()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Value copyWith(void Function(Value) updates) => super.copyWith((message) => updates(message as Value)) as Value;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Value copyWith(void Function(Value) updates) =>
+      super.copyWith((message) => updates(message as Value)) as Value;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -159,7 +188,8 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
   Value createEmptyInstance() => create();
   static $pb.PbList<Value> createRepeated() => $pb.PbList<Value>();
   @$core.pragma('dart2js:noInline')
-  static Value getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Value>(create);
+  static Value getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Value>(create);
   static Value? _defaultInstance;
 
   Value_Kind whichKind() => _Value_KindByTag[$_whichOneof(0)]!;
@@ -169,7 +199,10 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
   @$pb.TagNumber(1)
   NullValue get nullValue => $_getN(0);
   @$pb.TagNumber(1)
-  set nullValue(NullValue v) { setField(1, v); }
+  set nullValue(NullValue v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasNullValue() => $_has(0);
   @$pb.TagNumber(1)
@@ -179,7 +212,10 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
   @$pb.TagNumber(2)
   $core.double get numberValue => $_getN(1);
   @$pb.TagNumber(2)
-  set numberValue($core.double v) { $_setDouble(1, v); }
+  set numberValue($core.double v) {
+    $_setDouble(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasNumberValue() => $_has(1);
   @$pb.TagNumber(2)
@@ -189,7 +225,10 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
   @$pb.TagNumber(3)
   $core.String get stringValue => $_getSZ(2);
   @$pb.TagNumber(3)
-  set stringValue($core.String v) { $_setString(2, v); }
+  set stringValue($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasStringValue() => $_has(2);
   @$pb.TagNumber(3)
@@ -199,7 +238,10 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
   @$pb.TagNumber(4)
   $core.bool get boolValue => $_getBF(3);
   @$pb.TagNumber(4)
-  set boolValue($core.bool v) { $_setBool(3, v); }
+  set boolValue($core.bool v) {
+    $_setBool(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasBoolValue() => $_has(3);
   @$pb.TagNumber(4)
@@ -209,7 +251,10 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
   @$pb.TagNumber(5)
   Struct get structValue => $_getN(4);
   @$pb.TagNumber(5)
-  set structValue(Struct v) { setField(5, v); }
+  set structValue(Struct v) {
+    setField(5, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasStructValue() => $_has(4);
   @$pb.TagNumber(5)
@@ -221,7 +266,10 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
   @$pb.TagNumber(6)
   ListValue get listValue => $_getN(5);
   @$pb.TagNumber(6)
-  set listValue(ListValue v) { setField(6, v); }
+  set listValue(ListValue v) {
+    setField(6, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasListValue() => $_has(5);
   @$pb.TagNumber(6)
@@ -244,24 +292,33 @@ class ListValue extends $pb.GeneratedMessage with $mixin.ListValueMixin {
     return $result;
   }
   ListValue._() : super();
-  factory ListValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ListValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory ListValue.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ListValue.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.ListValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.ListValueMixin.fromProto3JsonHelper)
-    ..pc<Value>(1, _omitFieldNames ? '' : 'values', $pb.PbFieldType.PM, subBuilder: Value.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'ListValue',
+      package:
+          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
+      createEmptyInstance: create,
+      toProto3Json: $mixin.ListValueMixin.toProto3JsonHelper,
+      fromProto3Json: $mixin.ListValueMixin.fromProto3JsonHelper)
+    ..pc<Value>(1, _omitFieldNames ? '' : 'values', $pb.PbFieldType.PM,
+        subBuilder: Value.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ListValue clone() => ListValue()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ListValue copyWith(void Function(ListValue) updates) => super.copyWith((message) => updates(message as ListValue)) as ListValue;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ListValue copyWith(void Function(ListValue) updates) =>
+      super.copyWith((message) => updates(message as ListValue)) as ListValue;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -270,7 +327,8 @@ class ListValue extends $pb.GeneratedMessage with $mixin.ListValueMixin {
   ListValue createEmptyInstance() => create();
   static $pb.PbList<ListValue> createRepeated() => $pb.PbList<ListValue>();
   @$core.pragma('dart2js:noInline')
-  static ListValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListValue>(create);
+  static ListValue getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListValue>(create);
   static ListValue? _defaultInstance;
 
   /// Repeated field of dynamically typed values.
@@ -278,6 +336,6 @@ class ListValue extends $pb.GeneratedMessage with $mixin.ListValueMixin {
   $core.List<Value> get values => $_getList(0);
 }
 
-
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');
+const _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/struct.pb.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/struct.pb.dart
@@ -1,16 +1,3 @@
-// Copyright 2024 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 //
 //  Generated code. Do not modify.
 //  source: google/protobuf/struct.proto
@@ -50,38 +37,24 @@ class Struct extends $pb.GeneratedMessage with $mixin.StructMixin {
     return $result;
   }
   Struct._() : super();
-  factory Struct.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Struct.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory Struct.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Struct.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'Struct',
-      package:
-          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
-      createEmptyInstance: create,
-      toProto3Json: $mixin.StructMixin.toProto3JsonHelper,
-      fromProto3Json: $mixin.StructMixin.fromProto3JsonHelper)
-    ..m<$core.String, Value>(1, _omitFieldNames ? '' : 'fields',
-        entryClassName: 'Struct.FieldsEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.OM,
-        valueCreator: Value.create,
-        valueDefaultOrMaker: Value.getDefault,
-        packageName: const $pb.PackageName('google.protobuf'))
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Struct', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.StructMixin.toProto3JsonHelper, fromProto3Json: $mixin.StructMixin.fromProto3JsonHelper)
+    ..m<$core.String, Value>(1, _omitFieldNames ? '' : 'fields', entryClassName: 'Struct.FieldsEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OM, valueCreator: Value.create, valueDefaultOrMaker: Value.getDefault, packageName: const $pb.PackageName('google.protobuf'))
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   Struct clone() => Struct()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  Struct copyWith(void Function(Struct) updates) =>
-      super.copyWith((message) => updates(message as Struct)) as Struct;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Struct copyWith(void Function(Struct) updates) => super.copyWith((message) => updates(message as Struct)) as Struct;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -90,8 +63,7 @@ class Struct extends $pb.GeneratedMessage with $mixin.StructMixin {
   Struct createEmptyInstance() => create();
   static $pb.PbList<Struct> createRepeated() => $pb.PbList<Struct>();
   @$core.pragma('dart2js:noInline')
-  static Struct getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Struct>(create);
+  static Struct getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Struct>(create);
   static Struct? _defaultInstance;
 
   /// Unordered map of dynamically typed values.
@@ -100,12 +72,12 @@ class Struct extends $pb.GeneratedMessage with $mixin.StructMixin {
 }
 
 enum Value_Kind {
-  nullValue,
-  numberValue,
-  stringValue,
-  boolValue,
-  structValue,
-  listValue,
+  nullValue, 
+  numberValue, 
+  stringValue, 
+  boolValue, 
+  structValue, 
+  listValue, 
   notSet
 }
 
@@ -146,53 +118,39 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
     return $result;
   }
   Value._() : super();
-  factory Value.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Value.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory Value.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Value.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
   static const $core.Map<$core.int, Value_Kind> _Value_KindByTag = {
-    1: Value_Kind.nullValue,
-    2: Value_Kind.numberValue,
-    3: Value_Kind.stringValue,
-    4: Value_Kind.boolValue,
-    5: Value_Kind.structValue,
-    6: Value_Kind.listValue,
-    0: Value_Kind.notSet
+    1 : Value_Kind.nullValue,
+    2 : Value_Kind.numberValue,
+    3 : Value_Kind.stringValue,
+    4 : Value_Kind.boolValue,
+    5 : Value_Kind.structValue,
+    6 : Value_Kind.listValue,
+    0 : Value_Kind.notSet
   };
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'Value',
-      package:
-          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
-      createEmptyInstance: create,
-      toProto3Json: $mixin.ValueMixin.toProto3JsonHelper,
-      fromProto3Json: $mixin.ValueMixin.fromProto3JsonHelper)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Value', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.ValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.ValueMixin.fromProto3JsonHelper)
     ..oo(0, [1, 2, 3, 4, 5, 6])
-    ..e<NullValue>(1, _omitFieldNames ? '' : 'nullValue', $pb.PbFieldType.OE,
-        defaultOrMaker: NullValue.NULL_VALUE,
-        valueOf: NullValue.valueOf,
-        enumValues: NullValue.values)
-    ..a<$core.double>(
-        2, _omitFieldNames ? '' : 'numberValue', $pb.PbFieldType.OD)
+    ..e<NullValue>(1, _omitFieldNames ? '' : 'nullValue', $pb.PbFieldType.OE, defaultOrMaker: NullValue.NULL_VALUE, valueOf: NullValue.valueOf, enumValues: NullValue.values)
+    ..a<$core.double>(2, _omitFieldNames ? '' : 'numberValue', $pb.PbFieldType.OD)
     ..aOS(3, _omitFieldNames ? '' : 'stringValue')
     ..aOB(4, _omitFieldNames ? '' : 'boolValue')
-    ..aOM<Struct>(5, _omitFieldNames ? '' : 'structValue',
-        subBuilder: Struct.create)
-    ..aOM<ListValue>(6, _omitFieldNames ? '' : 'listValue',
-        subBuilder: ListValue.create)
-    ..hasRequiredFields = false;
+    ..aOM<Struct>(5, _omitFieldNames ? '' : 'structValue', subBuilder: Struct.create)
+    ..aOM<ListValue>(6, _omitFieldNames ? '' : 'listValue', subBuilder: ListValue.create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   Value clone() => Value()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  Value copyWith(void Function(Value) updates) =>
-      super.copyWith((message) => updates(message as Value)) as Value;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Value copyWith(void Function(Value) updates) => super.copyWith((message) => updates(message as Value)) as Value;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -201,8 +159,7 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
   Value createEmptyInstance() => create();
   static $pb.PbList<Value> createRepeated() => $pb.PbList<Value>();
   @$core.pragma('dart2js:noInline')
-  static Value getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Value>(create);
+  static Value getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Value>(create);
   static Value? _defaultInstance;
 
   Value_Kind whichKind() => _Value_KindByTag[$_whichOneof(0)]!;
@@ -212,10 +169,7 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
   @$pb.TagNumber(1)
   NullValue get nullValue => $_getN(0);
   @$pb.TagNumber(1)
-  set nullValue(NullValue v) {
-    setField(1, v);
-  }
-
+  set nullValue(NullValue v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasNullValue() => $_has(0);
   @$pb.TagNumber(1)
@@ -225,10 +179,7 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
   @$pb.TagNumber(2)
   $core.double get numberValue => $_getN(1);
   @$pb.TagNumber(2)
-  set numberValue($core.double v) {
-    $_setDouble(1, v);
-  }
-
+  set numberValue($core.double v) { $_setDouble(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasNumberValue() => $_has(1);
   @$pb.TagNumber(2)
@@ -238,10 +189,7 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
   @$pb.TagNumber(3)
   $core.String get stringValue => $_getSZ(2);
   @$pb.TagNumber(3)
-  set stringValue($core.String v) {
-    $_setString(2, v);
-  }
-
+  set stringValue($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasStringValue() => $_has(2);
   @$pb.TagNumber(3)
@@ -251,10 +199,7 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
   @$pb.TagNumber(4)
   $core.bool get boolValue => $_getBF(3);
   @$pb.TagNumber(4)
-  set boolValue($core.bool v) {
-    $_setBool(3, v);
-  }
-
+  set boolValue($core.bool v) { $_setBool(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasBoolValue() => $_has(3);
   @$pb.TagNumber(4)
@@ -264,10 +209,7 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
   @$pb.TagNumber(5)
   Struct get structValue => $_getN(4);
   @$pb.TagNumber(5)
-  set structValue(Struct v) {
-    setField(5, v);
-  }
-
+  set structValue(Struct v) { setField(5, v); }
   @$pb.TagNumber(5)
   $core.bool hasStructValue() => $_has(4);
   @$pb.TagNumber(5)
@@ -279,10 +221,7 @@ class Value extends $pb.GeneratedMessage with $mixin.ValueMixin {
   @$pb.TagNumber(6)
   ListValue get listValue => $_getN(5);
   @$pb.TagNumber(6)
-  set listValue(ListValue v) {
-    setField(6, v);
-  }
-
+  set listValue(ListValue v) { setField(6, v); }
   @$pb.TagNumber(6)
   $core.bool hasListValue() => $_has(5);
   @$pb.TagNumber(6)
@@ -305,33 +244,24 @@ class ListValue extends $pb.GeneratedMessage with $mixin.ListValueMixin {
     return $result;
   }
   ListValue._() : super();
-  factory ListValue.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ListValue.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ListValue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ListValue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'ListValue',
-      package:
-          const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'),
-      createEmptyInstance: create,
-      toProto3Json: $mixin.ListValueMixin.toProto3JsonHelper,
-      fromProto3Json: $mixin.ListValueMixin.fromProto3JsonHelper)
-    ..pc<Value>(1, _omitFieldNames ? '' : 'values', $pb.PbFieldType.PM,
-        subBuilder: Value.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ListValue', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.protobuf'), createEmptyInstance: create, toProto3Json: $mixin.ListValueMixin.toProto3JsonHelper, fromProto3Json: $mixin.ListValueMixin.fromProto3JsonHelper)
+    ..pc<Value>(1, _omitFieldNames ? '' : 'values', $pb.PbFieldType.PM, subBuilder: Value.create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ListValue clone() => ListValue()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ListValue copyWith(void Function(ListValue) updates) =>
-      super.copyWith((message) => updates(message as ListValue)) as ListValue;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ListValue copyWith(void Function(ListValue) updates) => super.copyWith((message) => updates(message as ListValue)) as ListValue;
 
   $pb.BuilderInfo get info_ => _i;
 
@@ -340,8 +270,7 @@ class ListValue extends $pb.GeneratedMessage with $mixin.ListValueMixin {
   ListValue createEmptyInstance() => create();
   static $pb.PbList<ListValue> createRepeated() => $pb.PbList<ListValue>();
   @$core.pragma('dart2js:noInline')
-  static ListValue getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListValue>(create);
+  static ListValue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ListValue>(create);
   static ListValue? _defaultInstance;
 
   /// Repeated field of dynamically typed values.
@@ -349,6 +278,6 @@ class ListValue extends $pb.GeneratedMessage with $mixin.ListValueMixin {
   $core.List<Value> get values => $_getList(0);
 }
 
+
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames =
-    $core.bool.fromEnvironment('protobuf.omit_message_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/struct.pbenum.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/struct.pbenum.dart
@@ -1,16 +1,3 @@
-// Copyright 2024 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 //
 //  Generated code. Do not modify.
 //  source: google/protobuf/struct.proto
@@ -31,18 +18,17 @@ import 'package:protobuf/protobuf.dart' as $pb;
 ///
 ///  The JSON representation for `NullValue` is JSON `null`.
 class NullValue extends $pb.ProtobufEnum {
-  static const NullValue NULL_VALUE =
-      NullValue._(0, _omitEnumNames ? '' : 'NULL_VALUE');
+  static const NullValue NULL_VALUE = NullValue._(0, _omitEnumNames ? '' : 'NULL_VALUE');
 
-  static const $core.List<NullValue> values = <NullValue>[
+  static const $core.List<NullValue> values = <NullValue> [
     NULL_VALUE,
   ];
 
-  static final $core.Map<$core.int, NullValue> _byValue =
-      $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, NullValue> _byValue = $pb.ProtobufEnum.initByValue(values);
   static NullValue? valueOf($core.int value) => _byValue[value];
 
   const NullValue._($core.int v, $core.String n) : super(v, n);
 }
+
 
 const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/struct.pbenum.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/struct.pbenum.dart
@@ -18,17 +18,18 @@ import 'package:protobuf/protobuf.dart' as $pb;
 ///
 ///  The JSON representation for `NullValue` is JSON `null`.
 class NullValue extends $pb.ProtobufEnum {
-  static const NullValue NULL_VALUE = NullValue._(0, _omitEnumNames ? '' : 'NULL_VALUE');
+  static const NullValue NULL_VALUE =
+      NullValue._(0, _omitEnumNames ? '' : 'NULL_VALUE');
 
-  static const $core.List<NullValue> values = <NullValue> [
+  static const $core.List<NullValue> values = <NullValue>[
     NULL_VALUE,
   ];
 
-  static final $core.Map<$core.int, NullValue> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, NullValue> _byValue =
+      $pb.ProtobufEnum.initByValue(values);
   static NullValue? valueOf($core.int value) => _byValue[value];
 
   const NullValue._($core.int v, $core.String n) : super(v, n);
 }
-
 
 const _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/struct.pbjson.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/struct.pbjson.dart
@@ -22,14 +22,21 @@ const NullValue$json = {
 };
 
 /// Descriptor for `NullValue`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List nullValueDescriptor = $convert.base64Decode(
-    'CglOdWxsVmFsdWUSDgoKTlVMTF9WQUxVRRAA');
+final $typed_data.Uint8List nullValueDescriptor =
+    $convert.base64Decode('CglOdWxsVmFsdWUSDgoKTlVMTF9WQUxVRRAA');
 
 @$core.Deprecated('Use structDescriptor instead')
 const Struct$json = {
   '1': 'Struct',
   '2': [
-    {'1': 'fields', '3': 1, '4': 3, '5': 11, '6': '.google.protobuf.Struct.FieldsEntry', '10': 'fields'},
+    {
+      '1': 'fields',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.google.protobuf.Struct.FieldsEntry',
+      '10': 'fields'
+    },
   ],
   '3': [Struct_FieldsEntry$json],
 };
@@ -39,7 +46,14 @@ const Struct_FieldsEntry$json = {
   '1': 'FieldsEntry',
   '2': [
     {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.google.protobuf.Value', '10': 'value'},
+    {
+      '1': 'value',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Value',
+      '10': 'value'
+    },
   ],
   '7': {'7': true},
 };
@@ -54,12 +68,36 @@ final $typed_data.Uint8List structDescriptor = $convert.base64Decode(
 const Value$json = {
   '1': 'Value',
   '2': [
-    {'1': 'null_value', '3': 1, '4': 1, '5': 14, '6': '.google.protobuf.NullValue', '9': 0, '10': 'nullValue'},
+    {
+      '1': 'null_value',
+      '3': 1,
+      '4': 1,
+      '5': 14,
+      '6': '.google.protobuf.NullValue',
+      '9': 0,
+      '10': 'nullValue'
+    },
     {'1': 'number_value', '3': 2, '4': 1, '5': 1, '9': 0, '10': 'numberValue'},
     {'1': 'string_value', '3': 3, '4': 1, '5': 9, '9': 0, '10': 'stringValue'},
     {'1': 'bool_value', '3': 4, '4': 1, '5': 8, '9': 0, '10': 'boolValue'},
-    {'1': 'struct_value', '3': 5, '4': 1, '5': 11, '6': '.google.protobuf.Struct', '9': 0, '10': 'structValue'},
-    {'1': 'list_value', '3': 6, '4': 1, '5': 11, '6': '.google.protobuf.ListValue', '9': 0, '10': 'listValue'},
+    {
+      '1': 'struct_value',
+      '3': 5,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Struct',
+      '9': 0,
+      '10': 'structValue'
+    },
+    {
+      '1': 'list_value',
+      '3': 6,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.ListValue',
+      '9': 0,
+      '10': 'listValue'
+    },
   ],
   '8': [
     {'1': 'kind'},
@@ -79,7 +117,14 @@ final $typed_data.Uint8List valueDescriptor = $convert.base64Decode(
 const ListValue$json = {
   '1': 'ListValue',
   '2': [
-    {'1': 'values', '3': 1, '4': 3, '5': 11, '6': '.google.protobuf.Value', '10': 'values'},
+    {
+      '1': 'values',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.google.protobuf.Value',
+      '10': 'values'
+    },
   ],
 };
 
@@ -87,4 +132,3 @@ const ListValue$json = {
 final $typed_data.Uint8List listValueDescriptor = $convert.base64Decode(
     'CglMaXN0VmFsdWUSLgoGdmFsdWVzGAEgAygLMhYuZ29vZ2xlLnByb3RvYnVmLlZhbHVlUgZ2YW'
     'x1ZXM=');
-

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/struct.pbjson.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/google/protobuf/struct.pbjson.dart
@@ -1,16 +1,3 @@
-// Copyright 2024 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 //
 //  Generated code. Do not modify.
 //  source: google/protobuf/struct.proto
@@ -35,21 +22,14 @@ const NullValue$json = {
 };
 
 /// Descriptor for `NullValue`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List nullValueDescriptor =
-    $convert.base64Decode('CglOdWxsVmFsdWUSDgoKTlVMTF9WQUxVRRAA');
+final $typed_data.Uint8List nullValueDescriptor = $convert.base64Decode(
+    'CglOdWxsVmFsdWUSDgoKTlVMTF9WQUxVRRAA');
 
 @$core.Deprecated('Use structDescriptor instead')
 const Struct$json = {
   '1': 'Struct',
   '2': [
-    {
-      '1': 'fields',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.google.protobuf.Struct.FieldsEntry',
-      '10': 'fields'
-    },
+    {'1': 'fields', '3': 1, '4': 3, '5': 11, '6': '.google.protobuf.Struct.FieldsEntry', '10': 'fields'},
   ],
   '3': [Struct_FieldsEntry$json],
 };
@@ -59,14 +39,7 @@ const Struct_FieldsEntry$json = {
   '1': 'FieldsEntry',
   '2': [
     {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    {
-      '1': 'value',
-      '3': 2,
-      '4': 1,
-      '5': 11,
-      '6': '.google.protobuf.Value',
-      '10': 'value'
-    },
+    {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.google.protobuf.Value', '10': 'value'},
   ],
   '7': {'7': true},
 };
@@ -81,36 +54,12 @@ final $typed_data.Uint8List structDescriptor = $convert.base64Decode(
 const Value$json = {
   '1': 'Value',
   '2': [
-    {
-      '1': 'null_value',
-      '3': 1,
-      '4': 1,
-      '5': 14,
-      '6': '.google.protobuf.NullValue',
-      '9': 0,
-      '10': 'nullValue'
-    },
+    {'1': 'null_value', '3': 1, '4': 1, '5': 14, '6': '.google.protobuf.NullValue', '9': 0, '10': 'nullValue'},
     {'1': 'number_value', '3': 2, '4': 1, '5': 1, '9': 0, '10': 'numberValue'},
     {'1': 'string_value', '3': 3, '4': 1, '5': 9, '9': 0, '10': 'stringValue'},
     {'1': 'bool_value', '3': 4, '4': 1, '5': 8, '9': 0, '10': 'boolValue'},
-    {
-      '1': 'struct_value',
-      '3': 5,
-      '4': 1,
-      '5': 11,
-      '6': '.google.protobuf.Struct',
-      '9': 0,
-      '10': 'structValue'
-    },
-    {
-      '1': 'list_value',
-      '3': 6,
-      '4': 1,
-      '5': 11,
-      '6': '.google.protobuf.ListValue',
-      '9': 0,
-      '10': 'listValue'
-    },
+    {'1': 'struct_value', '3': 5, '4': 1, '5': 11, '6': '.google.protobuf.Struct', '9': 0, '10': 'structValue'},
+    {'1': 'list_value', '3': 6, '4': 1, '5': 11, '6': '.google.protobuf.ListValue', '9': 0, '10': 'listValue'},
   ],
   '8': [
     {'1': 'kind'},
@@ -130,14 +79,7 @@ final $typed_data.Uint8List valueDescriptor = $convert.base64Decode(
 const ListValue$json = {
   '1': 'ListValue',
   '2': [
-    {
-      '1': 'values',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.google.protobuf.Value',
-      '10': 'values'
-    },
+    {'1': 'values', '3': 1, '4': 3, '5': 11, '6': '.google.protobuf.Value', '10': 'values'},
   ],
 };
 
@@ -145,3 +87,4 @@ const ListValue$json = {
 final $typed_data.Uint8List listValueDescriptor = $convert.base64Decode(
     'CglMaXN0VmFsdWUSLgoGdmFsdWVzGAEgAygLMhYuZ29vZ2xlLnByb3RvYnVmLlZhbHVlUgZ2YW'
     'x1ZXM=');
+

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_error.pb.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_error.pb.dart
@@ -1,16 +1,3 @@
-// Copyright 2024 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 //
 //  Generated code. Do not modify.
 //  source: graphql_error.proto
@@ -62,49 +49,36 @@ class GraphqlError extends $pb.GeneratedMessage {
     return $result;
   }
   GraphqlError._() : super();
-  factory GraphqlError.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GraphqlError.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GraphqlError.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GraphqlError.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GraphqlError',
-      package: const $pb.PackageName(
-          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GraphqlError', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'message')
-    ..pc<SourceLocation>(
-        2, _omitFieldNames ? '' : 'locations', $pb.PbFieldType.PM,
-        subBuilder: SourceLocation.create)
-    ..aOM<$1.ListValue>(3, _omitFieldNames ? '' : 'path',
-        subBuilder: $1.ListValue.create)
-    ..aOM<GraphqlErrorExtensions>(4, _omitFieldNames ? '' : 'extensions',
-        subBuilder: GraphqlErrorExtensions.create)
-    ..hasRequiredFields = false;
+    ..pc<SourceLocation>(2, _omitFieldNames ? '' : 'locations', $pb.PbFieldType.PM, subBuilder: SourceLocation.create)
+    ..aOM<$1.ListValue>(3, _omitFieldNames ? '' : 'path', subBuilder: $1.ListValue.create)
+    ..aOM<GraphqlErrorExtensions>(4, _omitFieldNames ? '' : 'extensions', subBuilder: GraphqlErrorExtensions.create)
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GraphqlError clone() => GraphqlError()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GraphqlError copyWith(void Function(GraphqlError) updates) =>
-      super.copyWith((message) => updates(message as GraphqlError))
-          as GraphqlError;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GraphqlError copyWith(void Function(GraphqlError) updates) => super.copyWith((message) => updates(message as GraphqlError)) as GraphqlError;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GraphqlError create() => GraphqlError._();
   GraphqlError createEmptyInstance() => create();
-  static $pb.PbList<GraphqlError> createRepeated() =>
-      $pb.PbList<GraphqlError>();
+  static $pb.PbList<GraphqlError> createRepeated() => $pb.PbList<GraphqlError>();
   @$core.pragma('dart2js:noInline')
-  static GraphqlError getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<GraphqlError>(create);
+  static GraphqlError getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GraphqlError>(create);
   static GraphqlError? _defaultInstance;
 
   /// The detailed error message.
@@ -113,10 +87,7 @@ class GraphqlError extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get message => $_getSZ(0);
   @$pb.TagNumber(1)
-  set message($core.String v) {
-    $_setString(0, v);
-  }
-
+  set message($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMessage() => $_has(0);
   @$pb.TagNumber(1)
@@ -144,10 +115,7 @@ class GraphqlError extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $1.ListValue get path => $_getN(2);
   @$pb.TagNumber(3)
-  set path($1.ListValue v) {
-    setField(3, v);
-  }
-
+  set path($1.ListValue v) { setField(3, v); }
   @$pb.TagNumber(3)
   $core.bool hasPath() => $_has(2);
   @$pb.TagNumber(3)
@@ -159,10 +127,7 @@ class GraphqlError extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   GraphqlErrorExtensions get extensions => $_getN(3);
   @$pb.TagNumber(4)
-  set extensions(GraphqlErrorExtensions v) {
-    setField(4, v);
-  }
-
+  set extensions(GraphqlErrorExtensions v) { setField(4, v); }
   @$pb.TagNumber(4)
   $core.bool hasExtensions() => $_has(3);
   @$pb.TagNumber(4)
@@ -187,53 +152,41 @@ class SourceLocation extends $pb.GeneratedMessage {
     return $result;
   }
   SourceLocation._() : super();
-  factory SourceLocation.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SourceLocation.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SourceLocation.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SourceLocation.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'SourceLocation',
-      package: const $pb.PackageName(
-          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SourceLocation', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'line', $pb.PbFieldType.O3)
     ..a<$core.int>(2, _omitFieldNames ? '' : 'column', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SourceLocation clone() => SourceLocation()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  SourceLocation copyWith(void Function(SourceLocation) updates) =>
-      super.copyWith((message) => updates(message as SourceLocation))
-          as SourceLocation;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SourceLocation copyWith(void Function(SourceLocation) updates) => super.copyWith((message) => updates(message as SourceLocation)) as SourceLocation;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static SourceLocation create() => SourceLocation._();
   SourceLocation createEmptyInstance() => create();
-  static $pb.PbList<SourceLocation> createRepeated() =>
-      $pb.PbList<SourceLocation>();
+  static $pb.PbList<SourceLocation> createRepeated() => $pb.PbList<SourceLocation>();
   @$core.pragma('dart2js:noInline')
-  static SourceLocation getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<SourceLocation>(create);
+  static SourceLocation getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SourceLocation>(create);
   static SourceLocation? _defaultInstance;
 
   /// Line number starting at 1.
   @$pb.TagNumber(1)
   $core.int get line => $_getIZ(0);
   @$pb.TagNumber(1)
-  set line($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set line($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasLine() => $_has(0);
   @$pb.TagNumber(1)
@@ -243,10 +196,7 @@ class SourceLocation extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get column => $_getIZ(1);
   @$pb.TagNumber(2)
-  set column($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set column($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasColumn() => $_has(1);
   @$pb.TagNumber(2)
@@ -267,44 +217,33 @@ class GraphqlErrorExtensions extends $pb.GeneratedMessage {
     return $result;
   }
   GraphqlErrorExtensions._() : super();
-  factory GraphqlErrorExtensions.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GraphqlErrorExtensions.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory GraphqlErrorExtensions.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GraphqlErrorExtensions.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      _omitMessageNames ? '' : 'GraphqlErrorExtensions',
-      package: const $pb.PackageName(
-          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GraphqlErrorExtensions', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'file')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  GraphqlErrorExtensions clone() =>
-      GraphqlErrorExtensions()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GraphqlErrorExtensions copyWith(
-          void Function(GraphqlErrorExtensions) updates) =>
-      super.copyWith((message) => updates(message as GraphqlErrorExtensions))
-          as GraphqlErrorExtensions;
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GraphqlErrorExtensions clone() => GraphqlErrorExtensions()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GraphqlErrorExtensions copyWith(void Function(GraphqlErrorExtensions) updates) => super.copyWith((message) => updates(message as GraphqlErrorExtensions)) as GraphqlErrorExtensions;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GraphqlErrorExtensions create() => GraphqlErrorExtensions._();
   GraphqlErrorExtensions createEmptyInstance() => create();
-  static $pb.PbList<GraphqlErrorExtensions> createRepeated() =>
-      $pb.PbList<GraphqlErrorExtensions>();
+  static $pb.PbList<GraphqlErrorExtensions> createRepeated() => $pb.PbList<GraphqlErrorExtensions>();
   @$core.pragma('dart2js:noInline')
-  static GraphqlErrorExtensions getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<GraphqlErrorExtensions>(create);
+  static GraphqlErrorExtensions getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GraphqlErrorExtensions>(create);
   static GraphqlErrorExtensions? _defaultInstance;
 
   /// The source file name where the error occurred.
@@ -313,16 +252,13 @@ class GraphqlErrorExtensions extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get file => $_getSZ(0);
   @$pb.TagNumber(1)
-  set file($core.String v) {
-    $_setString(0, v);
-  }
-
+  set file($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasFile() => $_has(0);
   @$pb.TagNumber(1)
   void clearFile() => clearField(1);
 }
 
+
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames =
-    $core.bool.fromEnvironment('protobuf.omit_message_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_error.pb.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_error.pb.dart
@@ -49,36 +49,49 @@ class GraphqlError extends $pb.GeneratedMessage {
     return $result;
   }
   GraphqlError._() : super();
-  factory GraphqlError.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GraphqlError.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GraphqlError.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GraphqlError.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GraphqlError', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'GraphqlError',
+      package: const $pb.PackageName(
+          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'message')
-    ..pc<SourceLocation>(2, _omitFieldNames ? '' : 'locations', $pb.PbFieldType.PM, subBuilder: SourceLocation.create)
-    ..aOM<$1.ListValue>(3, _omitFieldNames ? '' : 'path', subBuilder: $1.ListValue.create)
-    ..aOM<GraphqlErrorExtensions>(4, _omitFieldNames ? '' : 'extensions', subBuilder: GraphqlErrorExtensions.create)
-    ..hasRequiredFields = false
-  ;
+    ..pc<SourceLocation>(
+        2, _omitFieldNames ? '' : 'locations', $pb.PbFieldType.PM,
+        subBuilder: SourceLocation.create)
+    ..aOM<$1.ListValue>(3, _omitFieldNames ? '' : 'path',
+        subBuilder: $1.ListValue.create)
+    ..aOM<GraphqlErrorExtensions>(4, _omitFieldNames ? '' : 'extensions',
+        subBuilder: GraphqlErrorExtensions.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GraphqlError clone() => GraphqlError()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GraphqlError copyWith(void Function(GraphqlError) updates) => super.copyWith((message) => updates(message as GraphqlError)) as GraphqlError;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GraphqlError copyWith(void Function(GraphqlError) updates) =>
+      super.copyWith((message) => updates(message as GraphqlError))
+          as GraphqlError;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GraphqlError create() => GraphqlError._();
   GraphqlError createEmptyInstance() => create();
-  static $pb.PbList<GraphqlError> createRepeated() => $pb.PbList<GraphqlError>();
+  static $pb.PbList<GraphqlError> createRepeated() =>
+      $pb.PbList<GraphqlError>();
   @$core.pragma('dart2js:noInline')
-  static GraphqlError getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GraphqlError>(create);
+  static GraphqlError getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GraphqlError>(create);
   static GraphqlError? _defaultInstance;
 
   /// The detailed error message.
@@ -87,7 +100,10 @@ class GraphqlError extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get message => $_getSZ(0);
   @$pb.TagNumber(1)
-  set message($core.String v) { $_setString(0, v); }
+  set message($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasMessage() => $_has(0);
   @$pb.TagNumber(1)
@@ -115,7 +131,10 @@ class GraphqlError extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $1.ListValue get path => $_getN(2);
   @$pb.TagNumber(3)
-  set path($1.ListValue v) { setField(3, v); }
+  set path($1.ListValue v) {
+    setField(3, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasPath() => $_has(2);
   @$pb.TagNumber(3)
@@ -127,7 +146,10 @@ class GraphqlError extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   GraphqlErrorExtensions get extensions => $_getN(3);
   @$pb.TagNumber(4)
-  set extensions(GraphqlErrorExtensions v) { setField(4, v); }
+  set extensions(GraphqlErrorExtensions v) {
+    setField(4, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasExtensions() => $_has(3);
   @$pb.TagNumber(4)
@@ -152,41 +174,53 @@ class SourceLocation extends $pb.GeneratedMessage {
     return $result;
   }
   SourceLocation._() : super();
-  factory SourceLocation.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SourceLocation.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory SourceLocation.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SourceLocation.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SourceLocation', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'SourceLocation',
+      package: const $pb.PackageName(
+          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
+      createEmptyInstance: create)
     ..a<$core.int>(1, _omitFieldNames ? '' : 'line', $pb.PbFieldType.O3)
     ..a<$core.int>(2, _omitFieldNames ? '' : 'column', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SourceLocation clone() => SourceLocation()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SourceLocation copyWith(void Function(SourceLocation) updates) => super.copyWith((message) => updates(message as SourceLocation)) as SourceLocation;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SourceLocation copyWith(void Function(SourceLocation) updates) =>
+      super.copyWith((message) => updates(message as SourceLocation))
+          as SourceLocation;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static SourceLocation create() => SourceLocation._();
   SourceLocation createEmptyInstance() => create();
-  static $pb.PbList<SourceLocation> createRepeated() => $pb.PbList<SourceLocation>();
+  static $pb.PbList<SourceLocation> createRepeated() =>
+      $pb.PbList<SourceLocation>();
   @$core.pragma('dart2js:noInline')
-  static SourceLocation getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SourceLocation>(create);
+  static SourceLocation getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<SourceLocation>(create);
   static SourceLocation? _defaultInstance;
 
   /// Line number starting at 1.
   @$pb.TagNumber(1)
   $core.int get line => $_getIZ(0);
   @$pb.TagNumber(1)
-  set line($core.int v) { $_setSignedInt32(0, v); }
+  set line($core.int v) {
+    $_setSignedInt32(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasLine() => $_has(0);
   @$pb.TagNumber(1)
@@ -196,7 +230,10 @@ class SourceLocation extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get column => $_getIZ(1);
   @$pb.TagNumber(2)
-  set column($core.int v) { $_setSignedInt32(1, v); }
+  set column($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasColumn() => $_has(1);
   @$pb.TagNumber(2)
@@ -217,33 +254,44 @@ class GraphqlErrorExtensions extends $pb.GeneratedMessage {
     return $result;
   }
   GraphqlErrorExtensions._() : super();
-  factory GraphqlErrorExtensions.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GraphqlErrorExtensions.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GraphqlErrorExtensions.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GraphqlErrorExtensions.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GraphqlErrorExtensions', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'GraphqlErrorExtensions',
+      package: const $pb.PackageName(
+          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
+      createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'file')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  GraphqlErrorExtensions clone() => GraphqlErrorExtensions()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GraphqlErrorExtensions copyWith(void Function(GraphqlErrorExtensions) updates) => super.copyWith((message) => updates(message as GraphqlErrorExtensions)) as GraphqlErrorExtensions;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GraphqlErrorExtensions clone() =>
+      GraphqlErrorExtensions()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GraphqlErrorExtensions copyWith(
+          void Function(GraphqlErrorExtensions) updates) =>
+      super.copyWith((message) => updates(message as GraphqlErrorExtensions))
+          as GraphqlErrorExtensions;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GraphqlErrorExtensions create() => GraphqlErrorExtensions._();
   GraphqlErrorExtensions createEmptyInstance() => create();
-  static $pb.PbList<GraphqlErrorExtensions> createRepeated() => $pb.PbList<GraphqlErrorExtensions>();
+  static $pb.PbList<GraphqlErrorExtensions> createRepeated() =>
+      $pb.PbList<GraphqlErrorExtensions>();
   @$core.pragma('dart2js:noInline')
-  static GraphqlErrorExtensions getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GraphqlErrorExtensions>(create);
+  static GraphqlErrorExtensions getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GraphqlErrorExtensions>(create);
   static GraphqlErrorExtensions? _defaultInstance;
 
   /// The source file name where the error occurred.
@@ -252,13 +300,16 @@ class GraphqlErrorExtensions extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get file => $_getSZ(0);
   @$pb.TagNumber(1)
-  set file($core.String v) { $_setString(0, v); }
+  set file($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasFile() => $_has(0);
   @$pb.TagNumber(1)
   void clearFile() => clearField(1);
 }
 
-
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');
+const _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_error.pbenum.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_error.pbenum.dart
@@ -8,4 +8,3 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_error.pbjson.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_error.pbjson.dart
@@ -18,9 +18,30 @@ const GraphqlError$json = {
   '1': 'GraphqlError',
   '2': [
     {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
-    {'1': 'locations', '3': 2, '4': 3, '5': 11, '6': '.google.firebase.dataconnect.v1.SourceLocation', '10': 'locations'},
-    {'1': 'path', '3': 3, '4': 1, '5': 11, '6': '.google.protobuf.ListValue', '10': 'path'},
-    {'1': 'extensions', '3': 4, '4': 1, '5': 11, '6': '.google.firebase.dataconnect.v1.GraphqlErrorExtensions', '10': 'extensions'},
+    {
+      '1': 'locations',
+      '3': 2,
+      '4': 3,
+      '5': 11,
+      '6': '.google.firebase.dataconnect.v1.SourceLocation',
+      '10': 'locations'
+    },
+    {
+      '1': 'path',
+      '3': 3,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.ListValue',
+      '10': 'path'
+    },
+    {
+      '1': 'extensions',
+      '3': 4,
+      '4': 1,
+      '5': 11,
+      '6': '.google.firebase.dataconnect.v1.GraphqlErrorExtensions',
+      '10': 'extensions'
+    },
   ],
 };
 
@@ -55,6 +76,6 @@ const GraphqlErrorExtensions$json = {
 };
 
 /// Descriptor for `GraphqlErrorExtensions`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List graphqlErrorExtensionsDescriptor = $convert.base64Decode(
-    'ChZHcmFwaHFsRXJyb3JFeHRlbnNpb25zEhIKBGZpbGUYASABKAlSBGZpbGU=');
-
+final $typed_data.Uint8List graphqlErrorExtensionsDescriptor =
+    $convert.base64Decode(
+        'ChZHcmFwaHFsRXJyb3JFeHRlbnNpb25zEhIKBGZpbGUYASABKAlSBGZpbGU=');

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_error.pbjson.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_error.pbjson.dart
@@ -1,16 +1,3 @@
-// Copyright 2024 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 //
 //  Generated code. Do not modify.
 //  source: graphql_error.proto
@@ -31,30 +18,9 @@ const GraphqlError$json = {
   '1': 'GraphqlError',
   '2': [
     {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
-    {
-      '1': 'locations',
-      '3': 2,
-      '4': 3,
-      '5': 11,
-      '6': '.google.firebase.dataconnect.v1.SourceLocation',
-      '10': 'locations'
-    },
-    {
-      '1': 'path',
-      '3': 3,
-      '4': 1,
-      '5': 11,
-      '6': '.google.protobuf.ListValue',
-      '10': 'path'
-    },
-    {
-      '1': 'extensions',
-      '3': 4,
-      '4': 1,
-      '5': 11,
-      '6': '.google.firebase.dataconnect.v1.GraphqlErrorExtensions',
-      '10': 'extensions'
-    },
+    {'1': 'locations', '3': 2, '4': 3, '5': 11, '6': '.google.firebase.dataconnect.v1.SourceLocation', '10': 'locations'},
+    {'1': 'path', '3': 3, '4': 1, '5': 11, '6': '.google.protobuf.ListValue', '10': 'path'},
+    {'1': 'extensions', '3': 4, '4': 1, '5': 11, '6': '.google.firebase.dataconnect.v1.GraphqlErrorExtensions', '10': 'extensions'},
   ],
 };
 
@@ -89,6 +55,6 @@ const GraphqlErrorExtensions$json = {
 };
 
 /// Descriptor for `GraphqlErrorExtensions`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List graphqlErrorExtensionsDescriptor =
-    $convert.base64Decode(
-        'ChZHcmFwaHFsRXJyb3JFeHRlbnNpb25zEhIKBGZpbGUYASABKAlSBGZpbGU=');
+final $typed_data.Uint8List graphqlErrorExtensionsDescriptor = $convert.base64Decode(
+    'ChZHcmFwaHFsRXJyb3JFeHRlbnNpb25zEhIKBGZpbGUYASABKAlSBGZpbGU=');
+

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_response_extensions.pb.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_response_extensions.pb.dart
@@ -18,7 +18,8 @@ import 'google/protobuf/struct.pb.dart' as $1;
 
 /// Data Connect specific properties for a path under response.data.
 /// (-- Design doc: http://go/fdc-caching-wire-protocol --)
-class GraphqlResponseExtensions_DataConnectProperties extends $pb.GeneratedMessage {
+class GraphqlResponseExtensions_DataConnectProperties
+    extends $pb.GeneratedMessage {
   factory GraphqlResponseExtensions_DataConnectProperties({
     $1.ListValue? path,
     $core.String? entityId,
@@ -41,36 +42,59 @@ class GraphqlResponseExtensions_DataConnectProperties extends $pb.GeneratedMessa
     return $result;
   }
   GraphqlResponseExtensions_DataConnectProperties._() : super();
-  factory GraphqlResponseExtensions_DataConnectProperties.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GraphqlResponseExtensions_DataConnectProperties.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GraphqlResponseExtensions_DataConnectProperties.fromBuffer(
+          $core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GraphqlResponseExtensions_DataConnectProperties.fromJson(
+          $core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GraphqlResponseExtensions.DataConnectProperties', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
-    ..aOM<$1.ListValue>(1, _omitFieldNames ? '' : 'path', subBuilder: $1.ListValue.create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames
+          ? ''
+          : 'GraphqlResponseExtensions.DataConnectProperties',
+      package: const $pb.PackageName(
+          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
+      createEmptyInstance: create)
+    ..aOM<$1.ListValue>(1, _omitFieldNames ? '' : 'path',
+        subBuilder: $1.ListValue.create)
     ..aOS(2, _omitFieldNames ? '' : 'entityId')
     ..pPS(3, _omitFieldNames ? '' : 'entityIds')
-    ..aOM<$2.Duration>(4, _omitFieldNames ? '' : 'maxAge', subBuilder: $2.Duration.create)
-    ..hasRequiredFields = false
-  ;
+    ..aOM<$2.Duration>(4, _omitFieldNames ? '' : 'maxAge',
+        subBuilder: $2.Duration.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  GraphqlResponseExtensions_DataConnectProperties clone() => GraphqlResponseExtensions_DataConnectProperties()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GraphqlResponseExtensions_DataConnectProperties copyWith(void Function(GraphqlResponseExtensions_DataConnectProperties) updates) => super.copyWith((message) => updates(message as GraphqlResponseExtensions_DataConnectProperties)) as GraphqlResponseExtensions_DataConnectProperties;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GraphqlResponseExtensions_DataConnectProperties clone() =>
+      GraphqlResponseExtensions_DataConnectProperties()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GraphqlResponseExtensions_DataConnectProperties copyWith(
+          void Function(GraphqlResponseExtensions_DataConnectProperties)
+              updates) =>
+      super.copyWith((message) => updates(
+              message as GraphqlResponseExtensions_DataConnectProperties))
+          as GraphqlResponseExtensions_DataConnectProperties;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
-  static GraphqlResponseExtensions_DataConnectProperties create() => GraphqlResponseExtensions_DataConnectProperties._();
-  GraphqlResponseExtensions_DataConnectProperties createEmptyInstance() => create();
-  static $pb.PbList<GraphqlResponseExtensions_DataConnectProperties> createRepeated() => $pb.PbList<GraphqlResponseExtensions_DataConnectProperties>();
+  static GraphqlResponseExtensions_DataConnectProperties create() =>
+      GraphqlResponseExtensions_DataConnectProperties._();
+  GraphqlResponseExtensions_DataConnectProperties createEmptyInstance() =>
+      create();
+  static $pb.PbList<GraphqlResponseExtensions_DataConnectProperties>
+      createRepeated() =>
+          $pb.PbList<GraphqlResponseExtensions_DataConnectProperties>();
   @$core.pragma('dart2js:noInline')
-  static GraphqlResponseExtensions_DataConnectProperties getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GraphqlResponseExtensions_DataConnectProperties>(create);
+  static GraphqlResponseExtensions_DataConnectProperties getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
+          GraphqlResponseExtensions_DataConnectProperties>(create);
   static GraphqlResponseExtensions_DataConnectProperties? _defaultInstance;
 
   /// The path under response.data where the rest of the fields apply.
@@ -81,7 +105,10 @@ class GraphqlResponseExtensions_DataConnectProperties extends $pb.GeneratedMessa
   @$pb.TagNumber(1)
   $1.ListValue get path => $_getN(0);
   @$pb.TagNumber(1)
-  set path($1.ListValue v) { setField(1, v); }
+  set path($1.ListValue v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasPath() => $_has(0);
   @$pb.TagNumber(1)
@@ -93,7 +120,10 @@ class GraphqlResponseExtensions_DataConnectProperties extends $pb.GeneratedMessa
   @$pb.TagNumber(2)
   $core.String get entityId => $_getSZ(1);
   @$pb.TagNumber(2)
-  set entityId($core.String v) { $_setString(1, v); }
+  set entityId($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasEntityId() => $_has(1);
   @$pb.TagNumber(2)
@@ -110,7 +140,10 @@ class GraphqlResponseExtensions_DataConnectProperties extends $pb.GeneratedMessa
   @$pb.TagNumber(4)
   $2.Duration get maxAge => $_getN(3);
   @$pb.TagNumber(4)
-  set maxAge($2.Duration v) { setField(4, v); }
+  set maxAge($2.Duration v) {
+    setField(4, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasMaxAge() => $_has(3);
   @$pb.TagNumber(4)
@@ -123,7 +156,8 @@ class GraphqlResponseExtensions_DataConnectProperties extends $pb.GeneratedMessa
 /// `GraphqlResponse` or `ExecuteQueryResponse`.
 class GraphqlResponseExtensions extends $pb.GeneratedMessage {
   factory GraphqlResponseExtensions({
-    $core.Iterable<GraphqlResponseExtensions_DataConnectProperties>? dataConnect,
+    $core.Iterable<GraphqlResponseExtensions_DataConnectProperties>?
+        dataConnect,
   }) {
     final $result = create();
     if (dataConnect != null) {
@@ -132,33 +166,46 @@ class GraphqlResponseExtensions extends $pb.GeneratedMessage {
     return $result;
   }
   GraphqlResponseExtensions._() : super();
-  factory GraphqlResponseExtensions.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GraphqlResponseExtensions.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory GraphqlResponseExtensions.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GraphqlResponseExtensions.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
 
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GraphqlResponseExtensions', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
-    ..pc<GraphqlResponseExtensions_DataConnectProperties>(1, _omitFieldNames ? '' : 'dataConnect', $pb.PbFieldType.PM, subBuilder: GraphqlResponseExtensions_DataConnectProperties.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'GraphqlResponseExtensions',
+      package: const $pb.PackageName(
+          _omitMessageNames ? '' : 'google.firebase.dataconnect.v1'),
+      createEmptyInstance: create)
+    ..pc<GraphqlResponseExtensions_DataConnectProperties>(
+        1, _omitFieldNames ? '' : 'dataConnect', $pb.PbFieldType.PM,
+        subBuilder: GraphqlResponseExtensions_DataConnectProperties.create)
+    ..hasRequiredFields = false;
 
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  GraphqlResponseExtensions clone() => GraphqlResponseExtensions()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GraphqlResponseExtensions copyWith(void Function(GraphqlResponseExtensions) updates) => super.copyWith((message) => updates(message as GraphqlResponseExtensions)) as GraphqlResponseExtensions;
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GraphqlResponseExtensions clone() =>
+      GraphqlResponseExtensions()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GraphqlResponseExtensions copyWith(
+          void Function(GraphqlResponseExtensions) updates) =>
+      super.copyWith((message) => updates(message as GraphqlResponseExtensions))
+          as GraphqlResponseExtensions;
 
   $pb.BuilderInfo get info_ => _i;
 
   @$core.pragma('dart2js:noInline')
   static GraphqlResponseExtensions create() => GraphqlResponseExtensions._();
   GraphqlResponseExtensions createEmptyInstance() => create();
-  static $pb.PbList<GraphqlResponseExtensions> createRepeated() => $pb.PbList<GraphqlResponseExtensions>();
+  static $pb.PbList<GraphqlResponseExtensions> createRepeated() =>
+      $pb.PbList<GraphqlResponseExtensions>();
   @$core.pragma('dart2js:noInline')
-  static GraphqlResponseExtensions getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GraphqlResponseExtensions>(create);
+  static GraphqlResponseExtensions getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GraphqlResponseExtensions>(create);
   static GraphqlResponseExtensions? _defaultInstance;
 
   /// Data Connect specific GraphQL extension, a list of paths and properties.
@@ -166,9 +213,10 @@ class GraphqlResponseExtensions extends $pb.GeneratedMessage {
   /// extensions in the wild unless we're implementing a common 3P pattern in
   /// extensions such as versioning and telemetry. --)
   @$pb.TagNumber(1)
-  $core.List<GraphqlResponseExtensions_DataConnectProperties> get dataConnect => $_getList(0);
+  $core.List<GraphqlResponseExtensions_DataConnectProperties> get dataConnect =>
+      $_getList(0);
 }
 
-
 const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
-const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');
+const _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_response_extensions.pb.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_response_extensions.pb.dart
@@ -1,0 +1,174 @@
+//
+//  Generated code. Do not modify.
+//  source: graphql_response_extensions.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'google/protobuf/duration.pb.dart' as $2;
+import 'google/protobuf/struct.pb.dart' as $1;
+
+/// Data Connect specific properties for a path under response.data.
+/// (-- Design doc: http://go/fdc-caching-wire-protocol --)
+class GraphqlResponseExtensions_DataConnectProperties extends $pb.GeneratedMessage {
+  factory GraphqlResponseExtensions_DataConnectProperties({
+    $1.ListValue? path,
+    $core.String? entityId,
+    $core.Iterable<$core.String>? entityIds,
+    $2.Duration? maxAge,
+  }) {
+    final $result = create();
+    if (path != null) {
+      $result.path = path;
+    }
+    if (entityId != null) {
+      $result.entityId = entityId;
+    }
+    if (entityIds != null) {
+      $result.entityIds.addAll(entityIds);
+    }
+    if (maxAge != null) {
+      $result.maxAge = maxAge;
+    }
+    return $result;
+  }
+  GraphqlResponseExtensions_DataConnectProperties._() : super();
+  factory GraphqlResponseExtensions_DataConnectProperties.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GraphqlResponseExtensions_DataConnectProperties.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GraphqlResponseExtensions.DataConnectProperties', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
+    ..aOM<$1.ListValue>(1, _omitFieldNames ? '' : 'path', subBuilder: $1.ListValue.create)
+    ..aOS(2, _omitFieldNames ? '' : 'entityId')
+    ..pPS(3, _omitFieldNames ? '' : 'entityIds')
+    ..aOM<$2.Duration>(4, _omitFieldNames ? '' : 'maxAge', subBuilder: $2.Duration.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GraphqlResponseExtensions_DataConnectProperties clone() => GraphqlResponseExtensions_DataConnectProperties()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GraphqlResponseExtensions_DataConnectProperties copyWith(void Function(GraphqlResponseExtensions_DataConnectProperties) updates) => super.copyWith((message) => updates(message as GraphqlResponseExtensions_DataConnectProperties)) as GraphqlResponseExtensions_DataConnectProperties;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GraphqlResponseExtensions_DataConnectProperties create() => GraphqlResponseExtensions_DataConnectProperties._();
+  GraphqlResponseExtensions_DataConnectProperties createEmptyInstance() => create();
+  static $pb.PbList<GraphqlResponseExtensions_DataConnectProperties> createRepeated() => $pb.PbList<GraphqlResponseExtensions_DataConnectProperties>();
+  @$core.pragma('dart2js:noInline')
+  static GraphqlResponseExtensions_DataConnectProperties getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GraphqlResponseExtensions_DataConnectProperties>(create);
+  static GraphqlResponseExtensions_DataConnectProperties? _defaultInstance;
+
+  /// The path under response.data where the rest of the fields apply.
+  /// Each element may be a string (field name) or number (array index).
+  /// The root of response.data is denoted by the empty list `[]`.
+  /// (-- To simplify client logic, the server should never set this to null.
+  /// i.e. Use `[]` if the properties below apply to everything in data. --)
+  @$pb.TagNumber(1)
+  $1.ListValue get path => $_getN(0);
+  @$pb.TagNumber(1)
+  set path($1.ListValue v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPath() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPath() => clearField(1);
+  @$pb.TagNumber(1)
+  $1.ListValue ensurePath() => $_ensure(0);
+
+  /// A single Entity ID. Set if the path points to a single entity.
+  @$pb.TagNumber(2)
+  $core.String get entityId => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set entityId($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasEntityId() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearEntityId() => clearField(2);
+
+  /// A list of Entity IDs. Set if the path points to an array of entities. An
+  /// ID is present for each element of the array at the corresponding index.
+  @$pb.TagNumber(3)
+  $core.List<$core.String> get entityIds => $_getList(2);
+
+  /// The server-suggested duration before data under path is considered stale.
+  /// (-- Right now, this field is never set. For future plans, see
+  /// http://go/fdc-sdk-caching-config#heading=h.rmvncy2rao3g --)
+  @$pb.TagNumber(4)
+  $2.Duration get maxAge => $_getN(3);
+  @$pb.TagNumber(4)
+  set maxAge($2.Duration v) { setField(4, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasMaxAge() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearMaxAge() => clearField(4);
+  @$pb.TagNumber(4)
+  $2.Duration ensureMaxAge() => $_ensure(3);
+}
+
+/// GraphqlResponseExtensions contains additional information of
+/// `GraphqlResponse` or `ExecuteQueryResponse`.
+class GraphqlResponseExtensions extends $pb.GeneratedMessage {
+  factory GraphqlResponseExtensions({
+    $core.Iterable<GraphqlResponseExtensions_DataConnectProperties>? dataConnect,
+  }) {
+    final $result = create();
+    if (dataConnect != null) {
+      $result.dataConnect.addAll(dataConnect);
+    }
+    return $result;
+  }
+  GraphqlResponseExtensions._() : super();
+  factory GraphqlResponseExtensions.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GraphqlResponseExtensions.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GraphqlResponseExtensions', package: const $pb.PackageName(_omitMessageNames ? '' : 'google.firebase.dataconnect.v1'), createEmptyInstance: create)
+    ..pc<GraphqlResponseExtensions_DataConnectProperties>(1, _omitFieldNames ? '' : 'dataConnect', $pb.PbFieldType.PM, subBuilder: GraphqlResponseExtensions_DataConnectProperties.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GraphqlResponseExtensions clone() => GraphqlResponseExtensions()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GraphqlResponseExtensions copyWith(void Function(GraphqlResponseExtensions) updates) => super.copyWith((message) => updates(message as GraphqlResponseExtensions)) as GraphqlResponseExtensions;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GraphqlResponseExtensions create() => GraphqlResponseExtensions._();
+  GraphqlResponseExtensions createEmptyInstance() => create();
+  static $pb.PbList<GraphqlResponseExtensions> createRepeated() => $pb.PbList<GraphqlResponseExtensions>();
+  @$core.pragma('dart2js:noInline')
+  static GraphqlResponseExtensions getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GraphqlResponseExtensions>(create);
+  static GraphqlResponseExtensions? _defaultInstance;
+
+  /// Data Connect specific GraphQL extension, a list of paths and properties.
+  /// (-- Future fields should go inside to avoid name conflicts with other GQL
+  /// extensions in the wild unless we're implementing a common 3P pattern in
+  /// extensions such as versioning and telemetry. --)
+  @$pb.TagNumber(1)
+  $core.List<GraphqlResponseExtensions_DataConnectProperties> get dataConnect => $_getList(0);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_response_extensions.pbenum.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_response_extensions.pbenum.dart
@@ -8,4 +8,3 @@
 // ignore_for_file: constant_identifier_names, library_prefixes
 // ignore_for_file: non_constant_identifier_names, prefer_final_fields
 // ignore_for_file: unnecessary_import, unnecessary_this, unused_import
-

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_response_extensions.pbenum.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_response_extensions.pbenum.dart
@@ -1,6 +1,6 @@
 //
 //  Generated code. Do not modify.
-//  source: graphql_error.proto
+//  source: graphql_response_extensions.proto
 //
 // @dart = 2.12
 

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_response_extensions.pbjson.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_response_extensions.pbjson.dart
@@ -1,0 +1,44 @@
+//
+//  Generated code. Do not modify.
+//  source: graphql_response_extensions.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use graphqlResponseExtensionsDescriptor instead')
+const GraphqlResponseExtensions$json = {
+  '1': 'GraphqlResponseExtensions',
+  '2': [
+    {'1': 'data_connect', '3': 1, '4': 3, '5': 11, '6': '.google.firebase.dataconnect.v1.GraphqlResponseExtensions.DataConnectProperties', '10': 'dataConnect'},
+  ],
+  '3': [GraphqlResponseExtensions_DataConnectProperties$json],
+};
+
+@$core.Deprecated('Use graphqlResponseExtensionsDescriptor instead')
+const GraphqlResponseExtensions_DataConnectProperties$json = {
+  '1': 'DataConnectProperties',
+  '2': [
+    {'1': 'path', '3': 1, '4': 1, '5': 11, '6': '.google.protobuf.ListValue', '10': 'path'},
+    {'1': 'entity_id', '3': 2, '4': 1, '5': 9, '10': 'entityId'},
+    {'1': 'entity_ids', '3': 3, '4': 3, '5': 9, '10': 'entityIds'},
+    {'1': 'max_age', '3': 4, '4': 1, '5': 11, '6': '.google.protobuf.Duration', '10': 'maxAge'},
+  ],
+};
+
+/// Descriptor for `GraphqlResponseExtensions`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List graphqlResponseExtensionsDescriptor = $convert.base64Decode(
+    'ChlHcmFwaHFsUmVzcG9uc2VFeHRlbnNpb25zEnIKDGRhdGFfY29ubmVjdBgBIAMoCzJPLmdvb2'
+    'dsZS5maXJlYmFzZS5kYXRhY29ubmVjdC52MS5HcmFwaHFsUmVzcG9uc2VFeHRlbnNpb25zLkRh'
+    'dGFDb25uZWN0UHJvcGVydGllc1ILZGF0YUNvbm5lY3QatwEKFURhdGFDb25uZWN0UHJvcGVydG'
+    'llcxIuCgRwYXRoGAEgASgLMhouZ29vZ2xlLnByb3RvYnVmLkxpc3RWYWx1ZVIEcGF0aBIbCgll'
+    'bnRpdHlfaWQYAiABKAlSCGVudGl0eUlkEh0KCmVudGl0eV9pZHMYAyADKAlSCWVudGl0eUlkcx'
+    'IyCgdtYXhfYWdlGAQgASgLMhkuZ29vZ2xlLnByb3RvYnVmLkR1cmF0aW9uUgZtYXhBZ2U=');
+

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_response_extensions.pbjson.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/generated/graphql_response_extensions.pbjson.dart
@@ -17,7 +17,15 @@ import 'dart:typed_data' as $typed_data;
 const GraphqlResponseExtensions$json = {
   '1': 'GraphqlResponseExtensions',
   '2': [
-    {'1': 'data_connect', '3': 1, '4': 3, '5': 11, '6': '.google.firebase.dataconnect.v1.GraphqlResponseExtensions.DataConnectProperties', '10': 'dataConnect'},
+    {
+      '1': 'data_connect',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6':
+          '.google.firebase.dataconnect.v1.GraphqlResponseExtensions.DataConnectProperties',
+      '10': 'dataConnect'
+    },
   ],
   '3': [GraphqlResponseExtensions_DataConnectProperties$json],
 };
@@ -26,10 +34,24 @@ const GraphqlResponseExtensions$json = {
 const GraphqlResponseExtensions_DataConnectProperties$json = {
   '1': 'DataConnectProperties',
   '2': [
-    {'1': 'path', '3': 1, '4': 1, '5': 11, '6': '.google.protobuf.ListValue', '10': 'path'},
+    {
+      '1': 'path',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.ListValue',
+      '10': 'path'
+    },
     {'1': 'entity_id', '3': 2, '4': 1, '5': 9, '10': 'entityId'},
     {'1': 'entity_ids', '3': 3, '4': 3, '5': 9, '10': 'entityIds'},
-    {'1': 'max_age', '3': 4, '4': 1, '5': 11, '6': '.google.protobuf.Duration', '10': 'maxAge'},
+    {
+      '1': 'max_age',
+      '3': 4,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Duration',
+      '10': 'maxAge'
+    },
   ],
 };
 
@@ -41,4 +63,3 @@ final $typed_data.Uint8List graphqlResponseExtensionsDescriptor = $convert.base6
     'llcxIuCgRwYXRoGAEgASgLMhouZ29vZ2xlLnByb3RvYnVmLkxpc3RWYWx1ZVIEcGF0aBIbCgll'
     'bnRpdHlfaWQYAiABKAlSCGVudGl0eUlkEh0KCmVudGl0eV9pZHMYAyADKAlSCWVudGl0eUlkcx'
     'IyCgdtYXhfYWdlGAQgASgLMhkuZ29vZ2xlLnByb3RvYnVmLkR1cmF0aW9uUgZtYXhBZ2U=');
-

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/grpc_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/grpc_transport.dart
@@ -173,7 +173,8 @@ ServerResponse handleResponse<Data>(CommonResponse<Data> commonResponse) {
   Map<String, dynamic>? jsond = commonResponse.data as Map<String, dynamic>?;
   String jsonEncoded = jsonEncode(commonResponse.data);
 
-  Map<String, dynamic> jsonExt = commonResponse.extensions as Map<String, dynamic>;
+  Map<String, dynamic> jsonExt =
+      commonResponse.extensions as Map<String, dynamic>;
 
   if (commonResponse.errors.isNotEmpty) {
     Map<String, dynamic>? data =
@@ -230,10 +231,8 @@ class CommonResponse<Data> {
 
   static CommonResponse<Data> fromExecuteQuery<Data>(
       Deserializer<Data> deserializer, ExecuteQueryResponse response) {
-        print("grpc data:\n ${response.data.toProto3Json()}");
-        print("grpc extensions:\n ${response.extensions?.toProto3Json() ?? "nil extension"}");
-    return CommonResponse(
-        deserializer, response.data.toProto3Json(), response.errors, response.extensions.toProto3Json());
+    return CommonResponse(deserializer, response.data.toProto3Json(),
+        response.errors, response.extensions.toProto3Json());
   }
 
   final Deserializer<Data> deserializer;

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/grpc_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/grpc_transport.dart
@@ -173,8 +173,8 @@ ServerResponse handleResponse<Data>(CommonResponse<Data> commonResponse) {
   Map<String, dynamic>? jsond = commonResponse.data as Map<String, dynamic>?;
   String jsonEncoded = jsonEncode(commonResponse.data);
 
-  Map<String, dynamic> jsonExt =
-      commonResponse.extensions as Map<String, dynamic>;
+  Map<String, dynamic>? jsonExt =
+      commonResponse.extensions as Map<String, dynamic>?;
 
   if (commonResponse.errors.isNotEmpty) {
     Map<String, dynamic>? data =

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/grpc_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/grpc_transport.dart
@@ -173,6 +173,8 @@ ServerResponse handleResponse<Data>(CommonResponse<Data> commonResponse) {
   Map<String, dynamic>? jsond = commonResponse.data as Map<String, dynamic>?;
   String jsonEncoded = jsonEncode(commonResponse.data);
 
+  Map<String, dynamic> jsonExt = commonResponse.extensions as Map<String, dynamic>;
+
   if (commonResponse.errors.isNotEmpty) {
     Map<String, dynamic>? data =
         jsonDecode(jsonEncoded) as Map<String, dynamic>?;
@@ -202,7 +204,7 @@ ServerResponse handleResponse<Data>(CommonResponse<Data> commonResponse) {
 
   // no errors - return a standard response
   if (jsond != null) {
-    return ServerResponse(jsond);
+    return ServerResponse(jsond, extensions: jsonExt);
   } else {
     return ServerResponse({});
   }
@@ -219,20 +221,23 @@ DataConnectTransport getTransport(
     GRPCTransport(transportOptions, options, appId, sdkType, appCheck);
 
 class CommonResponse<Data> {
-  CommonResponse(this.deserializer, this.data, this.errors);
+  CommonResponse(this.deserializer, this.data, this.errors, this.extensions);
   static CommonResponse<Data> fromExecuteMutation<Data>(
       Deserializer<Data> deserializer, ExecuteMutationResponse response) {
     return CommonResponse(
-        deserializer, response.data.toProto3Json(), response.errors);
+        deserializer, response.data.toProto3Json(), response.errors, null);
   }
 
   static CommonResponse<Data> fromExecuteQuery<Data>(
       Deserializer<Data> deserializer, ExecuteQueryResponse response) {
+        print("grpc data:\n ${response.data.toProto3Json()}");
+        print("grpc extensions:\n ${response.extensions?.toProto3Json() ?? "nil extension"}");
     return CommonResponse(
-        deserializer, response.data.toProto3Json(), response.errors);
+        deserializer, response.data.toProto3Json(), response.errors, response.extensions.toProto3Json());
   }
 
   final Deserializer<Data> deserializer;
   final Object? data;
   final List<GraphqlError> errors;
+  final Object? extensions;
 }

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
@@ -117,6 +117,7 @@ class RestTransport implements DataConnectTransport {
       );
       Map<String, dynamic> bodyJson =
           jsonDecode(r.body) as Map<String, dynamic>;
+      print("bodyJson $bodyJson");
       if (r.statusCode != 200) {
         String message =
             bodyJson.containsKey('message') ? bodyJson['message']! : r.body;

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
@@ -117,7 +117,6 @@ class RestTransport implements DataConnectTransport {
       );
       Map<String, dynamic> bodyJson =
           jsonDecode(r.body) as Map<String, dynamic>;
-      print("bodyJson $bodyJson");
       if (r.statusCode != 200) {
         String message =
             bodyJson.containsKey('message') ? bodyJson['message']! : r.body;

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
@@ -127,7 +127,13 @@ class RestTransport implements DataConnectTransport {
           "Received a status code of ${r.statusCode} with a message '$message'",
         );
       }
-      return ServerResponse(bodyJson);
+      final Map<String, dynamic>? extensions =
+          bodyJson['extensions'] as Map<String, dynamic>?;
+      final serverResponse = ServerResponse(bodyJson, extensions: extensions);
+      if (extensions != null && extensions.containsKey('ttl')) {
+        serverResponse.ttl = Duration(seconds: extensions['ttl'] as int);
+      }
+      return serverResponse;
     } on Exception catch (e) {
       if (e is DataConnectError) {
         rethrow;

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
@@ -117,6 +117,7 @@ class RestTransport implements DataConnectTransport {
       );
       Map<String, dynamic> bodyJson =
           jsonDecode(r.body) as Map<String, dynamic>;
+
       if (r.statusCode != 200) {
         String message =
             bodyJson.containsKey('message') ? bodyJson['message']! : r.body;

--- a/packages/firebase_data_connect/firebase_data_connect/protos/connector_service.proto
+++ b/packages/firebase_data_connect/firebase_data_connect/protos/connector_service.proto
@@ -1,30 +1,29 @@
-/*
- * Copyright 2024 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-// Adapted from http://google3/google/firebase/dataconnect/v1main/connector_service.proto;rcl=596717236
 
+// Adapted from third_party/firebase/dataconnect/emulator/server/api/connector_service.proto
 syntax = "proto3";
 
 package google.firebase.dataconnect.v1;
 
 import "google/api/field_behavior.proto";
-import "graphql_error.proto";
 import "google/protobuf/struct.proto";
+import "graphql_error.proto";
+import "graphql_response_extensions.proto";
 
-option java_package = "google.firebase.dataconnect.proto";
+option java_package = "com.google.firebase.dataconnect.api";
 option java_multiple_files = true;
 
 // Firebase Data Connect provides means to deploy a set of predefined GraphQL
@@ -40,12 +39,11 @@ option java_multiple_files = true;
 // token.
 service ConnectorService {
   // Execute a predefined query in a Connector.
-  rpc ExecuteQuery(ExecuteQueryRequest) returns (ExecuteQueryResponse) {
-  }
+  rpc ExecuteQuery(ExecuteQueryRequest) returns (ExecuteQueryResponse) {}
 
   // Execute a predefined mutation in a Connector.
-  rpc ExecuteMutation(ExecuteMutationRequest) returns (ExecuteMutationResponse) {
-  }
+  rpc ExecuteMutation(ExecuteMutationRequest)
+      returns (ExecuteMutationResponse) {}
 }
 
 // The ExecuteQuery request to Firebase Data Connect.
@@ -94,6 +92,8 @@ message ExecuteQueryResponse {
   google.protobuf.Struct data = 1;
   // Errors of this response.
   repeated GraphqlError errors = 2;
+  // Additional response information.
+  GraphqlResponseExtensions extensions = 3;
 }
 
 // The ExecuteMutation response from Firebase Data Connect.
@@ -102,4 +102,6 @@ message ExecuteMutationResponse {
   google.protobuf.Struct data = 1;
   // Errors of this response.
   repeated GraphqlError errors = 2;
+  // Additional response information.
+  GraphqlResponseExtensions extensions = 3;
 }

--- a/packages/firebase_data_connect/firebase_data_connect/protos/firebase/graphql_response_extensions.proto
+++ b/packages/firebase_data_connect/firebase_data_connect/protos/firebase/graphql_response_extensions.proto
@@ -1,0 +1,59 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Adapted from third_party/firebase/dataconnect/emulator/server/api/graphql_response_extensions.proto
+
+syntax = "proto3";
+
+package google.firebase.dataconnect.v1;
+
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+
+option java_multiple_files = true;
+option java_outer_classname = "GraphqlResponseExtensionsProto";
+option java_package = "com.google.firebase.dataconnect.api";
+
+// GraphqlResponseExtensions contains additional information of
+// `GraphqlResponse` or `ExecuteQueryResponse`.
+message GraphqlResponseExtensions {
+  // Data Connect specific properties for a path under response.data.
+  // (-- Design doc: http://go/fdc-caching-wire-protocol --)
+  message DataConnectProperties {
+    // The path under response.data where the rest of the fields apply.
+    // Each element may be a string (field name) or number (array index).
+    // The root of response.data is denoted by the empty list `[]`.
+    // (-- To simplify client logic, the server should never set this to null.
+    // i.e. Use `[]` if the properties below apply to everything in data. --)
+    google.protobuf.ListValue path = 1;
+
+    // A single Entity ID. Set if the path points to a single entity.
+    string entity_id = 2;
+
+    // A list of Entity IDs. Set if the path points to an array of entities. An
+    // ID is present for each element of the array at the corresponding index.
+    repeated string entity_ids = 3;
+
+    // The server-suggested duration before data under path is considered stale.
+    // (-- Right now, this field is never set. For future plans, see
+    // http://go/fdc-sdk-caching-config#heading=h.rmvncy2rao3g --)
+    google.protobuf.Duration max_age = 4;
+  }
+  // Data Connect specific GraphQL extension, a list of paths and properties.
+  // (-- Future fields should go inside to avoid name conflicts with other GQL
+  // extensions in the wild unless we're implementing a common 3P pattern in
+  // extensions such as versioning and telemetry. --)
+  repeated DataConnectProperties data_connect = 1;
+}
+

--- a/packages/firebase_data_connect/firebase_data_connect/protos/google/duration.proto
+++ b/packages/firebase_data_connect/firebase_data_connect/protos/google/duration.proto
@@ -1,0 +1,116 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/protobuf/types/known/durationpb";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "DurationProto";
+option java_multiple_files = true;
+option objc_class_prefix = "GPB";
+
+// A Duration represents a signed, fixed-length span of time represented
+// as a count of seconds and fractions of seconds at nanosecond
+// resolution. It is independent of any calendar and concepts like "day"
+// or "month". It is related to Timestamp in that the difference between
+// two Timestamp values is a Duration and it can be added or subtracted
+// from a Timestamp. Range is approximately +-10,000 years.
+//
+// # Examples
+//
+// Example 1: Compute Duration from two Timestamps in pseudo code.
+//
+//     Timestamp start = ...;
+//     Timestamp end = ...;
+//     Duration duration = ...;
+//
+//     duration.seconds = end.seconds - start.seconds;
+//     duration.nanos = end.nanos - start.nanos;
+//
+//     if (duration.seconds < 0 && duration.nanos > 0) {
+//       duration.seconds += 1;
+//       duration.nanos -= 1000000000;
+//     } else if (duration.seconds > 0 && duration.nanos < 0) {
+//       duration.seconds -= 1;
+//       duration.nanos += 1000000000;
+//     }
+//
+// Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
+//
+//     Timestamp start = ...;
+//     Duration duration = ...;
+//     Timestamp end = ...;
+//
+//     end.seconds = start.seconds + duration.seconds;
+//     end.nanos = start.nanos + duration.nanos;
+//
+//     if (end.nanos < 0) {
+//       end.seconds -= 1;
+//       end.nanos += 1000000000;
+//     } else if (end.nanos >= 1000000000) {
+//       end.seconds += 1;
+//       end.nanos -= 1000000000;
+//     }
+//
+// Example 3: Compute Duration from datetime.timedelta in Python.
+//
+//     td = datetime.timedelta(days=3, minutes=10)
+//     duration = Duration()
+//     duration.FromTimedelta(td)
+//
+// # JSON Mapping
+//
+// In JSON format, the Duration type is encoded as a string rather than an
+// object, where the string ends in the suffix "s" (indicating seconds) and
+// is preceded by the number of seconds, with nanoseconds expressed as
+// fractional seconds. For example, 3 seconds with 0 nanoseconds should be
+// encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
+// be expressed in JSON format as "3.000000001s", and 3 seconds and 1
+// microsecond should be expressed in JSON format as "3.000001s".
+//
+//
+message Duration {
+  // Signed seconds of the span of time. Must be from -315,576,000,000
+  // to +315,576,000,000 inclusive. Note: these bounds are computed from:
+  // 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+  int64 seconds = 1;
+
+  // Signed fractions of a second at nanosecond resolution of the span
+  // of time. Durations less than one second are represented with a 0
+  // `seconds` field and a positive or negative `nanos` field. For durations
+  // of one second or more, a non-zero value for the `nanos` field must be
+  // of the same sign as the `seconds` field. Must be from -999,999,999
+  // to +999,999,999 inclusive.
+  int32 nanos = 2;
+}

--- a/packages/firebase_data_connect/firebase_data_connect/pubspec.yaml
+++ b/packages/firebase_data_connect/firebase_data_connect/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   firebase_auth: ^6.1.3
   firebase_core: ^4.3.0
   firebase_core_platform_interface: ^6.0.2
+  fixnum: ^1.1.1
   flutter:
     sdk: flutter
   grpc: ^3.2.4

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/cache/cache_manager_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/cache/cache_manager_test.dart
@@ -144,10 +144,11 @@ void main() {
 
       Map<String, dynamic> jsonData =
           jsonDecode(simpleQueryResponse) as Map<String, dynamic>;
-      await cache.update(
-          'itemsSimple', ServerResponse(jsonData, extensions: simpleQueryExtensions));
+      await cache.update('itemsSimple',
+          ServerResponse(jsonData, extensions: simpleQueryExtensions));
 
-      Map<String, dynamic>? cachedData = await cache.resultTree('itemsSimple', true);
+      Map<String, dynamic>? cachedData =
+          await cache.resultTree('itemsSimple', true);
 
       expect(jsonData['data'], cachedData);
     }); // test set get
@@ -181,8 +182,8 @@ void main() {
 
       Map<String, dynamic> jsonDataOne =
           jsonDecode(simpleQueryResponse) as Map<String, dynamic>;
-      await cache.update(
-          queryOneId, ServerResponse(jsonDataOne, extensions: simpleQueryExtensions));
+      await cache.update(queryOneId,
+          ServerResponse(jsonDataOne, extensions: simpleQueryExtensions));
 
       Map<String, dynamic> jsonDataTwo =
           jsonDecode(simpleQueryTwoResponse) as Map<String, dynamic>;
@@ -243,8 +244,8 @@ void main() {
 
       Map<String, dynamic> jsonData =
           jsonDecode(simpleQueryResponse) as Map<String, dynamic>;
-      await cache.update(
-          'itemsSimple', ServerResponse(jsonData, extensions: simpleQueryExtensions));
+      await cache.update('itemsSimple',
+          ServerResponse(jsonData, extensions: simpleQueryExtensions));
 
       QueryRef ref = QueryRef(
         dataConnect,
@@ -308,7 +309,8 @@ void main() {
       await cache.update('queryAnyValue',
           ServerResponse(jsonData, extensions: anyValueSingleExt));
 
-      Map<String, dynamic>? cachedData = await cache.resultTree('queryAnyValue', true);
+      Map<String, dynamic>? cachedData =
+          await cache.resultTree('queryAnyValue', true);
 
       expect(cachedData?['anyValueItem']?['name'], 'AnyItem B');
       List<dynamic> values = cachedData?['anyValueItem']?['blob']?['values'];

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/cache/cache_manager_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/cache/cache_manager_test.dart
@@ -51,18 +51,27 @@ void main() {
   const String simpleQueryResponse = '''
     {"data": {"items":[
     
-    {"desc":"itemDesc1","name":"itemOne", "cacheId":"123","price":4},
-    {"desc":"itemDesc2","name":"itemTwo", "cacheId":"345","price":7}
+    {"desc":"itemDesc1","name":"itemOne","price":4},
+    {"desc":"itemDesc2","name":"itemTwo","price":7}
     
     ]}}
   ''';
+
+  final Map<String, dynamic> simpleQueryExtensions = {
+    "dataConnect": [
+      {
+        "path": ["items"],
+        "entityIds": ["123", "345"]
+      }
+    ]
+  };
 
   // query that updates the price for cacheId 123 to 11
   const String simpleQueryResponseUpdate = '''
     {"data": {"items":[
     
-    {"desc":"itemDesc1","name":"itemOne", "cacheId":"123","price":11},
-    {"desc":"itemDesc2","name":"itemTwo", "cacheId":"345","price":7}
+    {"desc":"itemDesc1","name":"itemOne","price":11},
+    {"desc":"itemDesc2","name":"itemTwo","price":7}
     
     ]}}
   ''';
@@ -70,9 +79,18 @@ void main() {
   // query two has same object as query one so should refer to same Entity.
   const String simpleQueryTwoResponse = '''
     {"data": {
-    "item": { "desc":"itemDesc1","name":"itemOne", "cacheId":"123","price":4 }
+    "item": { "desc":"itemDesc1","name":"itemOne","price":4 }
     }}
   ''';
+
+  final Map<String, dynamic> simpleQueryTwoExtensions = {
+    "dataConnect": [
+      {
+        "path": ["item"],
+        "entityId": "123"
+      }
+    ]
+  };
 
   group('Cache Provider Tests', () {
     setUp(() async {
@@ -126,7 +144,8 @@ void main() {
 
       Map<String, dynamic> jsonData =
           jsonDecode(simpleQueryResponse) as Map<String, dynamic>;
-      await cache.update('itemsSimple', ServerResponse(jsonData));
+      await cache.update(
+          'itemsSimple', ServerResponse(jsonData, extensions: simpleQueryExtensions));
 
       Map<String, dynamic>? cachedData = await cache.get('itemsSimple', true);
 
@@ -162,15 +181,18 @@ void main() {
 
       Map<String, dynamic> jsonDataOne =
           jsonDecode(simpleQueryResponse) as Map<String, dynamic>;
-      await cache.update(queryOneId, ServerResponse(jsonDataOne));
+      await cache.update(
+          queryOneId, ServerResponse(jsonDataOne, extensions: simpleQueryExtensions));
 
       Map<String, dynamic> jsonDataTwo =
           jsonDecode(simpleQueryTwoResponse) as Map<String, dynamic>;
-      await cache.update(queryTwoId, ServerResponse(jsonDataTwo));
+      await cache.update(queryTwoId,
+          ServerResponse(jsonDataTwo, extensions: simpleQueryTwoExtensions));
 
       Map<String, dynamic> jsonDataOneUpdate =
           jsonDecode(simpleQueryResponseUpdate) as Map<String, dynamic>;
-      await cache.update(queryOneId, ServerResponse(jsonDataOneUpdate));
+      await cache.update(queryOneId,
+          ServerResponse(jsonDataOneUpdate, extensions: simpleQueryExtensions));
       // shared object should be updated.
       // now reload query two from cache and check object value.
       // it should be updated
@@ -221,7 +243,8 @@ void main() {
 
       Map<String, dynamic> jsonData =
           jsonDecode(simpleQueryResponse) as Map<String, dynamic>;
-      await cache.update('itemsSimple', ServerResponse(jsonData));
+      await cache.update(
+          'itemsSimple', ServerResponse(jsonData, extensions: simpleQueryExtensions));
 
       QueryRef ref = QueryRef(
         dataConnect,

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/cache/cache_manager_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/cache/cache_manager_test.dart
@@ -58,10 +58,10 @@ void main() {
   ''';
 
   final Map<String, dynamic> simpleQueryExtensions = {
-    "dataConnect": [
+    'dataConnect': [
       {
-        "path": ["items"],
-        "entityIds": ["123", "345"]
+        'path': ['items'],
+        'entityIds': ['123', '345']
       }
     ]
   };
@@ -84,10 +84,10 @@ void main() {
   ''';
 
   final Map<String, dynamic> simpleQueryTwoExtensions = {
-    "dataConnect": [
+    'dataConnect': [
       {
-        "path": ["item"],
-        "entityId": "123"
+        'path': ['item'],
+        'entityId': '123'
       }
     ]
   };

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/cache/result_tree_processor_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/cache/result_tree_processor_test.dart
@@ -65,7 +65,7 @@ void main() {
       Map<String, dynamic> jsonData =
           jsonDecode(simpleQueryResponse) as Map<String, dynamic>;
       DehydrationResult result =
-          await rp.dehydrate('itemsSimple', jsonData['data'], cp, simpleQueryPaths);
+          await rp.dehydrateResults('itemsSimple', jsonData['data'], cp, simpleQueryPaths);
       expect(result.dehydratedTree.nestedObjectLists?.length, 1);
       expect(result.dehydratedTree.nestedObjectLists?['items']?.length, 2);
       expect(result.dehydratedTree.nestedObjectLists?['items']?.first.entity,
@@ -74,7 +74,7 @@ void main() {
       Map<String, dynamic> jsonDataTwo =
           jsonDecode(simpleQueryResponseTwo) as Map<String, dynamic>;
       DehydrationResult resultTwo =
-          await rp.dehydrate('itemsSimpleTwo', jsonDataTwo['data'], cp, simpleQueryTwoPaths);
+          await rp.dehydrateResults('itemsSimpleTwo', jsonDataTwo['data'], cp, simpleQueryTwoPaths);
 
       List<String>? guids = result.dehydratedTree.nestedObjectLists?['items']
           ?.map((item) => item.entity?.guid)

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/cache/result_tree_processor_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/cache/result_tree_processor_test.dart
@@ -32,14 +32,24 @@ void main() {
   ''';
 
   final Map<DataConnectPath, PathMetadata> simpleQueryPaths = {
-    DataConnectPath([DataConnectFieldPathSegment('items'), DataConnectListIndexPathSegment(0)]):
-        PathMetadata(
-            path: DataConnectPath([DataConnectFieldPathSegment('items'), DataConnectListIndexPathSegment(0)]),
-            entityId: '123'),
-    DataConnectPath([DataConnectFieldPathSegment('items'), DataConnectListIndexPathSegment(1)]):
-        PathMetadata(
-            path: DataConnectPath([DataConnectFieldPathSegment('items'), DataConnectListIndexPathSegment(1)]),
-            entityId: '345'),
+    DataConnectPath([
+      DataConnectFieldPathSegment('items'),
+      DataConnectListIndexPathSegment(0)
+    ]): PathMetadata(
+        path: DataConnectPath([
+          DataConnectFieldPathSegment('items'),
+          DataConnectListIndexPathSegment(0)
+        ]),
+        entityId: '123'),
+    DataConnectPath([
+      DataConnectFieldPathSegment('items'),
+      DataConnectListIndexPathSegment(1)
+    ]): PathMetadata(
+        path: DataConnectPath([
+          DataConnectFieldPathSegment('items'),
+          DataConnectListIndexPathSegment(1)
+        ]),
+        entityId: '345'),
   };
 
   // query two has same object as query one so should refer to same Entity.
@@ -64,8 +74,8 @@ void main() {
 
       Map<String, dynamic> jsonData =
           jsonDecode(simpleQueryResponse) as Map<String, dynamic>;
-      DehydrationResult result =
-          await rp.dehydrateResults('itemsSimple', jsonData['data'], cp, simpleQueryPaths);
+      DehydrationResult result = await rp.dehydrateResults(
+          'itemsSimple', jsonData['data'], cp, simpleQueryPaths);
       expect(result.dehydratedTree.nestedObjectLists?.length, 1);
       expect(result.dehydratedTree.nestedObjectLists?['items']?.length, 2);
       expect(result.dehydratedTree.nestedObjectLists?['items']?.first.entity,
@@ -73,8 +83,8 @@ void main() {
 
       Map<String, dynamic> jsonDataTwo =
           jsonDecode(simpleQueryResponseTwo) as Map<String, dynamic>;
-      DehydrationResult resultTwo =
-          await rp.dehydrateResults('itemsSimpleTwo', jsonDataTwo['data'], cp, simpleQueryTwoPaths);
+      DehydrationResult resultTwo = await rp.dehydrateResults(
+          'itemsSimpleTwo', jsonDataTwo['data'], cp, simpleQueryTwoPaths);
 
       List<String>? guids = result.dehydratedTree.nestedObjectLists?['items']
           ?.map((item) => item.entity?.guid)

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/common/common_library_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/common/common_library_test.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:nativewrappers/_internal/vm/bin/vmservice_io.dart';
-
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_data_connect/firebase_data_connect.dart';
 import 'package:firebase_data_connect/src/common/common_library.dart';

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/common/common_library_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/common/common_library_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:nativewrappers/_internal/vm/bin/vmservice_io.dart';
+
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_data_connect/firebase_data_connect.dart';
 import 'package:firebase_data_connect/src/common/common_library.dart';


### PR DESCRIPTION
## Description

- Support for reading entity ids from paths in response extension
- Hardening SQLite to use transactions for edits
- Setup schema versioning to handle future schema updates.
- Handle edge cases - multi-dimensional arrays, mixed type arrays, scalar arrays

