### PR TITLE
feat(ai): add a list of the MIME types supported by AI Logic

### DIFF
--- a/packages/firebase_ai/firebase_ai/lib/firebase_ai.dart
+++ b/packages/firebase_ai/firebase_ai/lib/firebase_ai.dart
@@ -118,6 +118,7 @@ export 'src/live_api.dart'
         SlidingWindow,
         Transcription;
 export 'src/live_session.dart' show LiveSession;
+export 'src/mime_types.dart' show FirebaseAIMimeTypes;
 export 'src/schema.dart' show JSONSchema, Schema, SchemaType;
 export 'src/server_template/template_chat.dart'
     show TemplateChatSession, StartTemplateChatExtension;

--- a/packages/firebase_ai/firebase_ai/lib/src/mime_types.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/mime_types.dart
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// MIME types supported by Gemini multimodal models.
+///
+/// Model capabilities can vary. Check the
+/// [Firebase AI Logic documentation](https://firebase.google.com/docs/ai-logic)
+/// before relying on a MIME type for a specific model.
+abstract final class FirebaseAIMimeTypes {
+  /// Supported image MIME types.
+  static const List<String> image = <String>[
+    'image/png',
+    'image/jpeg',
+    'image/webp',
+  ];
+
+  /// Supported video MIME types.
+  static const List<String> video = <String>[
+    'video/x-flv',
+    'video/quicktime',
+    'video/mpeg',
+    'video/mpegps',
+    'video/mpg',
+    'video/mp4',
+    'video/webm',
+    'video/wmv',
+    'video/3gpp',
+  ];
+
+  /// Supported audio MIME types.
+  static const List<String> audio = <String>[
+    'audio/aac',
+    'audio/flac',
+    'audio/mp3',
+    'audio/m4a',
+    'audio/mpeg',
+    'audio/mpga',
+    'audio/mp4',
+    'audio/opus',
+    'audio/pcm',
+    'audio/wav',
+    'audio/webm',
+  ];
+
+  /// Supported document MIME types.
+  static const List<String> document = <String>[
+    'application/pdf',
+    'text/plain',
+  ];
+
+  /// All supported multimodal MIME types.
+  static const List<String> all = <String>[
+    ...image,
+    ...video,
+    ...audio,
+    ...document,
+  ];
+}

--- a/packages/firebase_ai/firebase_ai/test/mime_types_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/mime_types_test.dart
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:firebase_ai/firebase_ai.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('exposes supported MIME types by media category', () {
+    expect(
+      FirebaseAIMimeTypes.image,
+      const <String>['image/png', 'image/jpeg', 'image/webp'],
+    );
+    expect(
+      FirebaseAIMimeTypes.document,
+      const <String>['application/pdf', 'text/plain'],
+    );
+    expect(
+      FirebaseAIMimeTypes.all,
+      containsAll(<String>[
+        ...FirebaseAIMimeTypes.image,
+        ...FirebaseAIMimeTypes.video,
+        ...FirebaseAIMimeTypes.audio,
+        ...FirebaseAIMimeTypes.document,
+      ]),
+    );
+  });
+}


### PR DESCRIPTION
## Description

Adds constant lists of Firebase AI-supported MIME types grouped by image, video, audio, and document, with a combined list for general filtering.

```dart
if (FirebaseAIMimeTypes.image.contains(file.mimeType)) {
  // Handle a supported image.
}
```

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17628

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
