### PR TITLE
feat(ai): add missing HARM_CATEGORY_IMAGE_* enum types

### DIFF
--- a/packages/firebase_ai/firebase_ai/lib/src/api.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/api.dart
@@ -626,7 +626,19 @@ enum HarmCategory {
   sexuallyExplicit('HARM_CATEGORY_SEXUALLY_EXPLICIT'),
 
   /// Promotes or enables access to harmful goods, services, and activities.
-  dangerousContent('HARM_CATEGORY_DANGEROUS_CONTENT');
+  dangerousContent('HARM_CATEGORY_DANGEROUS_CONTENT'),
+
+  /// Image content containing hate speech.
+  imageHate('HARM_CATEGORY_IMAGE_HATE'),
+
+  /// Image content that is dangerous.
+  imageDangerousContent('HARM_CATEGORY_IMAGE_DANGEROUS_CONTENT'),
+
+  /// Image content containing harassment.
+  imageHarassment('HARM_CATEGORY_IMAGE_HARASSMENT'),
+
+  /// Image content that is sexually explicit.
+  imageSexuallyExplicit('HARM_CATEGORY_IMAGE_SEXUALLY_EXPLICIT');
 
   const HarmCategory(this._jsonString);
 
@@ -638,7 +650,13 @@ enum HarmCategory {
       'HARM_CATEGORY_HATE_SPEECH' => HarmCategory.hateSpeech,
       'HARM_CATEGORY_SEXUALLY_EXPLICIT' => HarmCategory.sexuallyExplicit,
       'HARM_CATEGORY_DANGEROUS_CONTENT' => HarmCategory.dangerousContent,
-      _ => throw FormatException('Unhandled HarmCategory format', jsonObject),
+      'HARM_CATEGORY_IMAGE_HATE' => HarmCategory.imageHate,
+      'HARM_CATEGORY_IMAGE_DANGEROUS_CONTENT' =>
+        HarmCategory.imageDangerousContent,
+      'HARM_CATEGORY_IMAGE_HARASSMENT' => HarmCategory.imageHarassment,
+      'HARM_CATEGORY_IMAGE_SEXUALLY_EXPLICIT' =>
+        HarmCategory.imageSexuallyExplicit,
+      _ => HarmCategory.unknown,
     };
   }
 

