### PR TITLE
fix(core): bump Firebase C++ SDK to 13.5.0 (CMake deprecation fix)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -66,4 +66,3 @@ Horváth István <horvatska01@gmail.com>
 Liu Zhisong <liuzs0666@gmail.com>
 Ievgenii Kovtun <jeka.ns@gmail.com>
 Dinu-Stefan Rusu <rusudinustefan@gmail.com>
-David Bebawy <dbebawy@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -66,3 +66,4 @@ Horváth István <horvatska01@gmail.com>
 Liu Zhisong <liuzs0666@gmail.com>
 Ievgenii Kovtun <jeka.ns@gmail.com>
 Dinu-Stefan Rusu <rusudinustefan@gmail.com>
+David Bebawy <dbebawy@gmail.com>

--- a/packages/firebase_core/firebase_core/windows/CMakeLists.txt
+++ b/packages/firebase_core/firebase_core/windows/CMakeLists.txt
@@ -4,7 +4,7 @@
 # customers of the plugin.
 cmake_minimum_required(VERSION 3.14)
 
-set(FIREBASE_SDK_VERSION "13.4.0")
+set(FIREBASE_SDK_VERSION "13.5.0")
 
 if (EXISTS $ENV{FIREBASE_CPP_SDK_DIR}/include/firebase/version.h)
     file(READ "$ENV{FIREBASE_CPP_SDK_DIR}/include/firebase/version.h" existing_version)


### PR DESCRIPTION
## Description

Bumps `FIREBASE_SDK_VERSION` from `13.4.0` to `13.5.0` in the `firebase_core` Windows CMakeLists.txt.

The bundled Firebase C++ SDK 13.4.0 sets `cmake_minimum_required(VERSION 3.1)` in its `CMakeLists.txt`, which:
- Triggers a **deprecation warning** on CMake 3.25+
- Causes a **hard error** on CMake 4.x (shipped with Visual Studio 2026)

Firebase C++ SDK 13.5.0 ([firebase/firebase-cpp-sdk#1599](https://github.com/firebase/firebase-cpp-sdk/issues/1599)) bumps the minimum CMake version to `3.22`, resolving both the warning and the hard error.

## Related Issues

Fixes https://github.com/firebase/flutterfire/issues/12849

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

**Note on tests:** This is a one-line build configuration change (SDK version bump in CMakeLists.txt). The SDK version is validated at CMake build time — the Windows CI workflow's E2E build serves as the integration test. There is no Dart-level behavior change. Verified that [firebase_cpp_sdk_windows_13.5.0.zip](https://dl.google.com/firebase/sdk/cpp/firebase_cpp_sdk_windows_13.5.0.zip) is available on Google's CDN.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/