### PR TITLE
docs(auth,ios): update Apple Sign In docs to showcase adding scopes

### DIFF
--- a/docs/auth/federated-auth.md
+++ b/docs/auth/federated-auth.md
@@ -215,11 +215,18 @@ For further information, see this [issue](https://github.com/firebase/flutterfir
   and [enable Apple as a sign-in provider](/docs/auth/web/apple#enable-apple-as-a-sign-in-provider).
 
 
+To have Apple present the full first-time sign-in UI (including the "Share/Hide email" option),
+you must request the `email` and `name` scopes:
+{: .callout .callout-info}
+
 ```dart
 import 'package:firebase_auth/firebase_auth.dart';
 
 Future<UserCredential> signInWithApple() async {
   final appleProvider = AppleAuthProvider();
+  appleProvider.addScope('email');
+  appleProvider.addScope('name');
+
   if (kIsWeb) {
     await FirebaseAuth.instance.signInWithPopup(appleProvider);
   } else {
@@ -266,6 +273,8 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 Future<UserCredential> signInWithApple() async {
   final appleProvider = AppleAuthProvider();
+  appleProvider.addScope('email');
+  appleProvider.addScope('name');
 
   UserCredential userCredential = await FirebaseAuth.instance.signInWithPopup(appleProvider);
   // Keep the authorization code returned from Apple platforms


### PR DESCRIPTION
## Description

Update Apple Sign-In documentation to include `email` and `name` scopes in all code examples. Without these scopes, the native iOS `ASAuthorizationAppleIDRequest` is sent with an empty scopes list, which causes Apple to skip the first-time "Share/Hide email" UI and return `null` for the user's email. Also added an info callout making this requirement explicit.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17773

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
