### PR TITLE
feat(analytics): add support for items in logEvent

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/android/src/main/kotlin/io/flutter/plugins/firebase/analytics/FlutterFirebaseAnalyticsPlugin.kt
+++ b/packages/firebase_analytics/firebase_analytics/android/src/main/kotlin/io/flutter/plugins/firebase/analytics/FlutterFirebaseAnalyticsPlugin.kt
@@ -310,11 +310,11 @@ class FlutterFirebaseAnalyticsPlugin : FlutterFirebasePlugin,
       } else if (value == null) {
         bundle.putString(key, null)
       } else if (value is Iterable<*>) {
-        val list = ArrayList<Parcelable?>()
+        val list = mutableListOf<Parcelable>()
 
         for (item in value) {
           if (item is Map<*, *>) {
-            list.add(createBundleFromMap(item as Map<String, Any>))
+            createBundleFromMap(item as Map<String, Any>)?.let { list.add(it) }
           } else {
             if (item != null) {
               throw IllegalArgumentException(
@@ -327,7 +327,7 @@ class FlutterFirebaseAnalyticsPlugin : FlutterFirebasePlugin,
           }
         }
 
-        bundle.putParcelableArrayList(key, list)
+        bundle.putParcelableArray(key, list.toTypedArray())
       } else if (value is Map<*, *>) {
         bundle.putParcelable(key, createBundleFromMap(value as Map<String, Any>))
       } else {

--- a/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
@@ -100,15 +100,27 @@ class FirebaseAnalytics extends FirebasePluginPlatform {
   Future<void> logEvent({
     required String name,
     Map<String, Object>? parameters,
+    List<AnalyticsEventItem>? items,
     AnalyticsCallOptions? callOptions,
   }) async {
     _logEventNameValidation(name);
 
     _assertParameterTypesAreCorrect(parameters);
+    _assertItemsParameterTypesAreCorrect(items);
+
+    final Map<String, Object>? effectiveParameters;
+    if (items != null) {
+      effectiveParameters = filterOutNulls(<String, Object?>{
+        _ITEMS: _marshalItems(items),
+        if (parameters != null) ...parameters,
+      });
+    } else {
+      effectiveParameters = parameters;
+    }
 
     await _delegate.logEvent(
       name: name,
-      parameters: parameters,
+      parameters: effectiveParameters,
       callOptions: callOptions,
     );
   }

--- a/packages/firebase_analytics/firebase_analytics/test/firebase_analytics_test.dart
+++ b/packages/firebase_analytics/firebase_analytics/test/firebase_analytics_test.dart
@@ -189,6 +189,21 @@ void main() {
           value: 123.90,
         );
       });
+
+      test('logEvent with items rejects invalid item parameter types', () {
+        expect(
+          () => analytics!.logEvent(
+            name: 'custom_event',
+            items: [
+              AnalyticsEventItem(
+                itemId: 'id',
+                parameters: {'invalid': true},
+              ),
+            ],
+          ),
+          throwsA(isA<AssertionError>()),
+        );
+      });
     });
 
     group('filter out nulls', () {

--- a/tests/integration_test/firebase_analytics/firebase_analytics_e2e_test.dart
+++ b/tests/integration_test/firebase_analytics/firebase_analytics_e2e_test.dart
@@ -102,11 +102,33 @@ void main() {
           parameters: {
             'foo': 'bar',
             'baz': 500,
-            // Lists are not supported
+            // Lists are not supported in parameters
             'items': [analyticsEventItem],
           },
         ),
         throwsA(isA<AssertionError>()),
+      );
+
+      // test logEvent with typed items parameter
+      await expectLater(
+        FirebaseAnalytics.instance.logEvent(
+          name: 'testing-items',
+          items: [analyticsEventItem],
+        ),
+        completes,
+      );
+
+      // test logEvent with both items and parameters
+      await expectLater(
+        FirebaseAnalytics.instance.logEvent(
+          name: 'testing-items-and-parameters',
+          items: [analyticsEventItem],
+          parameters: {
+            'foo': 'bar',
+            'baz': 500,
+          },
+        ),
+        completes,
       );
 
       // test 3 reserved events


### PR DESCRIPTION
## Description

Add optional `List<AnalyticsEventItem>? items` parameter to `FirebaseAnalytics.logEvent()`. This allows developers to pass strongly-typed items to custom/generic event names without needing to use specialized methods like `logAddToCart` or `logPurchase`. The items are marshalled identically to how the existing specialized methods handle them.

```dart
await FirebaseAnalytics.instance.logEvent(
  name: 'custom_ecommerce_event',
  items: [
    AnalyticsEventItem(itemId: 'SKU_123', itemName: 'T-Shirt', price: 9.99),
  ],
  parameters: {'extra_param': 'value'},
);
```

No platform-level changes are needed — the native SDKs (Android, iOS, Web) already support items in generic logEvent calls via the existing parameter map infrastructure.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17404

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
