### PR TITLE
fix(database, iOS): remove unnecessary order modifier checks in query construction

### DIFF
--- a/packages/firebase_database/firebase_database/ios/firebase_database/Sources/firebase_database/FLTFirebaseDatabasePlugin.swift
+++ b/packages/firebase_database/firebase_database/ios/firebase_database/Sources/firebase_database/FLTFirebaseDatabasePlugin.swift
@@ -389,7 +389,6 @@ public class FLTFirebaseDatabasePlugin: NSObject, FlutterPlugin, FLTFirebasePlug
     let reference = database.reference(withPath: request.path)
 
     var query: DatabaseQuery = reference
-    var hasOrderModifier = false
     for modifier in request.modifiers {
       guard let type = modifier["type"] as? String else { continue }
 
@@ -400,17 +399,13 @@ public class FLTFirebaseDatabasePlugin: NSObject, FlutterPlugin, FLTFirebasePlug
           case "orderByChild":
             if let path = modifier["path"] as? String {
               query = query.queryOrdered(byChild: path)
-              hasOrderModifier = true
             }
           case "orderByKey":
             query = query.queryOrderedByKey()
-            hasOrderModifier = true
           case "orderByValue":
             query = query.queryOrderedByValue()
-            hasOrderModifier = true
           case "orderByPriority":
             query = query.queryOrderedByPriority()
-            hasOrderModifier = true
           default:
             break
           }
@@ -422,17 +417,13 @@ public class FLTFirebaseDatabasePlugin: NSObject, FlutterPlugin, FLTFirebasePlug
           let key = modifier["key"] as? String
           switch name {
           case "startAt":
-            if !hasOrderModifier {
-              query = query.queryLimited(toFirst: 0)
-            } else if let key {
+            if let key {
               query = query.queryStarting(atValue: value, childKey: key)
             } else {
               query = query.queryStarting(atValue: value)
             }
           case "startAfter":
-            if !hasOrderModifier {
-              query = query.queryLimited(toFirst: 0)
-            } else if let key {
+            if let key {
               query = query.queryStarting(afterValue: value, childKey: key)
             } else {
               query = query.queryStarting(afterValue: value)

--- a/tests/integration_test/firebase_database/query_e2e.dart
+++ b/tests/integration_test/firebase_database/query_e2e.dart
@@ -52,6 +52,21 @@ void setupQueryTests() {
         },
       );
 
+      test(
+        'onValue with startAt(value, key) and no orderBy should not crash',
+        () async {
+          await ref.set({
+            'a': 1,
+            'b': 2,
+          });
+
+          final event =
+              await ref.startAt(1772319600000, key: 'start').onValue.first;
+
+          expect(event.type, DatabaseEventType.value);
+        },
+      );
+
       test('starts at the correct value', () async {
         await ref.set({
           'a': 1,

--- a/tests/integration_test/firebase_database/query_e2e.dart
+++ b/tests/integration_test/firebase_database/query_e2e.dart
@@ -56,12 +56,11 @@ void setupQueryTests() {
         'onValue with startAt(value, key) and no orderBy should not crash',
         () async {
           await ref.set({
-            'a': 1,
-            'b': 2,
+            't1': {'timestamp': 1, 'value': 'old'},
+            't2': {'timestamp': 1000, 'value': 'current'},
           });
 
-          final event =
-              await ref.startAt(1772319600000, key: 'start').onValue.first;
+          final event = await ref.startAt(1000, key: 't2').onValue.first;
 
           expect(event.type, DatabaseEventType.value);
         },


### PR DESCRIPTION
## Description

Fixes a crash on iOS when subscribing with `onValue` to a query that uses `startAt` or `startAfter` (including with a secondary key) without a preceding `orderBy` modifier ([#18132](https://github.com/firebase/flutterfire/issues/18132)).

Previously, the plugin used `hasOrderModifier` to special-case this scenario in `queryObserve` by calling `queryLimited(toFirst: 0)`. This is not valid in the Firebase iOS SDK and triggers `validateLimitRange:`.

This change removes that guard. The plugin now always applies the standard `queryStarting(atValue:...)` or `queryStarting(afterValue:...)` calls, matching other query paths and allowing the native SDK to handle the query correctly.

## Related Issues
Fixes https://github.com/firebase/flutterfire/issues/18132

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
