### PR TITLE
fix(web): WASM - After a SignOut with an active authStateChange/idTokenChange a null check would be thrown

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -135,7 +135,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
             );
           }
         }).listen((UserWeb? webUser) {
-          _authStateChangesListeners[app.name]!.add(webUser);
+          _authStateChangesListeners[app.name]?.add(webUser);
         });
         break;
       case StateListener.idTokenChange:
@@ -174,8 +174,8 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
             );
           }
         }).listen((UserWeb? webUser) {
-          _idTokenChangesListeners[app.name]!.add(webUser);
-          _userChangesListeners[app.name]!.add(webUser);
+          _idTokenChangesListeners[app.name]?.add(webUser);
+          _userChangesListeners[app.name]?.add(webUser);
         });
         break;
       case StateListener.userStateChange:


### PR DESCRIPTION
## Description

When WASM is being used, a SignOut with an active authStateChange/idTokenChange would throw a null check error

## Related Issues
Fixes https://github.com/firebase/flutterfire/issues/18412

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.
