### PR TITLE
docs(auth,android): add documentation about android:taskAffinity when using OAuth signing

### DIFF
--- a/docs/auth/federated-auth.md
+++ b/docs/auth/federated-auth.md
@@ -12,6 +12,13 @@ Both native platforms and web support creating a credential which can then be pa
 or `linkWithCredential` methods. Alternatively on web platforms, you can trigger the authentication process via
 a popup or redirect.
 
+Note: On Android, `signInWithProvider` opens a Chrome Custom Tab for the OAuth flow. If your
+`AndroidManifest.xml` contains `android:taskAffinity=""` (Flutter's default template), the Custom Tab
+will close when the user switches apps (e.g. to open a password manager), and returning will give a
+`web-context-already-presented` error. To fix this, remove `android:taskAffinity=""` from your
+`AndroidManifest.xml`.
+{: .callout .callout-warning}
+
 ## Google
 
 Most configuration is already setup when using Google Sign-In with Firebase, however you need to ensure your machine's


### PR DESCRIPTION
## Description

Add a warning note to the federated auth documentation about `android:taskAffinity=""` causing Chrome Custom Tabs to close when switching apps during OAuth sign-in on Android. This attribute is in Flutter's default template and leads to a `web-context-already-presented` error.

### Fix

Remove `android:taskAffinity=""` from your `AndroidManifest.xml`:

```xml
<!-- Remove this line -->
<activity
    android:taskAffinity=""  <!-- delete this -->
    ...>
```

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17831

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
