### PR TITLE
fix(storage,web): contentType inference for web

### DIFF
--- a/packages/firebase_storage/firebase_storage/lib/firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage/lib/firebase_storage.dart
@@ -8,9 +8,6 @@ library firebase_storage;
 import 'dart:async';
 import 'dart:convert' show utf8, base64;
 import 'dart:io' show File;
-// TODO(Lyokone): remove once we bump Flutter SDK min version to 3.3
-// ignore: unnecessary_import
-import 'dart:typed_data' show Uint8List;
 
 // import 'package:flutter/foundation.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -18,6 +15,7 @@ import 'package:firebase_core_platform_interface/firebase_core_platform_interfac
     show FirebasePluginPlatform;
 import 'package:firebase_storage_platform_interface/firebase_storage_platform_interface.dart';
 import 'package:flutter/foundation.dart';
+import 'package:mime/mime.dart';
 
 import 'src/utils.dart';
 

--- a/packages/firebase_storage/firebase_storage/lib/src/reference.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/reference.dart
@@ -103,13 +103,35 @@ class Reference {
     return _delegate.getData(maxSize);
   }
 
+  /// Infers the content type from the reference [name] if not already set.
+  SettableMetadata? _withInferredContentType(SettableMetadata? metadata) {
+    if (metadata?.contentType != null) return metadata;
+
+    final inferred = lookupMimeType(name);
+    if (inferred == null) return metadata;
+
+    if (metadata == null) {
+      return SettableMetadata(contentType: inferred);
+    }
+
+    return SettableMetadata(
+      cacheControl: metadata.cacheControl,
+      contentDisposition: metadata.contentDisposition,
+      contentEncoding: metadata.contentEncoding,
+      contentLanguage: metadata.contentLanguage,
+      contentType: inferred,
+      customMetadata: metadata.customMetadata,
+    );
+  }
+
   /// Uploads data to this reference's location.
   ///
   /// Use this method to upload fixed sized data as a [Uint8List].
   ///
   /// Optionally, you can also set metadata onto the uploaded object.
   UploadTask putData(Uint8List data, [SettableMetadata? metadata]) {
-    return UploadTask._(storage, _delegate.putData(data, metadata));
+    return UploadTask._(
+        storage, _delegate.putData(data, _withInferredContentType(metadata)));
   }
 
   /// Upload a [Blob]. Note; this is only supported on web platforms.