--- a/packages/firebase_ai/firebase_ai/lib/src/developer/api.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/developer/api.dart
@@ -49,7 +49,13 @@ String _harmCategoryToJson(HarmCategory harmCategory) => switch (harmCategory) {
       HarmCategory.harassment => 'HARM_CATEGORY_HARASSMENT',
       HarmCategory.hateSpeech => 'HARM_CATEGORY_HATE_SPEECH',
       HarmCategory.sexuallyExplicit => 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
-      HarmCategory.dangerousContent => 'HARM_CATEGORY_DANGEROUS_CONTENT'
+      HarmCategory.dangerousContent => 'HARM_CATEGORY_DANGEROUS_CONTENT',
+      HarmCategory.imageHate => 'HARM_CATEGORY_IMAGE_HATE',
+      HarmCategory.imageDangerousContent =>
+        'HARM_CATEGORY_IMAGE_DANGEROUS_CONTENT',
+      HarmCategory.imageHarassment => 'HARM_CATEGORY_IMAGE_HARASSMENT',
+      HarmCategory.imageSexuallyExplicit =>
+        'HARM_CATEGORY_IMAGE_SEXUALLY_EXPLICIT',
     };
 
 Object _safetySettingToJson(SafetySetting safetySetting) {
@@ -241,5 +247,11 @@ HarmCategory _parseHarmCategory(Object jsonObject) => switch (jsonObject) {
       'HARM_CATEGORY_HATE_SPEECH' => HarmCategory.hateSpeech,
       'HARM_CATEGORY_SEXUALLY_EXPLICIT' => HarmCategory.sexuallyExplicit,
       'HARM_CATEGORY_DANGEROUS_CONTENT' => HarmCategory.dangerousContent,
-      _ => throw unhandledFormat('HarmCategory', jsonObject),
+      'HARM_CATEGORY_IMAGE_HATE' => HarmCategory.imageHate,
+      'HARM_CATEGORY_IMAGE_DANGEROUS_CONTENT' =>
+        HarmCategory.imageDangerousContent,
+      'HARM_CATEGORY_IMAGE_HARASSMENT' => HarmCategory.imageHarassment,
+      'HARM_CATEGORY_IMAGE_SEXUALLY_EXPLICIT' =>
+        HarmCategory.imageSexuallyExplicit,
+      _ => HarmCategory.unknown,
     };

--- a/packages/firebase_ai/firebase_ai/test/api_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/api_test.dart
@@ -289,6 +289,13 @@ void main() {
           'HARM_CATEGORY_SEXUALLY_EXPLICIT');
       expect(HarmCategory.dangerousContent.toJson(),
           'HARM_CATEGORY_DANGEROUS_CONTENT');
+      expect(HarmCategory.imageHate.toJson(), 'HARM_CATEGORY_IMAGE_HATE');
+      expect(HarmCategory.imageDangerousContent.toJson(),
+          'HARM_CATEGORY_IMAGE_DANGEROUS_CONTENT');
+      expect(HarmCategory.imageHarassment.toJson(),
+          'HARM_CATEGORY_IMAGE_HARASSMENT');
+      expect(HarmCategory.imageSexuallyExplicit.toJson(),
+          'HARM_CATEGORY_IMAGE_SEXUALLY_EXPLICIT');
     });
 
     test('HarmProbability toJson and toString', () {
@@ -734,6 +741,75 @@ void main() {
         expect(response.usageMetadata!.totalTokenCount, 30);
         expect(response.usageMetadata!.promptTokensDetails, hasLength(1));
         expect(response.usageMetadata!.candidatesTokensDetails, hasLength(1));
+      });
+
+      test('parses image harm categories in safetyRatings', () {
+        final json = {
+          'candidates': [
+            {
+              'content': {
+                'role': 'model',
+                'parts': [
+                  {'text': ''}
+                ]
+              },
+              'finishReason': 'STOP',
+              'safetyRatings': [
+                {
+                  'category': 'HARM_CATEGORY_IMAGE_DANGEROUS_CONTENT',
+                  'probability': 'NEGLIGIBLE'
+                },
+                {
+                  'category': 'HARM_CATEGORY_IMAGE_SEXUALLY_EXPLICIT',
+                  'probability': 'NEGLIGIBLE'
+                },
+                {
+                  'category': 'HARM_CATEGORY_IMAGE_HATE',
+                  'probability': 'NEGLIGIBLE'
+                },
+                {
+                  'category': 'HARM_CATEGORY_IMAGE_HARASSMENT',
+                  'probability': 'NEGLIGIBLE'
+                },
+              ]
+            }
+          ]
+        };
+        final response =
+            VertexSerialization().parseGenerateContentResponse(json);
+        final ratings = response.candidates.first.safetyRatings!;
+        expect(ratings.map((r) => r.category), [
+          HarmCategory.imageDangerousContent,
+          HarmCategory.imageSexuallyExplicit,
+          HarmCategory.imageHate,
+          HarmCategory.imageHarassment,
+        ]);
+      });
+
+      test('falls back to HarmCategory.unknown for unrecognized values', () {
+        final json = {
+          'candidates': [
+            {
+              'content': {
+                'role': 'model',
+                'parts': [
+                  {'text': ''}
+                ]
+              },
+              'finishReason': 'STOP',
+              'safetyRatings': [
+                {
+                  'category': 'HARM_CATEGORY_SOMETHING_NEW',
+                  'probability': 'NEGLIGIBLE'
+                }
+              ]
+            }
+          ]
+        };
+        final response =
+            VertexSerialization().parseGenerateContentResponse(json);
+        expect(response.candidates.first.safetyRatings!.first.category,
+            HarmCategory.unknown);
       });
 
       group('usageMetadata parsing', () {


### PR DESCRIPTION
## Description

Add the four `HARM_CATEGORY_IMAGE_*` values to `HarmCategory` so safety ratings returned by image generation models parse correctly instead of throwing `FormatException: Unhandled HarmCategory format`. Unknown categories now fall back to `HarmCategory.unknown` for forward compatibility.

## Related Issues

- Fixes #17472

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
