### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/docs/storage/start.md
+++ b/docs/storage/start.md
@@ -148,8 +148,9 @@ have to grant Firebase the ability to access these files using the
 [Google Cloud SDK](//cloud.google.com/sdk/docs/):
 
 ```bash
-# The following gsutil command cannot be translated because the permission for the -u flag is missing.
-gsutil -m acl ch -r -u service-PROJECT_NUMBER@gcp-sa-firebasestorage.iam.gserviceaccount.com gs://YOUR-CLOUD-STORAGE-BUCKET
+gcloud storage objects add-iam-policy-binding gs://YOUR-CLOUD-STORAGE-BUCKET \
+    --member="serviceAccount:service-PROJECT_NUMBER@gcp-sa-firebasestorage.iam.gserviceaccount.com" \
+    --role="roles/storage.objectViewer"
 ```
 
 You can find your project number as described in the [introduction to

--- a/docs/storage/start.md
+++ b/docs/storage/start.md
@@ -148,6 +148,7 @@ have to grant Firebase the ability to access these files using the
 [Google Cloud SDK](//cloud.google.com/sdk/docs/):
 
 ```bash
+# The following gsutil command cannot be translated because the permission for the -u flag is missing.
 gsutil -m acl ch -r -u service-PROJECT_NUMBER@gcp-sa-firebasestorage.iam.gserviceaccount.com gs://YOUR-CLOUD-STORAGE-BUCKET
 ```
 

--- a/packages/firebase_storage/firebase_storage_web/README.md
+++ b/packages/firebase_storage/firebase_storage_web/README.md
@@ -48,7 +48,7 @@ firebase_storage/example$ cat cors.json
 And then, with `gsutil`:
 
 ```
-firebase_storage/example$ gsutil cors set cors.json gs://my-example-bucket.appspot.com
+firebase_storage/example$ gcloud storage buckets update gs://my-example-bucket.appspot.com --cors-file=cors.json
 Setting CORS on gs://my-example-bucket.appspot.com/...
 ```
 


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
