### PR TITLE
fix(storage,android): fix an issue that could happen when app would get detached from the engine

### DIFF
--- a/packages/firebase_storage/firebase_storage/android/src/main/kotlin/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.kt
+++ b/packages/firebase_storage/firebase_storage/android/src/main/kotlin/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.kt
@@ -95,11 +95,13 @@ internal class FlutterFirebaseStorageTask private constructor(
     @JvmStatic
     fun cancelInProgressTasks() {
       synchronized(inProgressTasks) {
+        val tasks = ArrayList<FlutterFirebaseStorageTask>(inProgressTasks.size())
         for (i in 0 until inProgressTasks.size()) {
           val task: FlutterFirebaseStorageTask? = inProgressTasks.valueAt(i)
-          task?.destroy()
+          task?.let { tasks.add(it) }
         }
         inProgressTasks.clear()
+        tasks.forEach { it.destroy() }
       }
     }
 

--- a/tests/integration_test/firebase_storage/task_e2e.dart
+++ b/tests/integration_test/firebase_storage/task_e2e.dart
@@ -6,9 +6,12 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tests/firebase_options.dart';
 
 import './test_utils.dart';
 
@@ -345,6 +348,38 @@ void setupTaskTests() {
           retry: 2,
           // Windows `task.cancel()` is returning "false", same code on example app works as intended
           skip: defaultTargetPlatform == TargetPlatform.windows,
+        );
+
+        test(
+          'cancels multiple in-progress Android tasks during core reinitialization',
+          () async {
+            final tasks = <UploadTask>[
+              for (var i = 0; i < 3; i++)
+                storage
+                    .ref('flutter-tests/regression-18240-$i.txt')
+                    .putString('A' * 20000000),
+            ];
+            final completions = tasks
+                .map(
+                  (task) => task.then<void>(
+                    (_) {},
+                    onError: (_) {},
+                  ),
+                )
+                .toList();
+
+            try {
+              MethodChannelFirebase.isCoreInitialized = false;
+              await Firebase.initializeApp(
+                options: DefaultFirebaseOptions.currentPlatform,
+              ).timeout(const Duration(seconds: 30));
+            } finally {
+              MethodChannelFirebase.isCoreInitialized = true;
+              completions.forEach(unawaited);
+            }
+          },
+          retry: 2,
+          skip: kIsWeb || defaultTargetPlatform != TargetPlatform.android,
         );
       },
     );


### PR DESCRIPTION

## Description

Fixes an Android crash in `firebase_storage` when Firebase Core reinitialization or engine detach cancels three or more in-progress Storage tasks. The fix snapshots the shared in-progress task list before destroying tasks so cancellation no longer mutates the collection being iterated.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18240

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
