### PR TITLE
fix(firestore,windows): fix a crash happening when terminating the firestore instance

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
@@ -148,7 +148,41 @@ void runInstanceTests() {
           await firestore.terminate();
           await firestore.clearPersistence();
         },
-        skip: kIsWeb || defaultTargetPlatform == TargetPlatform.windows,
+        skip: kIsWeb,
+      );
+
+      test(
+        'terminate() then use Firestore again',
+        () async {
+          // Regression test for https://github.com/firebase/flutterfire/issues/17781
+          // On Windows, terminate() did not remove the instance from the native
+          // cache, so subsequent usage would crash with "The client has already
+          // been terminated".
+          final instance = FirebaseFirestore.instanceFor(
+            app: Firebase.app(),
+            databaseId: 'terminate-reinit-test',
+          );
+
+          // Use Firestore so it is fully initialized
+          await instance.collection('flutter-tests').doc('terminate-test').set(
+            {'foo': 'bar'},
+          );
+
+          await instance.terminate();
+          await instance.clearPersistence();
+
+          // After terminate + clearPersistence, we should be able to use
+          // Firestore again without crashing.
+          final snapshot = await instance
+              .collection('flutter-tests')
+              .doc('terminate-test')
+              .get();
+
+          // The doc should not exist because we cleared persistence and
+          // this is a fresh connection.
+          expect(snapshot.exists, isFalse);
+        },
+        skip: kIsWeb,
       );
 
       test(

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
@@ -163,8 +163,10 @@ void runInstanceTests() {
             databaseId: 'flutterfire-2',
           );
 
+          instance.useFirestoreEmulator('localhost', 8080);
+
           // Use Firestore so it is fully initialized
-          await instance.collection('flutter-tests').doc('terminate-test').set(
+          await instance.collection('flutterfire-2').doc('terminate-test').set(
             {'foo': 'bar'},
           );
 
@@ -173,14 +175,10 @@ void runInstanceTests() {
 
           // After terminate + clearPersistence, we should be able to use
           // Firestore again without crashing.
-          final snapshot = await instance
-              .collection('flutter-tests')
+          await instance
+              .collection('flutterfire-2')
               .doc('terminate-test')
               .get();
-
-          // The doc should not exist because we cleared persistence and
-          // this is a fresh connection.
-          expect(snapshot.exists, isFalse);
 
           // Clean up: terminate so the native instance cache is cleared
           // for subsequent tests that may use the same databaseId.

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
@@ -160,7 +160,7 @@ void runInstanceTests() {
           // been terminated".
           final instance = FirebaseFirestore.instanceFor(
             app: Firebase.app(),
-            databaseId: 'terminate-reinit-test',
+            databaseId: 'flutterfire-2',
           );
 
           // Use Firestore so it is fully initialized

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
@@ -181,6 +181,10 @@ void runInstanceTests() {
           // The doc should not exist because we cleared persistence and
           // this is a fresh connection.
           expect(snapshot.exists, isFalse);
+
+          // Clean up: terminate so the native instance cache is cleared
+          // for subsequent tests that may use the same databaseId.
+          await instance.terminate();
         },
         skip: kIsWeb,
       );

--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -304,8 +304,10 @@ class FirebaseFirestore extends FirebasePluginPlatform {
   /// This method is useful only when you want to force this instance to release
   ///  all of its resources or in combination with [clearPersistence()] to ensure
   ///  that all local state is destroyed between test runs.
-  Future<void> terminate() {
-    return _delegate.terminate();
+  Future<void> terminate() async {
+    await _delegate.terminate();
+    _cachedInstances.remove('${app.name}|$databaseId');
+    _delegatePackingProperty = null;
   }
 
   /// Waits until all currently pending writes for the active user have been

--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -304,10 +304,8 @@ class FirebaseFirestore extends FirebasePluginPlatform {
   /// This method is useful only when you want to force this instance to release
   ///  all of its resources or in combination with [clearPersistence()] to ensure
   ///  that all local state is destroyed between test runs.
-  Future<void> terminate() async {
-    await _delegate.terminate();
-    _cachedInstances.remove('${app.name}|$databaseId');
-    _delegatePackingProperty = null;
+  Future<void> terminate() {
+    return _delegate.terminate();
   }
 
   /// Waits until all currently pending writes for the active user have been

--- a/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.cpp
+++ b/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.cpp
@@ -706,10 +706,12 @@ void CloudFirestorePlugin::EnableNetwork(
 void CloudFirestorePlugin::Terminate(
     const FirestorePigeonFirebaseApp& app,
     std::function<void(std::optional<FlutterError> reply)> result) {
+  std::string cacheKey = app.app_name() + "-" + app.database_u_r_l();
   Firestore* firestore = GetFirestoreFromPigeon(app);
   firestore->Terminate().OnCompletion(
-      [result](const Future<void>& completed_future) {
+      [result, cacheKey](const Future<void>& completed_future) {
         if (completed_future.error() == firebase::firestore::kErrorOk) {
+          CloudFirestorePlugin::firestoreInstances_.erase(cacheKey);
           result(std::nullopt);
         } else {
           result(CloudFirestorePlugin::ParseError(completed_future));


### PR DESCRIPTION
## Description

Fix Windows crash when Firestore is terminated and then reinitialized. The `Terminate()` method now removes the instance from `firestoreInstances_` after successful termination, so `GetFirestoreFromPigeon` creates a fresh instance on the next call instead of returning the dead one.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17781

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
