### PR TITLE
fix(auth, android): fix an error casing that wasn't consistent accross platforms

### DIFF
--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/utils/exception.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/utils/exception.dart
@@ -154,7 +154,7 @@ String? _getCustomCode(Map? additionalData, String? message) {
   for (final recognizedCode in listOfRecognizedCode) {
     if (additionalData?['message'] == recognizedCode ||
         (message?.contains(recognizedCode) ?? false)) {
-      return recognizedCode;
+      return recognizedCode.toLowerCase().replaceAll('_', '-');
     }
   }
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/method_channel_tests/utils_tests/exception_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/method_channel_tests/utils_tests/exception_test.dart
@@ -44,7 +44,7 @@ void main() {
         () => convertPlatformException(platformException, StackTrace.empty),
         throwsA(
           isA<FirebaseAuthException>()
-              .having((e) => e.code, 'code', 'BLOCKING_FUNCTION_ERROR_RESPONSE')
+              .having((e) => e.code, 'code', 'blocking-function-error-response')
               .having((e) => e.message, 'message',
                   '{"error":{"details":"The user is not allowed to log in","message":"","status":"PERMISSION_DENIED"}}'),
         ),


### PR DESCRIPTION
## Description

`_getCustomCode` returns raw SCREAMING_SNAKE_CASE codes (`BLOCKING_FUNCTION_ERROR_RESPONSE`, `INVALID_LOGIN_CREDENTIALS`) on Android, while all other `FirebaseAuthException.code` values use kebab-case. This normalizes them to kebab-case for consistency across platforms.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18020

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
