### PR TITLE
chore: fix melos bs

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -105,7 +105,7 @@ melos:
       # https://github.com/dart-lang/pub/issues/3404). Disabling this feature
       # makes the CI much more stable.
       runPubGetInParallel: false
-      usePubspecOverrides: true
+      usePubspecOverrides: false
 
   scripts:
     lint:all:


### PR DESCRIPTION
`melos bootstrap` was failing with `Cannot override workspace packages` because melos was generating per-package `pubspec_overrides.yaml` files  