### PR TITLE
fix(fdc,web): add WASM support and improve CI

### DIFF
--- a/.github/workflows/e2e_tests_fdc.yaml
+++ b/.github/workflows/e2e_tests_fdc.yaml
@@ -333,3 +333,82 @@ jobs:
           key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
           # Must match the restore path exactly
           path: ~/.cache/firebase/emulators
+
+  web-wasm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
+        name: Install Node.js 20
+        with:
+          node-version: '20'
+      - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Setup PostgreSQL for Linux/macOS/Windows
+        uses: ikalnytskyi/action-setup-postgres@v7
+      - uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff
+        with:
+          channel: 'stable'
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
+      - uses: bluefireteam/melos-action@c7dcb921b23cc520cace360b95d02b37bf09cdaa
+        with:
+          run-bootstrap: false
+          melos-version: '5.3.0'
+      - name: 'Bootstrap package'
+        run: melos bootstrap --scope "firebase_data_connect*"
+      - name: 'Install Tools'
+        run: |
+          sudo npm i -g firebase-tools
+          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
+      - name: Firebase Emulator Cache
+        id: firebase-emulator-cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
+        with:
+          # The firebase emulators are pure javascript and java, OS-independent
+          enableCrossOsArchive: true
+          # Must match the save path exactly
+          path: ~/.cache/firebase/emulators
+          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
+          restore-keys: firebase-emulators-v3
+      - name: Start Firebase Emulator
+        run: |
+          cd ./packages/firebase_data_connect/firebase_data_connect/example
+          unset PGSERVICEFILE
+          firebase experiments:enable dataconnect
+          ./start-firebase-emulator.sh
+      - name: 'E2E Tests'
+        working-directory: 'packages/firebase_data_connect/firebase_data_connect/example'
+        # Web devices are not supported for the `flutter test` command yet. As a
+        # workaround we can use the `flutter drive` command. Tracking issue:
+        # https://github.com/flutter/flutter/issues/66264
+        run: |
+          chromedriver --port=4444 --trace-buffer-size=100000 &
+          mv ./web/wasm_index.html ./web/index.html
+          flutter drive --target=./integration_test/e2e_test.dart --driver=./test_driver/integration_test.dart -d chrome --wasm --dart-define=CI=true | tee output.log
+          # We have to check the output for failed tests matching the string "[E]"
+          output=$(<output.log)
+          if [[ "$output" =~ \[E\] ]]; then
+          # You will see "All tests passed." in the logs even when tests failed.
+          echo "All tests did not pass. Please check the logs for more information."
+          exit 1
+          fi
+        shell: bash
+      - name: Save Firestore Emulator Cache
+        # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        continue-on-error: true
+        with:
+          # The firebase emulators are pure javascript and java, OS-independent
+          enableCrossOsArchive: true
+          key: ${{ steps.firebase-emulator-cache.outputs.cache-primary-key }}
+          # Must match the restore path exactly
+          path: ~/.cache/firebase/emulators

--- a/.github/workflows/e2e_tests_fdc.yaml
+++ b/.github/workflows/e2e_tests_fdc.yaml
@@ -338,7 +338,7 @@ jobs:
           path: ~/.cache/firebase/emulators
 
   web-wasm:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e_tests_fdc.yaml
+++ b/.github/workflows/e2e_tests_fdc.yaml
@@ -21,6 +21,9 @@ on:
       - '**/example/**'
       - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   android:
     runs-on: ubuntu-latest

--- a/packages/firebase_data_connect/firebase_data_connect/example/web/wasm_index.html
+++ b/packages/firebase_data_connect/firebase_data_connect/example/web/wasm_index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Flutter web app</title>
+  <script src="flutter.js"></script>
+</head>
+<body>
+  <script>
+    {{flutter_build_config}}
+    _flutter.loader.load();
+  </script>
+</body>
+</html>

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
@@ -22,6 +22,7 @@ import 'package:flutter/foundation.dart';
 
 import './network/transport_library.dart'
     if (dart.library.io) './network/grpc_library.dart'
+    if (dart.library.js_interop) './network/rest_library.dart'
     if (dart.library.html) './network/rest_library.dart';
 
 import 'cache/cache_data_types.dart';


### PR DESCRIPTION
## Description

Data Connect fails when compiled to WASM because the conditional import for the network transport only checks `dart.library.io` and `dart.library.html`. In WASM, neither is true, so it falls through to the stub implementation that throws `UnimplementedError`. This adds `dart.library.js_interop` to resolve to the REST transport, which works in WASM.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18070

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
