### PR TITLE
ci: Remove synchronize trigger for title check

### DIFF
--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - edited
-      - synchronize
 
 jobs:
   validate:


### PR DESCRIPTION
The title is only updated in create and edit events, so this trigger is unnecessary.