@@ -117,7 +139,8 @@ class Reference {
   /// Optionally, you can also set metadata onto the uploaded object.
   UploadTask putBlob(dynamic blob, [SettableMetadata? metadata]) {
     assert(blob != null);
-    return UploadTask._(storage, _delegate.putBlob(blob, metadata));
+    return UploadTask._(
+        storage, _delegate.putBlob(blob, _withInferredContentType(metadata)));
   }
 
   /// Upload a [File] from the filesystem. The file must exist.

--- a/packages/firebase_storage/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   firebase_storage_web: ^3.11.3
   flutter:
     sdk: flutter
+  mime: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/firebase_storage/firebase_storage/test/reference_test.dart
+++ b/packages/firebase_storage/firebase_storage/test/reference_test.dart
@@ -16,6 +16,7 @@ import 'package:mockito/mockito.dart';
 import 'mock.dart';
 
 MockReferencePlatform mockReference = MockReferencePlatform();
+MockReferencePlatform mockJpgReference = MockReferencePlatform();
 MockListResultPlatform mockListResultPlatform = MockListResultPlatform();
 MockUploadTaskPlatform mockUploadTaskPlatform = MockUploadTaskPlatform();
 MockDownloadTaskPlatform mockDownloadTaskPlatform = MockDownloadTaskPlatform();
@@ -305,6 +306,135 @@ Future<void> main() async {
         expect(result, isA<Task>());
 
         verify(mockReference.writeToFile(testFile));
+      });
+    });
+
+    group('putData() contentType inference', () {
+      late Reference jpgRef;
+
+      setUp(() {
+        when(kMockStoragePlatform.ref(any)).thenReturn(mockJpgReference);
+        when(mockJpgReference.bucket).thenReturn(testBucket);
+        when(mockJpgReference.fullPath).thenReturn('foo/photo.jpg');
+        when(mockJpgReference.name).thenReturn('photo.jpg');
+        jpgRef = storage.ref('foo/photo.jpg');
+      });
+
+      test('infers contentType from ref name when no metadata', () {
+        List<int> list = utf8.encode('hello');
+        Uint8List data = Uint8List.fromList(list);
+        when(mockJpgReference.putData(data, any))
+            .thenReturn(mockUploadTaskPlatform);
+
+        jpgRef.putData(data);
+
+        final captured = verify(mockJpgReference.putData(data, captureAny))
+            .captured
+            .single as SettableMetadata;
+        expect(captured.contentType, 'image/jpeg');
+      });
+
+      test('infers contentType when metadata has no contentType', () {
+        List<int> list = utf8.encode('hello');
+        Uint8List data = Uint8List.fromList(list);
+        when(mockJpgReference.putData(data, any))
+            .thenReturn(mockUploadTaskPlatform);
+
+        jpgRef.putData(data, SettableMetadata(contentLanguage: 'en'));
+
+        final captured = verify(mockJpgReference.putData(data, captureAny))
+            .captured
+            .single as SettableMetadata;
+        expect(captured.contentType, 'image/jpeg');
+        expect(captured.contentLanguage, 'en');
+      });
+
+      test('preserves explicit contentType', () {
+        List<int> list = utf8.encode('hello');
+        Uint8List data = Uint8List.fromList(list);
+        when(mockJpgReference.putData(data, any))
+            .thenReturn(mockUploadTaskPlatform);
+
+        jpgRef.putData(
+            data, SettableMetadata(contentType: 'application/octet-stream'));
+
+        final captured = verify(mockJpgReference.putData(data, captureAny))
+            .captured
+            .single as SettableMetadata;
+        expect(captured.contentType, 'application/octet-stream');
+      });
+
+      test('preserves customMetadata when inferring contentType', () {
+        List<int> list = utf8.encode('hello');
+        Uint8List data = Uint8List.fromList(list);
+        when(mockJpgReference.putData(data, any))
+            .thenReturn(mockUploadTaskPlatform);
+
+        jpgRef.putData(
+            data,
+            SettableMetadata(
+                customMetadata: {'activity': 'test'}));
+
+        final captured = verify(mockJpgReference.putData(data, captureAny))
+            .captured
+            .single as SettableMetadata;
+        expect(captured.contentType, 'image/jpeg');
+        expect(captured.customMetadata, {'activity': 'test'});
+      });
+
+      test('no inference when ref has no extension', () {
+        // Reset to the default mock with no extension
+        when(kMockStoragePlatform.ref(any)).thenReturn(mockReference);
+        when(mockReference.name).thenReturn(testName);
+        final noExtRef = storage.ref();
+
+        List<int> list = utf8.encode('hello');
+        Uint8List data = Uint8List.fromList(list);
+        when(mockReference.putData(data, null))
+            .thenReturn(mockUploadTaskPlatform);
+
+        noExtRef.putData(data);
+
+        verify(mockReference.putData(data, null));
+      });
+    });
+
+    group('putBlob() contentType inference', () {
+      late Reference jpgRef;
+
+      setUp(() {
+        when(kMockStoragePlatform.ref(any)).thenReturn(mockJpgReference);
+        when(mockJpgReference.bucket).thenReturn(testBucket);
+        when(mockJpgReference.fullPath).thenReturn('foo/photo.jpg');
+        when(mockJpgReference.name).thenReturn('photo.jpg');
+        jpgRef = storage.ref('foo/photo.jpg');
+      });
+
+      test('infers contentType from ref name when no metadata', () {
+        when(mockJpgReference.putBlob(any, any))
+            .thenReturn(mockUploadTaskPlatform);
+
+        jpgRef.putBlob('blob-data');
+
+        final captured =
+            verify(mockJpgReference.putBlob(any, captureAny))
+                .captured
+                .single as SettableMetadata;
+        expect(captured.contentType, 'image/jpeg');
+      });
+
+      test('preserves explicit contentType', () {
+        when(mockJpgReference.putBlob(any, any))
+            .thenReturn(mockUploadTaskPlatform);
+
+        jpgRef.putBlob(
+            'blob-data', SettableMetadata(contentType: 'text/plain'));
+
+        final captured =
+            verify(mockJpgReference.putBlob(any, captureAny))
+                .captured
+                .single as SettableMetadata;
+        expect(captured.contentType, 'text/plain');
       });
     });
 

