### PR TITLE
fix(firestore): preserve detailed native Firestore error messages

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreException.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreException.java
@@ -219,6 +219,12 @@ public class FlutterFirebaseFirestoreException extends Exception {
       }
     }
 
+    if (nativeException != null
+        && nativeException.getMessage() != null
+        && !nativeException.getMessage().isEmpty()) {
+      message = nativeException.getMessage();
+    }
+
     this.code = code;
     this.message = message;
   }

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/document_reference_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/document_reference_e2e.dart
@@ -268,6 +268,30 @@ void runDocumentReferenceTests() {
     });
 
     group('DocumentReference.get()', () {
+      test(
+        'preserves native error messages when offline',
+        () async {
+          final document =
+              await initializeTest('document-get-server-while-offline');
+          await firestore.disableNetwork();
+          addTearDown(firestore.enableNetwork);
+
+          await expectLater(
+            document.get(const GetOptions(source: Source.server)),
+            throwsA(
+              isA<FirebaseException>()
+                  .having((error) => error.code, 'code', 'unavailable')
+                  .having(
+                    (error) => error.message,
+                    'message',
+                    contains('offline'),
+                  ),
+            ),
+          );
+        },
+        skip: kIsWeb,
+      );
+
       test('gets a document from server', () async {
         DocumentReference<Map<String, dynamic>> document =
             await initializeTest('document-get-server');

--- a/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Sources/cloud_firestore/FLTFirebaseFirestoreUtils.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Sources/cloud_firestore/FLTFirebaseFirestoreUtils.m
@@ -253,6 +253,10 @@ const NSInteger FLTFirebaseFirestoreErrorCodePipelineParse = -1;
       break;
   }
 
+  if (error.localizedDescription.length > 0) {
+    message = error.localizedDescription;
+  }
+
   return @[ code, message ];
 }
 


### PR DESCRIPTION
## Description

Firestore's Android and Apple exception converters replaced detailed native SDK error messages with generic text for each normalized error code. This preserves the native message when available while retaining FlutterFire's cross-platform error codes.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/12045

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
