### PR TITLE
fix(cloud_firestore): guard shared transactions map against concurrent access

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -62,6 +62,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class FlutterFirebaseFirestorePlugin
@@ -83,7 +84,9 @@ public class FlutterFirebaseFirestorePlugin
 
   private final AtomicReference<Activity> activity = new AtomicReference<>(null);
 
-  private final Map<String, Transaction> transactions = new HashMap<>();
+  // Written from Firestore's transaction worker threads and read from the plugin's
+  // cached thread pool, so this must be a thread-safe map (see #18417).
+  private final Map<String, Transaction> transactions = new ConcurrentHashMap<>();
   private final Map<String, EventChannel> eventChannels = new HashMap<>();
   private final Map<String, StreamHandler> streamHandlers = new HashMap<>();
   private final Map<String, OnTransactionResultListener> transactionHandlers = new HashMap<>();

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/transaction_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/transaction_e2e.dart
@@ -481,6 +481,39 @@ void runTransactionTests() {
         expect(snapshot2.exists, isFalse);
       });
 
+      test(
+        'runs many transactions concurrently without corrupting native state',
+        () async {
+          // Regression test for
+          // https://github.com/firebase/flutterfire/issues/18417: concurrent
+          // transactions used to mutate the plugin's shared transaction map
+          // from multiple threads without synchronization, which could crash
+          // iOS with a heap-corruption SIGABRT.
+          const int count = 30;
+
+          final refs = [
+            for (var i = 0; i < count; i++)
+              firestore.doc('flutter-tests/transaction-concurrent-$i'),
+          ];
+
+          await Future.wait([
+            for (final ref in refs)
+              firestore.runTransaction((Transaction transaction) async {
+                final snapshot = await transaction.get(ref);
+                transaction.set(ref, {
+                  'value': ((snapshot.data()?['value'] as int?) ?? 0) + 1,
+                });
+              }),
+          ]);
+
+          final snapshots = await Future.wait(refs.map((ref) => ref.get()));
+          for (final snapshot in snapshots) {
+            expect(snapshot.exists, isTrue);
+            expect(snapshot.data()!['value'], isA<int>());
+          }
+        },
+      );
+
       // TODO(Lyokone): adding auth make some tests fails in macOS
       // test(
       //     'should not fail to complete transaction if user is authenticated',

--- a/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Sources/cloud_firestore/FLTFirebaseFirestorePlugin.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Sources/cloud_firestore/FLTFirebaseFirestorePlugin.m
@@ -662,7 +662,10 @@ FlutterStandardMethodCodec *_codec;
     FIRFirestore *firestore = [self getFIRFirestoreFromAppNameFromPigeon:app];
     FIRDocumentReference *document = [firestore documentWithPath:path];
 
-    FIRTransaction *transaction = self->_transactions[transactionId];
+    FIRTransaction *transaction;
+    @synchronized(self->_transactions) {
+      transaction = self->_transactions[transactionId];
+    }
 
     if (transaction == nil) {
       completion(
@@ -782,10 +785,16 @@ FlutterStandardMethodCodec *_codec;
           timeout:timeout
           maxAttempts:maxAttempts
           started:^(FIRTransaction *_Nonnull transaction) {
-            self->_transactions[transactionId] = transaction;
+            // Called from Firestore's transaction worker queue; multiple
+            // in-flight transactions may hit this concurrently.
+            @synchronized(self->_transactions) {
+              self->_transactions[transactionId] = transaction;
+            }
           }
           ended:^{
-            self->_transactions[transactionId] = nil;
+            @synchronized(self->_transactions) {
+              [self->_transactions removeObjectForKey:transactionId];
+            }
           }];
 
   _transactionHandlers[transactionId] = handler;


### PR DESCRIPTION
## Description

Running many `FirebaseFirestore.runTransaction` calls concurrently on iOS crashes the app with SIGABRT (`___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED`).

The plugin's shared `_transactions` `NSMutableDictionary` is accessed from multiple queues with no synchronization:

- **written** from Firestore's transaction worker queue via the `started:` / `ended:` listeners (`transactionCreateApp`), which run once per transaction *attempt* — contention retries amplify the parallelism;
- **read** from a global concurrent queue in `transactionGetApp`.

`NSMutableDictionary` is not thread-safe: two concurrent mutations can trip a rehash on a corrupted table and abort the process inside `mdict_rehashd`.

This PR wraps all remaining accesses in `@synchronized(self->_transactions)`, matching the synchronization already used for the same dictionary in `cleanupEventListeners`. The `ended:` path now uses `removeObjectForKey:` (equivalent to the previous subscript-nil assignment). The macOS sources symlink to the iOS files, so both platforms are covered by the same change.

Android has the identical race — `transactions` is a plain `HashMap` written from Firestore's transaction worker threads (`TransactionStreamHandler` `started` callback) and read from the plugin's cached thread pool (`transactionGet`). Switched it to `ConcurrentHashMap`.

**Testing:** added an e2e regression test (`transaction_e2e.dart`) that runs 30 transactions concurrently — exercising the concurrent `started:`/`ended:` writes and the `transactionGet` read path. Being a data race, the original crash is probabilistic rather than deterministic: the stress snippet from the issue (~150 un-awaited `runTransaction` calls targeting the same document, where contention retries amplify parallelism) reliably crashes a physical device within seconds on cloud_firestore 5.6.12 / current `main`.

## Related Issues

Fixes #18417
Same crash signature as #16899 (closed as stale); likely related to #9527.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
