### PR TITLE
chore(fdc): Use service classes to fetch auth and appcheck instances

### DIFF
--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
@@ -215,8 +215,8 @@ class FirebaseDataConnect extends FirebasePluginPlatform {
       required ConnectorConfig connectorConfig,
       CacheSettings? cacheSettings}) {
     app ??= Firebase.app();
-    auth ??= app.getService<FirebaseAuth>();
-    appCheck ??= app.getService<FirebaseAppCheck>();
+    auth ??= FirebaseAuth.instanceFor(app: app);
+    appCheck ??= FirebaseAppCheck.instanceFor(app: app);
 
     if (cachedInstances[app.name] != null &&
         cachedInstances[app.name]![connectorConfig.toJson()] != null) {

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
@@ -98,23 +98,23 @@ class FirebaseDataConnect extends FirebasePluginPlatform {
     }
     transportOptions ??=
         TransportOptions('firebasedataconnect.googleapis.com', null, true);
-    final effectiveAuth = auth ?? app.getService<FirebaseAuth>();
-    final effectiveAppCheck = appCheck ?? app.getService<FirebaseAppCheck>();
+    auth ??= app.getService<FirebaseAuth>();
+    appCheck ??= app.getService<FirebaseAppCheck>();
 
     final rest = RestTransport(
       transportOptions!,
       options,
       app.options.appId,
       _sdkType,
-      effectiveAppCheck,
+      appCheck,
     );
     final ws = WebSocketTransport(
       transportOptions!,
       options,
       app.options.appId,
       _sdkType,
-      effectiveAppCheck,
-      effectiveAuth,
+      appCheck,
+      auth,
     );
     transport = _RoutingTransport(rest, ws);
   }

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
@@ -33,7 +33,11 @@ class FirebaseDataConnect extends FirebasePluginPlatform {
   FirebaseDataConnect(
       {required this.app,
       required this.connectorConfig,
+      @Deprecated(
+          'Passing an explicit instance is deprecated, internal handling is now automatic.')
       this.auth,
+      @Deprecated(
+          'Passing an explicit instance is deprecated, internal handling is now automatic.')
       this.appCheck,
       CallerSDKType? sdkType,
       this.cacheSettings})
@@ -94,20 +98,23 @@ class FirebaseDataConnect extends FirebasePluginPlatform {
     }
     transportOptions ??=
         TransportOptions('firebasedataconnect.googleapis.com', null, true);
+    final effectiveAuth = auth ?? app.getService<FirebaseAuth>();
+    final effectiveAppCheck = appCheck ?? app.getService<FirebaseAppCheck>();
+
     final rest = RestTransport(
       transportOptions!,
       options,
       app.options.appId,
       _sdkType,
-      appCheck,
+      effectiveAppCheck,
     );
     final ws = WebSocketTransport(
       transportOptions!,
       options,
       app.options.appId,
       _sdkType,
-      appCheck,
-      auth,
+      effectiveAppCheck,
+      effectiveAuth,
     );
     transport = _RoutingTransport(rest, ws);
   }
@@ -198,14 +205,18 @@ class FirebaseDataConnect extends FirebasePluginPlatform {
   /// If pass in [appCheck], request session will get protected from abusing.
   static FirebaseDataConnect instanceFor(
       {FirebaseApp? app,
+      @Deprecated(
+          'Passing an explicit instance is deprecated, internal handling is now automatic.')
       FirebaseAuth? auth,
+      @Deprecated(
+          'Passing an explicit instance is deprecated, internal handling is now automatic.')
       FirebaseAppCheck? appCheck,
       CallerSDKType? sdkType,
       required ConnectorConfig connectorConfig,
       CacheSettings? cacheSettings}) {
     app ??= Firebase.app();
-    auth ??= FirebaseAuth.instanceFor(app: app);
-    appCheck ??= FirebaseAppCheck.instanceFor(app: app);
+    auth ??= app.getService<FirebaseAuth>();
+    appCheck ??= app.getService<FirebaseAppCheck>();
 
     if (cachedInstances[app.name] != null &&
         cachedInstances[app.name]![connectorConfig.toJson()] != null) {

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/cache/cache_manager_test.mocks.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/cache/cache_manager_test.mocks.dart
@@ -120,6 +120,16 @@ class MockFirebaseApp extends _i1.Mock implements _i3.FirebaseApp {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
+
+  @override
+  void registerService<T extends _i3.FirebaseService>(T? service) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #registerService,
+          [service],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [ConnectorConfig].

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/firebase_data_connect_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/firebase_data_connect_test.dart
@@ -38,6 +38,35 @@ class MockFirebaseAuth extends Mock implements FirebaseAuth {
 
 class MockFirebaseAppCheck extends Mock implements FirebaseAppCheck {}
 
+class DynamicMockFirebaseApp extends Mock implements FirebaseApp {
+  DynamicMockFirebaseApp({
+    required this.name,
+    required this.options,
+    this.mockAuth,
+    this.mockAppCheck,
+  });
+
+  @override
+  final String name;
+
+  @override
+  final FirebaseOptions options;
+
+  final FirebaseAuth? mockAuth;
+  final FirebaseAppCheck? mockAppCheck;
+
+  @override
+  T? getService<T extends FirebaseService>() {
+    if (T == FirebaseAppCheck) {
+      return mockAppCheck as T?;
+    }
+    if (T == FirebaseAuth) {
+      return mockAuth as T?;
+    }
+    return null;
+  }
+}
+
 class MockTransportOptions extends Mock implements TransportOptions {}
 
 class MockDataConnectTransport extends Mock implements DataConnectTransport {}
@@ -194,6 +223,92 @@ void main() {
         FirebaseDataConnect.cachedInstances['appName']!['connectorConfigStr'],
         equals(instance),
       );
+    });
+
+    test(
+        'instanceFor discovers dynamic FirebaseAuth and FirebaseAppCheck from FirebaseApp registry when parameters are omitted',
+        () {
+      FirebaseDataConnect.cachedInstances.clear();
+
+      final dynamicApp = DynamicMockFirebaseApp(
+        name: 'dynamicAppName',
+        options: const FirebaseOptions(
+          apiKey: 'fake_api_key',
+          appId: 'fake_app_id',
+          messagingSenderId: 'fake_messaging_sender_id',
+          projectId: 'fake_project_id',
+        ),
+        mockAuth: mockAuth,
+        mockAppCheck: mockAppCheck,
+      );
+
+      when(mockConnectorConfig.toJson())
+          .thenReturn('dynamicConnectorConfigStr');
+
+      final instance = FirebaseDataConnect.instanceFor(
+        app: dynamicApp,
+        connectorConfig: mockConnectorConfig,
+      );
+
+      expect(instance.auth, equals(mockAuth));
+      expect(instance.appCheck, equals(mockAppCheck));
+    });
+
+    test('instanceFor handles fallback to null if getService returns null', () {
+      FirebaseDataConnect.cachedInstances.clear();
+
+      final fallbackApp = DynamicMockFirebaseApp(
+        name: 'fallbackAppName',
+        options: const FirebaseOptions(
+          apiKey: 'fake_api_key',
+          appId: 'fake_app_id',
+          messagingSenderId: 'fake_messaging_sender_id',
+          projectId: 'fake_project_id',
+        ),
+        mockAuth: null,
+        mockAppCheck: null,
+      );
+
+      when(mockConnectorConfig.toJson())
+          .thenReturn('fallbackConnectorConfigStr');
+
+      final instance = FirebaseDataConnect.instanceFor(
+        app: fallbackApp,
+        connectorConfig: mockConnectorConfig,
+      );
+
+      expect(instance.auth, isNull);
+      expect(instance.appCheck, isNull);
+    });
+
+    test(
+        'checkTransport resolves dynamic service instances from registry just-in-time',
+        () {
+      FirebaseDataConnect.cachedInstances.clear();
+
+      final dynamicApp = DynamicMockFirebaseApp(
+        name: 'transportAppName',
+        options: const FirebaseOptions(
+          apiKey: 'fake_api_key',
+          appId: 'fake_app_id',
+          messagingSenderId: 'fake_messaging_sender_id',
+          projectId: 'fake_project_id',
+        ),
+        mockAuth: mockAuth,
+        mockAppCheck: mockAppCheck,
+      );
+
+      final instance = FirebaseDataConnect(
+        app: dynamicApp,
+        connectorConfig: mockConnectorConfig,
+      );
+
+      instance.checkTransport();
+
+      final dynamic routingTransport = instance.transport;
+      expect(routingTransport.rest.appCheck, equals(mockAppCheck));
+      expect(routingTransport.websocket.auth, equals(mockAuth));
+      expect(routingTransport.websocket.appCheck, equals(mockAppCheck));
     });
   });
 }

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/firebase_data_connect_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/firebase_data_connect_test.dart
@@ -226,62 +226,6 @@ void main() {
     });
 
     test(
-        'instanceFor discovers dynamic FirebaseAuth and FirebaseAppCheck from FirebaseApp registry when parameters are omitted',
-        () {
-      FirebaseDataConnect.cachedInstances.clear();
-
-      final dynamicApp = DynamicMockFirebaseApp(
-        name: 'dynamicAppName',
-        options: const FirebaseOptions(
-          apiKey: 'fake_api_key',
-          appId: 'fake_app_id',
-          messagingSenderId: 'fake_messaging_sender_id',
-          projectId: 'fake_project_id',
-        ),
-        mockAuth: mockAuth,
-        mockAppCheck: mockAppCheck,
-      );
-
-      when(mockConnectorConfig.toJson())
-          .thenReturn('dynamicConnectorConfigStr');
-
-      final instance = FirebaseDataConnect.instanceFor(
-        app: dynamicApp,
-        connectorConfig: mockConnectorConfig,
-      );
-
-      expect(instance.auth, equals(mockAuth));
-      expect(instance.appCheck, equals(mockAppCheck));
-    });
-
-    test('instanceFor handles fallback to null if getService returns null', () {
-      FirebaseDataConnect.cachedInstances.clear();
-
-      final fallbackApp = DynamicMockFirebaseApp(
-        name: 'fallbackAppName',
-        options: const FirebaseOptions(
-          apiKey: 'fake_api_key',
-          appId: 'fake_app_id',
-          messagingSenderId: 'fake_messaging_sender_id',
-          projectId: 'fake_project_id',
-        ),
-        mockAuth: null,
-        mockAppCheck: null,
-      );
-
-      when(mockConnectorConfig.toJson())
-          .thenReturn('fallbackConnectorConfigStr');
-
-      final instance = FirebaseDataConnect.instanceFor(
-        app: fallbackApp,
-        connectorConfig: mockConnectorConfig,
-      );
-
-      expect(instance.auth, isNull);
-      expect(instance.appCheck, isNull);
-    });
-
-    test(
         'checkTransport resolves dynamic service instances from registry just-in-time',
         () {
       FirebaseDataConnect.cachedInstances.clear();

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/firebase_data_connect_test.mocks.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/firebase_data_connect_test.mocks.dart
@@ -120,6 +120,16 @@ class MockFirebaseApp extends _i1.Mock implements _i3.FirebaseApp {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
+
+  @override
+  void registerService<T extends _i3.FirebaseService>(T? service) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #registerService,
+          [service],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [ConnectorConfig].


### PR DESCRIPTION
Use service resolvers to get auth and app check parameters. 