### PR TITLE
chore: remove unused extend from PlatformInterface

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/cloud_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/cloud_firestore.dart
@@ -5,7 +5,7 @@
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
-    show FirebasePluginPlatform;
+    show FirebasePlugin;
 import 'package:flutter/foundation.dart';
 import 'package:meta/meta.dart';
 

--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -15,7 +15,7 @@ part of '../cloud_firestore.dart';
 ///
 /// FirebaseFirestore firestore = FirebaseFirestore.instanceFor(app: secondaryApp);
 /// ```
-class FirebaseFirestore extends FirebasePluginPlatform {
+class FirebaseFirestore extends FirebasePlugin {
   FirebaseFirestore._({
     required this.app,
     required this.databaseId,

--- a/packages/cloud_functions/cloud_functions/lib/cloud_functions.dart
+++ b/packages/cloud_functions/cloud_functions/lib/cloud_functions.dart
@@ -11,7 +11,7 @@ import 'dart:typed_data';
 import 'package:cloud_functions_platform_interface/cloud_functions_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
-    show FirebasePluginPlatform;
+    show FirebasePlugin;
 import 'package:flutter/foundation.dart';
 
 export 'package:cloud_functions_platform_interface/cloud_functions_platform_interface.dart'

--- a/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
+++ b/packages/cloud_functions/cloud_functions/lib/src/firebase_functions.dart
@@ -8,7 +8,7 @@ part of '../cloud_functions.dart';
 /// The entry point for accessing FirebaseFunctions.
 ///
 /// You can get an instance by calling [FirebaseFunctions.instance].
-class FirebaseFunctions extends FirebasePluginPlatform {
+class FirebaseFunctions extends FirebasePlugin {
   FirebaseFunctions._({required this.app, String? region})
       : _region = region ??= 'us-central1',
         super(app.name, 'plugins.flutter.io/firebase_functions');

--- a/packages/firebase_ai/firebase_ai/lib/src/firebase_ai.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/firebase_ai.dart
@@ -16,7 +16,7 @@ import 'package:firebase_app_check/firebase_app_check.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
-    show FirebasePluginPlatform;
+    show FirebasePlugin;
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
@@ -26,7 +26,7 @@ import 'base_model.dart';
 const _defaultLocation = 'us-central1';
 
 /// The entrypoint for generative models.
-class FirebaseAI extends FirebasePluginPlatform {
+class FirebaseAI extends FirebasePlugin {
   FirebaseAI._({
     required this.app,
     required this.location,

--- a/packages/firebase_analytics/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/firebase_analytics.dart
@@ -5,7 +5,7 @@
 import 'package:firebase_analytics_platform_interface/firebase_analytics_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
-    show FirebasePluginPlatform;
+    show FirebasePlugin;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 

--- a/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
@@ -5,7 +5,7 @@
 part of '../firebase_analytics.dart';
 
 /// Firebase Analytics API.
-class FirebaseAnalytics extends FirebasePluginPlatform {
+class FirebaseAnalytics extends FirebasePlugin {
   FirebaseAnalytics._({
     required this.app,
     this.webOptions,

--- a/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
@@ -5,8 +5,7 @@
 
 part of '../firebase_app_check.dart';
 
-class FirebaseAppCheck extends FirebasePluginPlatform
-    implements FirebaseService {
+class FirebaseAppCheck extends FirebasePlugin implements FirebaseService {
   static Map<String, FirebaseAppCheck> _firebaseAppCheckInstances = {};
 
   FirebaseAppCheck._({required this.app})

--- a/packages/firebase_app_installations/firebase_app_installations/lib/firebase_app_installations.dart
+++ b/packages/firebase_app_installations/firebase_app_installations/lib/firebase_app_installations.dart
@@ -5,6 +5,6 @@
 import 'package:firebase_app_installations_platform_interface/firebase_app_installations_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
-    show FirebasePluginPlatform;
+    show FirebasePlugin;
 
 part 'src/firebase_app_installations.dart';

--- a/packages/firebase_app_installations/firebase_app_installations/lib/src/firebase_app_installations.dart
+++ b/packages/firebase_app_installations/firebase_app_installations/lib/src/firebase_app_installations.dart
@@ -4,7 +4,7 @@
 
 part of '../firebase_app_installations.dart';
 
-class FirebaseInstallations extends FirebasePluginPlatform {
+class FirebaseInstallations extends FirebasePlugin {
   FirebaseInstallations._({required this.app})
       : super(app.name, 'plugins.flutter.io/firebase_app_installations');
 

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -6,7 +6,7 @@
 part of '../firebase_auth.dart';
 
 /// The entry point of the Firebase Authentication SDK.
-class FirebaseAuth extends FirebasePluginPlatform implements FirebaseService {
+class FirebaseAuth extends FirebasePlugin implements FirebaseService {
   // Cached instances of [FirebaseAuth].
   static Map<String, FirebaseAuth> _firebaseAuthInstances = {};
 

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase.dart
@@ -33,7 +33,7 @@ class MethodChannelFirebase extends FirebasePlatform {
   }
 
   /// Creates and attaches a new [MethodChannelFirebaseApp] to the [MethodChannelFirebase]
-  /// and adds any constants to the [FirebasePluginPlatform] class.
+  /// and adds any constants to the [FirebasePlugin] class.
   void _initializeFirebaseAppFromMap(CoreInitializeResponse response) {
     MethodChannelFirebaseApp methodChannelFirebaseApp =
         MethodChannelFirebaseApp(
@@ -45,8 +45,7 @@ class MethodChannelFirebase extends FirebasePlatform {
 
     appInstances[methodChannelFirebaseApp.name] = methodChannelFirebaseApp;
 
-    FirebasePluginPlatform
-            ._constantsForPluginApps[methodChannelFirebaseApp.name] =
+    FirebasePlugin._constantsForPluginApps[methodChannelFirebaseApp.name] =
         response.pluginConstants;
   }
 

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase_app.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase_app.dart
@@ -52,7 +52,7 @@ class MethodChannelFirebaseApp extends FirebaseAppPlatform {
     await _api.delete(name);
 
     MethodChannelFirebase.appInstances.remove(name);
-    FirebasePluginPlatform._constantsForPluginApps.remove(name);
+    FirebasePlugin._constantsForPluginApps.remove(name);
     _isDeleted = true;
   }
 

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/platform_interface/platform_interface_firebase_plugin.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/platform_interface/platform_interface_firebase_plugin.dart
@@ -37,4 +37,3 @@ abstract class FirebasePlugin {
     return {};
   }
 }
-

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/platform_interface/platform_interface_firebase_plugin.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/platform_interface/platform_interface_firebase_plugin.dart
@@ -5,14 +5,13 @@
 
 part of '../../firebase_core_platform_interface.dart';
 
-/// The interface that other FlutterFire plugins must extend.
+/// The base class that other FlutterFire plugins must extend.
 ///
 /// This class provides access to common plugin properties and constants which
 /// are available once the user has initialized FlutterFire.
-abstract class FirebasePluginPlatform extends PlatformInterface {
+abstract class FirebasePlugin {
   // ignore: public_member_api_docs
-  FirebasePluginPlatform(this._appName, this._methodChannelName)
-      : super(token: _token);
+  FirebasePlugin(this._appName, this._methodChannelName);
 
   /// The global data store for all constants, for each plugin and [FirebaseAppPlatform] instance.
   ///
@@ -26,13 +25,6 @@ abstract class FirebasePluginPlatform extends PlatformInterface {
 
   final String _methodChannelName;
 
-  static final Object _token = Object();
-
-  // ignore: public_member_api_docs
-  static void verify(FirebasePluginPlatform instance) {
-    PlatformInterface.verify(instance, _token);
-  }
-
   /// Returns any plugin constants this plugin app instance has initialized.
   Map<dynamic, dynamic> get pluginConstants {
     final appConstants =
@@ -45,3 +37,4 @@ abstract class FirebasePluginPlatform extends PlatformInterface {
     return {};
   }
 }
+

--- a/packages/firebase_core/firebase_core_platform_interface/test/platform_interface_tests/platform_interface_firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/test/platform_interface_tests/platform_interface_firebase_core_test.dart
@@ -39,6 +39,12 @@ void main() {
       FirebasePlatform.instance = mock;
     });
   });
+
+  group('$FirebasePlugin', () {
+    test('is not a platform interface', () {
+      expect(TestFirebasePlugin(), isNot(isA<PlatformInterface>()));
+    });
+  });
 }
 
 class ImplementsFirebasePlatform implements FirebasePlatform {
@@ -70,3 +76,7 @@ class FirebaseCoreMockPlatform extends Mock
         MockPlatformInterfaceMixin
     implements
         FirebasePlatform {}
+
+class TestFirebasePlugin extends FirebasePlugin {
+  TestFirebasePlugin() : super(defaultFirebaseAppName, 'test_plugin');
+}

--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/firebase_crashlytics.dart
@@ -5,7 +5,7 @@
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
-    show FirebasePluginPlatform;
+    show FirebasePlugin;
 import 'package:firebase_crashlytics_platform_interface/firebase_crashlytics_platform_interface.dart';
 import 'package:flutter/foundation.dart'
     show DiagnosticLevel, FlutterError, FlutterErrorDetails, kDebugMode;

--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -8,7 +8,7 @@ part of '../firebase_crashlytics.dart';
 /// The entry point for accessing a [FirebaseCrashlytics].
 ///
 /// You can get an instance by calling [FirebaseCrashlytics.instance].
-class FirebaseCrashlytics extends FirebasePluginPlatform {
+class FirebaseCrashlytics extends FirebasePlugin {
   FirebaseCrashlytics._({required this.app})
       : super(app.name, 'plugins.flutter.io/firebase_crashlytics');
 

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
@@ -27,7 +27,7 @@ import 'cache/cache_data_types.dart';
 import 'cache/cache.dart';
 
 /// DataConnect class
-class FirebaseDataConnect extends FirebasePluginPlatform {
+class FirebaseDataConnect extends FirebasePlugin {
   /// Constructor for initializing Data Connect
   @visibleForTesting
   FirebaseDataConnect(

--- a/packages/firebase_database/firebase_database/lib/firebase_database.dart
+++ b/packages/firebase_database/firebase_database/lib/firebase_database.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
-    show FirebasePluginPlatform;
+    show FirebasePlugin;
 import 'package:firebase_database_platform_interface/firebase_database_platform_interface.dart';
 import 'package:flutter/foundation.dart';
 

--- a/packages/firebase_database/firebase_database/lib/src/firebase_database.dart
+++ b/packages/firebase_database/firebase_database/lib/src/firebase_database.dart
@@ -6,7 +6,7 @@ part of '../firebase_database.dart';
 
 /// The entry point for accessing a Firebase Database. You can get an instance
 /// by calling `FirebaseDatabase.instance` or `FirebaseDatabase.instanceFor()`.
-class FirebaseDatabase extends FirebasePluginPlatform {
+class FirebaseDatabase extends FirebasePlugin {
   FirebaseDatabase._({required this.app, this.databaseURL})
       : super(app.name, 'plugins.flutter.io/firebase_database') {
     if (databaseURL != null && databaseURL!.endsWith('/')) {

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/lib/firebase_in_app_messaging.dart
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/lib/firebase_in_app_messaging.dart
@@ -4,10 +4,10 @@
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
-    show FirebasePluginPlatform;
+    show FirebasePlugin;
 import 'package:firebase_in_app_messaging_platform_interface/firebase_in_app_messaging_platform_interface.dart';
 
-class FirebaseInAppMessaging extends FirebasePluginPlatform {
+class FirebaseInAppMessaging extends FirebasePlugin {
   FirebaseInAppMessaging._({required this.app})
       : super(app.name, 'plugins.flutter.io/firebase_in_app_messaging');
 

--- a/packages/firebase_messaging/firebase_messaging/lib/firebase_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/firebase_messaging.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
-    show FirebasePluginPlatform;
+    show FirebasePlugin;
 import 'package:firebase_messaging_platform_interface/firebase_messaging_platform_interface.dart';
 
 export 'package:firebase_messaging_platform_interface/firebase_messaging_platform_interface.dart'

--- a/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
@@ -8,7 +8,7 @@ part of '../firebase_messaging.dart';
 /// The [FirebaseMessaging] entry point.
 ///
 /// To get a new instance, call [FirebaseMessaging.instance].
-class FirebaseMessaging extends FirebasePluginPlatform {
+class FirebaseMessaging extends FirebasePlugin {
   // Cached and lazily loaded instance of [FirebaseMessagingPlatform] to avoid
   // creating a [MethodChannelFirebaseMessaging] when not needed or creating an
   // instance with the default app before a user specifies an app.

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/lib/firebase_ml_model_downloader.dart
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/lib/firebase_ml_model_downloader.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
-    show FirebasePluginPlatform;
+    show FirebasePlugin;
 import 'package:firebase_ml_model_downloader_platform_interface/firebase_ml_model_downloader_platform_interface.dart';
 import 'package:flutter/foundation.dart';
 

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/lib/src/firebase_ml_model_downloader.dart
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/lib/src/firebase_ml_model_downloader.dart
@@ -4,7 +4,7 @@
 
 part of '../firebase_ml_model_downloader.dart';
 
-class FirebaseModelDownloader extends FirebasePluginPlatform {
+class FirebaseModelDownloader extends FirebasePlugin {
   FirebaseModelDownloader._({required this.app})
       : super(app.name, 'plugins.flutter.io/firebase_ml_model_downloader');
 

--- a/packages/firebase_performance/firebase_performance/lib/src/firebase_performance.dart
+++ b/packages/firebase_performance/firebase_performance/lib/src/firebase_performance.dart
@@ -7,7 +7,7 @@ part of '../firebase_performance.dart';
 /// The Firebase Performance API.
 ///
 /// You can get an instance by calling [FirebasePerformance.instance].
-class FirebasePerformance extends FirebasePluginPlatform {
+class FirebasePerformance extends FirebasePlugin {
   FirebasePerformance._({required this.app})
       : super(app.name, 'plugins.flutter.io/firebase_performance');
 

--- a/packages/firebase_remote_config/firebase_remote_config/lib/firebase_remote_config.dart
+++ b/packages/firebase_remote_config/firebase_remote_config/lib/firebase_remote_config.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
-    show FirebasePluginPlatform;
+    show FirebasePlugin;
 import 'package:firebase_remote_config_platform_interface/firebase_remote_config_platform_interface.dart';
 
 export 'package:firebase_remote_config_platform_interface/firebase_remote_config_platform_interface.dart'

--- a/packages/firebase_remote_config/firebase_remote_config/lib/src/firebase_remote_config.dart
+++ b/packages/firebase_remote_config/firebase_remote_config/lib/src/firebase_remote_config.dart
@@ -9,7 +9,7 @@ part of '../firebase_remote_config.dart';
 /// You can get an instance by calling [FirebaseRemoteConfig.instance]. Note
 /// [FirebaseRemoteConfig.instance] is async.
 // ignore: prefer_mixin
-class FirebaseRemoteConfig extends FirebasePluginPlatform {
+class FirebaseRemoteConfig extends FirebasePlugin {
   FirebaseRemoteConfig._({required this.app})
       : super(app.name, 'plugins.flutter.io/firebase_remote_config');
 

--- a/packages/firebase_storage/firebase_storage/lib/firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage/lib/firebase_storage.dart
@@ -12,7 +12,7 @@ import 'dart:io' show File;
 // import 'package:flutter/foundation.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
-    show FirebasePluginPlatform;
+    show FirebasePlugin;
 import 'package:firebase_storage_platform_interface/firebase_storage_platform_interface.dart';
 import 'package:flutter/foundation.dart';
 import 'package:mime/mime.dart';

--- a/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
@@ -6,7 +6,7 @@
 part of firebase_storage;
 
 /// The entrypoint for [FirebaseStorage].
-class FirebaseStorage extends FirebasePluginPlatform {
+class FirebaseStorage extends FirebasePlugin {
   FirebaseStorage._({required this.app, required this.bucket})
       : super(app.name, 'plugins.flutter.io/firebase_storage');
 


### PR DESCRIPTION
## Description

`FirebasePluginPlatform` was an app-facing plugin base class but still extended `PlatformInterface`, making implementations unnecessarily fragile. This replaces it with `FirebasePlugin` as the non-platform-interface base and updates FlutterFire plugin classes to extend `FirebasePlugin`.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/8945

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
