### PR TITLE
docs(firebase_auth): replace deprecated fetchSignInMethodsForEmail in error handling docs

### DIFF
--- a/docs/auth/errors.md
+++ b/docs/auth/errors.md
@@ -98,3 +98,4 @@ to be linked or your **Identity Platform** project configuration must be adjuste
 See [Phone Authentication — iOS: reCAPTCHA SDK and Identity Platform](/docs/auth/phone-auth#ios-recaptcha-sdk-and-identity-platform) for
 recommended setup, the Safari flow, and a documented **GCP / Identity Toolkit** workaround with trade-offs.
 
+

--- a/docs/auth/errors.md
+++ b/docs/auth/errors.md
@@ -1,5 +1,5 @@
-Project: /docs/_project.yaml
-Book: /docs/_book.yaml
+Project: /docs/\_project.yaml
+Book: /docs/\_book.yaml
 
 <link rel="stylesheet" type="text/css" href="/styles/docs.css" />
 
@@ -51,49 +51,40 @@ try {
 } on FirebaseAuthException catch (e) {
   if (e.code == 'account-exists-with-different-credential') {
     // The account already exists with a different credential
-    String email = e.email;
-    AuthCredential pendingCredential = e.credential;
+    String email = e.email!;
+    AuthCredential pendingCredential = e.credential!;
 
-    // Fetch a list of what sign-in methods exist for the conflicting user
-    List<String> userSignInMethods = await auth.fetchSignInMethodsForEmail(email);
+    // Note: fetchSignInMethodsForEmail() is deprecated.
+    // Instead, attempt sign-in directly with known providers
+    // and handle the linking flow accordingly.
 
-    // If the user has several sign-in methods,
-    // the first method in the list will be the "recommended" method to use.
-    if (userSignInMethods.first == 'password') {
-      // Prompt the user to enter their password
-      String password = '...';
-
-      // Sign the user in to their account with the password
+    // Try signing in with email/password if applicable
+    try {
       UserCredential userCredential = await auth.signInWithEmailAndPassword(
         email: email,
-        password: password,
+        password: promptUserForPassword(), // prompt user for password
       );
-
       // Link the pending credential with the existing account
-      await userCredential.user.linkWithCredential(pendingCredential);
-
+      await userCredential.user!.linkWithCredential(pendingCredential);
       // Success! Go back to your application flow
       return goToApplication();
+    } on FirebaseAuthException catch (_) {
+      // Email/password sign-in failed, try another provider
     }
 
-    // Since other providers are now external, you must now sign the user in with another
-    // auth provider, such as Facebook.
-    if (userSignInMethods.first == 'facebook.com') {
-      // Create a new Facebook credential
-      String accessToken = await triggerFacebookAuthentication();
-      var facebookAuthCredential = FacebookAuthProvider.credential(accessToken);
+    // Try signing in with Facebook if applicable
+    String accessToken = await triggerFacebookAuthentication();
+    var facebookAuthCredential =
+        FacebookAuthProvider.credential(accessToken);
 
-      // Sign the user in with the credential
-      UserCredential userCredential = await auth.signInWithCredential(facebookAuthCredential);
+    UserCredential userCredential =
+        await auth.signInWithCredential(facebookAuthCredential);
 
-      // Link the pending credential with the existing account
-      await userCredential.user.linkWithCredential(pendingCredential);
+    // Link the pending credential with the existing account
+    await userCredential.user!.linkWithCredential(pendingCredential);
 
-      // Success! Go back to your application flow
-      return goToApplication();
-    }
-
-    // Handle other OAuth providers...
+    // Success! Go back to your application flow
+    return goToApplication();
   }
 }
 ```

--- a/docs/auth/errors.md
+++ b/docs/auth/errors.md
@@ -51,7 +51,11 @@ try {
 } on FirebaseAuthException catch (e) {
   if (e.code == 'account-exists-with-different-credential') {
     // The account already exists with a different credential
-    String email = e.email!;
+    final email = e.email;
+    if(email == null) {
+    print('Email not provided in error')
+    return;
+    }
     AuthCredential pendingCredential = e.credential!;
 
     // Note: fetchSignInMethodsForEmail() is deprecated.

--- a/docs/auth/errors.md
+++ b/docs/auth/errors.md
@@ -60,9 +60,10 @@ try {
 
     // Try signing in with email/password if applicable
     try {
+      String password = '...';
       UserCredential userCredential = await auth.signInWithEmailAndPassword(
         email: email,
-        password: promptUserForPassword(), // prompt user for password
+        password: password,
       );
       // Link the pending credential with the existing account
       await userCredential.user!.linkWithCredential(pendingCredential);

--- a/docs/auth/errors.md
+++ b/docs/auth/errors.md
@@ -1,5 +1,5 @@
-Project: /docs/\_project.yaml
-Book: /docs/\_book.yaml
+Project: /docs/_project.yaml
+Book: /docs/_book.yaml
 
 <link rel="stylesheet" type="text/css" href="/styles/docs.css" />
 
@@ -97,3 +97,4 @@ to be linked or your **Identity Platform** project configuration must be adjuste
 
 See [Phone Authentication — iOS: reCAPTCHA SDK and Identity Platform](/docs/auth/phone-auth#ios-recaptcha-sdk-and-identity-platform) for
 recommended setup, the Safari flow, and a documented **GCP / Identity Toolkit** workaround with trade-offs.
+

--- a/docs/auth/errors.md
+++ b/docs/auth/errors.md
@@ -70,7 +70,12 @@ try {
         password: password,
       );
       // Link the pending credential with the existing account
-      await userCredential.user!.linkWithCredential(pendingCredential);
+      final user = userCredential.user;
+      if (user == null) {
+        print('User not available after sign-in');
+        return;
+      }
+      await user.linkWithCredential(pendingCredential);
       // Success! Go back to your application flow
       return goToApplication();
     } on FirebaseAuthException catch (_) {
@@ -86,7 +91,12 @@ try {
         await auth.signInWithCredential(facebookAuthCredential);
 
     // Link the pending credential with the existing account
-    await userCredential.user!.linkWithCredential(pendingCredential);
+    final user = userCredential.user;
+    if (user == null) {
+      print('User not available after Facebook sign-in');
+      return;
+    }
+    await user.linkWithCredential(pendingCredential);
 
     // Success! Go back to your application flow
     return goToApplication();


### PR DESCRIPTION
## Description

The `fetchSignInMethodsForEmail()` method is deprecated but the error 
handling documentation still referenced it for handling 
`account-exists-with-different-credential` errors. This PR updates 
the code example to use the recommended approach instead.

## Related Issues

Fixes #12909

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.