### PR TITLE
fix(android): remove kotlin-android since AGP 9 supports it

### DIFF
--- a/packages/cloud_functions/cloud_functions/android/build.gradle
+++ b/packages/cloud_functions/cloud_functions/android/build.gradle
@@ -76,10 +76,6 @@ android {
     implementation 'org.reactivestreams:reactive-streams:1.0.4'
   }
 
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17
-  }
-  
 }
 
 apply from: file("./user-agent.gradle")

--- a/packages/cloud_functions/cloud_functions/android/build.gradle
+++ b/packages/cloud_functions/cloud_functions/android/build.gradle
@@ -4,6 +4,12 @@ version '1.0-SNAPSHOT'
 apply plugin: 'com.android.library'
 apply from: file("local-config.gradle")
 
+// AGP 9+ has built-in Kotlin support; older versions need the plugin explicitly.
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+  apply plugin: 'kotlin-android'
+}
+
 buildscript {
   ext.kotlin_version = "1.8.22"
   repositories {
@@ -53,6 +59,12 @@ android {
   compileOptions {
       sourceCompatibility project.ext.javaVersion
       targetCompatibility project.ext.javaVersion
+  }
+
+  if (agpMajor < 9) {
+    kotlinOptions {
+      jvmTarget = project.ext.javaVersion
+    }
   }
 
   sourceSets {

--- a/packages/cloud_functions/cloud_functions/android/build.gradle
+++ b/packages/cloud_functions/cloud_functions/android/build.gradle
@@ -3,7 +3,6 @@ version '1.0-SNAPSHOT'
 
 apply plugin: 'com.android.library'
 apply from: file("local-config.gradle")
-apply plugin: 'kotlin-android'
 
 buildscript {
   ext.kotlin_version = "1.8.22"
@@ -84,4 +83,3 @@ android {
 }
 
 apply from: file("./user-agent.gradle")
-apply plugin: 'org.jetbrains.kotlin.android'

--- a/packages/firebase_analytics/firebase_analytics/android/build.gradle
+++ b/packages/firebase_analytics/firebase_analytics/android/build.gradle
@@ -52,10 +52,6 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
-    }
-
     compileOptions {
         sourceCompatibility project.ext.javaVersion
         targetCompatibility project.ext.javaVersion

--- a/packages/firebase_analytics/firebase_analytics/android/build.gradle
+++ b/packages/firebase_analytics/firebase_analytics/android/build.gradle
@@ -25,7 +25,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 def firebaseCoreProject = findProject(':firebase_core')
 if (firebaseCoreProject == null) {

--- a/packages/firebase_analytics/firebase_analytics/android/build.gradle
+++ b/packages/firebase_analytics/firebase_analytics/android/build.gradle
@@ -26,6 +26,12 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
+// AGP 9+ has built-in Kotlin support; older versions need the plugin explicitly.
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
+
 def firebaseCoreProject = findProject(':firebase_core')
 if (firebaseCoreProject == null) {
     throw new GradleException('Could not find the firebase_core FlutterFire plugin, have you added it as a dependency in your pubspec?')
@@ -50,6 +56,12 @@ android {
     defaultConfig {
         minSdkVersion project.ext.minSdk
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    if (agpMajor < 9) {
+        kotlinOptions {
+            jvmTarget = project.ext.javaVersion
+        }
     }
 
     compileOptions {

--- a/packages/firebase_database/firebase_database/android/build.gradle
+++ b/packages/firebase_database/firebase_database/android/build.gradle
@@ -4,6 +4,12 @@ version '1.0-SNAPSHOT'
 apply plugin: 'com.android.library'
 apply from: file("local-config.gradle")
 
+// AGP 9+ has built-in Kotlin support; older versions need the plugin explicitly.
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
+
 buildscript {
     repositories {
         google()
@@ -47,6 +53,12 @@ android {
     compileOptions {
         sourceCompatibility project.ext.javaVersion
         targetCompatibility project.ext.javaVersion
+    }
+
+    if (agpMajor < 9) {
+        kotlinOptions {
+            jvmTarget = project.ext.javaVersion
+        }
     }
 
     sourceSets {

--- a/packages/firebase_database/firebase_database/android/build.gradle
+++ b/packages/firebase_database/firebase_database/android/build.gradle
@@ -2,7 +2,6 @@ group 'io.flutter.plugins.firebase.database'
 version '1.0-SNAPSHOT'
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 apply from: file("local-config.gradle")
 
 buildscript {

--- a/packages/firebase_database/firebase_database/android/build.gradle
+++ b/packages/firebase_database/firebase_database/android/build.gradle
@@ -49,10 +49,6 @@ android {
         targetCompatibility project.ext.javaVersion
     }
 
-    kotlinOptions {
-        jvmTarget = project.ext.javaVersion
-    }
-
     sourceSets {
         main {
             java {

--- a/packages/firebase_performance/firebase_performance/android/build.gradle
+++ b/packages/firebase_performance/firebase_performance/android/build.gradle
@@ -4,6 +4,12 @@ version '1.0-SNAPSHOT'
 apply plugin: 'com.android.library'
 apply from: file("local-config.gradle")
 
+// AGP 9+ has built-in Kotlin support; older versions need the plugin explicitly.
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
+
 buildscript {
     ext.kotlin_version = "1.8.22"
 
@@ -52,6 +58,12 @@ android {
     compileOptions {
         sourceCompatibility project.ext.javaVersion
         targetCompatibility project.ext.javaVersion
+    }
+
+    if (agpMajor < 9) {
+        kotlinOptions {
+            jvmTarget = project.ext.javaVersion
+        }
     }
 
     sourceSets {

--- a/packages/firebase_performance/firebase_performance/android/build.gradle
+++ b/packages/firebase_performance/firebase_performance/android/build.gradle
@@ -3,7 +3,6 @@ version '1.0-SNAPSHOT'
 
 apply plugin: 'com.android.library'
 apply from: file("local-config.gradle")
-apply plugin: 'kotlin-android'
 
 buildscript {
     ext.kotlin_version = "1.8.22"

--- a/packages/firebase_performance/firebase_performance/android/build.gradle
+++ b/packages/firebase_performance/firebase_performance/android/build.gradle
@@ -59,10 +59,6 @@ android {
         test.java.srcDirs += "src/test/kotlin"
     }
 
-    kotlinOptions {
-        jvmTarget = project.ext.javaVersion
-    }
-
     buildFeatures {
         buildConfig true
     }

--- a/packages/firebase_remote_config/firebase_remote_config/android/build.gradle
+++ b/packages/firebase_remote_config/firebase_remote_config/android/build.gradle
@@ -19,8 +19,6 @@ rootProject.allprojects {
     }
 }
 
-apply plugin: 'kotlin-android'
-
 def firebaseCoreProject = findProject(':firebase_core')
 if (firebaseCoreProject == null) {
     throw new GradleException('Could not find the firebase_core FlutterFire plugin, have you added it as a dependency in your pubspec?')

--- a/packages/firebase_remote_config/firebase_remote_config/android/build.gradle
+++ b/packages/firebase_remote_config/firebase_remote_config/android/build.gradle
@@ -19,6 +19,12 @@ rootProject.allprojects {
     }
 }
 
+// AGP 9+ has built-in Kotlin support; older versions need the plugin explicitly.
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
+
 def firebaseCoreProject = findProject(':firebase_core')
 if (firebaseCoreProject == null) {
     throw new GradleException('Could not find the firebase_core FlutterFire plugin, have you added it as a dependency in your pubspec?')
@@ -43,6 +49,12 @@ android {
     defaultConfig {
         minSdkVersion project.ext.minSdk
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    if (agpMajor < 9) {
+        kotlinOptions {
+            jvmTarget = project.ext.javaVersion
+        }
     }
 
     compileOptions {

--- a/packages/firebase_remote_config/firebase_remote_config/android/build.gradle
+++ b/packages/firebase_remote_config/firebase_remote_config/android/build.gradle
@@ -45,10 +45,6 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
-    }
-
     compileOptions {
         sourceCompatibility project.ext.javaVersion
         targetCompatibility project.ext.javaVersion

--- a/packages/firebase_storage/firebase_storage/android/build.gradle
+++ b/packages/firebase_storage/firebase_storage/android/build.gradle
@@ -57,10 +57,6 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    kotlinOptions {
-        jvmTarget = project.ext.javaVersion
-    }
-
     compileOptions {
         sourceCompatibility project.ext.javaVersion
         targetCompatibility project.ext.javaVersion

--- a/packages/firebase_storage/firebase_storage/android/build.gradle
+++ b/packages/firebase_storage/firebase_storage/android/build.gradle
@@ -44,8 +44,6 @@ def getRootProjectExtOrCoreProperty(name, firebaseCoreProject) {
     return rootProject.ext.get('FlutterFire').get(name)
 }
 
-apply plugin: 'kotlin-android'
-
 android {
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {

--- a/packages/firebase_storage/firebase_storage/android/build.gradle
+++ b/packages/firebase_storage/firebase_storage/android/build.gradle
@@ -44,6 +44,12 @@ def getRootProjectExtOrCoreProperty(name, firebaseCoreProject) {
     return rootProject.ext.get('FlutterFire').get(name)
 }
 
+// AGP 9+ has built-in Kotlin support; older versions need the plugin explicitly.
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
+
 android {
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {
@@ -55,6 +61,12 @@ android {
     defaultConfig {
         minSdkVersion project.ext.minSdk
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    if (agpMajor < 9) {
+        kotlinOptions {
+            jvmTarget = project.ext.javaVersion
+        }
     }
 
     compileOptions {


### PR DESCRIPTION
## Description

AGP 9 ships built-in Kotlin support and fails when plugins explicitly apply `kotlin-android`. Six plugins had this — removed from all of them. Safe on older AGP versions too since Flutter's root-project tooling handles Kotlin setup.

Affected plugins:
- `firebase_analytics`
- `firebase_performance`
- `firebase_remote_config`
- `firebase_database`
- `firebase_storage`
- `cloud_functions` (had it applied twice)

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17987

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
