### PR TITLE
fix(functions): prevent collision when listening multiple times to the same stream

### DIFF
--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_https_callable.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_https_callable.dart
@@ -16,16 +16,12 @@ class MethodChannelHttpsCallable extends HttpsCallablePlatform {
   /// Creates a new [MethodChannelHttpsCallable] instance.
   MethodChannelHttpsCallable(FirebaseFunctionsPlatform functions,
       String? origin, String? name, HttpsCallableOptions options, Uri? uri)
-      : _transformedUri = uri?.pathSegments.join('_').replaceAll('.', '_'),
-        super(functions, origin, name, options, uri) {
-    _eventChannelId = name ?? _transformedUri ?? '';
-    _channel =
-        EventChannel('plugins.flutter.io/firebase_functions/$_eventChannelId');
-  }
+      : _baseEventChannelId =
+            name ?? uri?.pathSegments.join('_').replaceAll('.', '_') ?? '',
+        super(functions, origin, name, options, uri);
 
-  late final EventChannel _channel;
-  final String? _transformedUri;
-  late String _eventChannelId;
+  static int _streamIdCounter = 0;
+  final String _baseEventChannelId;
 
   @override
   Future<dynamic> call([Object? parameters]) async {
@@ -54,10 +50,15 @@ class MethodChannelHttpsCallable extends HttpsCallablePlatform {
 
   @override
   Stream<dynamic> stream(Object? parameters) async* {
+    // Each stream() call gets a unique channel ID to prevent collisions
+    // when invoking the same function concurrently. See #18036.
+    final eventChannelId = '${_baseEventChannelId}_${_streamIdCounter++}';
+    final channel =
+        EventChannel('plugins.flutter.io/firebase_functions/$eventChannelId');
     try {
       await MethodChannelFirebaseFunctions.pigeonChannel
           .registerEventChannel(<String, Object>{
-        'eventChannelId': _eventChannelId,
+        'eventChannelId': eventChannelId,
         'appName': functions.app!.name,
         'region': functions.region,
       });
@@ -69,7 +70,7 @@ class MethodChannelHttpsCallable extends HttpsCallablePlatform {
         'limitedUseAppCheckToken': options.limitedUseAppCheckToken,
         'timeout': options.timeout.inMilliseconds,
       };
-      yield* _channel.receiveBroadcastStream(eventData).map((message) {
+      yield* channel.receiveBroadcastStream(eventData).map((message) {
         if (message is Map) {
           return Map<String, dynamic>.from(message);
         }

--- a/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
+++ b/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
@@ -346,6 +346,27 @@ void main() {
         await expectLater(stream, emits(isA<StreamResponse>()));
       });
 
+      test(
+        'concurrent streams on the same callable do not collide',
+        () async {
+          // Regression test for https://github.com/firebase/flutterfire/issues/18036
+          final stream1 = callable
+              .stream('foo')
+              .where((event) => event is Chunk)
+              .map((event) => (event as Chunk).partialData)
+              .first;
+          final stream2 = callable
+              .stream(123)
+              .where((event) => event is Chunk)
+              .map((event) => (event as Chunk).partialData)
+              .first;
+
+          final results = await Future.wait([stream1, stream2]);
+          expect(results[0], equals('string'));
+          expect(results[1], equals('number'));
+        },
+      );
+
       test('should emit a [Result] as last value', () async {
         final stream = await callable.stream().last;
         expect(


### PR DESCRIPTION
## Description

Fix stream collisions when calling `HttpsCallable.stream` concurrently on the same function.

The `EventChannel` name was derived solely from the function name, so parallel `.stream()` calls shared the same channel — causing data from one call to leak into another.

Each `stream()` invocation now gets a unique channel ID via a static counter.

Added E2E test that runs two concurrent `.stream()` calls with different input types on the same callable and verifies each stream receives only its own data.

## Related Issues

Fixes https://github.com/firebase/flutterfire/issues/18036

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
