### PR TITLE
fix(messaging,ios): fix an issue where the scene initializer could be called twice in latest Flutter versions

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
@@ -43,6 +43,9 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   // Track if scene delegate connected (for iOS 13+ scene delegate support)
   BOOL _sceneDidConnect;
 
+  // Guard against calling setupNotificationHandling twice
+  BOOL _notificationHandlingSetup;
+
 #ifdef __FF_NOTIFICATIONS_SUPPORTED_PLATFORM
   API_AVAILABLE(ios(10), macosx(10.14))
   __weak id<UNUserNotificationCenterDelegate> _originalNotificationCenterDelegate;
@@ -63,6 +66,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   if (self) {
     _initialNotificationGathered = NO;
     _sceneDidConnect = NO;
+    _notificationHandlingSetup = NO;
     _channel = channel;
     _registrar = registrar;
     // Application
@@ -222,6 +226,31 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 
 - (void)setupNotificationHandlingWithRemoteNotification:
     (nullable NSDictionary *)remoteNotification {
+  // If notification handling was already set up (e.g. from application_onDidFinishLaunchingNotification)
+  // and we're called again (e.g. from scene:willConnectToSession:), only process the notification
+  // but skip delegate/swizzler re-registration to avoid _originalNotificationCenterDelegate
+  // being set to self, which causes infinite recursion in didReceiveNotificationResponse. See #18037.
+  if (_notificationHandlingSetup) {
+    if (remoteNotification != nil) {
+      _initialNotification =
+          [FLTFirebaseMessagingPlugin remoteMessageUserInfoToDict:remoteNotification];
+      _initialNotificationID = remoteNotification[@"gcm.message_id"];
+      _initialNotificationGathered = YES;
+      [self initialNotificationCallback];
+    } else if (_sceneDidConnect && !_initialNotificationGathered) {
+      // Scene connected with no notification — delay to allow didReceiveRemoteNotification
+      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)),
+                     dispatch_get_main_queue(), ^{
+                       if (!self->_initialNotificationGathered) {
+                         self->_initialNotificationGathered = YES;
+                         [self initialNotificationCallback];
+                       }
+                     });
+    }
+    return;
+  }
+  _notificationHandlingSetup = YES;
+
   if (remoteNotification != nil) {
     // If remoteNotification exists, it is the notification that opened the app.
     _initialNotification =

--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
@@ -226,10 +226,11 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 
 - (void)setupNotificationHandlingWithRemoteNotification:
     (nullable NSDictionary *)remoteNotification {
-  // If notification handling was already set up (e.g. from application_onDidFinishLaunchingNotification)
-  // and we're called again (e.g. from scene:willConnectToSession:), only process the notification
-  // but skip delegate/swizzler re-registration to avoid _originalNotificationCenterDelegate
-  // being set to self, which causes infinite recursion in didReceiveNotificationResponse. See #18037.
+  // If notification handling was already set up (e.g. from
+  // application_onDidFinishLaunchingNotification) and we're called again (e.g. from
+  // scene:willConnectToSession:), only process the notification but skip delegate/swizzler
+  // re-registration to avoid _originalNotificationCenterDelegate being set to self, which causes
+  // infinite recursion in didReceiveNotificationResponse. See #18037.
   if (_notificationHandlingSetup) {
     if (remoteNotification != nil) {
       _initialNotification =


### PR DESCRIPTION
## Description

Fix EXC_BAD_ACCESS crash on iOS when tapping a notification under UIScene lifecycle (`FlutterImplicitEngineDelegate`).

`setupNotificationHandlingWithRemoteNotification:` was called twice (from `UIApplicationDidFinishLaunchingNotification` + `scene:willConnectToSession:`), causing `_originalNotificationCenterDelegate` to point to `self` → infinite recursion on notification tap.

Added a guard so delegate/swizzler setup only runs once, while still allowing the second call to process the launch notification.

**No test:** requires a real push notification tap delivered by the OS under UIScene lifecycle — not possible from E2E or unit tests.

## Related Issues

Fixes https://github.com/firebase/flutterfire/issues/18037

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
