### PR TITLE
feat(ai): add mediaResolution parameter

### DIFF
--- a/packages/firebase_ai/firebase_ai/lib/firebase_ai.dart
+++ b/packages/firebase_ai/firebase_ai/lib/firebase_ai.dart
@@ -26,6 +26,7 @@ export 'src/api.dart'
         GroundingChunk,
         ThinkingConfig,
         ThinkingLevel,
+        MediaResolution,
         HarmBlockThreshold,
         HarmCategory,
         HarmProbability,

--- a/packages/firebase_ai/firebase_ai/lib/src/api.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/api.dart
@@ -1067,6 +1067,41 @@ enum ResponseModalities {
   String toJson() => _jsonString;
 }
 
+/// The media resolution to use for media inputs.
+enum MediaResolution {
+  /// Default media resolution selected by the model.
+  unspecified('MEDIA_RESOLUTION_UNSPECIFIED'),
+
+  /// Lower token count, resulting in faster processing and lower cost.
+  low('MEDIA_RESOLUTION_LOW'),
+
+  /// A balance between detail, cost, and latency.
+  medium('MEDIA_RESOLUTION_MEDIUM'),
+
+  /// Higher token count, providing more detail for media inputs.
+  high('MEDIA_RESOLUTION_HIGH'),
+
+  /// Highest token count for image inputs.
+  ///
+  /// This value is only supported on individual media parts.
+  ultraHigh('MEDIA_RESOLUTION_ULTRA_HIGH');
+
+  const MediaResolution(this._jsonString);
+  final String _jsonString;
+
+  /// Parse a media resolution from a JSON value.
+  static MediaResolution parseValue(String value) => switch (value) {
+        'MEDIA_RESOLUTION_LOW' => MediaResolution.low,
+        'MEDIA_RESOLUTION_MEDIUM' => MediaResolution.medium,
+        'MEDIA_RESOLUTION_HIGH' => MediaResolution.high,
+        'MEDIA_RESOLUTION_ULTRA_HIGH' => MediaResolution.ultraHigh,
+        _ => MediaResolution.unspecified,
+      };
+
+  // ignore: public_member_api_docs
+  String toJson() => _jsonString;
+}
+
 /// A preset that balances the trade-off between reasoning quality and response
 /// speed for a model's "thinking" process.
 ///
@@ -1170,7 +1205,9 @@ abstract class BaseGenerationConfig {
     this.presencePenalty,
     this.frequencyPenalty,
     this.responseModalities,
-  });
+    this.mediaResolution,
+  }) : assert(mediaResolution != MediaResolution.ultraHigh,
+            'MediaResolution.ultraHigh is only supported on individual media parts.');
 
   /// Number of generated responses to return.
   ///
