### PR TITLE
ci(android): store AVD on /mnt for emulator e2e workflows

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -98,6 +98,13 @@ jobs:
           remove-codeql: true
           remove-docker-images: true
           remove-large-packages: true
+      - name: Prepare AVD home on /mnt
+        # GitHub-hosted runners mount a ~74GB volume at /mnt. Create it before AVD cache
+        # restore and android-emulator-runner (avdmanager needs the space at create time).
+        run: |
+          sudo mkdir -p /mnt/avd
+          sudo chown "$USER:$USER" /mnt/avd
+          df -h / /mnt
       - name: AVD cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         continue-on-error: true
@@ -105,11 +112,19 @@ jobs:
         with:
           # Must match the save path exactly
           path: |
-            ~/.android/avd/*
+            /mnt/avd/*
             ~/.android/adb*
           key: avd-${{ runner.os }}-${{ env.AVD_API_LEVEL }}-${{ env.AVD_TARGET }}-${{ env.AVD_ARCH }}
+      - name: Link AVD home to /mnt
+        # android-emulator-runner exportVariables ANDROID_AVD_HOME to $HOME/.android/avd
+        run: |
+          mkdir -p "$HOME/.android"
+          rm -rf "$HOME/.android/avd"
+          ln -s /mnt/avd "$HOME/.android/avd"
       - name: Start AVD then run E2E tests
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a
+        env:
+          ANDROID_AVD_HOME: /mnt/avd
         with:
           api-level: ${{ env.AVD_API_LEVEL }}
           target: ${{ env.AVD_TARGET }}
@@ -141,7 +156,7 @@ jobs:
           key: ${{ steps.avd-cache.outputs.cache-primary-key }}
           # Must match the restore path exactly
           path: |
-            ~/.android/avd/*
+            /mnt/avd/*
             ~/.android/adb*
 
   agp9-compatibility:

--- a/.github/workflows/e2e_tests_fdc.yaml
+++ b/.github/workflows/e2e_tests_fdc.yaml
@@ -97,6 +97,11 @@ jobs:
           remove-codeql: true
           remove-docker-images: true
           remove-large-packages: true
+      - name: Prepare AVD home on /mnt
+        run: |
+          sudo mkdir -p /mnt/avd
+          sudo chown "$USER:$USER" /mnt/avd
+          df -h / /mnt
       - name: AVD cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         id: avd-cache
@@ -104,11 +109,18 @@ jobs:
         with:
           # Must match the save path exactly
           path: |
-            ~/.android/avd/*
+            /mnt/avd/*
             ~/.android/adb*
           key: avd-${{ runner.os }}-${{ env.AVD_API_LEVEL }}-${{ env.AVD_TARGET }}-${{ env.AVD_ARCH }}
+      - name: Link AVD home to /mnt
+        run: |
+          mkdir -p "$HOME/.android"
+          rm -rf "$HOME/.android/avd"
+          ln -s /mnt/avd "$HOME/.android/avd"
       - name: Start AVD then run E2E tests
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a
+        env:
+          ANDROID_AVD_HOME: /mnt/avd
         with:
           api-level: ${{ env.AVD_API_LEVEL }}
           target: ${{ env.AVD_TARGET }}
@@ -126,7 +138,7 @@ jobs:
           key: ${{ steps.avd-cache.outputs.cache-primary-key }}
           # Must match the restore path exactly
           path: |
-            ~/.android/avd/*
+            /mnt/avd/*
             ~/.android/adb*
       - name: Save Firestore Emulator Cache
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.

--- a/.github/workflows/e2e_tests_pipeline.yaml
+++ b/.github/workflows/e2e_tests_pipeline.yaml
@@ -79,17 +79,29 @@ jobs:
           remove-codeql: true
           remove-docker-images: true
           remove-large-packages: true
+      - name: Prepare AVD home on /mnt
+        run: |
+          sudo mkdir -p /mnt/avd
+          sudo chown "$USER:$USER" /mnt/avd
+          df -h / /mnt
       - name: AVD cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         continue-on-error: true
         id: avd-cache
         with:
           path: |
-            ~/.android/avd/*
+            /mnt/avd/*
             ~/.android/adb*
           key: avd-${{ runner.os }}-${{ env.AVD_API_LEVEL }}-${{ env.AVD_TARGET }}-${{ env.AVD_ARCH }}
+      - name: Link AVD home to /mnt
+        run: |
+          mkdir -p "$HOME/.android"
+          rm -rf "$HOME/.android/avd"
+          ln -s /mnt/avd "$HOME/.android/avd"
       - name: Start AVD then run pipeline E2E tests
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a
+        env:
+          ANDROID_AVD_HOME: /mnt/avd
         with:
           api-level: ${{ env.AVD_API_LEVEL }}
           target: ${{ env.AVD_TARGET }}
@@ -108,7 +120,7 @@ jobs:
         with:
           key: ${{ steps.avd-cache.outputs.cache-primary-key }}
           path: |
-            ~/.android/avd/*
+            /mnt/avd/*
             ~/.android/adb*
 
   pipeline-e2e-web:


### PR DESCRIPTION
## Problem

This was an e2e flake failure mode that surfaced on the sister repository react-native-firebase, I'm porting it here in an attempt to solve an e2e failure that will hit here, before it does 🫡 

On GitHub-hosted `ubuntu-latest` runners, AVD userdata is created on the root filesystem (`/`). After bootstrap, Gradle, and SDK install, `/` can drop to ~7 GB free while a fresh API 36 AVD needs ~7.4 GB — the emulator fails immediately:

```
FATAL | Not enough space to create userdata partition.
Available: 7090.64 MB, need 7372.80 MB
```

Runners also mount a secondary volume at `/mnt` (~66–74 GB free) that we were not using for AVD storage. FlutterFire currently runs API 34 (smaller userdata) and frees disk before the emulator, so this has not surfaced yet, but the same failure mode applies on cache misses or future API bumps.

## How android-emulator-runner uses `ANDROID_AVD_HOME`

[`sdk-installer.ts`](https://github.com/ReactiveCircus/android-emulator-runner/blob/main/src/sdk-installer.ts) sets `ANDROID_AVD_HOME` (via `core.exportVariable`) to `$HOME/.android/avd`. [`emulator-manager.ts`](https://github.com/ReactiveCircus/android-emulator-runner/blob/main/src/emulator-manager.ts) creates the AVD under `${process.env.ANDROID_AVD_HOME}/${avdName}.avd`. The action README’s [AVD cache example](https://github.com/ReactiveCircus/android-emulator-runner#running-hardware-accelerated-emulators-on-linux-runners) also documents caching `~/.android/avd/*`.

## Fix

In all three `android-emulator-runner` workflows (`android.yaml`, `e2e_tests_pipeline.yaml`, `e2e_tests_fdc.yaml`):

1. **Prepare AVD home on /mnt** — create `/mnt/avd` and `chown` it before cache restore / `avdmanager create avd`.
2. **AVD cache paths** — restore/save `/mnt/avd/*` instead of `~/.android/avd/*`.
3. **Link AVD home to /mnt** — symlink `$HOME/.android/avd` → `/mnt/avd` before the action runs (the action always targets `$HOME/.android/avd`; a `pre-emulator-launch-script` symlink is too late).
4. **`ANDROID_AVD_HOME: /mnt/avd`** on the emulator-runner step.

## Test plan

- [ ] Android e2e workflow (`android.yaml`) green on PR
- [ ] Pipeline Android e2e (`e2e_tests_pipeline.yaml`) green on PR
- [ ] FDC Android e2e (`e2e_tests_fdc.yaml`) green on PR