### PR TITLE
fix(auth): fix inconsistence in casing in the native iOS SDK and Web SDK

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
@@ -113,6 +113,9 @@ static NSMutableDictionary<NSNumber *, FIRAuthCredential *> *credentialsMap;
   // Map an id to a MultiFactorResolver object.
   NSMutableDictionary<NSString *, FIRTOTPSecret *> *_multiFactorTotpSecretMap;
 
+  // Emulator host/port per app, used to build REST URLs for workarounds.
+  NSMutableDictionary<NSString *, NSDictionary *> *_emulatorConfigs;
+
   NSObject<FlutterBinaryMessenger> *_binaryMessenger;
   NSMutableDictionary<NSString *, FlutterEventChannel *> *_eventChannels;
   NSMutableDictionary<NSString *, NSObject<FlutterStreamHandler> *> *_streamHandlers;
@@ -134,6 +137,7 @@ static NSMutableDictionary<NSNumber *, FIRAuthCredential *> *credentialsMap;
     _multiFactorResolverMap = [NSMutableDictionary dictionary];
     _multiFactorAssertionMap = [NSMutableDictionary dictionary];
     _multiFactorTotpSecretMap = [NSMutableDictionary dictionary];
+    _emulatorConfigs = [NSMutableDictionary dictionary];
   }
   return self;
 }
@@ -1137,7 +1141,20 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
                if (error != nil) {
                  completion(nil, [FLTFirebaseAuthPlugin convertToFlutterError:error]);
                } else {
-                 completion([self parseActionCode:info], nil);
+                 PigeonActionCodeInfo *result = [self parseActionCode:info];
+                 if (result.operation == ActionCodeInfoOperationUnknown) {
+                   // Workaround: Firebase iOS SDK >=11.12.0 returns .unknown because
+                   // actionCodeOperation(forRequestType:) only matches camelCase but the
+                   // REST API returns SCREAMING_SNAKE_CASE (e.g. "VERIFY_EMAIL").
+                   // Re-fetch the raw requestType via REST to resolve the operation.
+                   // See: https://github.com/firebase/flutterfire/issues/17452
+                   [self resolveActionCodeOperationForApp:app
+                                                    code:code
+                                            fallbackInfo:result
+                                              completion:completion];
+                 } else {
+                   completion(result, nil);
+                 }
                }
              }];
 }
@@ -1165,6 +1182,91 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
   }
 
   return [PigeonActionCodeInfo makeWithOperation:operation data:data];