@@ -1249,6 +1286,14 @@ abstract class BaseGenerationConfig {
   /// The list of desired response modalities.
   final List<ResponseModalities>? responseModalities;
 
+  /// The resolution to use for media inputs.
+  ///
+  /// Higher resolutions provide more detail to the model, at the cost of
+  /// increased token usage, latency, and cost.
+  ///
+  /// [MediaResolution.ultraHigh] is only supported on individual media parts.
+  final MediaResolution? mediaResolution;
+
   // ignore: public_member_api_docs
   Map<String, Object?> toJson() => {
         if (candidateCount case final candidateCount?)
@@ -1265,6 +1310,8 @@ abstract class BaseGenerationConfig {
         if (responseModalities case final responseModalities?)
           'responseModalities':
               responseModalities.map((modality) => modality.toJson()).toList(),
+        if (mediaResolution case final mediaResolution?)
+          'mediaResolution': mediaResolution.toJson(),
       };
 }
 
@@ -1281,6 +1328,7 @@ final class GenerationConfig extends BaseGenerationConfig {
     super.presencePenalty,
     super.frequencyPenalty,
     super.responseModalities,
+    super.mediaResolution,
     this.responseMimeType,
     this.responseSchema,
     this.responseJsonSchema,

--- a/packages/firebase_ai/firebase_ai/lib/src/content.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/content.dart
@@ -41,8 +41,10 @@ final class Content {
   static Content text(String text) => Content('user', [TextPart(text)]);
 
   /// Return a [Content] with [InlineDataPart].
-  static Content inlineData(String mimeType, Uint8List bytes) =>
-      Content('user', [InlineDataPart(mimeType, bytes)]);
+  static Content inlineData(String mimeType, Uint8List bytes,
+          {MediaResolution? mediaResolution}) =>
+      Content('user',
+          [InlineDataPart(mimeType, bytes, mediaResolution: mediaResolution)]);
 
   /// Return a [Content] with multiple [Part]s.
   static Content multi(Iterable<Part> parts) => Content('user', [...parts]);
@@ -100,6 +102,10 @@ Part parsePart(Object? jsonObject) {
   final thoughtSignature = jsonObject.containsKey('thoughtSignature')
       ? jsonObject['thoughtSignature']! as String
       : null;
+  final mediaResolution = switch (jsonObject['mediaResolution']) {
+    {'level': final String level} => MediaResolution.parseValue(level),
+    _ => null,
+  };
 
   if (jsonObject.containsKey('functionCall')) {
     final functionCall = jsonObject['functionCall'];
@@ -157,6 +163,7 @@ Part parsePart(Object? jsonObject) {
         inlineDataResult['mimeType'] as String,
         base64Decode(inlineDataResult['data'] as String),
         willContinue: inlineDataResult['willContinue'] as bool?,
+        mediaResolution: mediaResolution,
         isThought: isThought,
         thoughtSignature: thoughtSignature,
       );
@@ -174,7 +181,9 @@ Part parsePart(Object? jsonObject) {
       }
     } =>
       FileData._(mimeType, fileUri,
-          isThought: isThought, thoughtSignature: thoughtSignature),
+          mediaResolution: mediaResolution,
+          isThought: isThought,
+          thoughtSignature: thoughtSignature),
     _ => () {
         log('unhandled part format: $jsonObject');
         return UnknownPart(jsonObject);
@@ -261,6 +270,7 @@ final class InlineDataPart extends Part {
     this.mimeType,
     this.bytes, {
     this.willContinue,
+    this.mediaResolution,
     bool? isThought,
   }) : super(
           isThought: isThought,
@@ -273,6 +283,7 @@ final class InlineDataPart extends Part {
     this.mimeType,
     this.bytes, {
     this.willContinue,
+    this.mediaResolution,
     bool? isThought,
     String? thoughtSignature,
   }) : super(
@@ -284,6 +295,7 @@ final class InlineDataPart extends Part {
     this.mimeType,
     this.bytes, {
     this.willContinue,
+    this.mediaResolution,
     bool? isThought,
     String? thoughtSignature,
   }) : super(
@@ -300,6 +312,12 @@ final class InlineDataPart extends Part {
 
   /// Whether there's more inline data coming for streaming.
   final bool? willContinue;
+
+  /// The resolution to use for this media part.
+  ///
+  /// This overrides the request-level media resolution for this part.
+  final MediaResolution? mediaResolution;
+
   @override
   Object toJson() {
     final superJson = super.toJson() as Map<String, Object?>;
@@ -310,6 +328,8 @@ final class InlineDataPart extends Part {
         'mimeType': mimeType,
         if (willContinue != null) 'willContinue': willContinue,
       },
+      if (mediaResolution != null)
+        'mediaResolution': {'level': mediaResolution!.toJson()},
     };
   }
 
@@ -433,6 +453,7 @@ final class FileData extends Part {
   const FileData(
     this.mimeType,
     this.fileUri, {
+    this.mediaResolution,
     bool? isThought,
   }) : super(
           isThought: isThought,
@@ -444,6 +465,7 @@ final class FileData extends Part {
   const FileData.forTest(
     this.mimeType,
     this.fileUri, {
+    this.mediaResolution,
     bool? isThought,
     String? thoughtSignature,
   }) : super(
@@ -454,6 +476,7 @@ final class FileData extends Part {
   const FileData._(
     this.mimeType,
     this.fileUri, {
+    this.mediaResolution,
     bool? isThought,
     String? thoughtSignature,
   }) : super(
@@ -468,12 +491,19 @@ final class FileData extends Part {
   /// The gs link for Firebase Storage reference
   final String fileUri;
 
+  /// The resolution to use for this media part.
+  ///
+  /// This overrides the request-level media resolution for this part.
+  final MediaResolution? mediaResolution;
+
   @override
   Object toJson() {
     final superJson = super.toJson() as Map<String, Object?>;
     return <String, Object?>{
       ...superJson,
       'file_data': {'file_uri': fileUri, 'mime_type': mimeType},
+      if (mediaResolution != null)
+        'mediaResolution': {'level': mediaResolution!.toJson()},
     };
   }
 }

--- a/packages/firebase_ai/firebase_ai/lib/src/live_api.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/live_api.dart
@@ -168,7 +168,8 @@ final class LiveGenerationConfig extends BaseGenerationConfig {
       super.topP,
       super.topK,
       super.presencePenalty,
-      super.frequencyPenalty});
+      super.frequencyPenalty,
+      super.mediaResolution});
 
   /// The speech configuration.
   final SpeechConfig? speechConfig;

--- a/packages/firebase_ai/firebase_ai/test/api_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/api_test.dart
@@ -516,6 +516,23 @@ void main() {
   });
 
   group('GenerationConfig & BaseGenerationConfig', () {
+    test('GenerationConfig serializes mediaResolution', () {
+      final config = GenerationConfig(
+        mediaResolution: MediaResolution.high,
+      );
+
+      expect(config.toJson(), {
+        'mediaResolution': 'MEDIA_RESOLUTION_HIGH',
+      });
+    });
+
+    test('GenerationConfig rejects ultraHigh mediaResolution', () {
+      expect(
+        () => GenerationConfig(mediaResolution: MediaResolution.ultraHigh),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
     test('GenerationConfig toJson with all fields', () {
       final schema = Schema.object(properties: {});
       final thinkingConfig = ThinkingConfig(thinkingBudget: 100);
@@ -532,6 +549,7 @@ void main() {
         frequencyPenalty: 0.4,
         responseMimeType: 'application/json',
         responseSchema: schema,
+        mediaResolution: MediaResolution.medium,
         thinkingConfig: thinkingConfig,
         imageConfig: imageConfig,
       );
@@ -546,6 +564,7 @@ void main() {
         'stopSequences': ['\n', 'stop'],
         'responseMimeType': 'application/json',
         'responseSchema': schema.toJson(),
+        'mediaResolution': 'MEDIA_RESOLUTION_MEDIUM',
         'thinkingConfig': {'thinkingBudget': 100},
         'imageConfig': {
           'aspectRatio': '1:1',

--- a/packages/firebase_ai/firebase_ai/test/content_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/content_test.dart
@@ -15,6 +15,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:firebase_ai/src/api.dart';
 import 'package:firebase_ai/src/content.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -44,6 +45,29 @@ void main() {
       final content =
           Content('user', [InlineDataPart('image/png', Uint8List(0))]);
       expect(content.parts[0], isA<InlineDataPart>());
+    });
+
+    test('inlineData() accepts mediaResolution', () {
+      final content = Content.inlineData(
+        'image/png',
+        Uint8List(0),
+        mediaResolution: MediaResolution.high,
+      );
+
+      expect(content.toJson(), {
+        'role': 'user',
+        'parts': [
+          {
+            'inlineData': {
+              'mimeType': 'image/png',
+              'data': '',
+            },
+            'mediaResolution': {
+              'level': 'MEDIA_RESOLUTION_HIGH',
+            },
+          }
+        ],
+      });
     });
 
     test('multi()', () {
@@ -125,6 +149,24 @@ void main() {
       expect(inlineData['willContinue'], true);
     });
 
+    test('InlineDataPart serializes mediaResolution', () {
+      final part = InlineDataPart(
+        'image/png',
+        Uint8List(0),
+        mediaResolution: MediaResolution.ultraHigh,
+      );
+
+      expect(part.toJson(), {
+        'inlineData': {
+          'mimeType': 'image/png',
+          'data': '',
+        },
+        'mediaResolution': {
+          'level': 'MEDIA_RESOLUTION_ULTRA_HIGH',
+        },
+      });
+    });
+
     test('FunctionCall with isThought and thoughtSignature toJson', () {
       const part = FunctionCall.forTest(
           'myFunction',
@@ -181,6 +223,24 @@ void main() {
       expect(fileData['mime_type'], 'image/png');
       expect(fileData['file_uri'], 'gs://bucket-name/path');
       expect(json['thought'], true);
+    });
+
+    test('FileData serializes mediaResolution', () {
+      const part = FileData(
+        'image/png',
+        'gs://bucket-name/path',
+        mediaResolution: MediaResolution.high,
+      );
+
+      expect(part.toJson(), {
+        'file_data': {
+          'mime_type': 'image/png',
+          'file_uri': 'gs://bucket-name/path',
+        },
+        'mediaResolution': {
+          'level': 'MEDIA_RESOLUTION_HIGH',
+        },
+      });
     });
   });
 

--- a/packages/firebase_ai/firebase_ai/test/live_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/live_test.dart
@@ -48,6 +48,7 @@ void main() {
         temperature: 0.8,
         topP: 0.95,
         topK: 40,
+        mediaResolution: MediaResolution.low,
       );
 
       expect(liveGenerationConfig.toJson(), {
@@ -61,6 +62,7 @@ void main() {
           }
         },
         'responseModalities': ['TEXT', 'AUDIO'],
+        'mediaResolution': 'MEDIA_RESOLUTION_LOW',
       });
 
       final liveGenerationConfigWithoutOptionals = LiveGenerationConfig();


### PR DESCRIPTION
## Description

Adds the missing `mediaResolution` parameter to `firebase_ai`.

This introduces a `MediaResolution` enum and wires it through `BaseGenerationConfig` so request-level media resolution is available on both `GenerationConfig` and `LiveGenerationConfig`, serialized as `mediaResolution` in the request payload.

It also supports per-part media resolution on `InlineDataPart` and `FileData`, including `MediaResolution.ultraHigh`, serialized as `mediaResolution: { level: ... }`. `MediaResolution.ultraHigh` is rejected on request-level generation config because the Gemini API documents it as per-part only.

Reference: https://ai.google.dev/gemini-api/docs/media-resolution

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17406


## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
