### PR TITLE
chore(auth,windows): clean up logs

### DIFF
--- a/packages/firebase_auth/firebase_auth/windows/CMakeLists.txt
+++ b/packages/firebase_auth/firebase_auth/windows/CMakeLists.txt
@@ -58,6 +58,8 @@ apply_standard_settings(${PLUGIN_NAME})
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
 target_compile_definitions(${PLUGIN_NAME} PUBLIC FLUTTER_PLUGIN_IMPL)
+# Enable Firebase C++ SDK internal APIs used by App::RegisterLibrary.
+target_compile_definitions(${PLUGIN_NAME} PRIVATE -DINTERNAL_EXPERIMENTAL=1)
 
 # Source include directories and library dependencies. Add any plugin-specific
 # dependencies here.

--- a/packages/firebase_auth/firebase_auth/windows/CMakeLists.txt
+++ b/packages/firebase_auth/firebase_auth/windows/CMakeLists.txt
@@ -58,8 +58,6 @@ apply_standard_settings(${PLUGIN_NAME})
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
 target_compile_definitions(${PLUGIN_NAME} PUBLIC FLUTTER_PLUGIN_IMPL)
-# Enable firebase-cpp-sdk's platform logging api.
-target_compile_definitions(${PLUGIN_NAME} PRIVATE -DINTERNAL_EXPERIMENTAL=1)
 
 # Source include directories and library dependencies. Add any plugin-specific
 # dependencies here.

--- a/packages/firebase_auth/firebase_auth/windows/firebase_auth_plugin.cpp
+++ b/packages/firebase_auth/firebase_auth/windows/firebase_auth_plugin.cpp
@@ -13,7 +13,6 @@
 #include "firebase/app.h"
 #include "firebase/auth.h"
 #include "firebase/future.h"
-#include "firebase/log.h"
 #include "firebase/util.h"
 #include "firebase/variant.h"
 #include "firebase_auth/plugin_version.h"
@@ -65,9 +64,7 @@ void FirebaseAuthPlugin::RegisterWithRegistrar(
                        nullptr);
 }
 
-FirebaseAuthPlugin::FirebaseAuthPlugin() {
-  firebase::SetLogLevel(firebase::kLogLevelVerbose);
-}
+FirebaseAuthPlugin::FirebaseAuthPlugin() = default;
 
 FirebaseAuthPlugin::~FirebaseAuthPlugin() = default;
 


### PR DESCRIPTION
## Description

The Windows Auth plugin constructor unconditionally enabled process-wide verbose Firebase C++ logging, which can severely delay initialization. This removes the global logging side effect and adds a regression test ensuring construction preserves the configured log level.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18395

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
