### PR TITLE
fix(auth,ios): fix crash that could happen when reloading currentUser informations

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
@@ -1947,7 +1947,7 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
     if (error != nil) {
       completion(nil, [FLTFirebaseAuthPlugin convertToFlutterError:error]);
     } else {
-      completion([PigeonParser getPigeonDetails:auth.currentUser], nil);
+      completion([PigeonParser getPigeonDetails:currentUser], nil);
     }
   }];
 }
@@ -2023,7 +2023,7 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
                       if (reloadError != nil) {
                         completion(nil, [FLTFirebaseAuthPlugin convertToFlutterError:reloadError]);
                       } else {
-                        completion([PigeonParser getPigeonDetails:auth.currentUser], nil);
+                        completion([PigeonParser getPigeonDetails:currentUser], nil);
                       }
                     }];
                   }
@@ -2053,7 +2053,7 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
                 if (reloadError != nil) {
                   completion(nil, [FLTFirebaseAuthPlugin convertToFlutterError:reloadError]);
                 } else {
-                  completion([PigeonParser getPigeonDetails:auth.currentUser], nil);
+                  completion([PigeonParser getPigeonDetails:currentUser], nil);
                 }
               }];
             }
@@ -2111,7 +2111,7 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
                                                                 completion(
                                                                     [PigeonParser
                                                                         getPigeonDetails:
-                                                                            auth.currentUser],
+                                                                            currentUser],
                                                                     nil);
                                                               }
                                                             }];
@@ -2164,7 +2164,7 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
         if (reloadError != nil) {
           completion(nil, [FLTFirebaseAuthPlugin convertToFlutterError:reloadError]);
         } else {
-          completion([PigeonParser getPigeonDetails:auth.currentUser], nil);
+          completion([PigeonParser getPigeonDetails:currentUser], nil);
         }
       }];
     }

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
@@ -2109,9 +2109,8 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
                                                                                  reloadError]);
                                                               } else {
                                                                 completion(
-                                                                    [PigeonParser
-                                                                        getPigeonDetails:
-                                                                            currentUser],
+                                                                    [PigeonParser getPigeonDetails:
+                                                                                      currentUser],
                                                                     nil);
                                                               }
                                                             }];

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/PigeonParser.m
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/PigeonParser.m
@@ -32,12 +32,12 @@
 }
 
 + (PigeonUserInfo *)getPigeonUserInfo:(nonnull FIRUser *)user {
+  NSString *photoUrlString = user.photoURL.absoluteString;
   return [PigeonUserInfo
               makeWithUid:user.uid
                     email:user.email
               displayName:user.displayName
-                 photoUrl:(user.photoURL.absoluteString.length > 0) ? user.photoURL.absoluteString
-                                                                    : nil
+                 photoUrl:(photoUrlString.length > 0) ? photoUrlString : nil
               phoneNumber:user.phoneNumber
               isAnonymous:user.isAnonymous
           isEmailVerified:user.emailVerified
@@ -54,6 +54,7 @@
       [NSMutableArray arrayWithCapacity:providerData.count];
 
   for (id<FIRUserInfo> userInfo in providerData) {
+    NSString *photoUrlStr = userInfo.photoURL.absoluteString;
     NSDictionary *dataDict = @{
       @"providerId" : userInfo.providerID,
       // Can be null on emulator
@@ -61,7 +62,7 @@
       @"displayName" : userInfo.displayName ?: [NSNull null],
       @"email" : userInfo.email ?: [NSNull null],
       @"phoneNumber" : userInfo.phoneNumber ?: [NSNull null],
-      @"photoURL" : userInfo.photoURL.absoluteString ?: [NSNull null],
+      @"photoURL" : photoUrlStr ?: [NSNull null],
       // isAnonymous is always false on in a providerData object (the user is not anonymous)
       @"isAnonymous" : @NO,
       // isEmailVerified is always true on in a providerData object (the email is verified by the

--- a/tests/integration_test/firebase_auth/firebase_auth_user_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_user_e2e_test.dart
@@ -490,6 +490,62 @@ void main() {
           }
           expect(FirebaseAuth.instance.currentUser, isNull);
         });
+
+        test(
+          'should preserve photoURL after reload',
+          () async {
+            await FirebaseAuth.instance.createUserWithEmailAndPassword(
+              email: email,
+              password: testPassword,
+            );
+            await FirebaseAuth.instance.currentUser!.updatePhotoURL(
+              'http://photo.url/test.jpg',
+            );
+            await FirebaseAuth.instance.currentUser!.reload();
+
+            expect(
+              FirebaseAuth.instance.currentUser!.photoURL,
+              'http://photo.url/test.jpg',
+            );
+
+            // Reload again to exercise the PigeonParser path
+            // with a non-null photoURL
+            await FirebaseAuth.instance.currentUser!.reload();
+
+            expect(
+              FirebaseAuth.instance.currentUser!.photoURL,
+              'http://photo.url/test.jpg',
+            );
+            expect(
+              FirebaseAuth.instance.currentUser!.displayName,
+              isNull,
+            );
+          },
+          skip: kIsWeb ||
+              defaultTargetPlatform == TargetPlatform.macOS ||
+              defaultTargetPlatform == TargetPlatform.windows,
+        );
+
+        test(
+          'should handle reload when photoURL is null',
+          () async {
+            await FirebaseAuth.instance.createUserWithEmailAndPassword(
+              email: email,
+              password: testPassword,
+            );
+
+            // User created without photoURL — reload should not crash
+            await FirebaseAuth.instance.currentUser!.reload();
+
+            expect(
+              FirebaseAuth.instance.currentUser!.photoURL,
+              isNull,
+            );
+          },
+          skip: kIsWeb ||
+              defaultTargetPlatform == TargetPlatform.macOS ||
+              defaultTargetPlatform == TargetPlatform.windows,
+        );
       });
 
       group(


### PR DESCRIPTION
## Description

Fix SIGSEGV crash (`absoluteString > dereference garbage pointer 0xdeadbeef`) on iOS caused by a race condition in async completion blocks. Five methods (`reloadApp`, `updateEmail`, `updatePassword`, `updatePhoneNumber`, `updateProfile`) were re-fetching `auth.currentUser` inside async callbacks instead of using the locally captured `currentUser`, leading to use-after-free when auth state changed concurrently. Also fixed `PigeonParser` to evaluate `photoURL.absoluteString` once into a local variable instead of twice in a ternary expression.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17933

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
