### PR TITLE
ci: update swift-integration tests to work on main

### DIFF
--- a/.github/workflows/scripts/swift-integration.dart
+++ b/.github/workflows/scripts/swift-integration.dart
@@ -214,7 +214,10 @@ Future<void> updatePackageSwiftForPackage(
     }
 
     // handles forked repositories
-    final repoSlug = headRepo != baseRepo ? headRepo : baseRepo;
+    final repoSlug =
+        (headRepo != null && headRepo.isNotEmpty && headRepo != baseRepo)
+            ? headRepo
+            : baseRepo;
     print('repoSlug: $repoSlug');
     print('branch: $branch');
 


### PR DESCRIPTION
## Description

On pushes to `main`, `PR_HEAD_REPO` is empty (no PR context), so the repo slug comparison `headRepo != baseRepo` evaluates to `"" != "firebase/flutterfire"` which is `true`, picking the empty string as the repo slug. This produces an invalid SPM package URL (`https://github.com/`) which SPM resolves as a package named `github.com` instead of `flutterfire`, breaking all plugin target dependencies.

The fix adds null/empty checks before comparing `headRepo` with `baseRepo`.

## Related Issues

- Fixes the `swift-integration` CI job failing on `main` branch pushes

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
