### PR TITLE
fix(app_check): fix an issue with debug token that would sometime not be passed properly

### DIFF
--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
@@ -92,18 +92,6 @@ class MethodChannelFirebaseAppCheck extends FirebaseAppCheckPlatform {
     WindowsAppCheckProvider? providerWindows,
   }) async {
     try {
-      String? debugToken;
-      if (providerAndroid is AndroidDebugProvider &&
-          providerAndroid.debugToken != null) {
-        debugToken = providerAndroid.debugToken;
-      } else if (providerApple is AppleDebugProvider &&
-          providerApple.debugToken != null) {
-        debugToken = providerApple.debugToken;
-      } else if (providerWindows is WindowsDebugProvider &&
-          providerWindows.debugToken != null) {
-        debugToken = providerWindows.debugToken;
-      }
-
       await _pigeonApi.activate(
         app.name,
         defaultTargetPlatform == TargetPlatform.android || kDebugMode
@@ -120,7 +108,11 @@ class MethodChannelFirebaseAppCheck extends FirebaseAppCheckPlatform {
                 newProvider: providerApple,
               )
             : null,
-        debugToken,
+        _getDebugToken(
+          providerAndroid: providerAndroid,
+          providerApple: providerApple,
+          providerWindows: providerWindows,
+        ),
       );
     } on PlatformException catch (e, s) {
       convertPlatformException(e, s);
@@ -162,5 +154,30 @@ class MethodChannelFirebaseAppCheck extends FirebaseAppCheckPlatform {
     } on PlatformException catch (e, s) {
       convertPlatformException(e, s);
     }
+  }
+}
+
+String? _getDebugToken({
+  AndroidAppCheckProvider? providerAndroid,
+  AppleAppCheckProvider? providerApple,
+  WindowsAppCheckProvider? providerWindows,
+}) {
+  switch (defaultTargetPlatform) {
+    case TargetPlatform.android:
+      return providerAndroid is AndroidDebugProvider
+          ? providerAndroid.debugToken
+          : null;
+    case TargetPlatform.iOS:
+    case TargetPlatform.macOS:
+      return providerApple is AppleDebugProvider
+          ? providerApple.debugToken
+          : null;
+    case TargetPlatform.windows:
+      return providerWindows is WindowsDebugProvider
+          ? providerWindows.debugToken
+          : null;
+    case TargetPlatform.fuchsia:
+    case TargetPlatform.linux:
+      return null;
   }
 }

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/test/method_channel_tests/method_channel_firebase_app_check_test.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/test/method_channel_tests/method_channel_firebase_app_check_test.dart
@@ -3,7 +3,10 @@
 // found in the LICENSE file.
 
 import 'package:firebase_app_check_platform_interface/firebase_app_check_platform_interface.dart';
+import 'package:firebase_app_check_platform_interface/src/pigeon/messages.pigeon.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../mock.dart';
@@ -26,6 +29,15 @@ void main() {
       );
     });
 
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMessageHandler(
+        'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.activate',
+        null,
+      );
+    });
+
     group('delegateFor()', () {
       test('returns a [FirebaseAppCheckPlatform]', () {
         final appCheck = FirebaseAppCheckPlatform.instance;
@@ -42,6 +54,72 @@ void main() {
         final appCheck = MethodChannelFirebaseAppCheck.instance;
         // ignore: invalid_use_of_protected_member
         expect(appCheck.setInitialValues(), appCheck);
+      });
+    });
+
+    group('activate()', () {
+      test('passes the Apple debug token on Apple platforms', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        final calls = <List<Object?>>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler(
+          'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.activate',
+          (ByteData? message) async {
+            calls.add(
+              FirebaseAppCheckHostApi.pigeonChannelCodec.decodeMessage(message)
+                  as List<Object?>,
+            );
+            return FirebaseAppCheckHostApi.pigeonChannelCodec.encodeMessage(
+              <Object?>[],
+            );
+          },
+        );
+
+        final appCheck = MethodChannelFirebaseAppCheck(app: secondaryApp);
+
+        await appCheck.activate(
+          providerAndroid: const AndroidDebugProvider(
+            debugToken: 'android-debug-token',
+          ),
+          providerApple: const AppleDebugProvider(
+            debugToken: 'apple-debug-token',
+          ),
+        );
+
+        expect(calls, hasLength(1));
+        expect(calls.single[3], 'apple-debug-token');
+      });
+
+      test('passes the Android debug token on Android', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        final calls = <List<Object?>>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler(
+          'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.activate',
+          (ByteData? message) async {
+            calls.add(
+              FirebaseAppCheckHostApi.pigeonChannelCodec.decodeMessage(message)
+                  as List<Object?>,
+            );
+            return FirebaseAppCheckHostApi.pigeonChannelCodec.encodeMessage(
+              <Object?>[],
+            );
+          },
+        );
+
+        final appCheck = MethodChannelFirebaseAppCheck(app: secondaryApp);
+
+        await appCheck.activate(
+          providerAndroid: const AndroidDebugProvider(
+            debugToken: 'android-debug-token',
+          ),
+          providerApple: const AppleDebugProvider(
+            debugToken: 'apple-debug-token',
+          ),
+        );
+
+        expect(calls, hasLength(1));
+        expect(calls.single[3], 'android-debug-token');
       });
     });
   });

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/test/method_channel_tests/method_channel_firebase_app_check_test.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/test/method_channel_tests/method_channel_firebase_app_check_test.dart
@@ -6,7 +6,6 @@ import 'package:firebase_app_check_platform_interface/firebase_app_check_platfor
 import 'package:firebase_app_check_platform_interface/src/pigeon/messages.pigeon.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../mock.dart';
