### PR TITLE
fix(firestore, iOS): change firebase-ios-sdk dependency from 'from' to 'exact' version in multiple Package.swift files

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Package.swift
+++ b/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "cloud-firestore", targets: ["cloud_firestore"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/cloud_firestore/cloud_firestore/macos/cloud_firestore/Package.swift
+++ b/packages/cloud_firestore/cloud_firestore/macos/cloud_firestore/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "cloud-firestore", targets: ["cloud_firestore"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/cloud_functions/cloud_functions/ios/cloud_functions/Package.swift
+++ b/packages/cloud_functions/cloud_functions/ios/cloud_functions/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     .library(name: "cloud-functions", targets: ["cloud_functions"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/cloud_functions/cloud_functions/macos/cloud_functions/Package.swift
+++ b/packages/cloud_functions/cloud_functions/macos/cloud_functions/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     .library(name: "cloud-functions", targets: ["cloud_functions"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics/Package.swift
+++ b/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     .library(name: "firebase-analytics", targets: ["firebase_analytics"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_analytics/firebase_analytics/macos/firebase_analytics/Package.swift
+++ b/packages/firebase_analytics/firebase_analytics/macos/firebase_analytics/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     .library(name: "firebase-analytics", targets: ["firebase_analytics"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Package.swift
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     .library(name: "firebase-app-check", targets: ["firebase_app_check"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_app_check/firebase_app_check/macos/firebase_app_check/Package.swift
+++ b/packages/firebase_app_check/firebase_app_check/macos/firebase_app_check/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     .library(name: "firebase-app-check", targets: ["firebase_app_check"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_app_installations/firebase_app_installations/ios/firebase_app_installations/Package.swift
+++ b/packages/firebase_app_installations/firebase_app_installations/ios/firebase_app_installations/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     .library(name: "firebase-app-installations", targets: ["firebase_app_installations"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_app_installations/firebase_app_installations/macos/firebase_app_installations/Package.swift
+++ b/packages/firebase_app_installations/firebase_app_installations/macos/firebase_app_installations/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     .library(name: "firebase-app-installations", targets: ["firebase_app_installations"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Package.swift
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "firebase-auth", targets: ["firebase_auth"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_auth/firebase_auth/macos/firebase_auth/Package.swift
+++ b/packages/firebase_auth/firebase_auth/macos/firebase_auth/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "firebase-auth", targets: ["firebase_auth"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
+++ b/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "firebase-core", targets: ["firebase_core"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
   ],
   targets: [
     .target(

--- a/packages/firebase_core/firebase_core/macos/firebase_core/Package.swift
+++ b/packages/firebase_core/firebase_core/macos/firebase_core/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "firebase-core", targets: ["firebase_core"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
   ],
   targets: [
     .target(

--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics/Package.swift
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "firebase-crashlytics", targets: ["firebase_crashlytics"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_crashlytics/firebase_crashlytics/macos/firebase_crashlytics/Package.swift
+++ b/packages/firebase_crashlytics/firebase_crashlytics/macos/firebase_crashlytics/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "firebase-crashlytics", targets: ["firebase_crashlytics"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_database/firebase_database/ios/firebase_database/Package.swift
+++ b/packages/firebase_database/firebase_database/ios/firebase_database/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "firebase-database", targets: ["firebase_database"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_database/firebase_database/macos/firebase_database/Package.swift
+++ b/packages/firebase_database/firebase_database/macos/firebase_database/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "firebase-database", targets: ["firebase_database"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/firebase_in_app_messaging/Package.swift
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/firebase_in_app_messaging/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "firebase-in-app-messaging", targets: ["firebase_in_app_messaging"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Package.swift
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "firebase-messaging", targets: ["firebase_messaging"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_messaging/firebase_messaging/macos/firebase_messaging/Package.swift
+++ b/packages/firebase_messaging/firebase_messaging/macos/firebase_messaging/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "firebase-messaging", targets: ["firebase_messaging"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/ios/firebase_ml_model_downloader/Package.swift
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/ios/firebase_ml_model_downloader/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     .library(name: "firebase-ml-model-downloader", targets: ["firebase_ml_model_downloader"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/macos/firebase_ml_model_downloader/Package.swift
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/macos/firebase_ml_model_downloader/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     .library(name: "firebase-ml-model-downloader", targets: ["firebase_ml_model_downloader"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_performance/firebase_performance/ios/firebase_performance/Package.swift
+++ b/packages/firebase_performance/firebase_performance/ios/firebase_performance/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "firebase-performance", targets: ["firebase_performance"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Package.swift
+++ b/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     .library(name: "firebase-remote-config", targets: ["firebase_remote_config"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_remote_config/firebase_remote_config/macos/firebase_remote_config/Package.swift
+++ b/packages/firebase_remote_config/firebase_remote_config/macos/firebase_remote_config/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     .library(name: "firebase-remote-config", targets: ["firebase_remote_config"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_storage/firebase_storage/ios/firebase_storage/Package.swift
+++ b/packages/firebase_storage/firebase_storage/ios/firebase_storage/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "firebase-storage", targets: ["firebase_storage"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [

--- a/packages/firebase_storage/firebase_storage/macos/firebase_storage/Package.swift
+++ b/packages/firebase_storage/firebase_storage/macos/firebase_storage/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     .library(name: "firebase-storage", targets: ["firebase_storage"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version),
+    .package(url: "https://github.com/firebase/firebase-ios-sdk", exact: firebase_sdk_version),
     .package(name: "firebase_core", path: "../firebase_core"),
   ],
   targets: [


### PR DESCRIPTION
## Description

This is related to https://github.com/firebase/flutterfire/issues/18319.

Even though we specify `firebase-ios-sdk` version `12.13.0`, Swift Package Manager still resolves it to `12.14.0` because we’re using from in the package declaration:
```swift
.package(url: "https://github.com/firebase/firebase-ios-sdk", from: firebase_sdk_version)
```
With `from`, SPM is allowed to pick the latest compatible minor version. In this case, it resolved to `12.14.0`, which introduced an interface change and ended up breaking the build.

Using exact instead pins the dependency strictly to the specified version, preventing any automatic upgrades.
Reference: https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html

## Related Issues
Fixes https://github.com/firebase/flutterfire/issues/18319

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
