### PR TITLE
fix(cloud_firestore): correct auto-generated ID documentation

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/collection_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/collection_reference.dart
@@ -24,8 +24,9 @@ abstract class CollectionReference<T extends Object?> implements Query<T> {
   /// Returns a `DocumentReference` with an auto-generated ID, after
   /// populating it with provided [data].
   ///
-  /// The unique key generated is prefixed with a client-generated timestamp
-  /// so that the resulting list will be chronologically-sorted.
+  /// The auto-generated ID is a random string that does not contain a
+  /// timestamp, so documents will not be chronologically ordered by their
+  /// IDs.
   Future<DocumentReference<T>> add(T data);
 
   /// {@template cloud_firestore.collection_reference.doc}
@@ -33,8 +34,9 @@ abstract class CollectionReference<T extends Object?> implements Query<T> {
   ///
   /// If no [path] is provided, an auto-generated ID is used.
   ///
-  /// The unique key generated is prefixed with a client-generated timestamp
-  /// so that the resulting list will be chronologically-sorted.
+  /// The auto-generated ID is a random string that does not contain a
+  /// timestamp, so documents will not be chronologically ordered by their
+  /// IDs.
   /// {@endtemplate}
   DocumentReference<T> doc([String? path]);
 

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_collection_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_collection_reference.dart
@@ -44,8 +44,9 @@ abstract class CollectionReferencePlatform extends QueryPlatform {
   ///
   /// If no [path] is provided, an auto-generated ID is used.
   ///
-  /// The unique key generated is prefixed with a client-generated timestamp
-  /// so that the resulting list will be chronologically-sorted.
+  /// The auto-generated ID is a random string that does not contain a
+  /// timestamp, so documents will not be chronologically ordered by their
+  /// IDs.
   DocumentReferencePlatform doc([String? path]) {
     throw UnimplementedError('doc() is not implemented');
   }


### PR DESCRIPTION
## Description

The API documentation for `CollectionReference.add()` and `CollectionReference.doc()` incorrectly stated that auto-generated IDs are prefixed with a client-generated timestamp and that the resulting list will be chronologically-sorted. This behavior is specific to Firebase Realtime Database (`childByAutoId`/`push`), not Cloud Firestore. Firestore auto-generated IDs are random strings with no timestamp component and no ordering guarantees.

## Related Issues

Fixes #18422

## Checklist

- [x] I signed the [CLA](https://cla.developers.google.com/clas).
- [x] The title of my PR starts with a [Conventional Commit] type (`fix`).
- [x] My PR only addresses the documentation issue described in #18422.
- [x] I read the [Contributor Guide] and followed the process outlined there.
- [x] My changes only affect documentation comments (no code/behavior change).

## Changes

- `packages/cloud_firestore/cloud_firestore/lib/src/collection_reference.dart`: Updated dartdoc for `add()` and `doc()` (2 occurrences).
- `packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_collection_reference.dart`: Updated dartdoc for `doc()` (1 occurrence).

The same wording in `firebase_database` (Realtime Database) was left unchanged — for RTD, the timestamp-prefix description is correct.