### PR TITLE
fix(database,android): fix an issue where setPersistenceEnabled needed to be called first

### DIFF
--- a/packages/firebase_database/firebase_database/android/src/main/kotlin/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.kt
+++ b/packages/firebase_database/firebase_database/android/src/main/kotlin/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.kt
@@ -516,7 +516,9 @@ class FirebaseDatabasePlugin :
   override fun setPersistenceEnabled(app: DatabasePigeonFirebaseApp, enabled: Boolean, callback: (KotlinResult<Unit>) -> Unit) {
     try {
       val database = getDatabaseFromPigeonApp(app)
-      database.setPersistenceEnabled(enabled)
+      if (app.settings.persistenceEnabled == null) {
+        database.setPersistenceEnabled(enabled)
+      }
       callback(KotlinResult.success(Unit))
     } catch (e: Exception) {
       callback(KotlinResult.failure(e))
@@ -526,7 +528,9 @@ class FirebaseDatabasePlugin :
   override fun setPersistenceCacheSizeBytes(app: DatabasePigeonFirebaseApp, cacheSize: Long, callback: (KotlinResult<Unit>) -> Unit) {
     try {
       val database = getDatabaseFromPigeonApp(app)
-      database.setPersistenceCacheSizeBytes(cacheSize)
+      if (app.settings.cacheSizeBytes == null) {
+        database.setPersistenceCacheSizeBytes(cacheSize)
+      }
       callback(KotlinResult.success(Unit))
     } catch (e: Exception) {
       callback(KotlinResult.failure(e))

--- a/tests/integration_test/firebase_database/firebase_database_configuration_e2e.dart
+++ b/tests/integration_test/firebase_database/firebase_database_configuration_e2e.dart
@@ -2,8 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_database/firebase_database.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tests/firebase_options.dart';
 
 import 'firebase_database_e2e_test.dart';
 
@@ -37,5 +40,31 @@ void setupConfigurationTests() {
     test('setLoggingEnabled to false', () {
       database.setLoggingEnabled(false);
     });
+
+    test(
+      'setPersistenceEnabled can be followed immediately by goOnline',
+      () async {
+        for (var i = 0; i < 5; i++) {
+          final app = await Firebase.initializeApp(
+            name:
+                'firebase-database-persistence-${DateTime.now().microsecondsSinceEpoch}-$i',
+            options: DefaultFirebaseOptions.currentPlatform,
+          );
+          addTearDown(app.delete);
+
+          final database = FirebaseDatabase.instanceFor(app: app);
+
+          database.setPersistenceEnabled(true);
+          await database.goOnline();
+
+          await database.ref('persistence-enabled-regression').keepSynced(true);
+          await database
+              .ref('persistence-enabled-regression')
+              .keepSynced(false);
+          await database.goOffline();
+        }
+      },
+      skip: kIsWeb || defaultTargetPlatform != TargetPlatform.android,
+    );
   });
 }


### PR DESCRIPTION
## Description

Fixes an Android `firebase_database` regression where `setPersistenceEnabled()` could crash with `Calls to setPersistenceEnabled() must be made before any other usage of FirebaseDatabase instance`.

The Pigeon app settings already carry persistence and cache-size configuration to the native side. When a follow-up call such as `goOnline()` applies those settings first, the original setter message can arrive later and re-apply the same native SDK setting after the database has been used. Android now skips that duplicate native setter call when the value was already present in the Pigeon settings object.

An Android-only E2E regression test was added to cover calling `setPersistenceEnabled()` immediately before `goOnline()` on fresh database instances.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18254

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
