### PR TITLE
feat(ai): add support for cancellable clients for in-flight requests

### DIFF
--- a/packages/firebase_ai/firebase_ai/lib/src/firebase_ai.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/firebase_ai.dart
@@ -17,6 +17,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
     show FirebasePluginPlatform;
+import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
 import '../firebase_ai.dart';
@@ -142,6 +143,9 @@ class FirebaseAI extends FirebasePluginPlatform {
   /// The optional [safetySettings] and [generationConfig] can be used to
   /// control and guide the generation. See [SafetySetting] and
   /// [GenerationConfig] for details.
+  ///
+  /// The optional [httpClient] can be used to customize HTTP request handling,
+  /// such as adding support for cancelling in-flight requests.
   GenerativeModel generativeModel({
     required String model,
     List<SafetySetting>? safetySettings,
@@ -149,6 +153,7 @@ class FirebaseAI extends FirebasePluginPlatform {
     List<Tool>? tools,
     ToolConfig? toolConfig,
     Content? systemInstruction,
+    http.Client? httpClient,
   }) {
     return createGenerativeModel(
       model: model,
@@ -163,6 +168,7 @@ class FirebaseAI extends FirebasePluginPlatform {
       toolConfig: toolConfig,
       systemInstruction: systemInstruction,
       useLimitedUseAppCheckTokens: useLimitedUseAppCheckTokens,
+      httpClient: httpClient,
     );
   }
 

--- a/packages/firebase_ai/firebase_ai/lib/src/generative_model.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/generative_model.dart
@@ -210,6 +210,7 @@ GenerativeModel createGenerativeModel({
   List<Tool>? tools,
   ToolConfig? toolConfig,
   Content? systemInstruction,
+  http.Client? httpClient,
 }) =>
     GenerativeModel._(
       model: model,
@@ -224,6 +225,7 @@ GenerativeModel createGenerativeModel({
       tools: tools,
       toolConfig: toolConfig,
       systemInstruction: systemInstruction,
+      httpClient: httpClient,
     );
 
 /// Creates a model with an overridden [ApiClient] for testing.

--- a/packages/firebase_ai/firebase_ai/test/firebase_vertexai_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/firebase_vertexai_test.dart
@@ -12,11 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
+
 import 'package:firebase_ai/firebase_ai.dart';
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
 
 import 'mock.dart';
 
@@ -50,6 +54,16 @@ void main() {
       customAppCheck = FirebaseAppCheck.instanceFor(app: customApp);
       limitTokenAppCheck = FirebaseAppCheck.instanceFor(app: limitTokenApp);
       customAuth = FirebaseAuth.instanceFor(app: customApp);
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMessageHandler(
+        'dev.flutter.pigeon.firebase_app_check_platform_interface.'
+        'FirebaseAppCheckHostApi.getToken',
+        (_) async {
+          return const StandardMessageCodec().encodeMessage(
+            <Object?>['app-check-token'],
+          );
+        },
+      );
     });
 
     test('Singleton behavior', () {
@@ -129,5 +143,67 @@ void main() {
 
       expect(model, isA<GenerativeModel>());
     });
+
+    test('generativeModel uses provided HTTP client', () async {
+      final requests = <http.BaseRequest>[];
+      final client = _RecordingClient((request) {
+        requests.add(request);
+
+        if (request.url.path.endsWith(':streamGenerateContent')) {
+          return http.StreamedResponse(
+            Stream.value(utf8.encode('data: ${jsonEncode(_response)}\n\n')),
+            200,
+          );
+        }
+
+        return http.StreamedResponse(
+          Stream.value(utf8.encode(jsonEncode(_response))),
+          200,
+        );
+      });
+      final ai = FirebaseAI.googleAI(app: app);
+
+      final model = ai.generativeModel(
+        model: 'gemini-pro',
+        httpClient: client,
+      );
+
+      await model.generateContent([Content.text('prompt')]);
+      await model.generateContentStream([Content.text('prompt')]).drain<void>();
+
+      expect(requests, hasLength(2));
+      expect(
+        requests.first.url.path,
+        endsWith('/models/gemini-pro:generateContent'),
+      );
+      expect(
+        requests.last.url.path,
+        endsWith('/models/gemini-pro:streamGenerateContent'),
+      );
+    });
   });
 }
+
+class _RecordingClient extends http.BaseClient {
+  _RecordingClient(this._handler);
+
+  final http.StreamedResponse Function(http.BaseRequest request) _handler;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    return _handler(request);
+  }
+}
+
+const _response = {
+  'candidates': [
+    {
+      'content': {
+        'role': 'model',
+        'parts': [
+          {'text': 'Some Response'},
+        ],
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Description

Adds an optional `httpClient` parameter to `FirebaseAI.generativeModel()` and forwards it through the existing `createGenerativeModel` path into `HttpApiClient`. This lets callers provide custom HTTP behavior, including cancellable clients for in-flight unary and streaming generation requests.

A unit test verifies that the supplied client is used for both `generateContent` and `generateContentStream`.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18309

## Local Verification

- `flutter test test/firebase_vertexai_test.dart`
- `dart analyze`

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
