### PR TITLE
fix(firestore,windows): fix an issue that could happen when querying by DocumentReference value

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/document_reference_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/document_reference_e2e.dart
@@ -629,5 +629,39 @@ void runDocumentReferenceTests() {
         timeout: const Timeout.factor(3),
       );
     });
+
+    group('DocumentReference as field value', () {
+      // Regression test for https://github.com/firebase/flutterfire/issues/18028
+      test('can store and read a DocumentReference as a field value', () async {
+        final doc = await initializeTest('doc-ref-field');
+        final targetDoc = firestore.doc('flutter-tests/target-doc');
+
+        await doc.set({'ref': targetDoc});
+
+        final snapshot = await doc.get();
+        final refValue = snapshot.data()!['ref'];
+        expect(refValue, isA<DocumentReference>());
+        expect((refValue as DocumentReference).path, targetDoc.path);
+      });
+
+      test('can query by DocumentReference value', () async {
+        final collection =
+            firestore.collection('flutter-tests/doc-ref-query/items');
+        final targetDoc = firestore.doc('flutter-tests/target-doc');
+
+        // Clean up
+        final existing = await collection.get();
+        for (final doc in existing.docs) {
+          await doc.reference.delete();
+        }
+
+        await collection.add({'ref': targetDoc, 'name': 'test'});
+
+        final querySnapshot =
+            await collection.where('ref', isEqualTo: targetDoc).get();
+        expect(querySnapshot.docs, hasLength(1));
+        expect(querySnapshot.docs.first.data()['name'], 'test');
+      });
+    });
   });
 }

--- a/packages/cloud_firestore/cloud_firestore/windows/firestore_codec.cpp
+++ b/packages/cloud_firestore/cloud_firestore/windows/firestore_codec.cpp
@@ -225,8 +225,7 @@ cloud_firestore_windows::FirestoreCodec::ReadValueOfType(
 
       firebase::App* app = firebase::App::GetInstance(appName.c_str());
 
-      Firestore* firestore =
-          Firestore::GetInstance(app, databaseUrl.c_str());
+      Firestore* firestore = Firestore::GetInstance(app, databaseUrl.c_str());
       firestore->set_settings(settings);
 
       CloudFirestorePlugin::firestoreInstances_[cacheKey] =

--- a/packages/cloud_firestore/cloud_firestore/windows/firestore_codec.cpp
+++ b/packages/cloud_firestore/cloud_firestore/windows/firestore_codec.cpp
@@ -212,18 +212,24 @@ cloud_firestore_windows::FirestoreCodec::ReadValueOfType(
               std::get<CustomEncodableValue>(
                   FirestoreCodec::ReadValue(stream)));
 
-      if (CloudFirestorePlugin::firestoreInstances_.find(appName) !=
+      // Use composite key matching GetFirestoreFromPigeon to avoid
+      // creating a duplicate unique_ptr for the same Firestore instance.
+      // See https://github.com/firebase/flutterfire/issues/18028
+      std::string cacheKey = appName + "-" + databaseUrl;
+
+      if (CloudFirestorePlugin::firestoreInstances_.find(cacheKey) !=
           CloudFirestorePlugin::firestoreInstances_.end()) {
         return CustomEncodableValue(
-            CloudFirestorePlugin::firestoreInstances_[appName].get());
+            CloudFirestorePlugin::firestoreInstances_[cacheKey].get());
       }
 
       firebase::App* app = firebase::App::GetInstance(appName.c_str());
 
-      Firestore* firestore = Firestore::GetInstance(app);
+      Firestore* firestore =
+          Firestore::GetInstance(app, databaseUrl.c_str());
       firestore->set_settings(settings);
 
-      CloudFirestorePlugin::firestoreInstances_[appName] =
+      CloudFirestorePlugin::firestoreInstances_[cacheKey] =
           std::unique_ptr<firebase::firestore::Firestore>(firestore);
 
       return CustomEncodableValue(firestore);


### PR DESCRIPTION
## Description

Fix native crash on Windows when using `DocumentReference` as a query filter or field value.

The codec's `DATA_TYPE_FIRESTORE_INSTANCE` handler used `appName` as cache key, while `GetFirestoreFromPigeon` uses `appName + "-" + databaseUrl`. This caused a cache miss, creating a second `unique_ptr` wrapping the same `Firestore*` — double-free on teardown.

Fixed by using the same composite key and passing `databaseUrl` to `Firestore::GetInstance`.

## Related Issues

Fixes https://github.com/firebase/flutterfire/issues/18028

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
