### PR TITLE
docs(auth): add Android access token revocation guide

### DIFF
--- a/docs/auth/federated-auth.md
+++ b/docs/auth/federated-auth.md
@@ -284,6 +284,16 @@ Future<UserCredential> signInWithApple() async {
 }
 ```
 
+On Android platforms, obtain the access token then revoke the token using the
+`revokeAccessToken()` API.
+
+```dart
+// Keep the access token returned from Android platforms
+String? accessToken = userCredential.credential?.accessToken;
+// Revoke the access token
+await FirebaseAuth.instance.revokeAccessToken(accessToken!);
+```
+
 ## Apple Game Center (Apple only) {:#games}
 
 Ensure the "Game Center" sign-in provider is enabled on the [Firebase Console](https://console.firebase.google.com/project/_/authentication/providers).


### PR DESCRIPTION
## Description

*This PR updates the Federated identity and social sign-in documentation to include instructions for revoking access tokens on Android platforms using the `revokeAccessToken()` API*

## Related Issues

*#18214*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [✅] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [✅] All existing tests are passing.
- [✅] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [✅] I read and followed the [Flutter Style Guide].
- [✅] I signed the [CLA].
- [✅] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [✅] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
