### PR TITLE
feat(messaging, iOS): add support for `onInitialMessage`(event-driven alternative to `getInitialMessage`)

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
@@ -174,6 +174,7 @@ class Application extends StatefulWidget {
 class _Application extends State<Application> {
   String? _token;
   String? initialMessage;
+  String? _onInitialMessagePreview;
   bool _resolved = false;
 
   @override
@@ -201,6 +202,15 @@ class _Application extends State<Application> {
         '/message',
         arguments: MessageArguments(message, true),
       );
+    });
+
+    FirebaseMessaging.onInitialMessage.listen((RemoteMessage message) {
+      print(
+        'onInitialMessage: messageId=${message.messageId} data=${message.data}',
+      );
+      setState(() {
+        _onInitialMessagePreview = message.data.toString();
+      });
     });
   }
 
@@ -308,9 +318,16 @@ class _Application extends State<Application> {
             MetaCard(
               'Initial Message',
               Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(_resolved ? 'Resolved' : 'Resolving'),
                   Text(initialMessage ?? 'None'),
+                  const SizedBox(height: 8),
+                  Text(
+                    'onInitialMessage (iOS terminated tap)',
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                  Text(_onInitialMessagePreview ?? 'None yet'),
                 ],
               ),
             ),

--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
@@ -450,6 +450,11 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     NSDictionary *notificationDict =
         [FLTFirebaseMessagingPlugin remoteMessageUserInfoToDict:remoteNotification];
     [_channel invokeMethod:@"Messaging#onMessageOpenedApp" arguments:notificationDict];
+  } else if (_notificationOpenedAppID != nil &&
+             [_initialNotificationID isEqualToString:_notificationOpenedAppID]) {
+    NSDictionary *notificationDict =
+        [FLTFirebaseMessagingPlugin remoteMessageUserInfoToDict:remoteNotification];
+    [_channel invokeMethod:@"Messaging#onInitialMessage" arguments:notificationDict];
   }
 
   // Forward on to any other delegates.

--- a/packages/firebase_messaging/firebase_messaging/lib/firebase_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/firebase_messaging.dart
@@ -9,6 +9,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
     show FirebasePluginPlatform;
 import 'package:firebase_messaging_platform_interface/firebase_messaging_platform_interface.dart';
+import 'package:flutter/foundation.dart';
 
 export 'package:firebase_messaging_platform_interface/firebase_messaging_platform_interface.dart'
     show

