### PR TITLE
fix(database): fix a regression with database localEvents handling

### DIFF
--- a/packages/firebase_database/firebase_database/android/src/main/kotlin/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.kt
+++ b/packages/firebase_database/firebase_database/android/src/main/kotlin/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.kt
@@ -770,7 +770,7 @@ class FirebaseDatabasePlugin :
             callback(KotlinResult.success(Unit))
           }
         }
-      })
+      }, request.applyLocally)
     } catch (e: Exception) {
       // Convert generic exceptions to FlutterFirebaseDatabaseException for proper error handling
       val flutterException = if (e is FlutterFirebaseDatabaseException) e else FlutterFirebaseDatabaseException.unknown(e.message ?: "Unknown transaction error")

--- a/packages/firebase_database/firebase_database/ios/firebase_database/Sources/firebase_database/FLTFirebaseDatabasePlugin.swift
+++ b/packages/firebase_database/firebase_database/ios/firebase_database/Sources/firebase_database/FLTFirebaseDatabasePlugin.swift
@@ -304,7 +304,7 @@ public class FLTFirebaseDatabasePlugin: NSObject, FlutterPlugin, FLTFirebasePlug
       ]
 
       completion(.success(()))
-    }
+    } withLocalEvents: request.applyLocally
   }
 
   func databaseReferenceGetTransactionResult(app: DatabasePigeonFirebaseApp, transactionKey: Int64,

--- a/packages/firebase_database/firebase_database/ios/firebase_database/Sources/firebase_database/FLTFirebaseDatabasePlugin.swift
+++ b/packages/firebase_database/firebase_database/ios/firebase_database/Sources/firebase_database/FLTFirebaseDatabasePlugin.swift
@@ -251,7 +251,7 @@ public class FLTFirebaseDatabasePlugin: NSObject, FlutterPlugin, FLTFirebasePlug
     let database = getDatabaseFromPigeonApp(app)
     let reference = database.reference(withPath: request.path)
 
-    reference.runTransactionBlock { currentData in
+    reference.runTransactionBlock({ currentData in
       let semaphore = DispatchSemaphore(value: 0)
       var transactionResult: TransactionHandlerResult?
 
@@ -284,7 +284,7 @@ public class FLTFirebaseDatabasePlugin: NSObject, FlutterPlugin, FLTFirebasePlug
 
       currentData.value = result.value
       return TransactionResult.success(withValue: currentData)
-    } andCompletionBlock: { error, committed, snapshot in
+    }, andCompletionBlock: { error, committed, snapshot in
       if let error {
         completion(.failure(self.createFlutterError(error)))
         return
@@ -304,7 +304,7 @@ public class FLTFirebaseDatabasePlugin: NSObject, FlutterPlugin, FLTFirebasePlug
       ]
 
       completion(.success(()))
-    } withLocalEvents: request.applyLocally
+    }, withLocalEvents: request.applyLocally)
   }
 
   func databaseReferenceGetTransactionResult(app: DatabasePigeonFirebaseApp, transactionKey: Int64,

--- a/tests/integration_test/firebase_database/database_reference_e2e.dart
+++ b/tests/integration_test/firebase_database/database_reference_e2e.dart
@@ -126,6 +126,41 @@ void setupDatabaseReferenceTests() {
         expect(result.snapshot.value, 5);
       });
 
+      test('does not emit local transaction events when disabled', () async {
+        final ref = database.ref('tests/transaction-apply-locally-false');
+        await ref.set({'count': 0});
+
+        final initialEvent = Completer<void>();
+        final events = <Object?>[];
+        final subscription = ref.onValue.listen((event) {
+          if (!initialEvent.isCompleted) {
+            initialEvent.complete();
+            return;
+          }
+
+          events.add(event.snapshot.value);
+        });
+
+        try {
+          await initialEvent.future.timeout(const Duration(seconds: 5));
+
+          await ref.runTransaction(
+            (value) => Transaction.success({
+              'count': ((value as Map?)?['count'] as int? ?? 0) + 1,
+              'timestamp': ServerValue.timestamp,
+            }),
+            applyLocally: false,
+          );
+
+          await Future<void>.delayed(const Duration(seconds: 1));
+
+          expect(events, hasLength(1));
+        } finally {
+          await database.goOnline();
+          await subscription.cancel();
+        }
+      });
+
       test('executes transaction', () async {
         final ref = database.ref('tests/transaction-exec');
         await ref.set(0);


### PR DESCRIPTION
## Description

Fixes `runTransaction(applyLocally: false)` in `firebase_database` on Android and iOS. The Pigeon rewrite carried the `applyLocally` value through Dart, but the native transaction calls ignored it and used the default local-event behavior; this now forwards the flag to the native SDK transaction APIs and adds integration coverage for the suppressed local-event path.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18247

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
