### PR TITLE
fix(auth,ios): allow firebase_auth to compile under APPLICATION_EXTENSION_API_ONLY

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
@@ -153,7 +153,13 @@ static NSMutableDictionary<NSNumber *, FIRAuthCredential *> *credentialsMap;
   [registrar addMethodCallDelegate:instance channel:channel];
 
   [registrar publish:instance];
+#if !TARGET_OS_EXTENSION
+  // -[FlutterPluginRegistrar addApplicationDelegate:] is unavailable when
+  // building for an app extension target (APPLICATION_EXTENSION_API_ONLY=YES).
+  // The application-delegate callbacks below (openURL etc.) are never
+  // exercised in extensions because sign-in flows cannot run from there.
   [registrar addApplicationDelegate:instance];
+#endif
 #if !TARGET_OS_OSX
   if (@available(iOS 13.0, *)) {
     if ([registrar respondsToSelector:@selector(addSceneDelegate:)]) {
@@ -897,7 +903,7 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
     (nonnull ASAuthorizationController *)controller API_AVAILABLE(macos(10.15), ios(13.0)) {
 #if TARGET_OS_OSX
   return [[NSApplication sharedApplication] keyWindow];
-#else
+#elif !TARGET_OS_EXTENSION
   // UIApplication.keyWindow is deprecated in iOS 13+ with UIScene lifecycle.
   // Walk the connected scenes to find the foreground active window.
   if (@available(iOS 15.0, *)) {
@@ -924,6 +930,12 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
     }
   }
   return [[UIApplication sharedApplication] keyWindow];
+#else
+  // App-extension build: +[UIApplication sharedApplication] is unavailable.
+  // Sign-in flows that require a presentation anchor cannot run from an
+  // extension — the host app is the only context that can present them —
+  // so this method is not expected to be invoked here.
+  return (ASPresentationAnchor)nil;
 #endif
 }
 


### PR DESCRIPTION
Fixes #18232.

## What's wrong

When `firebase_auth` is built into an iOS target with `APPLICATION_EXTENSION_API_ONLY=YES` (Share Extension, Action Extension, etc.), Xcode rejects four call sites in `FLTFirebaseAuthPlugin.m`:

```
'addApplicationDelegate:' is unavailable: not available on iOS (App Extension)
  FLTFirebaseAuthPlugin.m:155

'sharedApplication' is unavailable: not available on iOS (App Extension)
  FLTFirebaseAuthPlugin.m:903
  FLTFirebaseAuthPlugin.m:913
  FLTFirebaseAuthPlugin.m:925
```

The current workaround — setting `APPLICATION_EXTENSION_API_ONLY = NO` on the firebase_auth pod via a Podfile post-install hook — lets the build pass, but the resulting extension binary contains references to APIs that App Store review can flag.

## Fix

Wrap the four sites in `#if !TARGET_OS_EXTENSION`:

1. `[registrar addApplicationDelegate:instance]` in `+registerWithRegistrar:` is gated; in extensions there is no application delegate to register against, so the openURL / scene-delegate paths below it are unreachable anyway.
2. The `presentationAnchorForAuthorizationController:` method already branched on `TARGET_OS_OSX`; this PR splits the iOS branch into `!TARGET_OS_EXTENSION` (existing UIScene/keyWindow logic) and a fallback that returns `nil`. Sign-in flows that need a presentation anchor cannot run from an extension context — the host app is the only place that can present them — so the method is not expected to be invoked from an extension build.

iOS and macOS host-app behaviour is unchanged.

## Test plan

- [ ] Build a host iOS app with firebase_auth on Xcode 17 — confirm no regression in OAuth / Sign-in-with-Apple presentation flows.
- [ ] Build a Share Extension target that registers firebase_auth via `FLTFirebaseAuthPlugin.register(with:)` with `APPLICATION_EXTENSION_API_ONLY=YES` — confirm clean compile, no \"not available on iOS (App Extension)\" diagnostics.
- [ ] Build the macOS host app — confirm `presentationAnchorForAuthorizationController:` still returns the macOS key window.
- [ ] Verify the build succeeds for both Swift Package Manager and CocoaPods consumers.

I have not yet run all of these locally; opening as a draft so a maintainer or CI can validate the full matrix before this is marked ready.

## Notes

- The macOS `.m` file at `packages/firebase_auth/firebase_auth/macos/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m` is a symlink to the iOS source, so this single edit covers both platforms.
- I did not update `CHANGELOG.md` since flutterfire generates changelog entries from conventional commit subjects at release time via melos.