### PR TITLE
fix: use builtin GITHUB_TOKEN instead of explicit secret

### DIFF
--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   validate:
+    permissions:
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017


### PR DESCRIPTION
Documented here: https://docs.github.com/en/actions/tutorials/authenticate-with-github_token