+}
+
+/// Maps a raw requestType string (either camelCase or SCREAMING_SNAKE_CASE) to
+/// the corresponding Pigeon enum value.
++ (ActionCodeInfoOperation)operationFromRequestType:(nullable NSString *)requestType {
+  static NSDictionary<NSString *, NSNumber *> *mapping;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    mapping = @{
+      @"PASSWORD_RESET" : @(ActionCodeInfoOperationPasswordReset),
+      @"resetPassword" : @(ActionCodeInfoOperationPasswordReset),
+      @"VERIFY_EMAIL" : @(ActionCodeInfoOperationVerifyEmail),
+      @"verifyEmail" : @(ActionCodeInfoOperationVerifyEmail),
+      @"RECOVER_EMAIL" : @(ActionCodeInfoOperationRecoverEmail),
+      @"recoverEmail" : @(ActionCodeInfoOperationRecoverEmail),
+      @"EMAIL_SIGNIN" : @(ActionCodeInfoOperationEmailSignIn),
+      @"signIn" : @(ActionCodeInfoOperationEmailSignIn),
+      @"VERIFY_AND_CHANGE_EMAIL" : @(ActionCodeInfoOperationVerifyAndChangeEmail),
+      @"verifyAndChangeEmail" : @(ActionCodeInfoOperationVerifyAndChangeEmail),
+      @"REVERT_SECOND_FACTOR_ADDITION" : @(ActionCodeInfoOperationRevertSecondFactorAddition),
+      @"revertSecondFactorAddition" : @(ActionCodeInfoOperationRevertSecondFactorAddition),
+    };
+  });
+
+  NSNumber *value = mapping[requestType];
+  return value ? (ActionCodeInfoOperation)value.integerValue : ActionCodeInfoOperationUnknown;
+}
+
+/// Calls the Identity Toolkit REST API directly to retrieve the raw requestType
+/// string, which the iOS SDK fails to parse correctly. Falls back to the original
+/// result if the REST call fails for any reason.
+- (void)resolveActionCodeOperationForApp:(nonnull AuthPigeonFirebaseApp *)app
+                                    code:(nonnull NSString *)code
+                            fallbackInfo:(nonnull PigeonActionCodeInfo *)fallbackInfo
+                              completion:(nonnull void (^)(PigeonActionCodeInfo *_Nullable,
+                                                           FlutterError *_Nullable))completion {
+  FIRApp *firebaseApp = [FLTFirebasePlugin firebaseAppNamed:app.appName];
+  NSString *apiKey = firebaseApp.options.APIKey;
+
+  NSString *baseURL;
+  NSDictionary *emulatorConfig = _emulatorConfigs[app.appName];
+  if (emulatorConfig) {
+    baseURL = [NSString stringWithFormat:@"http://%@:%@/identitytoolkit.googleapis.com",
+                                         emulatorConfig[@"host"], emulatorConfig[@"port"]];
+  } else {
+    baseURL = @"https://identitytoolkit.googleapis.com";
+  }
+
+  NSString *urlString =
+      [NSString stringWithFormat:@"%@/v1/accounts:resetPassword?key=%@", baseURL, apiKey];
+  NSURL *url = [NSURL URLWithString:urlString];
+
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+  request.HTTPMethod = @"POST";
+  [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+  request.HTTPBody = [NSJSONSerialization dataWithJSONObject:@{@"oobCode" : code}
+                                                    options:0
+                                                      error:nil];
+
+  NSURLSessionDataTask *task = [[NSURLSession sharedSession]
+      dataTaskWithRequest:request
+        completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response,
+                            NSError *_Nullable error) {
+          if (error || !data) {
+            completion(fallbackInfo, nil);
+            return;
+          }
+
+          NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+          if (!json || json[@"error"]) {
+            completion(fallbackInfo, nil);
+            return;
+          }
+
+          ActionCodeInfoOperation operation =
+              [FLTFirebaseAuthPlugin operationFromRequestType:json[@"requestType"]];
+
+          if (operation != ActionCodeInfoOperationUnknown) {
+            completion([PigeonActionCodeInfo makeWithOperation:operation data:fallbackInfo.data],
+                       nil);
+          } else {
+            completion(fallbackInfo, nil);
+          }
+        }];
+  [task resume];
 }
 
 - (void)confirmPasswordResetApp:(nonnull AuthPigeonFirebaseApp *)app
@@ -1600,6 +1702,7 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
             completion:(nonnull void (^)(FlutterError *_Nullable))completion {
   FIRAuth *auth = [self getFIRAuthFromAppNameFromPigeon:app];
   [auth useEmulatorWithHost:host port:port];
+  _emulatorConfigs[app.appName] = @{@"host" : host, @"port" : @(port)};
   completion(nil);
 }
 

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
@@ -1149,9 +1149,9 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
                    // Re-fetch the raw requestType via REST to resolve the operation.
                    // See: https://github.com/firebase/flutterfire/issues/17452
                    [self resolveActionCodeOperationForApp:app
-                                                    code:code
-                                            fallbackInfo:result
-                                              completion:completion];
+                                                     code:code
+                                             fallbackInfo:result
+                                               completion:completion];
                  } else {
                    completion(result, nil);
                  }
