### PR TITLE
fix(firestore, web): fix an issue where DocumentReference couldn't be read properly in web

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/document_reference_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/document_reference_e2e.dart
@@ -456,6 +456,19 @@ void runDocumentReferenceTests() {
         expect(data['infinity'], equals(double.infinity));
         expect(data['negative_infinity'], equals(double.negativeInfinity));
       });
+
+      test('sets data with DocumentReference as map key', () async {
+        DocumentReference<Map<String, dynamic>> document =
+            await initializeTest('document-set-ref-key');
+        DocumentReference<Map<String, dynamic>> refKey =
+            FirebaseFirestore.instance.doc('foo/bar');
+        await document.set({
+          'myMap': {refKey: 42.0},
+        });
+        DocumentSnapshot<Map<String, dynamic>> snapshot = await document.get();
+        final myMap = snapshot.data()!['myMap'] as Map<String, dynamic>;
+        expect(myMap[refKey.path], equals(42.0));
+      });
     });
 
     group('DocumentReference.update()', () {

--- a/packages/cloud_firestore/cloud_firestore/lib/src/utils/codec_utility.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/utils/codec_utility.dart
@@ -17,8 +17,11 @@ class _CodecUtility {
     if (data == null) {
       return null;
     }
-    Map<String, dynamic> output = Map.from(data);
-    output.updateAll((_, value) => valueEncode(value));
+    final output = <String, dynamic>{};
+    data.forEach((key, value) {
+      final stringKey = key is DocumentReference ? key.path : key as String;
+      output[stringKey] = valueEncode(value);
+    });
     return output;
   }
 

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/encode_utility.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/encode_utility.dart
@@ -18,8 +18,12 @@ class EncodeUtility {
     if (data == null) {
       return null;
     }
-    Map<String, dynamic> output = Map.from(data);
-    output.updateAll((key, value) => valueEncode(value));
+    final output = <String, dynamic>{};
+    data.forEach((key, value) {
+      final stringKey =
+          key is DocumentReferencePlatform ? key.path : key as String;
+      output[stringKey] = valueEncode(value);
+    });
     return output;
   }
 
@@ -126,8 +130,8 @@ class EncodeUtility {
       return firestore_interop.BytesJsImpl.fromUint8Array(value.bytes.toJS);
     } else if (value is DocumentReferenceWeb) {
       return value.firestoreWeb.doc(value.path);
-    } else if (value is Map<String, dynamic>) {
-      return encodeMapData(value);
+    } else if (value is Map) {
+      return encodeMapData(value.cast<Object, dynamic>());
     } else if (value is List<dynamic>) {
       return encodeArrayData(value);
     } else if (value is Iterable<dynamic>) {


### PR DESCRIPTION

## Description

`DocumentReference` used as a map key in Firestore document data throws `type '_JsonDocumentReference' is not a subtype of type 'String' in type cast`. The codec utilities only encoded map values, not keys. This converts `DocumentReference` keys to their path string automatically.

Fixed in both the method channel codec (`codec_utility.dart`) and the web encoder (`encode_utility.dart`).

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17996

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
