### PR TITLE
feat(ai): add unexpectedToolCall finish reason and corresponding tests

### DIFF
--- a/packages/firebase_ai/firebase_ai/lib/src/api.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/api.dart
@@ -770,6 +770,9 @@ enum FinishReason {
   /// The candidate content was flagged for malformed function call reasons.
   malformedFunctionCall('MALFORMED_FUNCTION_CALL'),
 
+  /// The model produced an unexpected tool call.
+  unexpectedToolCall('UNEXPECTED_TOOL_CALL'),
+
   /// Unknown reason.
   other('OTHER');
 
@@ -790,6 +793,7 @@ enum FinishReason {
       'RECITATION' => FinishReason.recitation,
       'OTHER' => FinishReason.other,
       'MALFORMED_FUNCTION_CALL' => FinishReason.malformedFunctionCall,
+      'UNEXPECTED_TOOL_CALL' => FinishReason.unexpectedToolCall,
       _ => throw FormatException('Unhandled FinishReason format', jsonObject),
     };
   }

--- a/packages/firebase_ai/firebase_ai/test/api_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/api_test.dart
@@ -315,6 +315,7 @@ void main() {
       expect(FinishReason.recitation.toJson(), 'RECITATION');
       expect(FinishReason.malformedFunctionCall.toJson(),
           'MALFORMED_FUNCTION_CALL');
+      expect(FinishReason.unexpectedToolCall.toJson(), 'UNEXPECTED_TOOL_CALL');
       expect(FinishReason.other.toJson(), 'OTHER');
     });
 
@@ -1046,6 +1047,18 @@ void main() {
               VertexSerialization().parseGenerateContentResponse(jsonResponse);
           expect(response.candidates.first.finishReason,
               FinishReason.malformedFunctionCall);
+        });
+
+        test('parses unexpectedToolCall finishReason', () {
+          final jsonResponse = {
+            'candidates': [
+              {'finishReason': 'UNEXPECTED_TOOL_CALL'}
+            ]
+          };
+          final response =
+              VertexSerialization().parseGenerateContentResponse(jsonResponse);
+          expect(response.candidates.first.finishReason,
+              FinishReason.unexpectedToolCall);
         });
 
         test(


### PR DESCRIPTION
## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues
Fixes https://github.com/firebase/flutterfire/issues/18181

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
