### PR TITLE
fix(fdc): remove unused logs

### DIFF
--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/core/ref.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/core/ref.dart
@@ -342,7 +342,6 @@ class QueryRef<Data, Variables> extends OperationRef<Data, Variables> {
     _serverStreamSubscription?.cancel();
     _serverStreamSubscription = null;
     _serverStream = null;
-    log("QueryRef $operationId: All subscribers cancelled. Unsubscribed from server stream.");
   }
 
   Stream<QueryResult<Data, Variables>> subscribe() {
@@ -373,7 +372,6 @@ class QueryRef<Data, Variables> extends OperationRef<Data, Variables> {
 
   void _streamFromServer() async {
     bool shouldRetry = await _shouldRetry();
-    log("QueryRef $operationId _streamFromServer loop started.");
     try {
       _serverStream = _transport.invokeStreamQuery<Data, Variables>(
         operationId,
@@ -386,7 +384,6 @@ class QueryRef<Data, Variables> extends OperationRef<Data, Variables> {
 
       _serverStreamSubscription = _serverStream!.listen(
         (serverResponse) async {
-          log("QueryRef $operationId _streamFromServer loop received snapshot.");
           if (dataConnect.cacheManager != null) {
             try {
               await dataConnect.cacheManager!
@@ -432,8 +429,6 @@ class QueryRef<Data, Variables> extends OperationRef<Data, Variables> {
   void publishResultToStream(QueryResult<Data, Variables> result) {
     if (_streamController != null) {
       _streamController?.add(result);
-    } else {
-      log("QueryRef $operationId _streamFromServer loop _streamController is null");
     }
   }
 

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/websocket_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/websocket_transport.dart
@@ -150,7 +150,6 @@ class WebSocketTransport implements DataConnectTransport {
     if (_channel == null) return;
     final encoded = jsonEncode(json);
     if (encoded.isNotEmpty) {
-      developer.log("Sending stream message \n $encoded");
       _channel!.sink.add(encoded);
     }
   }
@@ -229,7 +228,6 @@ class WebSocketTransport implements DataConnectTransport {
       } else {
         bodyString = message as String;
       }
-      developer.log("Received stream response \n $bodyString");
 
       final bodyJson = jsonDecode(bodyString) as Map<String, dynamic>;
       final response = StreamResponse.fromJson(bodyJson);
@@ -309,8 +307,6 @@ class WebSocketTransport implements DataConnectTransport {
   Timer? _reconnectTimer;
 
   void _scheduleReconnect() {
-    developer.log(
-        '${DateTime.now()} _scheduleReconnect $_reconnectAttempts $_isReconnecting $_isExpectedDisconnect');
     if (_isReconnecting || _isExpectedDisconnect) return;
     _isReconnecting = true;
 
@@ -323,13 +319,9 @@ class WebSocketTransport implements DataConnectTransport {
     final delay = min(
         _initialReconnectDelayMs * pow(2, _reconnectAttempts).toInt(),
         _maxReconnectDelayMs);
-    var startTime = DateTime.now();
-    developer.log('$startTime scheduling _performReconnect in $delay ms');
 
     _reconnectTimer?.cancel();
     _reconnectTimer = Timer(Duration(milliseconds: delay), () async {
-      developer.log(
-          '${DateTime.now()} calling delayed _performReconnect scheduled at $startTime');
       _performReconnect();
     });
   }
@@ -443,7 +435,6 @@ class WebSocketTransport implements DataConnectTransport {
 
   void _onDone() {
     if (_channel == null) return;
-    developer.log('WebSocket connection closed.');
     _channel = null;
     _isReconnecting = false;
     if (!_isExpectedDisconnect) {


### PR DESCRIPTION
## Description

Removes leftover debug `developer.log`/`log` calls in the Data Connect WebSocket transport and QueryRef stream loop that fired on every packet sent/received and on every reconnect cycle, flooding the log in non-production builds. Legitimate error logs are kept.

## Related Issues

- Fixes #18195

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
