### PR TITLE
feat(ai): add language code support for SpeechConfig

### DIFF
--- a/packages/firebase_ai/firebase_ai/lib/src/live_api.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/live_api.dart
@@ -50,13 +50,16 @@ class VoiceConfig {
 
 /// Configures speech synthesis settings.
 ///
-/// Allows specifying the desired voice for speech synthesis.
+/// Allows specifying the desired voice and language for speech synthesis.
 class SpeechConfig {
   /// Creates a [SpeechConfig] instance.
   ///
   /// [voiceName] See https://cloud.google.com/text-to-speech/docs/chirp3-hd
   /// for names and sound demos.
-  SpeechConfig({String? voiceName})
+  ///
+  /// [languageCode] The language code (BCP-47) for speech synthesis,
+  /// e.g. "en-US", "fr-FR", "de-DE".
+  SpeechConfig({String? voiceName, this.languageCode})
       : voiceConfig = voiceName != null
             ? VoiceConfig(
                 prebuiltVoiceConfig: PrebuiltVoiceConfig(voiceName: voiceName))
@@ -64,10 +67,17 @@ class SpeechConfig {
 
   /// The voice config to use for speech synthesis.
   final VoiceConfig? voiceConfig;
+
+  /// The language code (BCP-47) for speech synthesis,
+  /// e.g. "en-US", "fr-FR", "de-DE".
+  final String? languageCode;
+
   // ignore: public_member_api_docs
   Map<String, Object?> toJson() => {
         if (voiceConfig case final voiceConfig?)
-          'voice_config': voiceConfig.toJson()
+          'voice_config': voiceConfig.toJson(),
+        if (languageCode case final languageCode?)
+          'language_code': languageCode,
       };
 }
 

--- a/packages/firebase_ai/firebase_ai/test/live_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/live_test.dart
@@ -34,6 +34,22 @@ void main() {
       expect(speechConfigWithoutVoice.toJson(), {});
     });
 
+    test('SpeechConfig with languageCode toJson() returns correct JSON', () {
+      final speechConfigWithLanguage =
+          SpeechConfig(voiceName: 'Aoede', languageCode: 'en-US');
+      expect(speechConfigWithLanguage.toJson(), {
+        'voice_config': {
+          'prebuilt_voice_config': {'voice_name': 'Aoede'}
+        },
+        'language_code': 'en-US',
+      });
+
+      final speechConfigLanguageOnly = SpeechConfig(languageCode: 'fr-FR');
+      expect(speechConfigLanguageOnly.toJson(), {
+        'language_code': 'fr-FR',
+      });
+    });
+
     test('ResponseModalities enum toJson() returns correct value', () {
       expect(ResponseModalities.text.toJson(), 'TEXT');
       expect(ResponseModalities.image.toJson(), 'IMAGE');


### PR DESCRIPTION
## Description

Adds `languageCode` support to `SpeechConfig` for Firebase AI Live API sessions.

The Gemini Live API supports configuring speech synthesis language through `speech_config.language_code` for non-native-audio models. FlutterFire previously exposed `voiceName` but not the matching language code option, so users could not reproduce the same language behavior they get from Vertex AI.

This change:

- adds an optional `languageCode` parameter to `SpeechConfig`
- serializes it as `language_code` in the Live API request payload
- adds a unit test covering voice + language and language-only configurations

Reference: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/live-api/configure-language-voice

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17459

## Checklist

- [x] I added a regression test for the changed behavior.
- [x] I updated public API documentation comments.
- [x] I ran the focused test suite.
- [x] I ran the analyzer.
- [x] This is not a breaking change.
