### PR TITLE
fix(remote_config,windows): release mode wasn't linking properly for Windows

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -53,6 +53,8 @@ jobs:
       - name: "Install Tools"
         run: |
           npm install -g firebase-tools
+      - name: "Build Windows (Release)"
+        run: cd tests && flutter build windows --release
       - name: Start Firebase Emulator and run tests
         run: cd ./.github/workflows/scripts && firebase emulators:exec --project flutterfire-e2e-tests "cd ../../../tests && flutter test .\integration_test\e2e_test.dart -d windows"
 

--- a/packages/firebase_core/firebase_core/windows/CMakeLists.txt
+++ b/packages/firebase_core/firebase_core/windows/CMakeLists.txt
@@ -122,7 +122,7 @@ add_subdirectory(${FIREBASE_CPP_SDK_DIR} bin/ EXCLUDE_FROM_ALL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${FIREBASE_CPP_SDK_DIR}/include")
 
-set(FIREBASE_RELEASE_PATH_LIBS firebase_app firebase_auth firebase_storage firebase_firestore)
+set(FIREBASE_RELEASE_PATH_LIBS firebase_app firebase_auth firebase_remote_config firebase_storage firebase_firestore)
 foreach(firebase_lib IN ITEMS ${FIREBASE_RELEASE_PATH_LIBS})
     get_target_property(firebase_lib_path ${firebase_lib} IMPORTED_LOCATION)
     string(REPLACE "Debug" "Release" firebase_lib_release_path ${firebase_lib_path})


### PR DESCRIPTION
## Description

Add `firebase_remote_config` to the `FIREBASE_RELEASE_PATH_LIBS` list in the `firebase_core` Windows CMakeLists.txt. Without this, the Firebase C++ SDK's `firebase_remote_config.lib` always resolves to the Debug variant, causing linker errors (`__imp__CrtDbgReport`, `__imp__calloc_dbg`, `_Crt_new_delete`) when building in Release mode.

Also adds a `flutter build windows --release` step to the Windows CI workflow so this class of bug is caught automatically in the future.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18072

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