@@ -1238,8 +1238,8 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
   request.HTTPMethod = @"POST";
   [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
   request.HTTPBody = [NSJSONSerialization dataWithJSONObject:@{@"oobCode" : code}
-                                                    options:0
-                                                      error:nil];
+                                                     options:0
+                                                       error:nil];
 
   NSURLSessionDataTask *task = [[NSURLSession sharedSession]
       dataTaskWithRequest:request

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
@@ -575,6 +575,7 @@ extension type ConfirmationResultJsImpl._(JSObject _) implements JSObject {
 /// See: <https://firebase.google.com/docs/reference/js/firebase.auth.ActionCodeInfo>.
 extension type ActionCodeInfo._(JSObject _) implements JSObject {
   external ActionCodeData get data;
+  external JSString get operation;
 }
 
 /// Interface representing a user's metadata.

--- a/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
@@ -172,12 +172,32 @@ ActionCodeInfo? convertWebActionCodeInfo(
   }
 
   return ActionCodeInfo(
-    operation: ActionCodeInfoOperation.passwordReset,
+    operation:
+        _convertWebActionCodeOperation(webActionCodeInfo.operation.toDart),
     data: ActionCodeInfoData(
       email: webActionCodeInfo.data.email?.toDart,
       previousEmail: webActionCodeInfo.data.previousEmail?.toDart,
     ),
   );
+}
+
+ActionCodeInfoOperation _convertWebActionCodeOperation(String operation) {
+  switch (operation) {
+    case 'EMAIL_SIGNIN':
+      return ActionCodeInfoOperation.emailSignIn;
+    case 'PASSWORD_RESET':
+      return ActionCodeInfoOperation.passwordReset;
+    case 'RECOVER_EMAIL':
+      return ActionCodeInfoOperation.recoverEmail;
+    case 'REVERT_SECOND_FACTOR_ADDITION':
+      return ActionCodeInfoOperation.revertSecondFactorAddition;
+    case 'VERIFY_AND_CHANGE_EMAIL':
+      return ActionCodeInfoOperation.verifyAndChangeEmail;
+    case 'VERIFY_EMAIL':
+      return ActionCodeInfoOperation.verifyEmail;
+    default:
+      return ActionCodeInfoOperation.unknown;
+  }
 }
 
 /// Converts a [auth_interop.AdditionalUserInfo] into a [AdditionalUserInfo].

--- a/tests/integration_test/firebase_auth/firebase_auth_instance_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_instance_e2e_test.dart
@@ -271,6 +271,59 @@ void main() {
               fail(e.toString());
             }
           });
+
+          test('returns correct operation for verifyEmail action code',
+              () async {
+            final email = generateRandomEmail();
+            await FirebaseAuth.instance.createUserWithEmailAndPassword(
+              email: email,
+              password: testPassword,
+            );
+
+            await FirebaseAuth.instance.currentUser!.sendEmailVerification();
+
+            final oobCode = await emulatorOutOfBandCode(
+              email,
+              EmulatorOobCodeType.verifyEmail,
+            );
+            expect(oobCode, isNotNull);
+
+            final actionCodeInfo = await FirebaseAuth.instance.checkActionCode(
+              oobCode!.oobCode!,
+            );
+
+            expect(
+              actionCodeInfo.operation,
+              equals(ActionCodeInfoOperation.verifyEmail),
+            );
+          });
+
+          test('returns correct operation for passwordReset action code',
+              () async {
+            final email = generateRandomEmail();
+            await FirebaseAuth.instance.createUserWithEmailAndPassword(
+              email: email,
+              password: testPassword,
+            );
+            await ensureSignedOut();
+
+            await FirebaseAuth.instance.sendPasswordResetEmail(email: email);
+
+            final oobCode = await emulatorOutOfBandCode(
+              email,
+              EmulatorOobCodeType.passwordReset,
+            );
+            expect(oobCode, isNotNull);
+
+            final actionCodeInfo = await FirebaseAuth.instance.checkActionCode(
+              oobCode!.oobCode!,
+            );
+
+            expect(
+              actionCodeInfo.operation,
+              equals(ActionCodeInfoOperation.passwordReset),
+            );
+          });
         },
         skip: !kIsWeb && Platform.isWindows,
       );


### PR DESCRIPTION
## Description

`checkActionCode` on iOS always returns `ActionCodeInfoOperation.unknown` since Firebase iOS SDK 11.12.0. The upstream SDK's [`actionCodeOperation(forRequestType:)`](https://github.com/firebase/firebase-ios-sdk/blob/main/FirebaseAuth/Sources/Swift/ActionCode/ActionCodeInfo.swift#L45-L56) was changed from matching `"VERIFY_EMAIL"` to `"verifyEmail"`, but the REST API still returns SCREAMING_SNAKE_CASE. Since the raw `requestType` is internal to the SDK and not exposed on `FIRActionCodeInfo`, we work around this by making a direct REST call to the Identity Toolkit API when the operation comes back as unknown, and mapping both case formats ourselves. The workaround is self-disabling: once the upstream fix lands, the iOS SDK won't return `.unknown` anymore and the fallback path is never taken.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17452
- Upstream bug: https://github.com/firebase/firebase-ios-sdk/issues/15010 (closed without fix)
- Introduced by: https://github.com/firebase/firebase-ios-sdk/pull/14668

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
