### PR TITLE
feat(auth,android): add revokeAccessToken support for Android (#18206)

### DIFF
--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -679,6 +679,27 @@ public class FlutterFirebaseAuthPlugin
   }
 
   @Override
+  public void revokeAccessToken(
+      @NonNull GeneratedAndroidFirebaseAuth.AuthPigeonFirebaseApp app,
+      @NonNull String accessToken,
+      @NonNull GeneratedAndroidFirebaseAuth.VoidResult result) {
+    FirebaseAuth firebaseAuth = getAuthFromPigeon(app);
+
+    firebaseAuth
+        .revokeAccessToken(accessToken)
+        .addOnCompleteListener(
+            task -> {
+              if (task.isSuccessful()) {
+                result.success();
+              } else {
+                result.error(
+                    FlutterFirebaseAuthPluginException.parserExceptionToFlutter(
+                        task.getException()));
+              }
+            });
+  }
+
+  @Override
   public void initializeRecaptchaConfig(
       @NonNull GeneratedAndroidFirebaseAuth.AuthPigeonFirebaseApp app,
       @NonNull GeneratedAndroidFirebaseAuth.VoidResult result) {

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/GeneratedAndroidFirebaseAuth.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/GeneratedAndroidFirebaseAuth.java
@@ -2642,6 +2642,11 @@ public class GeneratedAndroidFirebaseAuth {
         @NonNull String authorizationCode,
         @NonNull VoidResult result);
 
+    void revokeAccessToken(
+        @NonNull AuthPigeonFirebaseApp app,
+        @NonNull String accessToken,
+        @NonNull VoidResult result);
+
     void initializeRecaptchaConfig(@NonNull AuthPigeonFirebaseApp app, @NonNull VoidResult result);
 
     /** The codec used by FirebaseAuthHostApi. */
@@ -3392,6 +3397,39 @@ public class GeneratedAndroidFirebaseAuth {
                     };
 
                 api.revokeTokenWithAuthorizationCode(appArg, authorizationCodeArg, resultCallback);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger,
+                "dev.flutter.pigeon.firebase_auth_platform_interface.FirebaseAuthHostApi.revokeAccessToken"
+                    + messageChannelSuffix,
+                getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                AuthPigeonFirebaseApp appArg = (AuthPigeonFirebaseApp) args.get(0);
+                String accessTokenArg = (String) args.get(1);
+                VoidResult resultCallback =
+                    new VoidResult() {
+                      public void success() {
+                        wrapped.add(0, null);
+                        reply.reply(wrapped);
+                      }
+
+                      public void error(Throwable error) {
+                        ArrayList<Object> wrappedError = wrapError(error);
+                        reply.reply(wrappedError);
+                      }
+                    };
+
+                api.revokeAccessToken(appArg, accessTokenArg, resultCallback);
               });
         } else {
           channel.setMessageHandler(null);

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -798,6 +798,11 @@ class FirebaseAuth extends FirebasePluginPlatform {
     return _delegate.revokeTokenWithAuthorizationCode(authorizationCode);
   }
 
+  /// Android only. Revokes the provided accessToken. Currently supports revoking Apple-issued accessToken only.
+  Future<void> revokeAccessToken(String accessToken) {
+    return _delegate.revokeAccessToken(accessToken);
+  }
+
   /// Signs out the current user.
   ///
   /// If successful, it also updates

--- a/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
@@ -35,6 +35,7 @@ void main() {
   const String kMockSmsCode = '123456';
   const String kMockLanguage = 'en';
   const String kMockOobCode = 'oobcode';
+  const String kMockAuthToken = '12460';
   const String kMockURL = 'http://www.example.com';
   const String kMockHost = 'www.example.com';
   const String kMockValidPassword =
@@ -778,6 +779,17 @@ void main() {
       });
     });
 
