### PR TITLE
docs(cloud_firestore): Remove Incorrect API Documentation For Document Creation Methods Doc() and Add()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -66,3 +66,4 @@ Horváth István <horvatska01@gmail.com>
 Liu Zhisong <liuzs0666@gmail.com>
 Ievgenii Kovtun <jeka.ns@gmail.com>
 Dinu-Stefan Rusu <rusudinustefan@gmail.com>
+Marwan Salim Ba Matraf <marwans12@hotmail.com>

--- a/packages/cloud_firestore/cloud_firestore/lib/src/collection_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/collection_reference.dart
@@ -23,18 +23,12 @@ abstract class CollectionReference<T extends Object?> implements Query<T> {
 
   /// Returns a `DocumentReference` with an auto-generated ID, after
   /// populating it with provided [data].
-  ///
-  /// The unique key generated is prefixed with a client-generated timestamp
-  /// so that the resulting list will be chronologically-sorted.
   Future<DocumentReference<T>> add(T data);
 
   /// {@template cloud_firestore.collection_reference.doc}
   /// Returns a `DocumentReference` with the provided path.
   ///
   /// If no [path] is provided, an auto-generated ID is used.
-  ///
-  /// The unique key generated is prefixed with a client-generated timestamp
-  /// so that the resulting list will be chronologically-sorted.
   /// {@endtemplate}
   DocumentReference<T> doc([String? path]);
 

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_collection_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_collection_reference.dart
@@ -43,9 +43,6 @@ abstract class CollectionReferencePlatform extends QueryPlatform {
   /// Returns a [DocumentReferencePlatform] with the provided [path].
   ///
   /// If no [path] is provided, an auto-generated ID is used.
-  ///
-  /// The unique key generated is prefixed with a client-generated timestamp
-  /// so that the resulting list will be chronologically-sorted.
   DocumentReferencePlatform doc([String? path]) {
     throw UnimplementedError('doc() is not implemented');
   }


### PR DESCRIPTION
## Description

This PR removes incorrect API documentation for Firestore's methods DocumentReference.add and DocumentReference.doc that states that the auto-generated id is prefixed with timestamp

## Related Issues

Fixes [#18422](https://github.com/firebase/flutterfire/issues/18422)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