--- a/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
@@ -62,6 +62,26 @@ class FirebaseMessaging extends FirebasePluginPlatform {
   static Stream<RemoteMessage> get onMessageOpenedApp =>
       FirebaseMessagingPlatform.onMessageOpenedApp.stream;
 
+  /// Returns a [Stream] of [RemoteMessage] events when the user opens the app by tapping the
+  /// notification that was delivered as the initial (terminated-state) message on **iOS**.
+  ///
+  /// Each event is a [RemoteMessage] in the same sense as [getInitialMessage]: if the application
+  /// was opened from a terminated state via a [RemoteMessage], that is the payload you receive here.
+  ///
+  /// This is an **event-driven** alternative to [getInitialMessage]
+  ///
+  /// See also [onMessageOpenedApp].
+  ///
+  /// Throws [UnsupportedError] when not running on iOS.
+  static Stream<RemoteMessage> get onInitialMessage {
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      throw UnsupportedError(
+        'onInitialMessage is only supported on iOS.',
+      );
+    }
+    return FirebaseMessagingPlatform.onInitialMessage.stream;
+  }
+
   // ignore: use_setters_to_change_properties
   /// Set a message handler function which is called when the app is in the
   /// background or terminated.

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/method_channel/method_channel_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/method_channel/method_channel_messaging.dart
@@ -106,6 +106,12 @@ class MethodChannelFirebaseMessaging extends FirebaseMessagingPlatform {
           FirebaseMessagingPlatform.onMessageOpenedApp
               .add(RemoteMessage.fromMap(messageMap));
           break;
+        case 'Messaging#onInitialMessage':
+          Map<String, dynamic> messageMap =
+              Map<String, dynamic>.from(call.arguments);
+          FirebaseMessagingPlatform.onInitialMessage
+              .add(RemoteMessage.fromMap(messageMap));
+          break;
         case 'Messaging#onBackgroundMessage':
           // Apple only. Android calls via separate background channel.
           Map<String, dynamic> messageMap =

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
@@ -95,6 +95,7 @@ abstract class FirebaseMessagingPlatform extends PlatformInterface {
   /// This is an **event-driven** alternative to [getInitialMessage]
   ///
   /// See also [onMessageOpenedApp].
+  // ignore: close_sinks, never closed
   static final StreamController<RemoteMessage> onInitialMessage =
       StreamController<RemoteMessage>.broadcast();
 

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
@@ -86,6 +86,18 @@ abstract class FirebaseMessagingPlatform extends PlatformInterface {
   static final StreamController<RemoteMessage> onMessageOpenedApp =
       StreamController<RemoteMessage>.broadcast();
 
+  /// Returns a [Stream] of [RemoteMessage] events when the user opens the app by tapping the
+  /// notification that was delivered as the initial (terminated-state) message on **iOS**.
+  ///
+  /// Each event is a [RemoteMessage] in the same sense as [getInitialMessage]: if the application
+  /// was opened from a terminated state via a [RemoteMessage], that is the payload you receive here.
+  ///
+  /// This is an **event-driven** alternative to [getInitialMessage]
+  ///
+  /// See also [onMessageOpenedApp].
+  static final StreamController<RemoteMessage> onInitialMessage =
+      StreamController<RemoteMessage>.broadcast();
+
   static BackgroundMessageHandler? _onBackgroundMessageHandler;
 
   /// Set a message handler function which is called when the app is in the

--- a/tests/integration_test/firebase_messaging/firebase_messaging_e2e_test.dart
+++ b/tests/integration_test/firebase_messaging/firebase_messaging_e2e_test.dart
@@ -131,6 +131,31 @@ void main() {
         });
       });
 
+      group('onInitialMessage', () {
+        test(
+          'throws UnsupportedError on non-iOS',
+          () {
+            expect(
+              () => FirebaseMessaging.onInitialMessage,
+              throwsA(isA<UnsupportedError>()),
+            );
+          },
+          skip: defaultTargetPlatform == TargetPlatform.iOS,
+        );
+
+        test(
+          'can listen multiple times on iOS',
+          () async {
+            StreamSubscription<RemoteMessage> sub =
+                FirebaseMessaging.onInitialMessage.listen((_) {});
+            await sub.cancel();
+            sub = FirebaseMessaging.onInitialMessage.listen((_) {});
+            await sub.cancel();
+          },
+          skip: defaultTargetPlatform != TargetPlatform.iOS,
+        );
+      });
+
       group(
         'getToken()',
         () {


### PR DESCRIPTION
## Description

This PR adds `FirebaseMessaging.onInitialMessage` on iOS: a `Stream<RemoteMessage>` that emits when the user taps the notification that launched the app from a terminated state.

 ### Background

In practice, many developers invoke `getInitialMessage()` inside `initState`. However, on iOS this often returns null because the notification response has not yet been delivered to the Flutter plugin when the call is made. If the same call is delayed slightly (for example using `Future.delayed`), the message is usually returned correctly. This timing-sensitive behavior has led to workarounds in production apps.

### What this PR adds

This PR introduces `FirebaseMessaging.onInitialMessage`, a `Stream<RemoteMessage>` that emits once the native iOS layer reports the notification interaction that launched the app. This provides:
- an event-driven alternative to getInitialMessage()
- a signal that is aligned with the actual delivery of the notification response
- a more reliable and lifecycle-safe way to handle cold-start notification taps

## Related Issues
https://github.com/firebase/flutterfire/issues/17991
https://github.com/firebase/flutterfire/issues/12453

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
