### PR TITLE
fix(database,android): fix a regression where rapidly opening and closing query streams on the same path could throw

### DIFF
--- a/packages/firebase_database/firebase_database/android/src/main/kotlin/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.kt
+++ b/packages/firebase_database/firebase_database/android/src/main/kotlin/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.kt
@@ -4,7 +4,6 @@
 
 package io.flutter.plugins.firebase.database
 
-import android.util.Log
 import androidx.annotation.NonNull
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.TaskCompletionSource
@@ -485,7 +484,7 @@ class FirebaseDatabasePlugin :
   }
 
   private fun removeEventStreamHandlers() {
-    for ((eventChannel, streamHandler) in streamHandlers) {
+    for ((eventChannel, streamHandler) in streamHandlers.toMap()) {
       streamHandler?.onCancel(null)
       eventChannel.setStreamHandler(null)
     }
@@ -847,20 +846,21 @@ class FirebaseDatabasePlugin :
 
   override fun queryObserve(app: DatabasePigeonFirebaseApp, request: QueryRequest, callback: (KotlinResult<String>) -> Unit) {
     try {
-      Log.d("FirebaseDatabase", "🔍 Kotlin: Setting up query observe for path=${request.path}")
       val database = getDatabaseFromPigeonApp(app)
       val reference = database.getReference(request.path)
       val query = queryFromModifiers(reference, request.modifiers)
 
       // Generate a unique channel name
-      val channelName = "firebase_database_query_${System.currentTimeMillis()}_${request.path.hashCode()}"
+      val channelName =
+        synchronized(this) { "firebase_database_query_${listenerCount++}" }
 
       // Set up the event channel
       val eventChannel = EventChannel(messenger, channelName)
       val streamHandler = EventStreamHandler(query, object : OnDispose {
         override fun run() {
           // Clean up when the stream is disposed
-         eventChannel.setStreamHandler(null)
+          eventChannel.setStreamHandler(null)
+          streamHandlers.remove(eventChannel)
         }
       })
       eventChannel.setStreamHandler(streamHandler)

--- a/tests/integration_test/firebase_database/query_e2e.dart
+++ b/tests/integration_test/firebase_database/query_e2e.dart
@@ -609,6 +609,43 @@ void setupQueryTests() {
       });
 
       test(
+        'cancels overlapping query streams without missing plugin',
+        () async {
+          const subscriptionCount = 128;
+          final queryRef = ref.child('overlapping-query-streams');
+          await queryRef.set({'value': 1});
+
+          final errors = <Object>[];
+          final subscriptions = <StreamSubscription<DatabaseEvent>>[];
+          final firstEventsReceived = Completer<void>();
+          var firstEventCount = 0;
+
+          for (var i = 0; i < subscriptionCount; i++) {
+            subscriptions.add(
+              queryRef.onValue.listen(
+                (_) {
+                  firstEventCount++;
+                  if (firstEventCount >= subscriptionCount &&
+                      !firstEventsReceived.isCompleted) {
+                    firstEventsReceived.complete();
+                  }
+                },
+                onError: errors.add,
+              ),
+            );
+          }
+
+          await firstEventsReceived.future.timeout(const Duration(seconds: 10));
+          await Future.wait(
+            subscriptions.map((subscription) => subscription.cancel()),
+          );
+
+          expect(errors, isEmpty);
+        },
+        skip: defaultTargetPlatform != TargetPlatform.android,
+      );
+
+      test(
           'throw a `permission-denied` exception when accessing restricted data',
           () async {
         final Completer<FirebaseException> errorReceived =


### PR DESCRIPTION
## Description

Fixes an Android `firebase_database` regression where rapidly opening and closing query streams on the same path could throw `MissingPluginException(No implementation found for method cancel ...)`.

The Pigeon query observer generated event channel names from the current timestamp and query path hash, which could collide for same-path listeners created close together. Android now uses the plugin's monotonic listener counter for query event channel names and removes disposed stream handlers from the plugin cache.

An Android-only E2E regression test was added to cover cancelling overlapping query streams.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18260

## Local Verification

- `dart analyze tests/integration_test/firebase_database/query_e2e.dart packages/firebase_database/firebase_database_platform_interface/lib/src/method_channel/method_channel_query.dart`
- Android E2E verification was attempted, but the local emulator/ADB session became unresponsive during install and started hanging on `adb`/`flutter devices`.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
