### PR TITLE
fix(remote-config, ios): fix hot reload issue

### DIFF
--- a/packages/firebase_remote_config/firebase_remote_config/example/lib/home_page.dart
+++ b/packages/firebase_remote_config/firebase_remote_config/example/lib/home_page.dart
@@ -176,8 +176,8 @@ class _ButtonAndTextState extends State<_ButtonAndText> {
       padding: const EdgeInsets.all(8),
       child: Row(
         children: [
-          Text(_text ?? widget.defaultText),
-          const Spacer(),
+          Expanded(child: Text(_text ?? widget.defaultText)),
+          const SizedBox(width: 8),
           ElevatedButton(
             onPressed: () async {
               final result = await widget.onPressed();

--- a/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Sources/firebase_remote_config/FirebaseRemoteConfigPlugin.swift
+++ b/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Sources/firebase_remote_config/FirebaseRemoteConfigPlugin.swift
@@ -60,6 +60,10 @@ public class FirebaseRemoteConfigPlugin: NSObject, FlutterPlugin, FlutterStreamH
   }
 
   public func didReinitializeFirebaseCore(_ completion: @escaping () -> Void) {
+    for listener in listenersMap.values {
+      listener.remove()
+    }
+    listenersMap.removeAll()
     completion()
   }
 


### PR DESCRIPTION
## Description

On iOS/macOS, `didReinitializeFirebaseCore()` did nothing — just called `completion()`. On hot restart, native config update listeners persisted and new ones were added on re-subscribe, causing duplicate `onConfigUpdated` callbacks. Android already correctly cleans up listeners in `didReinitializeFirebaseCore()`.

Added listener cleanup to match the Android implementation.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17955
- Fixes https://github.com/firebase/flutterfire/issues/12539

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
