### PR TITLE
fix(functions,web): fix a crash that could happen with the Int64 type

### DIFF
--- a/packages/cloud_functions/cloud_functions/lib/src/https_callable.dart
+++ b/packages/cloud_functions/cloud_functions/lib/src/https_callable.dart
@@ -79,7 +79,8 @@ class HttpsCallable {
 dynamic _updateRawDataToList(dynamic value) {
   if (value is Uint8List ||
       value is Int32List ||
-      value is Int64List ||
+      // Int64List is not supported by dart2js, skip the check on web.
+      (!kIsWeb && value is Int64List) ||
       value is Float32List ||
       value is Float64List) {
     return value.toList();

--- a/packages/cloud_functions/cloud_functions/test/https_callable_test.dart
+++ b/packages/cloud_functions/cloud_functions/test/https_callable_test.dart
@@ -3,6 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
+
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:cloud_functions_platform_interface/cloud_functions_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -93,6 +95,45 @@ void main() {
             equals(data.deepMap),
           ),
         );
+      });
+
+      test('converts typed data lists in map values to regular lists',
+          () async {
+        final result = await httpsCallable!.call({
+          'bytes': Uint8List.fromList([1, 2, 3]),
+          'ints': Int32List.fromList([4, 5, 6]),
+          'floats': Float32List.fromList([1.0, 2.0]),
+          'doubles': Float64List.fromList([3.0, 4.0]),
+        });
+        final data = result.data as Map;
+        expect(data['bytes'], isA<List<int>>());
+        expect(data['bytes'], isNot(isA<Uint8List>()));
+        expect(data['bytes'], equals([1, 2, 3]));
+        expect(data['ints'], isA<List<int>>());
+        expect(data['ints'], isNot(isA<Int32List>()));
+        expect(data['floats'], isA<List<double>>());
+        expect(data['floats'], isNot(isA<Float32List>()));
+        expect(data['doubles'], isA<List<double>>());
+        expect(data['doubles'], isNot(isA<Float64List>()));
+      });
+
+      test('converts typed data lists passed as direct parameters', () async {
+        final result = await httpsCallable!.call(Uint8List.fromList([7, 8, 9]));
+        expect(result.data, isA<List>());
+        expect(result.data, isNot(isA<Uint8List>()));
+        expect(result.data, equals([7, 8, 9]));
+      });
+
+      test('converts typed data lists inside list parameters', () async {
+        final result = await httpsCallable!.call([
+          Uint8List.fromList([1, 2]),
+          Int32List.fromList([3, 4]),
+        ]);
+        final data = result.data as List;
+        expect(data[0], isA<List<int>>());
+        expect(data[0], isNot(isA<Uint8List>()));
+        expect(data[1], isA<List<int>>());
+        expect(data[1], isNot(isA<Int32List>()));
       });
 
       test('parameter validation throws if any other type of data is passed',

--- a/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
+++ b/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
@@ -114,6 +114,28 @@ void main() {
       );
 
       test(
+        'accepts raw data as arguments on web (excluding Int64List)',
+        () async {
+          HttpsCallableResult result = await callable({
+            'type': 'rawData',
+            'list': Uint8List(100),
+            'int': Int32List(39),
+            'float': Float32List(23),
+            'double': Float64List(1001),
+          });
+          final data = result.data;
+          expect(data['list'], isA<List>());
+          expect(data['int'], isA<List>());
+          expect(data['float'], isA<List>());
+          expect(data['double'], isA<List>());
+        },
+        // This test is the web counterpart of the above test,
+        // verifying that typed data serialization works on dart2js
+        // without triggering "Int64 accessor not supported by dart2js".
+        skip: !kIsWeb,
+      );
+
+      test(
         '[HttpsCallableResult.data] should return Map<String, dynamic> type for returned objects',
         () async {
           HttpsCallable callable =


### PR DESCRIPTION
## Description

Fix "Int64 accessor not supported by dart2js" crash on Flutter web when calling `httpsCallable.call()`. The `_updateRawDataToList` helper checks `value is Int64List` on all platforms, but dart2js cannot evaluate this type check at all. Guarded it with `!kIsWeb` so it only runs on native platforms where Int64List is supported.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17924

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