+    group('revokeAccessToken()', () {
+      test('should call delegate method', () async {
+        // Necessary as we otherwise get a "null is not a Future<void>" error
+        when(mockAuthPlatform.revokeAccessToken(kMockAuthToken))
+            .thenAnswer((i) async {});
+
+        await auth.revokeAccessToken(kMockAuthToken);
+        verify(mockAuthPlatform.revokeAccessToken(kMockAuthToken));
+      });
+    });
+
     group('passwordPolicy', () {
       test('passwordPolicy should be initialized with correct parameters',
           () async {
@@ -1148,6 +1160,15 @@ class MockFirebaseAuth extends Mock
       }),
       returnValue: neverEndingFuture<String>(),
       returnValueForMissingStub: neverEndingFuture<String>(),
+    );
+  }
+
+  @override
+  Future<void> revokeAccessToken(String accessToken) {
+    return super.noSuchMethod(
+      Invocation.method(#revokeAccessToken, [accessToken]),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 }

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_firebase_auth.dart
@@ -665,6 +665,20 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
   }
 
   @override
+  Future<void> revokeAccessToken(String accessToken) async {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      throw UnimplementedError(
+          'revokeAccessToken() is only available on the Android platform.');
+    }
+
+    try {
+      await _api.revokeAccessToken(pigeonDefault, accessToken);
+    } catch (e, stack) {
+      convertPlatformException(e, stack);
+    }
+  }
+
+  @override
   Future<void> initializeRecaptchaConfig() async {
     try {
       await _api.initializeRecaptchaConfig(pigeonDefault);

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/pigeon/messages.pigeon.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/pigeon/messages.pigeon.dart
@@ -1479,6 +1479,31 @@ class FirebaseAuthHostApi {
     }
   }
 
+  Future<void> revokeAccessToken(
+      AuthPigeonFirebaseApp app, String accessToken) async {
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.firebase_auth_platform_interface.FirebaseAuthHostApi.revokeAccessToken$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList = await __pigeon_channel
+        .send(<Object?>[app, accessToken]) as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
   Future<void> initializeRecaptchaConfig(AuthPigeonFirebaseApp app) async {
     final String __pigeon_channelName =
         'dev.flutter.pigeon.firebase_auth_platform_interface.FirebaseAuthHostApi.initializeRecaptchaConfig$__pigeon_messageChannelSuffix';

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_firebase_auth.dart
@@ -717,6 +717,11 @@ abstract class FirebaseAuthPlatform extends PlatformInterface {
         'revokeTokenWithAuthorizationCode() is not implemented');
   }
 
+  /// Android only. Revokes the provided accessToken. Currently supports revoking Apple-issued accessToken only.
+  Future<void> revokeAccessToken(String accessToken) {
+    throw UnimplementedError('revokeAccessToken() is not implemented');
+  }
+
   /// Initializes the reCAPTCHA Enterprise client proactively to enhance reCAPTCHA signal collection and
   /// to complete reCAPTCHA-protected flows in a single attempt.
   Future<void> initializeRecaptchaConfig() {

--- a/packages/firebase_auth/firebase_auth_platform_interface/pigeons/messages.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pigeons/messages.dart
@@ -421,6 +421,12 @@ abstract class FirebaseAuthHostApi {
   );
 
   @async
+  void revokeAccessToken(
+    AuthPigeonFirebaseApp app,
+    String accessToken,
+  );
+
+  @async
   void initializeRecaptchaConfig(
     AuthPigeonFirebaseApp app,
   );

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/pigeon/test_api.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/pigeon/test_api.dart
@@ -187,6 +187,8 @@ abstract class TestFirebaseAuthHostApi {
   Future<void> revokeTokenWithAuthorizationCode(
       AuthPigeonFirebaseApp app, String authorizationCode);
 
+  Future<void> revokeAccessToken(AuthPigeonFirebaseApp app, String accessToken);
+
   Future<void> initializeRecaptchaConfig(AuthPigeonFirebaseApp app);
 
   static void setUp(
@@ -985,6 +987,41 @@ abstract class TestFirebaseAuthHostApi {
           try {
             await api.revokeTokenWithAuthorizationCode(
                 arg_app!, arg_authorizationCode!);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
+              Object?>(
+          'dev.flutter.pigeon.firebase_auth_platform_interface.FirebaseAuthHostApi.revokeAccessToken$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(__pigeon_channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(__pigeon_channel,
+                (Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.firebase_auth_platform_interface.FirebaseAuthHostApi.revokeAccessToken was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final AuthPigeonFirebaseApp? arg_app =
+              (args[0] as AuthPigeonFirebaseApp?);
+          assert(arg_app != null,
+              'Argument for dev.flutter.pigeon.firebase_auth_platform_interface.FirebaseAuthHostApi.revokeAccessToken was null, expected non-null AuthPigeonFirebaseApp.');
+          final String? arg_accessToken = (args[1] as String?);
+          assert(arg_accessToken != null,
+              'Argument for dev.flutter.pigeon.firebase_auth_platform_interface.FirebaseAuthHostApi.revokeAccessToken was null, expected non-null String.');
+          try {
+            await api.revokeAccessToken(arg_app!, arg_accessToken!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/platform_interface_tests/platform_interface_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/platform_interface_tests/platform_interface_auth_test.dart
@@ -353,6 +353,13 @@ void main() {
         throwsUnimplementedError,
       );
     });
+
+    test('throws if revokeAccessToken()', () async {
+      await expectLater(
+        () => firebaseAuthPlatform.revokeAccessToken('token'),
+        throwsUnimplementedError,
+      );
+    });
   });
 }
 


### PR DESCRIPTION
## Description

*This PR introduces the `revokeAccessToken` method to `FirebaseAuth`, specifically for the Android platform. This allows revoking Apple-issued access tokens on Android*

## Related Issues

*#18206*

## Checklist

- [✅] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [✅] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [✅] All existing and new tests are passing.
- [✅] I updated/added relevant documentation (doc comments with `///`).
- [✅] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [✅] I read and followed the [Flutter Style Guide].
- [✅] I signed the [CLA].
- [✅] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [✅] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
