### PR TITLE
fix(ai): firebase_ai server template image inputs passed as InlineDataPart were serialized as normal generative inlineData

### DIFF
--- a/packages/firebase_ai/firebase_ai/lib/src/base_model.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/base_model.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -375,7 +376,7 @@ abstract class BaseTemplateApiClientModel extends BaseApiClientModel {
       T Function(Map<String, Object?>) parse) {
     Map<String, Object?> body = {};
     if (inputs != null) {
-      body['inputs'] = inputs;
+      body['inputs'] = _serializeTemplateInputs(inputs);
     }
     if (history != null) {
       body['history'] = history.map((c) => c.toJson()).toList();
@@ -405,7 +406,7 @@ abstract class BaseTemplateApiClientModel extends BaseApiClientModel {
       T Function(Map<String, Object?>) parse) {
     Map<String, Object?> body = {};
     if (inputs != null) {
-      body['inputs'] = inputs;
+      body['inputs'] = _serializeTemplateInputs(inputs);
     }
     if (history != null) {
       body['history'] = history.map((c) => c.toJson()).toList();
@@ -428,4 +429,26 @@ abstract class BaseTemplateApiClientModel extends BaseApiClientModel {
   /// Returns the template name for the given [templateId].
   String templateName(String templateId) =>
       _templateUri.templateName(templateId);
+
+  Map<String, Object?> _serializeTemplateInputs(Map<String, Object?> inputs) {
+    return inputs.map((key, value) {
+      return MapEntry(key, _serializeTemplateInputValue(value));
+    });
+  }
+
+  Object? _serializeTemplateInputValue(Object? value) {
+    return switch (value) {
+      InlineDataPart(:final mimeType, :final bytes) => {
+          'isInline': true,
+          'mimeType': mimeType,
+          'contents': base64Encode(bytes),
+        },
+      Map<Object?, Object?>() => value.map((key, nestedValue) {
+          return MapEntry(key, _serializeTemplateInputValue(nestedValue));
+        }),
+      List<Object?>() =>
+        value.map(_serializeTemplateInputValue).toList(growable: false),
+      _ => value,
+    };
+  }
 }

--- a/packages/firebase_ai/firebase_ai/test/server_template_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/server_template_test.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:firebase_ai/firebase_ai.dart';
 import 'package:firebase_ai/src/base_model.dart';
@@ -83,6 +84,33 @@ void main() {
       final model = createModel(mockHttp);
       final response = await model
           .generateContent(templateId, inputs: {'prompt': 'Some prompt'});
+      expect(response.text, 'Some response');
+    });
+
+    test('generateContent serializes inline image inputs', () async {
+      final mockHttp = MockClient((request) async {
+        final body = jsonDecode(request.body) as Map<String, Object?>;
+        expect(body['inputs'], {
+          'screenshot': {
+            'isInline': true,
+            'mimeType': 'image/jpeg',
+            'contents': base64Encode([1, 2, 3]),
+          },
+        });
+        return http.Response(jsonEncode(_arbitraryGenerateContentResponse), 200,
+            headers: {'content-type': 'application/json'});
+      });
+
+      final model = createModel(mockHttp);
+      final response = await model.generateContent(
+        templateId,
+        inputs: {
+          'screenshot': InlineDataPart(
+            'image/jpeg',
+            Uint8List.fromList([1, 2, 3]),
+          ),
+        },
+      );
       expect(response.text, 'Some response');
     });
 


### PR DESCRIPTION

## Description

Fixes `firebase_ai` server template requests so `InlineDataPart` values in template inputs are serialized as inline media variables instead of generative-content `inlineData` parts. This lets image inputs passed to `TemplateGenerativeModel.generateContent` and streaming/history template calls reach the server template as base64 media content with the expected MIME type.

A unit regression test covers passing an `InlineDataPart` screenshot input through `generateContent`.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18326

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
