### PR TITLE
fix(app_check,web): fix an error that could occur when refreshing a token

### DIFF
--- a/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
@@ -171,9 +171,18 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
           _delegate!.idTokenChangedController?.close();
         },
       );
-      _delegate!.onTokenChanged(app.name).listen((event) {
-        _tokenChangesListeners[app.name]!.add(event.token.toDart);
-      });
+      _delegate!.onTokenChanged(app.name).listen(
+        (event) {
+          _tokenChangesListeners[app.name]!.add(event.token.toDart);
+        },
+        // Forward JS SDK errors (e.g. network failures during background
+        // token refresh) to the broadcast controller instead of letting them
+        // surface as unhandled zone errors. If nobody is listening on the
+        // broadcast stream the error is silently dropped.
+        onError: (Object error) {
+          _tokenChangesListeners[app.name]?.addError(error);
+        },
+      );
     }
   }
 


### PR DESCRIPTION
## Description

The internal stream subscription in `_initialiseStreamController` was missing an `onError` handler, causing JS SDK errors (e.g. network failures during background token refresh) to surface as unhandled zone exceptions. The fix forwards these errors to the broadcast `StreamController`, where they are silently dropped if nobody is listening or available to consumers via `onError`.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18128

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
