### PR TITLE
chore(sqlconnect): Update sqlite3 version dependency

### DIFF
--- a/packages/firebase_data_connect/firebase_data_connect/pubspec.yaml
+++ b/packages/firebase_data_connect/firebase_data_connect/pubspec.yaml
@@ -26,8 +26,7 @@ dependencies:
   path: ^1.9.0
   path_provider: ^2.0.0
   protobuf: ^3.1.0
-  sqlite3: ^2.9.0
-  sqlite3_flutter_libs: ^0.5.40
+  sqlite3: ^3.1.0
   web_socket_channel: ^3.0.1
 
 dev_dependencies:


### PR DESCRIPTION
Updating the sqlite3 version dependency to above 3.x to remove the flutter_lib dependency which is not necessary with 3.x .


