### PR TITLE
feat(analytics,ios): add support for FirebaseAnalyticsWithoutAdIdSupport with SPM

### DIFF
--- a/docs/analytics/_get-started.md
+++ b/docs/analytics/_get-started.md
@@ -83,6 +83,32 @@ await FirebaseAnalytics.instance
   );
 ```
 
+## Using Analytics without Ad ID support (iOS) {:#without-ad-id}
+
+If your app doesn't use IDFA, you can use `FirebaseAnalyticsWithoutAdIdSupport`
+instead of the default `FirebaseAnalytics` iOS dependency to avoid App Store
+review questions about advertising identifiers.
+
+### Swift Package Manager
+
+Set the `FIREBASE_ANALYTICS_WITHOUT_ADID` environment variable when building:
+
+```bash
+FIREBASE_ANALYTICS_WITHOUT_ADID=true flutter build ios
+```
+
+You can also add this variable to your Xcode scheme's environment variables
+for persistent configuration.
+
+### CocoaPods
+
+Add this to your app's `Podfile`:
+
+```ruby
+pod 'FirebaseAnalytics', :modular_headers => true
+pod 'FirebaseAnalyticsWithoutAdIdSupport', :modular_headers => true
+```
+
 ## Next steps
 
 * Use the [DebugView](/docs/analytics/debugview) to verify your events.

--- a/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics/Package.swift
+++ b/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics/Package.swift
@@ -79,6 +79,11 @@ guard let shared_spm_version = Version("\(firebase_core_version_string)\(shared_
   fatalError("Invalid firebase_core version: \(firebase_core_version_string)\(shared_spm_tag)")
 }
 
+// Set FIREBASE_ANALYTICS_WITHOUT_ADID=true to use FirebaseAnalyticsWithoutAdIdSupport
+// e.g. FIREBASE_ANALYTICS_WITHOUT_ADID=true flutter build ios
+let useWithoutAdId = ProcessInfo.processInfo.environment["FIREBASE_ANALYTICS_WITHOUT_ADID"] != nil
+let analyticsProduct = useWithoutAdId ? "FirebaseAnalyticsWithoutAdIdSupport" : "FirebaseAnalytics"
+
 let package = Package(
   name: "firebase_analytics",
   platforms: [
@@ -95,7 +100,7 @@ let package = Package(
     .target(
       name: "firebase_analytics",
       dependencies: [
-        .product(name: "FirebaseAnalytics", package: "firebase-ios-sdk"),
+        .product(name: analyticsProduct, package: "firebase-ios-sdk"),
         // Wrapper dependency
         .product(name: "firebase-core-shared", package: "flutterfire"),
       ],


### PR DESCRIPTION
## Description

The SPM `Package.swift` for `firebase_analytics` hardcodes `FirebaseAnalytics` as the dependency, with no way to use `FirebaseAnalyticsWithoutAdIdSupport`. With CocoaPods users could override the pod, but SPM doesn't support that.

Added an environment variable check: set `FIREBASE_ANALYTICS_WITHOUT_ADID=true` to switch the SPM dependency to `FirebaseAnalyticsWithoutAdIdSupport`.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17958

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
