### PR TITLE
feat(ai): Add languageCode parameter to SpeechConfig

### DIFF
--- a/packages/firebase_ai/firebase_ai/lib/src/live_api.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/live_api.dart
@@ -50,13 +50,16 @@ class VoiceConfig {
 
 /// Configures speech synthesis settings.
 ///
-/// Allows specifying the desired voice for speech synthesis.
+/// Allows specifying the desired voice and language for speech synthesis.
 class SpeechConfig {
   /// Creates a [SpeechConfig] instance.
   ///
   /// [voiceName] See https://cloud.google.com/text-to-speech/docs/chirp3-hd
   /// for names and sound demos.
-  SpeechConfig({String? voiceName})
+  ///
+  /// [languageCode] The language code (BCP-47) for the speech synthesis,
+  /// e.g. "en-US", "fr-FR", "de-DE".
+  SpeechConfig({String? voiceName, this.languageCode})
       : voiceConfig = voiceName != null
             ? VoiceConfig(
                 prebuiltVoiceConfig: PrebuiltVoiceConfig(voiceName: voiceName))
@@ -64,10 +67,16 @@ class SpeechConfig {
 
   /// The voice config to use for speech synthesis.
   final VoiceConfig? voiceConfig;
+
+  /// The language code (BCP-47) for speech synthesis,
+  /// e.g. "en-US", "fr-FR", "de-DE".
+  final String? languageCode;
   // ignore: public_member_api_docs
   Map<String, Object?> toJson() => {
         if (voiceConfig case final voiceConfig?)
-          'voice_config': voiceConfig.toJson()
+          'voice_config': voiceConfig.toJson(),
+        if (languageCode case final languageCode?)
+          'language_code': languageCode,
       };
 }
 

--- a/packages/firebase_ai/firebase_ai/test/live_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/live_test.dart
@@ -34,6 +34,22 @@ void main() {
       expect(speechConfigWithoutVoice.toJson(), {});
     });
 
+    test('SpeechConfig with languageCode toJson() returns correct JSON', () {
+      final speechConfigWithLanguage =
+          SpeechConfig(voiceName: 'Aoede', languageCode: 'en-US');
+      expect(speechConfigWithLanguage.toJson(), {
+        'voice_config': {
+          'prebuilt_voice_config': {'voice_name': 'Aoede'}
+        },
+        'language_code': 'en-US',
+      });
+
+      final speechConfigLanguageOnly = SpeechConfig(languageCode: 'fr-FR');
+      expect(speechConfigLanguageOnly.toJson(), {
+        'language_code': 'fr-FR',
+      });
+    });
+
     test('ResponseModalities enum toJson() returns correct value', () {
       expect(ResponseModalities.text.toJson(), 'TEXT');
       expect(ResponseModalities.image.toJson(), 'IMAGE');


### PR DESCRIPTION
## Description

Add `languageCode` (BCP-47) parameter to `SpeechConfig` for the Gemini Live API. This allows users to specify the language for speech synthesis (e.g. "en-US", "fr-FR").

Reference: [Configure language and voice | Vertex AI](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/live-api/configure-language-voice)

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17459

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
