### PR TITLE
fix(data_connect): fix UTF 8 characters decoding in data connect

### DIFF
--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
@@ -116,11 +116,12 @@ class RestTransport implements DataConnectTransport {
         headers: headers,
       );
       Map<String, dynamic> bodyJson =
-          jsonDecode(r.body) as Map<String, dynamic>;
+          jsonDecode(utf8.decode(r.bodyBytes)) as Map<String, dynamic>;
 
       if (r.statusCode != 200) {
-        String message =
-            bodyJson.containsKey('message') ? bodyJson['message']! : r.body;
+        String message = bodyJson.containsKey('message')
+            ? bodyJson['message']!
+            : utf8.decode(r.bodyBytes);
         throw DataConnectError(
           r.statusCode == 401
               ? DataConnectErrorCode.unauthorized

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.dart
@@ -282,7 +282,8 @@ void main() {
       // what the Firebase emulator sends). Without explicit UTF-8
       // decoding, the http package defaults to latin1, corrupting
       // multi-byte characters.
-      final koreanJson = '{"data": {"name": "\ud55c\uad6d\uc5b4 \ud14c\uc2a4\ud2b8"}}';
+      const koreanJson =
+          '{"data": {"name": "\ud55c\uad6d\uc5b4 \ud14c\uc2a4\ud2b8"}}';
       final mockResponse = http.Response.bytes(
         utf8.encode(koreanJson),
         200,
@@ -307,7 +308,8 @@ void main() {
         null,
       );
 
-      expect(result.data['data']['name'], equals('\ud55c\uad6d\uc5b4 \ud14c\uc2a4\ud2b8'));
+      expect(result.data['data']['name'],
+          equals('\ud55c\uad6d\uc5b4 \ud14c\uc2a4\ud2b8'));
     });
 
     test(

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.dart
@@ -275,6 +275,42 @@ void main() {
     });
 
     test(
+        'regression #17290 - invokeOperation should correctly decode UTF-8 response with international characters',
+        () async {
+      // Simulate a server response with Korean characters, where the
+      // Content-Type header does NOT include charset=utf-8 (which is
+      // what the Firebase emulator sends). Without explicit UTF-8
+      // decoding, the http package defaults to latin1, corrupting
+      // multi-byte characters.
+      final koreanJson = '{"data": {"name": "\ud55c\uad6d\uc5b4 \ud14c\uc2a4\ud2b8"}}';
+      final mockResponse = http.Response.bytes(
+        utf8.encode(koreanJson),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+      when(
+        mockHttpClient.post(
+          any,
+          headers: anyNamed('headers'),
+          body: anyNamed('body'),
+        ),
+      ).thenAnswer((_) async => mockResponse);
+
+      final deserializer = (String data) => 'Deserialized Data';
+
+      final result = await transport.invokeOperation(
+        'testQuery',
+        'executeQuery',
+        deserializer,
+        null,
+        null,
+        null,
+      );
+
+      expect(result.data['data']['name'], equals('\ud55c\uad6d\uc5b4 \ud14c\uc2a4\ud2b8'));
+    });
+
+    test(
         'invokeOperation should handle missing auth and appCheck tokens gracefully',
         () async {
       final mockResponse = http.Response('{"data": {"key": "value"}}', 200);


### PR DESCRIPTION
## Description

`RestTransport.invokeOperation` used `http.Response.body` to read the server response, which decodes bytes using the charset from the Content-Type header. When the server omits `charset=utf-8` (as the Firebase emulator does), the `http` package defaults to latin1 — corrupting multi-byte UTF-8 characters like Korean, Chinese, Japanese, etc.

Switched to `utf8.decode(response.bodyBytes)` for both the success and error paths so international characters are always decoded correctly.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17290

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
