### PR TITLE
fix(auth, windows): add opt-in flag to skip id-token EventChannel (FAST_FAIL_INVALID_ARG workaround)

### DIFF
--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel/method_channel_firebase_auth.dart
@@ -4,6 +4,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io' show Platform;
 
 import 'package:_flutterfire_internals/_flutterfire_internals.dart';
 import 'package:firebase_auth_platform_interface/src/method_channel/method_channel_multi_factor.dart';
@@ -17,6 +18,25 @@ import '../../firebase_auth_platform_interface.dart';
 import 'method_channel_user.dart';
 import 'method_channel_user_credential.dart';
 import 'utils/exception.dart';
+
+/// Returns `true` when the `id-token` [EventChannel] subscription should be
+/// skipped. Only effective on Windows when the host app has explicitly opted
+/// in via [FirebaseAuthPlatform.disableIdTokenChannelOnWindows]. Never
+/// returns `true` on web or on platforms other than Windows.
+///
+/// See [FirebaseAuthPlatform.disableIdTokenChannelOnWindows] for the
+/// rationale (upstream Flutter engine threading bug tracked in
+/// https://github.com/firebase/flutterfire/issues/18210 /
+/// https://github.com/flutter/flutter/issues/134346).
+bool _shouldSkipIdTokenChannel() {
+  if (kIsWeb) return false;
+  if (!FirebaseAuthPlatform.disableIdTokenChannelOnWindows) return false;
+  try {
+    return Platform.isWindows;
+  } on Object catch (_) {
+    return false;
+  }
+}
 
 /// Method Channel delegate for [FirebaseAuthPlatform].
 class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
