### PR TITLE
fix(crashlytics): quote shell interpolations in podspec to support repo paths with spaces

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics.podspec
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics.podspec
@@ -7,7 +7,7 @@ library_version = pubspec['version'].gsub('+', '-')
 current_dir = Dir.pwd
 calling_dir = File.dirname(__FILE__)
 project_dir = calling_dir.slice(0..(calling_dir.index('/.symlinks')))
-system("ruby #{current_dir}/crashlytics_add_upload_symbols -f -p #{project_dir} -n Runner.xcodeproj")
+system("ruby '#{current_dir}/crashlytics_add_upload_symbols' -f -p '#{project_dir}' -n Runner.xcodeproj")
 
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/firebase_crashlytics/firebase_crashlytics/macos/firebase_crashlytics.podspec
+++ b/packages/firebase_crashlytics/firebase_crashlytics/macos/firebase_crashlytics.podspec
@@ -11,7 +11,7 @@ if project_dir.include? "Flutter/ephemeral"
   # Note: macOS CWD can be based in <macosProjectDir>/Flutter/ephemeral - so we need to go up two levels.
   project_dir = File.expand_path(File.join(project_dir, '..', '..'))
 end
-system("ruby #{current_dir}/crashlytics_add_upload_symbols -f -p #{project_dir} -n Runner.xcodeproj")
+system("ruby '#{current_dir}/crashlytics_add_upload_symbols' -f -p '#{project_dir}' -n Runner.xcodeproj")
 
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"


### PR DESCRIPTION
## Summary

The iOS and macOS `firebase_crashlytics.podspec` files invoke `crashlytics_add_upload_symbols` via `system("ruby ... -p #{project_dir} ...")` without quoting `#{current_dir}` or `#{project_dir}`. When either path contains a space, the shell tokenizes at the space and `crashlytics_add_upload_symbols`'s `OptParser` receives a truncated `-p` argument, then fails with:

```
Project at /Users/foo/My Code/Project/Runner.xcodeproj does not exist.
Please check paths or incorporate Crashlytics upload symbols manually.
```

The dSYM auto-upload build phase never gets added to the Runner target, breaking Crashlytics symbolication for any developer whose repo path contains a space (common on macOS — `~/My Code/`, `~/Mobile Apps/`, `~/iCloud Drive/...`, etc.).

## Fix

Single-quote both `#{current_dir}` and `#{project_dir}` in both podspec files so the shell preserves the path verbatim:

```ruby
# Before
system("ruby #{current_dir}/crashlytics_add_upload_symbols -f -p #{project_dir} -n Runner.xcodeproj")

# After
system("ruby '#{current_dir}/crashlytics_add_upload_symbols' -f -p '#{project_dir}' -n Runner.xcodeproj")
```

Same change in both:
- `packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics.podspec`
- `packages/firebase_crashlytics/firebase_crashlytics/macos/firebase_crashlytics.podspec`

Single-quotes are the safe choice here — Ruby string interpolation has already happened by the time the shell sees the command, so single-quoting the resolved value protects against shell tokenization without disabling interpolation.

## Repro

1. Clone any Flutter project using `firebase_crashlytics` into a directory whose absolute path contains a space, e.g. `~/My Apps/example/`.
2. `cd ios && pod install` (or `cd macos && pod install`).
3. Observe the warning above. The Crashlytics upload-symbols build phase is not added to Runner.

## Testing

- Verified locally on macOS 14.x with `firebase_crashlytics` 5.2.0 from a repo path containing a space. Pre-fix: warning fires, build phase missing. Post-fix: clean install, build phase added.
- No behavior change for paths without spaces.

## Compatibility

- No breaking changes. Single-quoting interpolated paths is a strict superset of the unquoted behavior.
- No version bump beyond a normal Crashlytics patch release.

## Related

This bug has been worked around as a local pub-cache patch by multiple Flutter developers; this PR moves that fix upstream so paths-with-spaces work for everyone out of the box.