--- a/packages/firebase_storage/firebase_storage/test/reference_test.dart
+++ b/packages/firebase_storage/firebase_storage/test/reference_test.dart
@@ -371,9 +371,7 @@ Future<void> main() async {
             .thenReturn(mockUploadTaskPlatform);
 
         jpgRef.putData(
-            data,
-            SettableMetadata(
-                customMetadata: {'activity': 'test'}));
+            data, SettableMetadata(customMetadata: {'activity': 'test'}));
 
         final captured = verify(mockJpgReference.putData(data, captureAny))
             .captured
@@ -390,12 +388,11 @@ Future<void> main() async {
 
         List<int> list = utf8.encode('hello');
         Uint8List data = Uint8List.fromList(list);
-        when(mockReference.putData(data, null))
-            .thenReturn(mockUploadTaskPlatform);
+        when(mockReference.putData(data)).thenReturn(mockUploadTaskPlatform);
 
         noExtRef.putData(data);
 
-        verify(mockReference.putData(data, null));
+        verify(mockReference.putData(data));
       });
     });
 
@@ -416,10 +413,9 @@ Future<void> main() async {
 
         jpgRef.putBlob('blob-data');
 
-        final captured =
-            verify(mockJpgReference.putBlob(any, captureAny))
-                .captured
-                .single as SettableMetadata;
+        final captured = verify(mockJpgReference.putBlob(any, captureAny))
+            .captured
+            .single as SettableMetadata;
         expect(captured.contentType, 'image/jpeg');
       });
 
@@ -430,10 +426,9 @@ Future<void> main() async {
         jpgRef.putBlob(
             'blob-data', SettableMetadata(contentType: 'text/plain'));
 
-        final captured =
-            verify(mockJpgReference.putBlob(any, captureAny))
-                .captured
-                .single as SettableMetadata;
+        final captured = verify(mockJpgReference.putBlob(any, captureAny))
+            .captured
+            .single as SettableMetadata;
         expect(captured.contentType, 'text/plain');
       });
     });

--- a/tests/integration_test/firebase_storage/reference_e2e.dart
+++ b/tests/integration_test/firebase_storage/reference_e2e.dart
@@ -307,6 +307,46 @@ void setupReferenceTests() {
             expect(complete.metadata?.contentType, 'application/json');
           },
         );
+
+        test(
+          'infers contentType from .json ref path when no contentType set',
+          () async {
+            final Uint8List jsonData =
+                utf8.encode(jsonEncode({'key': 'value'}));
+            final Reference ref =
+                storage.ref('flutter-tests').child('flt-infer.json');
+            final TaskSnapshot complete = await ref.putData(jsonData);
+            expect(complete.metadata?.contentType, 'application/json');
+          },
+        );
+
+        test(
+          'infers contentType from .txt ref path and preserves customMetadata',
+          () async {
+            final Uint8List txtData = utf8.encode('hello world');
+            final Reference ref =
+                storage.ref('flutter-tests').child('flt-infer.txt');
+            final TaskSnapshot complete = await ref.putData(
+              txtData,
+              SettableMetadata(
+                customMetadata: {'activity': 'test'},
+              ),
+            );
+            expect(complete.metadata?.contentType, 'text/plain');
+            expect(complete.metadata?.customMetadata?['activity'], 'test');
+          },
+        );
+
+        test(
+          'infers contentType from .jpg ref path when no metadata provided',
+          () async {
+            final Uint8List imgData = Uint8List.fromList([0xFF, 0xD8, 0xFF]);
+            final Reference ref =
+                storage.ref('flutter-tests').child('flt-infer.jpg');
+            final TaskSnapshot complete = await ref.putData(imgData);
+            expect(complete.metadata?.contentType, 'image/jpeg');
+          },
+        );
       },
     );
 


### PR DESCRIPTION
## Description

`putData` and `putBlob` default to `application/octet-stream` when no `contentType` is set. This adds MIME type inference from the reference's file extension (via `package:mime`) in the common `Reference` class. Explicit `contentType` is never overridden.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17651

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