@@ -66,7 +65,7 @@ void main() {
           'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.activate',
           (ByteData? message) async {
             calls.add(
-              FirebaseAppCheckHostApi.pigeonChannelCodec.decodeMessage(message)
+              FirebaseAppCheckHostApi.pigeonChannelCodec.decodeMessage(message)!
                   as List<Object?>,
             );
             return FirebaseAppCheckHostApi.pigeonChannelCodec.encodeMessage(
@@ -98,7 +97,7 @@ void main() {
           'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.activate',
           (ByteData? message) async {
             calls.add(
-              FirebaseAppCheckHostApi.pigeonChannelCodec.decodeMessage(message)
+              FirebaseAppCheckHostApi.pigeonChannelCodec.decodeMessage(message)!
                   as List<Object?>,
             );
             return FirebaseAppCheckHostApi.pigeonChannelCodec.encodeMessage(

--- a/tests/integration_test/firebase_app_check/firebase_app_check_e2e_test.dart
+++ b/tests/integration_test/firebase_app_check/firebase_app_check_e2e_test.dart
@@ -2,12 +2,19 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: do_not_use_environment
+
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:tests/firebase_options.dart';
+
+const androidDebugToken =
+    String.fromEnvironment('APP_CHECK_ANDROID_DEBUG_TOKEN');
+
+const appleDebugToken = String.fromEnvironment('APP_CHECK_APPLE_DEBUG_TOKEN');
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -98,6 +105,56 @@ void main() {
           );
         },
         skip: defaultTargetPlatform != TargetPlatform.iOS,
+      );
+
+      test(
+        'uses Apple debug token when both Android and Apple debug tokens are configured',
+        () async {
+          await FirebaseAppCheck.instance.activate(
+            providerAndroid: const AndroidDebugProvider(
+              debugToken: androidDebugToken,
+            ),
+            providerApple: const AppleDebugProvider(
+              debugToken: appleDebugToken,
+            ),
+          );
+
+          await expectLater(
+            FirebaseAppCheck.instance.getToken(true),
+            completes,
+          );
+        },
+        skip: defaultTargetPlatform != TargetPlatform.iOS ||
+                androidDebugToken.isEmpty ||
+                appleDebugToken.isEmpty
+            ? 'Requires iOS plus APP_CHECK_ANDROID_DEBUG_TOKEN and '
+                'APP_CHECK_APPLE_DEBUG_TOKEN dart-defines.'
+            : null,
+      );
+
+      test(
+        'uses Android debug token when both Android and Apple debug tokens are configured',
+        () async {
+          await FirebaseAppCheck.instance.activate(
+            providerAndroid: const AndroidDebugProvider(
+              debugToken: androidDebugToken,
+            ),
+            providerApple: const AppleDebugProvider(
+              debugToken: appleDebugToken,
+            ),
+          );
+
+          await expectLater(
+            FirebaseAppCheck.instance.getToken(true),
+            completes,
+          );
+        },
+        skip: defaultTargetPlatform != TargetPlatform.android ||
+                androidDebugToken.isEmpty ||
+                appleDebugToken.isEmpty
+            ? 'Requires Android plus APP_CHECK_ANDROID_DEBUG_TOKEN and '
+                'APP_CHECK_APPLE_DEBUG_TOKEN dart-defines.'
+            : null,
       );
     },
   );


### PR DESCRIPTION
## Description

Fixes a `firebase_app_check` Pigeon migration regression where `activate()` passed a single debug token to native platforms but selected the Android token before the Apple token. The platform interface now selects the debug token for the current target platform, so iOS receives the Apple debug token when both Android and Apple debug providers are configured.

Adds a platform-interface regression test plus conditional Android/iOS E2E tests that exchange an App Check token when both Android and Apple debug tokens are configured.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18252

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
