### PR TITLE
fix(messaging,android): fix call race that could happen when using requestPermission

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebasePermissionManager.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebasePermissionManager.java
@@ -17,7 +17,11 @@ import io.flutter.plugin.common.PluginRegistry;
 import java.util.ArrayList;
 
 class FlutterFirebasePermissionManager implements PluginRegistry.RequestPermissionsResultListener {
+  private static final String REQUEST_IN_PROGRESS_ERROR =
+      "A request for permissions is already running, please wait for it to finish before doing "
+      + "another request.";
 
+  private final Object requestLock = new Object();
   private final int permissionCode = 240;
   @Nullable private RequestPermissionsSuccessCallback successCallback;
   private boolean requestInProgress = false;
@@ -30,42 +34,52 @@ class FlutterFirebasePermissionManager implements PluginRegistry.RequestPermissi
   @Override
   public boolean onRequestPermissionsResult(
       int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-    if (requestInProgress && requestCode == permissionCode && this.successCallback != null) {
-      requestInProgress = false;
-      boolean granted =
-          grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
+    final RequestPermissionsSuccessCallback callback;
+    synchronized (requestLock) {
+      if (!requestInProgress || requestCode != permissionCode || this.successCallback == null) {
+        return false;
+      }
 
-      this.successCallback.onSuccess(granted ? 1 : 0);
+      callback = this.successCallback;
+      this.successCallback = null;
+      requestInProgress = false;
+    }
+
+    boolean granted =
+        grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
+    callback.onSuccess(granted ? 1 : 0);
+    return true;
+  }
+
+  private boolean setRequestInProgress(RequestPermissionsSuccessCallback successCallback) {
+    synchronized (requestLock) {
+      if (requestInProgress) {
+        return false;
+      }
+
+      requestInProgress = true;
+      this.successCallback = successCallback;
       return true;
-    } else {
-      return false;
     }
   }
 
   @RequiresApi(api = 33)
-  public void requestPermissions(
-      Activity activity,
-      RequestPermissionsSuccessCallback successCallback,
-      ErrorCallback errorCallback) {
-    if (requestInProgress) {
-      errorCallback.onError(
-          "A request for permissions is already running, please wait for it to finish before doing another request.");
-      return;
-    }
-
+  public void requestPermissions(Activity activity,
+      RequestPermissionsSuccessCallback successCallback, ErrorCallback errorCallback) {
     if (activity == null) {
       errorCallback.onError("Unable to detect current Android Activity.");
       return;
     }
 
-    this.successCallback = successCallback;
+    if (!setRequestInProgress(successCallback)) {
+      errorCallback.onError(REQUEST_IN_PROGRESS_ERROR);
+      return;
+    }
+
     final ArrayList<String> permissions = new ArrayList<String>();
     permissions.add(Manifest.permission.POST_NOTIFICATIONS);
     final String[] requestNotificationPermission = permissions.toArray(new String[0]);
 
-    if (!requestInProgress) {
-      ActivityCompat.requestPermissions(activity, requestNotificationPermission, permissionCode);
-      requestInProgress = true;
-    }
+    ActivityCompat.requestPermissions(activity, requestNotificationPermission, permissionCode);
   }
 }

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebasePermissionManager.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebasePermissionManager.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 class FlutterFirebasePermissionManager implements PluginRegistry.RequestPermissionsResultListener {
   private static final String REQUEST_IN_PROGRESS_ERROR =
       "A request for permissions is already running, please wait for it to finish before doing "
-      + "another request.";
+          + "another request.";
 
   private final Object requestLock = new Object();
   private final int permissionCode = 240;
@@ -64,8 +64,10 @@ class FlutterFirebasePermissionManager implements PluginRegistry.RequestPermissi
   }
 
   @RequiresApi(api = 33)
-  public void requestPermissions(Activity activity,
-      RequestPermissionsSuccessCallback successCallback, ErrorCallback errorCallback) {
+  public void requestPermissions(
+      Activity activity,
+      RequestPermissionsSuccessCallback successCallback,
+      ErrorCallback errorCallback) {
     if (activity == null) {
       errorCallback.onError("Unable to detect current Android Activity.");
       return;


### PR DESCRIPTION
## Description

Fixes an Android crash in `firebase_messaging` when concurrent `requestPermission()` calls race through the native permission manager. The fix synchronizes the in-flight permission state and stored callback so only one OS permission request can start at a time, and the callback cannot be overwritten while a request is pending.

No automated test was added because FlutterFire CI does not currently run Android plugin JVM tests, and the existing integration test setup cannot reliably drive the Android runtime permission dialog. This was verified with the Android example build plus existing Dart analysis/tests.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18246

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
