### PR TITLE
fix(auth, android): update token retrieval in PigeonParser to handle Number type correctly

### DIFF
--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/PigeonParser.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/PigeonParser.java
@@ -179,7 +179,7 @@ public class PigeonParser {
   static AuthCredential getCredential(Map<String, Object> credentialMap) {
     // If the credential map contains a token, it means a native one has been stored
     if (credentialMap.get(Constants.TOKEN) != null) {
-      int token = (int) credentialMap.get(Constants.TOKEN);
+      int token = ((Number) credentialMap.get(Constants.TOKEN)).intValue();
       AuthCredential credential = FlutterFirebaseAuthPlugin.authCredentials.get(token);
 
       if (credential == null) {


### PR DESCRIPTION
## Description

Fixes an issue on Android where `signInWithCredential` fails with `[firebase_auth/channel-error]` after handling a `credential-already-in-use `error.

After the Pigeon 26 upgrade, credential maps from Dart encode integer fields as int64, so token arrives as java.lang.Long on Android. PigeonParser.getCredential cast it directly to int, causing `ClassCastException: java.lang.Long cannot be cast to java.lang.Integer`.

Read the native credential token with `((Number) …).intValue()` so both Integer and Long are accepted.

## Related Issues
Fixes https://github.com/firebase/flutterfire/issues/18320

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
