### PR TITLE
feat(core): Add Auth and AppCheck as App's registered service.

### DIFF
--- a/packages/firebase_ai/firebase_ai/example/lib/main.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/main.dart
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import 'package:firebase_ai/firebase_ai.dart';
-import 'package:firebase_app_check/firebase_app_check.dart';
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';

--- a/packages/firebase_ai/firebase_ai/example/lib/main.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/main.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:firebase_ai/firebase_ai.dart';
+import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
@@ -70,10 +71,10 @@ class _GenerativeAISampleState extends State<GenerativeAISample> {
 
   void _initializeModel(bool useVertexBackend) {
     if (useVertexBackend) {
-      final vertexInstance = FirebaseAI.vertexAI(auth: FirebaseAuth.instance);
+      final vertexInstance = FirebaseAI.vertexAI();
       _currentModel = vertexInstance.generativeModel(model: 'gemini-2.5-flash');
     } else {
-      final googleAI = FirebaseAI.googleAI(auth: FirebaseAuth.instance);
+      final googleAI = FirebaseAI.googleAI();
       _currentModel = googleAI.generativeModel(model: 'gemini-2.5-flash');
     }
   }

--- a/packages/firebase_ai/firebase_ai/example/lib/pages/chat_page.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/pages/chat_page.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 import 'package:flutter/material.dart';
 import 'package:firebase_ai/firebase_ai.dart';
 import '../widgets/message_widget.dart';

--- a/packages/firebase_ai/firebase_ai/example/lib/pages/chat_page.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/pages/chat_page.dart
@@ -57,12 +57,12 @@ class _ChatPageState extends State<ChatPage> {
           : null,
     );
     if (widget.useVertexBackend) {
-      _model = FirebaseAI.vertexAI(auth: FirebaseAuth.instance).generativeModel(
+      _model = FirebaseAI.vertexAI().generativeModel(
         model: 'gemini-2.5-flash',
         generationConfig: generationConfig,
       );
     } else {
-      _model = FirebaseAI.googleAI(auth: FirebaseAuth.instance).generativeModel(
+      _model = FirebaseAI.googleAI().generativeModel(
         model: 'gemini-2.5-flash',
         generationConfig: generationConfig,
       );

--- a/packages/firebase_ai/firebase_ai/example/lib/pages/chat_page.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/pages/chat_page.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:firebase_auth/firebase_auth.dart';
+
 import 'package:flutter/material.dart';
 import 'package:firebase_ai/firebase_ai.dart';
 import '../widgets/message_widget.dart';

--- a/packages/firebase_ai/firebase_ai/example/lib/pages/function_calling_page.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/pages/function_calling_page.dart
@@ -236,8 +236,8 @@ class _FunctionCallingPageState extends State<FunctionCallingPage> {
     );
 
     final aiClient = widget.useVertexBackend
-        ? FirebaseAI.vertexAI(auth: FirebaseAuth.instance)
-        : FirebaseAI.googleAI(auth: FirebaseAuth.instance);
+        ? FirebaseAI.vertexAI()
+        : FirebaseAI.googleAI();
 
     _functionCallModel = aiClient.generativeModel(
       model: 'gemini-2.5-flash',

--- a/packages/firebase_ai/firebase_ai/example/lib/pages/function_calling_page.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/pages/function_calling_page.dart
@@ -14,7 +14,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:firebase_ai/firebase_ai.dart';
-import 'package:firebase_auth/firebase_auth.dart';
+
 import '../utils/function_call_utils.dart';
 import '../widgets/message_widget.dart';
 

--- a/packages/firebase_ai/firebase_ai/example/lib/pages/function_calling_page.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/pages/function_calling_page.dart
@@ -235,9 +235,8 @@ class _FunctionCallingPageState extends State<FunctionCallingPage> {
           : null,
     );
 
-    final aiClient = widget.useVertexBackend
-        ? FirebaseAI.vertexAI()
-        : FirebaseAI.googleAI();
+    final aiClient =
+        widget.useVertexBackend ? FirebaseAI.vertexAI() : FirebaseAI.googleAI();
 
     _functionCallModel = aiClient.generativeModel(
       model: 'gemini-2.5-flash',

--- a/packages/firebase_ai/firebase_ai/example/lib/pages/grounding_page.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/pages/grounding_page.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 import 'package:flutter/material.dart';
 import 'package:firebase_ai/firebase_ai.dart';
 import '../widgets/message_widget.dart';
@@ -74,9 +73,8 @@ class _GroundingPageState extends State<GroundingPage> {
       }
     }
 
-    final aiProvider = widget.useVertexBackend
-        ? FirebaseAI.vertexAI()
-        : FirebaseAI.googleAI();
+    final aiProvider =
+        widget.useVertexBackend ? FirebaseAI.vertexAI() : FirebaseAI.googleAI();
 
     _model = aiProvider.generativeModel(
       model: 'gemini-2.5-flash',

--- a/packages/firebase_ai/firebase_ai/example/lib/pages/grounding_page.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/pages/grounding_page.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:firebase_auth/firebase_auth.dart';
+
 import 'package:flutter/material.dart';
 import 'package:firebase_ai/firebase_ai.dart';
 import '../widgets/message_widget.dart';

--- a/packages/firebase_ai/firebase_ai/example/lib/pages/grounding_page.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/pages/grounding_page.dart
@@ -75,8 +75,8 @@ class _GroundingPageState extends State<GroundingPage> {
     }
 
     final aiProvider = widget.useVertexBackend
-        ? FirebaseAI.vertexAI(auth: FirebaseAuth.instance)
-        : FirebaseAI.googleAI(auth: FirebaseAuth.instance);
+        ? FirebaseAI.vertexAI()
+        : FirebaseAI.googleAI();
 
     _model = aiProvider.generativeModel(
       model: 'gemini-2.5-flash',

--- a/packages/firebase_ai/firebase_ai/example/lib/pages/image_generation_page.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/pages/image_generation_page.dart
@@ -47,9 +47,8 @@ class _ImageGenerationPageState extends State<ImageGenerationPage> {
   }
 
   void _initializeModel() {
-    final aiClient = widget.useVertexBackend
-        ? FirebaseAI.vertexAI()
-        : FirebaseAI.googleAI();
+    final aiClient =
+        widget.useVertexBackend ? FirebaseAI.vertexAI() : FirebaseAI.googleAI();
 
     _model = aiClient.generativeModel(
       model: 'gemini-2.5-flash-image',

--- a/packages/firebase_ai/firebase_ai/example/lib/pages/image_generation_page.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/pages/image_generation_page.dart
@@ -15,7 +15,7 @@
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:firebase_ai/firebase_ai.dart';
-import 'package:firebase_auth/firebase_auth.dart';
+
 import '../widgets/message_widget.dart';
 
 class ImageGenerationPage extends StatefulWidget {

--- a/packages/firebase_ai/firebase_ai/example/lib/pages/image_generation_page.dart
+++ b/packages/firebase_ai/firebase_ai/example/lib/pages/image_generation_page.dart
@@ -48,8 +48,8 @@ class _ImageGenerationPageState extends State<ImageGenerationPage> {
 
   void _initializeModel() {
     final aiClient = widget.useVertexBackend
-        ? FirebaseAI.vertexAI(auth: FirebaseAuth.instance)
-        : FirebaseAI.googleAI(auth: FirebaseAuth.instance);
+        ? FirebaseAI.vertexAI()
+        : FirebaseAI.googleAI();
 
     _model = aiClient.generativeModel(
       model: 'gemini-2.5-flash-image',

--- a/packages/firebase_ai/firebase_ai/lib/src/base_model.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/base_model.dart
@@ -282,19 +282,23 @@ abstract class BaseModel {
   ) {
     return () async {
       Map<String, String> headers = {};
+      
+      final effectiveAppCheck = appCheck ?? app?.getService<FirebaseAppCheck>();
+      final effectiveAuth = auth ?? app?.getService<FirebaseAuth>();
+      
       // Override the client name in Google AI SDK
       headers['x-goog-api-client'] =
           'gl-dart/$packageVersion fire/$packageVersion';
-      if (appCheck != null) {
+      if (effectiveAppCheck != null) {
         final appCheckToken = useLimitedUseAppCheckTokens == true
-            ? await appCheck.getLimitedUseToken()
-            : await appCheck.getToken();
+            ? await effectiveAppCheck.getLimitedUseToken()
+            : await effectiveAppCheck.getToken();
         if (appCheckToken != null) {
           headers['X-Firebase-AppCheck'] = appCheckToken;
         }
       }
-      if (auth != null) {
-        final idToken = await auth.currentUser?.getIdToken();
+      if (effectiveAuth != null) {
+        final idToken = await effectiveAuth.currentUser?.getIdToken();
         if (idToken != null) {
           headers['Authorization'] = 'Firebase $idToken';
         }

--- a/packages/firebase_ai/firebase_ai/lib/src/base_model.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/base_model.dart
@@ -282,10 +282,10 @@ abstract class BaseModel {
   ) {
     return () async {
       Map<String, String> headers = {};
-      
+
       final effectiveAppCheck = appCheck ?? app?.getService<FirebaseAppCheck>();
       final effectiveAuth = auth ?? app?.getService<FirebaseAuth>();
-      
+
       // Override the client name in Google AI SDK
       headers['x-goog-api-client'] =
           'gl-dart/$packageVersion fire/$packageVersion';

--- a/packages/firebase_ai/firebase_ai/lib/src/firebase_ai.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/firebase_ai.dart
@@ -69,6 +69,7 @@ class FirebaseAI extends FirebasePluginPlatform {
   }) {
     app ??= Firebase.app();
     appCheck ??= app.getService<FirebaseAppCheck>();
+    auth ??= app.getService<FirebaseAuth>();
     var instanceKey = '${app.name}::vertexai::$location';
 
     if (_cachedInstances.containsKey(instanceKey)) {
@@ -102,6 +103,7 @@ class FirebaseAI extends FirebasePluginPlatform {
   }) {
     app ??= Firebase.app();
     appCheck ??= app.getService<FirebaseAppCheck>();
+    auth ??= app.getService<FirebaseAuth>();
     var instanceKey = '${app.name}::googleai';
 
     if (_cachedInstances.containsKey(instanceKey)) {

--- a/packages/firebase_ai/firebase_ai/lib/src/firebase_ai.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/firebase_ai.dart
@@ -68,6 +68,7 @@ class FirebaseAI extends FirebasePluginPlatform {
     bool? useLimitedUseAppCheckTokens,
   }) {
     app ??= Firebase.app();
+    appCheck ??= app.getService<FirebaseAppCheck>();
     var instanceKey = '${app.name}::vertexai::$location';
 
     if (_cachedInstances.containsKey(instanceKey)) {
@@ -100,6 +101,7 @@ class FirebaseAI extends FirebasePluginPlatform {
     bool? useLimitedUseAppCheckTokens,
   }) {
     app ??= Firebase.app();
+    appCheck ??= app.getService<FirebaseAppCheck>();
     var instanceKey = '${app.name}::googleai';
 
     if (_cachedInstances.containsKey(instanceKey)) {

--- a/packages/firebase_ai/firebase_ai/lib/src/firebase_ai.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/firebase_ai.dart
@@ -62,7 +62,11 @@ class FirebaseAI extends FirebasePluginPlatform {
   /// If pass in [appCheck], request session will get protected from abusing.
   static FirebaseAI vertexAI({
     FirebaseApp? app,
+    @Deprecated(
+        'Passing an explicit instance is deprecated, internal handling is now automatic.')
     FirebaseAppCheck? appCheck,
+    @Deprecated(
+        'Passing an explicit instance is deprecated, internal handling is now automatic.')
     FirebaseAuth? auth,
     String? location,
     bool? useLimitedUseAppCheckTokens,
@@ -97,7 +101,11 @@ class FirebaseAI extends FirebasePluginPlatform {
   /// If pass in [appCheck], request session will get protected from abusing.
   static FirebaseAI googleAI({
     FirebaseApp? app,
+    @Deprecated(
+        'Passing an explicit instance is deprecated, internal handling is now automatic.')
     FirebaseAppCheck? appCheck,
+    @Deprecated(
+        'Passing an explicit instance is deprecated, internal handling is now automatic.')
     FirebaseAuth? auth,
     bool? useLimitedUseAppCheckTokens,
   }) {

--- a/packages/firebase_ai/firebase_ai/test/base_model_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/base_model_test.dart
@@ -31,6 +31,20 @@ class MockFirebaseApp extends Mock implements FirebaseApp {
 
   @override
   bool get isAutomaticDataCollectionEnabled => true;
+
+  FirebaseAppCheck? mockAppCheck;
+  FirebaseAuth? mockAuth;
+
+  @override
+  T? getService<T extends FirebaseService>() {
+    if (T == FirebaseAppCheck) {
+      return mockAppCheck as T?;
+    }
+    if (T == FirebaseAuth) {
+      return mockAuth as T?;
+    }
+    return null;
+  }
 }
 
 // Mock FirebaseOptions
@@ -129,6 +143,84 @@ void main() {
       expect(headers['x-goog-api-client'], contains('gl-dart'));
       expect(headers['x-goog-api-client'], contains('fire'));
       expect(headers.length, 2);
+    });
+
+    test('firebaseTokens discovers App Check token dynamically at request time',
+        () async {
+      final mockApp = MockFirebaseApp();
+      final mockAppCheck = MockFirebaseAppCheck();
+      when(mockAppCheck.getToken())
+          .thenAnswer((_) async => 'dynamic-app-check-token');
+      mockApp.mockAppCheck = mockAppCheck;
+
+      final tokenFunction =
+          BaseModel.firebaseTokens(null, null, mockApp, false);
+      final headers = await tokenFunction();
+
+      expect(headers['X-Firebase-AppCheck'], 'dynamic-app-check-token');
+      expect(headers['X-Firebase-AppId'], 'test-app-id');
+      expect(headers.length, 3);
+    });
+
+    test('firebaseTokens discovers Auth ID token dynamically at request time',
+        () async {
+      final mockApp = MockFirebaseApp();
+      final mockAuth = MockFirebaseAuth();
+      final mockUser = MockUser();
+      when(mockUser.getIdToken()).thenAnswer((_) async => 'dynamic-id-token');
+      when(mockAuth.currentUser).thenReturn(mockUser);
+      mockApp.mockAuth = mockAuth;
+
+      final tokenFunction =
+          BaseModel.firebaseTokens(null, null, mockApp, false);
+      final headers = await tokenFunction();
+
+      expect(headers['Authorization'], 'Firebase dynamic-id-token');
+      expect(headers['X-Firebase-AppId'], 'test-app-id');
+      expect(headers.length, 3);
+    });
+
+    test('firebaseTokens discovers both tokens dynamically at request time',
+        () async {
+      final mockApp = MockFirebaseApp();
+      final mockAppCheck = MockFirebaseAppCheck();
+      final mockAuth = MockFirebaseAuth();
+      final mockUser = MockUser();
+
+      when(mockAppCheck.getToken())
+          .thenAnswer((_) async => 'dynamic-app-check-token');
+      when(mockUser.getIdToken()).thenAnswer((_) async => 'dynamic-id-token');
+      when(mockAuth.currentUser).thenReturn(mockUser);
+
+      mockApp.mockAppCheck = mockAppCheck;
+      mockApp.mockAuth = mockAuth;
+
+      final tokenFunction =
+          BaseModel.firebaseTokens(null, null, mockApp, false);
+      final headers = await tokenFunction();
+
+      expect(headers['X-Firebase-AppCheck'], 'dynamic-app-check-token');
+      expect(headers['Authorization'], 'Firebase dynamic-id-token');
+      expect(headers['X-Firebase-AppId'], 'test-app-id');
+      expect(headers.length, 4);
+    });
+
+    test(
+        'firebaseTokens discovers App Check token dynamically with limited use',
+        () async {
+      final mockApp = MockFirebaseApp();
+      final mockAppCheck = MockFirebaseAppCheck();
+
+      when(mockAppCheck.getLimitedUseToken())
+          .thenAnswer((_) async => 'dynamic-limited-use-token');
+      mockApp.mockAppCheck = mockAppCheck;
+
+      final tokenFunction = BaseModel.firebaseTokens(null, null, mockApp, true);
+      final headers = await tokenFunction();
+
+      expect(headers['X-Firebase-AppCheck'], 'dynamic-limited-use-token');
+      expect(headers['X-Firebase-AppId'], 'test-app-id');
+      expect(headers.length, 3);
     });
 
     test('firebaseTokens includes all tokens if available', () async {

--- a/packages/firebase_ai/firebase_ai/test/firebase_vertexai_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/firebase_vertexai_test.dart
@@ -96,6 +96,13 @@ void main() {
       expect(vertexAIAppCheck.useLimitedUseAppCheckTokens, true);
     });
 
+    test('Instance creation with auto-injected AppCheck', () {
+      final vertexAI = FirebaseAI.vertexAI(app: customApp);
+      
+      expect(vertexAI.app, equals(customApp));
+      expect(vertexAI.appCheck, equals(customAppCheck));
+    });
+
     test('generativeModel creation with Grounding tools', () {
       final ai = FirebaseAI.googleAI();
 

--- a/packages/firebase_ai/firebase_ai/test/firebase_vertexai_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/firebase_vertexai_test.dart
@@ -14,6 +14,7 @@
 
 import 'package:firebase_ai/firebase_ai.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -28,6 +29,7 @@ void main() {
   late FirebaseApp customApp;
   late FirebaseApp limitTokenApp;
   late FirebaseAppCheck customAppCheck;
+  late FirebaseAuth customAuth;
   late FirebaseAppCheck limitTokenAppCheck;
 
   group('FirebaseAI Tests', () {
@@ -47,6 +49,7 @@ void main() {
       appCheck = FirebaseAppCheck.instance;
       customAppCheck = FirebaseAppCheck.instanceFor(app: customApp);
       limitTokenAppCheck = FirebaseAppCheck.instanceFor(app: limitTokenApp);
+      customAuth = FirebaseAuth.instanceFor(app: customApp);
     });
 
     test('Singleton behavior', () {
@@ -98,9 +101,16 @@ void main() {
 
     test('Instance creation with auto-injected AppCheck', () {
       final vertexAI = FirebaseAI.vertexAI(app: customApp);
-      
+
       expect(vertexAI.app, equals(customApp));
       expect(vertexAI.appCheck, equals(customAppCheck));
+    });
+
+    test('Instance creation with auto-injected Auth', () {
+      final vertexAI = FirebaseAI.vertexAI(app: customApp);
+
+      expect(vertexAI.app, equals(customApp));
+      expect(vertexAI.auth, equals(customAuth));
     });
 
     test('generativeModel creation with Grounding tools', () {

--- a/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
@@ -5,7 +5,8 @@
 
 part of '../firebase_app_check.dart';
 
-class FirebaseAppCheck extends FirebasePluginPlatform implements FirebaseService {
+class FirebaseAppCheck extends FirebasePluginPlatform
+    implements FirebaseService {
   static Map<String, FirebaseAppCheck> _firebaseAppCheckInstances = {};
 
   FirebaseAppCheck._({required this.app})

--- a/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
@@ -5,7 +5,7 @@
 
 part of '../firebase_app_check.dart';
 
-class FirebaseAppCheck extends FirebasePluginPlatform {
+class FirebaseAppCheck extends FirebasePluginPlatform implements FirebaseService {
   static Map<String, FirebaseAppCheck> _firebaseAppCheckInstances = {};
 
   FirebaseAppCheck._({required this.app})

--- a/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
@@ -41,7 +41,9 @@ class FirebaseAppCheck extends FirebasePluginPlatform {
   /// Returns an instance using a specified [FirebaseApp].
   static FirebaseAppCheck instanceFor({required FirebaseApp app}) {
     return _firebaseAppCheckInstances.putIfAbsent(app.name, () {
-      return FirebaseAppCheck._(app: app);
+      final instance = FirebaseAppCheck._(app: app);
+      app.registerService<FirebaseAppCheck>(instance);
+      return instance;
     });
   }
 

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -45,7 +45,9 @@ class FirebaseAuth extends FirebasePluginPlatform {
     required FirebaseApp app,
   }) {
     return _firebaseAuthInstances.putIfAbsent(app.name, () {
-      return FirebaseAuth._(app: app);
+      final instance = FirebaseAuth._(app: app);
+      app.registerService<FirebaseAuth>(instance);
+      return instance;
     });
   }
 

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -6,7 +6,7 @@
 part of '../firebase_auth.dart';
 
 /// The entry point of the Firebase Authentication SDK.
-class FirebaseAuth extends FirebasePluginPlatform {
+class FirebaseAuth extends FirebasePluginPlatform implements FirebaseService {
   // Cached instances of [FirebaseAuth].
   static Map<String, FirebaseAuth> _firebaseAuthInstances = {};
 

--- a/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
@@ -71,4 +71,21 @@ class FirebaseApp {
 
   @override
   String toString() => '$FirebaseApp($name)';
+
+  static final Map<String, Map<Type, dynamic>> _registries = {};
+
+  /// Registers a service instance for this app.
+  void registerService<T>(T service) {
+    final registry = _registries.putIfAbsent(name, () => {});
+    registry[T] = service;
+  }
+
+  /// Returns a registered service instance for this app.
+  T? getService<T>() {
+    final registry = _registries[name];
+    if (registry != null) {
+      return registry[T] as T?;
+    }
+    return null;
+  }
 }

--- a/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
@@ -83,11 +83,7 @@ class FirebaseApp {
 
   /// Returns a registered service instance for this app.
   T? getService<T extends FirebaseService>() {
-    final registry = _registries[name];
-    if (registry != null) {
-      return registry[T] as T?;
-    }
-    return null;
+    return _registries[name]?[T] as T?;
   }
 }
 

--- a/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
@@ -76,13 +76,13 @@ class FirebaseApp {
   static final Map<String, Map<Type, dynamic>> _registries = {};
 
   /// Registers a service instance for this app.
-  void registerService<T>(T service) {
+  void registerService<T extends FirebaseService>(T service) {
     final registry = _registries.putIfAbsent(name, () => {});
     registry[T] = service;
   }
 
   /// Returns a registered service instance for this app.
-  T? getService<T>() {
+  T? getService<T extends FirebaseService>() {
     final registry = _registries[name];
     if (registry != null) {
       return registry[T] as T?;
@@ -90,3 +90,6 @@ class FirebaseApp {
     return null;
   }
 }
+
+/// A marker interface for Firebase services that can be registered in [FirebaseApp].
+abstract class FirebaseService {}

--- a/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
@@ -28,6 +28,7 @@ class FirebaseApp {
   /// Deleting the default app is not possible and throws an exception.
   Future<void> delete() async {
     await _delegate.delete();
+    _registries.remove(name);
   }
 
   /// The name of this [FirebaseApp].

--- a/packages/firebase_core/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core/test/firebase_core_test.dart
@@ -67,10 +67,10 @@ void main() {
 
     test('.registerService() and .getService()', () {
       FirebaseApp app = Firebase.app(testAppName);
-      
+
       const testService = 'testServiceInstance';
       app.registerService<String>(testService);
-      
+
       expect(app.getService<String>(), testService);
       expect(app.getService<int>(), isNull);
     });

--- a/packages/firebase_core/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core/test/firebase_core_test.dart
@@ -64,6 +64,16 @@ void main() {
         mock.app(testAppName),
       ]);
     });
+
+    test('.registerService() and .getService()', () {
+      FirebaseApp app = Firebase.app(testAppName);
+      
+      const testService = 'testServiceInstance';
+      app.registerService<String>(testService);
+      
+      expect(app.getService<String>(), testService);
+      expect(app.getService<int>(), isNull);
+    });
   });
 
   test('.initializeApp() with demoProjectId', () async {

--- a/packages/firebase_core/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core/test/firebase_core_test.dart
@@ -67,12 +67,11 @@ void main() {
 
     test('.registerService() and .getService()', () {
       FirebaseApp app = Firebase.app(testAppName);
-
-      const testService = 'testServiceInstance';
-      app.registerService<String>(testService);
-
-      expect(app.getService<String>(), testService);
-      expect(app.getService<int>(), isNull);
+      
+      final testService = TestService();
+      app.registerService<TestService>(testService);
+      
+      expect(app.getService<TestService>(), testService);
     });
   });
 
@@ -162,3 +161,5 @@ class MockFirebaseCore extends Mock
 
 // ignore: avoid_implementing_value_types
 class FakeFirebaseAppPlatform extends Fake implements FirebaseAppPlatform {}
+
+class TestService implements FirebaseService {}

--- a/packages/firebase_core/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core/test/firebase_core_test.dart
@@ -73,6 +73,21 @@ void main() {
 
       expect(app.getService<TestService>(), testService);
     });
+
+    test('.getService() returns null when registry is null', () {
+      String nullAppName = 'nullApp';
+      final FirebaseAppPlatform nullPlatformApp =
+          FirebaseAppPlatform(nullAppName, testOptions);
+      when(mock.app(nullAppName)).thenReturn(nullPlatformApp);
+
+      FirebaseApp app = Firebase.app(nullAppName);
+      expect(app.getService<TestService>(), isNull);
+    });
+
+    test('.getService() returns null when service is not registered', () {
+      FirebaseApp app = Firebase.app(testAppName);
+      expect(app.getService<AnotherTestService>(), isNull);
+    });
   });
 
   test('.initializeApp() with demoProjectId', () async {
@@ -163,3 +178,5 @@ class MockFirebaseCore extends Mock
 class FakeFirebaseAppPlatform extends Fake implements FirebaseAppPlatform {}
 
 class TestService implements FirebaseService {}
+
+class AnotherTestService implements FirebaseService {}

--- a/packages/firebase_core/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core/test/firebase_core_test.dart
@@ -67,10 +67,10 @@ void main() {
 
     test('.registerService() and .getService()', () {
       FirebaseApp app = Firebase.app(testAppName);
-      
+
       final testService = TestService();
       app.registerService<TestService>(testService);
-      
+
       expect(app.getService<TestService>(), testService);
     });
   });


### PR DESCRIPTION
## Description

This could enable firebase_ai to use Auth and AppCheck without explicit pass it into the ai service constructor.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
