### PR TITLE
fix(messaging,ios): fix a race condition that could happen when getting initial message

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
@@ -263,17 +263,22 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     // For scene delegates, if no notification was found in connectionOptions,
     // delay marking as gathered to allow didReceiveRemoteNotification to fire first
     // for contentAvailable notifications that caused the app to launch
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)),
-                   dispatch_get_main_queue(), ^{
-                     if (!self->_initialNotificationGathered) {
-                       self->_initialNotificationGathered = YES;
-                       [self initialNotificationCallback];
-                     }
-                   });
+    [self markInitialNotificationGatheredAfterDelay];
   } else {
-    // For non-scene delegate apps, mark as gathered immediately
-    _initialNotificationGathered = YES;
-    [self initialNotificationCallback];
+#if !TARGET_OS_OSX
+    if (@available(iOS 13.0, *)) {
+      // Scene delegate launch notification responses arrive after didFinishLaunching.
+      // Give scene:willConnectToSession:options: a chance to provide the tapped notification
+      // before resolving getInitialMessage() as nil.
+      [self markInitialNotificationGatheredAfterDelay];
+    } else {
+#endif
+      // For non-scene delegate apps, mark as gathered immediately
+      _initialNotificationGathered = YES;
+      [self initialNotificationCallback];
+#if !TARGET_OS_OSX
+    }
+#endif
   }
 
   [GULAppDelegateSwizzler registerAppDelegateInterceptor:self];
@@ -355,6 +360,16 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 #else
   [[UIApplication sharedApplication] registerForRemoteNotifications];
 #endif
+}
+
+- (void)markInitialNotificationGatheredAfterDelay {
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)),
+                 dispatch_get_main_queue(), ^{
+                   if (!self->_initialNotificationGathered) {
+                     self->_initialNotificationGathered = YES;
+                     [self initialNotificationCallback];
+                   }
+                 });
 }
 
 - (void)application_onDidFinishLaunchingNotification:(nonnull NSNotification *)notification {
@@ -631,6 +646,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     // User tapped the notification.
     remoteNotification =
         connectionOptions.notificationResponse.notification.request.content.userInfo;
+    _notificationOpenedAppID = remoteNotification[@"gcm.message_id"];
   }
 
   [self setupNotificationHandlingWithRemoteNotification:remoteNotification];


### PR DESCRIPTION
## Description

Fixes an iOS `firebase_messaging` race where `getInitialMessage()` could resolve to `null` for terminated-state notification launches under `UIScene`. The plugin now gives `scene:willConnectToSession:options:` a chance to provide `connectionOptions.notificationResponse` before resolving an empty initial message, and marks scene notification responses as the opened notification so the initial-message filter does not discard them.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17991

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