@@ -74,16 +94,21 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
   /// Creates a new instance with a given [FirebaseApp].
   MethodChannelFirebaseAuth({required FirebaseApp app})
       : super(appInstance: app) {
-    _api.registerIdTokenListener(pigeonDefault).then((channelName) {
-      final events = EventChannel(channelName, channel.codec);
-      events
-          .receiveGuardedBroadcastStream(onError: convertPlatformException)
-          .listen(
-        (arguments) {
-          _handleIdTokenChangesListener(app.name, arguments);
-        },
-      );
-    });
+    // Skip the `id-token` EventChannel subscription on Windows when the host
+    // app has opted in via `FirebaseAuthPlatform.disableIdTokenChannelOnWindows`.
+    // See `_shouldSkipIdTokenChannel()` for the rationale.
+    if (!_shouldSkipIdTokenChannel()) {
+      _api.registerIdTokenListener(pigeonDefault).then((channelName) {
+        final events = EventChannel(channelName, channel.codec);
+        events
+            .receiveGuardedBroadcastStream(onError: convertPlatformException)
+            .listen(
+          (arguments) {
+            _handleIdTokenChangesListener(app.name, arguments);
+          },
+        );
+      });
+    }
 
     _api.registerAuthStateListener(pigeonDefault).then((channelName) {
       final events = EventChannel(channelName, channel.codec);

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_firebase_auth.dart
@@ -41,6 +41,31 @@ abstract class FirebaseAuthPlatform extends PlatformInterface {
   /// If not `null`, this value will supersede `authDomain` property set in `initializeApp`.
   String? customAuthDomain;
 
+  /// Opt-in workaround for the Windows-only native threading bug tracked in:
+  ///   - https://github.com/firebase/flutterfire/issues/18210
+  ///   - https://github.com/flutter/flutter/issues/134346
+  ///
+  /// When set to `true` **before** calling [Firebase.initializeApp], the
+  /// method-channel implementation skips registering the `id-token`
+  /// [EventChannel] subscription on Windows. This avoids the
+  /// `FAST_FAIL_INVALID_ARG` (`0xc0000409` / `STATUS_STACK_BUFFER_OVERRUN`)
+  /// process abort produced when the native Windows `firebase_auth` plugin
+  /// dispatches id-token events from a background thread.
+  ///
+  /// Trade-off: with this flag enabled, `idTokenChanges()` and
+  /// `userChanges()` on Windows only emit on sign-in / sign-out (via the
+  /// separate `auth-state` channel). Mid-session token-refresh events
+  /// (e.g. custom-claims updates) are not observed until the underlying
+  /// engine fix ships. `authStateChanges()` and all imperative APIs
+  /// (`getIdToken`, `getIdTokenResult`, sign-in, sign-up, sign-out, etc.)
+  /// are unaffected.
+  ///
+  /// Has no effect on web or on platforms other than Windows.
+  ///
+  /// This flag is a temporary mitigation and will be removed in a future
+  /// release once the underlying engine bug is resolved.
+  static bool disableIdTokenChannelOnWindows = false;
+
   /// Create an instance using [app]
   FirebaseAuthPlatform({this.appInstance}) : super(token: _token);
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/platform_interface_tests/disable_id_token_channel_on_windows_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/platform_interface_tests/disable_id_token_channel_on_windows_test.dart
@@ -1,0 +1,33 @@
+// Copyright 2025, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Tests for the Windows-only opt-in
+/// [FirebaseAuthPlatform.disableIdTokenChannelOnWindows] flag that works
+/// around the upstream engine threading bug
+/// (https://github.com/firebase/flutterfire/issues/18210 /
+/// https://github.com/flutter/flutter/issues/134346).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() {
+    FirebaseAuthPlatform.disableIdTokenChannelOnWindows = false;
+  });
+
+  group('FirebaseAuthPlatform.disableIdTokenChannelOnWindows', () {
+    test('defaults to false so existing apps see no behavior change', () {
+      expect(FirebaseAuthPlatform.disableIdTokenChannelOnWindows, isFalse);
+    });
+
+    test('is a plain mutable static bool toggle', () {
+      FirebaseAuthPlatform.disableIdTokenChannelOnWindows = true;
+      expect(FirebaseAuthPlatform.disableIdTokenChannelOnWindows, isTrue);
+
+      FirebaseAuthPlatform.disableIdTokenChannelOnWindows = false;
+      expect(FirebaseAuthPlatform.disableIdTokenChannelOnWindows, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds `FirebaseAuthPlatform.disableIdTokenChannelOnWindows`, an opt-in
static flag that — when set to `true` **before**
`Firebase.initializeApp()` — skips the `id-token` `EventChannel`
subscription in `MethodChannelFirebaseAuth`'s constructor on Windows.

Default behavior is unchanged. Linux, macOS, Android, iOS, and Web are
not touched. The flag is a plain static `bool` so it is reachable
from user code **before** `MethodChannelFirebaseAuth`'s constructor
runs (any instance-level setter would arrive too late — the listener
is registered the moment `FirebaseAuthPlatform.instance` is first
accessed).

Fixes #18210. Related: #13340, #16888, #17800, #11933.

## Why

The Windows `firebase_auth_plugin` dispatches `id-token` events
from a native background thread. Flutter's engine requires platform
channel traffic on the platform thread and raises a
`FAST_FAIL_INVALID_ARG` (`0xc0000409` /
`STATUS_STACK_BUFFER_OVERRUN`) abort when that contract is violated.
Users hit this as a silent process termination shortly after
`signInWithEmailAndPassword()` or on cold starts with a cached
refresh token. cdb confirms the crashing frame:

```
flutter_windows!fml::KillProcess
flutter_windows!fml::LogMessage::~LogMessage
flutter_windows!flutter::PlatformMessageHandlerStandard::InvokeHandler
flutter_windows!flutter::IncomingMessageDispatcher::HandleMessage
firebase_auth_plugin.dll!EventChannel<...>::Send
firebase_auth_plugin.dll!<id-token listener callback>   << wrong thread
```

The true fix is upstream in the Flutter engine
(flutter/flutter#134346 — open since Sep 2023, currently P2). Until
`FlutterDesktopEnginePostPlatformThreadTask` (or equivalent) ships
and `firebase_auth_desktop` adopts it, affected apps have **no
supported workaround**: every Dart-side mitigation suggested in the
linked threads (`Future.microtask`,
`WidgetsBinding.addPostFrameCallback`, `Future.delayed`,
`runZonedGuarded`, custom `BinaryMessenger`) runs after the native
side has already dispatched from the wrong thread and cannot prevent
the abort. Not subscribing to `idTokenChanges()` in user code
doesn't help either — the listener is attached unconditionally by the
platform-interface constructor.

This PR gives affected apps an explicit, opt-in escape hatch that:

- Lives entirely in Dart.
- Costs nothing at runtime for apps that don't enable it.
- Is trivially removable once the engine fix lands (delete the flag
  and its one call site).

## What changes

1. `FirebaseAuthPlatform.disableIdTokenChannelOnWindows` — a new
   static `bool` field, default `false`, documented with links to
   the upstream tickets.
2. `MethodChannelFirebaseAuth`'s constructor — guards the id-token
   `EventChannel` registration with `_shouldSkipIdTokenChannel()`
   which only returns `true` when the flag is set **and** the host
   is Windows (and not web).
3. Unit test `disable_id_token_channel_on_windows_test.dart`
   covering the flag's default and toggle behavior.

No Pigeon, platform-interface-breaking, or generated-code changes.
No CHANGELOG edit — Melos generates that on release from the
conventional commit message.

## Scope / trade-offs when the flag is enabled on Windows

**Fully unaffected** — every imperative API and the most common
observer:

- All sign-in methods (`signInWithEmailAndPassword`, `signInWithCredential`,
  `signInWithCustomToken`, `signInAnonymously`, phone, popup, redirect).
- `signOut()`, `createUserWithEmailAndPassword()`.
- **`authStateChanges()` stream** — full fidelity (separate channel,
  already dispatched from the platform thread). Fires on sign-in,
  sign-out, and cold-start-with-cached-user.
- **`FirebaseAuth.instance.currentUser`** — populated correctly by
  `_handleAuthStateChangesListener` and by synchronous assignment
  inside every sign-in method.
- `user.getIdToken()` / `user.getIdToken(true)` /
  `user.getIdTokenResult(forceRefresh: true)` — imperative RPCs,
  unaffected.
- All user mutations: `updateDisplayName`, `updateEmail`,
  `updatePassword`, `updatePhoneNumber`, `updateProfile`,
  `reload`, `unlink`, `delete`, `reauthenticateWithCredential`,
  `verifyBeforeUpdateEmail`, etc.
- `sendPasswordResetEmail`, `confirmPasswordReset`,
  `applyActionCode`, `checkActionCode`, `verifyPasswordResetCode`.
- MFA, email verification, `useAuthEmulator`, tenant ID, custom
  auth domain.

**Degraded** — the real trade-off:

1. `idTokenChanges()` stream goes silent on Windows. Never emits —
   not on sign-in, sign-out, token refresh, nor custom-claims updates.
2. `userChanges()` stream loses native-driven emissions. It still
   emits when the app itself calls profile-mutation methods
   (`updateProfile`, `updateEmail`, `reload`, etc.) because
   those invoke `sendAuthChangesEvent` directly. It stops emitting
   from native sources (sign-in/out, token refresh, admin-driven
   custom-claims changes).
3. Auto-push of admin-side custom-claims updates does not reach the
   client via streams. Workaround: imperatively call
   `user.getIdToken(true)` when you need fresh claims.

This is strictly better than the current Windows status quo (process
abort on every cached login) for every app that does not rely on live
custom-claims stream notifications — which is most apps.

## Test plan

- `flutter test` for `firebase_auth_platform_interface` — all 181
  tests pass, including the 2 new ones in
  `disable_id_token_channel_on_windows_test.dart`.
- `dart analyze lib test` — no issues.
- `dart format --set-exit-if-changed` — no diff.
- Manually reproduced and verified on Windows 10 26200 with
  firebase_auth 6.4.0 / firebase_auth_platform_interface 8.1.9 via a
  local `dependency_override`:
  - Flag unset (default): `0xc0000409` abort on cached-login cold
    start, reproduced.
  - Flag set before `Firebase.initializeApp()`: no crash;
    `authStateChanges()` fires correctly on sign-in, sign-out, and
    cold-start-with-cached-user; app stable for 40s+ of sync traffic.

## Usage

```dart
import 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart';

void main() async {
  WidgetsFlutterBinding.ensureInitialized();
  FirebaseAuthPlatform.disableIdTokenChannelOnWindows = true;
  await Firebase.initializeApp(...);
  runApp(...);
}
```

## Follow-up (out of scope for this PR)

- Delete this flag and its call site when flutter/flutter#134346
  lands and `firebase_auth_desktop` dispatches its native event
  callbacks onto the platform thread.