### PR TITLE
fix(functions): cloud functions results only converted top-level maps

### DIFF
--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_https_callable.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_https_callable.dart
@@ -11,6 +11,18 @@ import '../../cloud_functions_platform_interface.dart';
 import 'method_channel_firebase_functions.dart';
 import 'utils/exception.dart';
 
+dynamic _convertNested(Object? value) {
+  if (value is List) {
+    return value.map(_convertNested).toList();
+  }
+  if (value is Map) {
+    return value.map<String, dynamic>(
+      (key, value) => MapEntry(key as String, _convertNested(value)),
+    );
+  }
+  return value;
+}
+
 /// Method Channel delegate for [HttpsCallablePlatform].
 class MethodChannelHttpsCallable extends HttpsCallablePlatform {
   /// Creates a new [MethodChannelHttpsCallable] instance.
@@ -38,11 +50,7 @@ class MethodChannelHttpsCallable extends HttpsCallablePlatform {
         'limitedUseAppCheckToken': options.limitedUseAppCheckToken,
       });
 
-      if (result is Map) {
-        return Map<String, dynamic>.from(result);
-      } else {
-        return result;
-      }
+      return _convertNested(result);
     } catch (e, s) {
       convertPlatformException(e, s);
     }
@@ -70,12 +78,7 @@ class MethodChannelHttpsCallable extends HttpsCallablePlatform {
         'limitedUseAppCheckToken': options.limitedUseAppCheckToken,
         'timeout': options.timeout.inMilliseconds,
       };
-      yield* channel.receiveBroadcastStream(eventData).map((message) {
-        if (message is Map) {
-          return Map<String, dynamic>.from(message);
-        }
-        return message;
-      });
+      yield* channel.receiveBroadcastStream(eventData).map(_convertNested);
     } catch (e, s) {
       convertPlatformException(e, s);
     }

--- a/packages/cloud_functions/cloud_functions_platform_interface/test/method_channel/method_channel_https_callable_test.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/test/method_channel/method_channel_https_callable_test.dart
@@ -11,13 +11,13 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../mock.dart';
+import '../pigeon/test_api.dart';
 
 void main() {
   setupFirebaseFunctionsMocks();
 
   MethodChannelFirebaseFunctions? functions;
   MethodChannelHttpsCallable? httpsCallable;
-  final List<MethodCall> logger = <MethodCall>[];
 
   // mock props
   bool mockPlatformExceptionThrown = false;
@@ -32,22 +32,15 @@ void main() {
     setUpAll(() async {
       FirebaseApp app = await Firebase.initializeApp();
 
-      handleMethodCall((call) async {
-        logger.add(call);
+      TestCloudFunctionsHostApi.setUp(_TestCloudFunctionsHostApi(() async {
         if (mockExceptionThrown) {
           throw Exception();
         } else if (mockPlatformExceptionThrown) {
           throw PlatformException(
               code: 'UNKNOWN', message: kPlatformExceptionMessage);
         }
-
-        switch (call.method) {
-          case 'FirebaseFunctions#call':
-            return kParameters;
-          default:
-            return null;
-        }
-      });
+        return kParameters;
+      }));
 
       functions =
           MethodChannelFirebaseFunctions(app: app, region: 'us-central1');
@@ -64,8 +57,6 @@ void main() {
       mockPlatformExceptionThrown = false;
       mockExceptionThrown = false;
       httpsCallable!.options = kOptions;
-
-      logger.clear();
     });
 
     group('constructor', () {
@@ -101,6 +92,22 @@ void main() {
     });
 
     group('call', () {
+      test('converts maps nested in lists', () async {
+        final originalParameters = kParameters;
+        addTearDown(() => kParameters = originalParameters);
+        kParameters = <Object?>[
+          <Object?, Object?>{'name': 'value'},
+        ];
+
+        final result = await httpsCallable!.call();
+
+        expect(result, isA<List<dynamic>>());
+        expect((result as List<dynamic>).single, isA<Map<String, dynamic>>());
+        expect(result, <dynamic>[
+          <String, dynamic>{'name': 'value'},
+        ]);
+      });
+
       test('catch an [Exception] error', () async {
         mockExceptionThrown = true;
         await testExceptionHandling('EXCEPTION', httpsCallable!.call);
@@ -114,4 +121,16 @@ void main() {
       });
     });
   });
+}
+
+class _TestCloudFunctionsHostApi implements TestCloudFunctionsHostApi {
+  _TestCloudFunctionsHostApi(this.callHandler);
+
+  final Future<Object?> Function() callHandler;
+
+  @override
+  Future<Object?> call(Map<String, Object?> arguments) => callHandler();
+
+  @override
+  Future<void> registerEventChannel(Map<String, Object> arguments) async {}
 }


### PR DESCRIPTION
## Description

Cloud Functions method-channel results only converted top-level maps to `Map<String, dynamic>`, leaving maps nested inside lists with platform-channel key types. This recursively converts nested lists and maps for callable and streaming results.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/13136

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
