### PR TITLE
fix(firestore): Preserves microseconds when serializing implicit DateTime values

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/timestamp_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/timestamp_e2e.dart
@@ -48,7 +48,7 @@ void runTimestampTests() {
       final timestamp = snapshot.data()!['foo'] as Timestamp;
 
       expect(timestamp, Timestamp.fromDate(date));
-      expect(timestamp.toDate(), date);
+      expect(timestamp.microsecondsSinceEpoch, date.microsecondsSinceEpoch);
     });
 
     test('updates a $Timestamp & returns', () async {

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/timestamp_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/timestamp_e2e.dart
@@ -37,6 +37,20 @@ void runTimestampTests() {
       );
     });
 
+    test('implicitly converts a DateTime without losing microseconds',
+        () async {
+      final doc = await initializeTest('datetime-microseconds');
+      final date = DateTime.utc(2023, 11, 1, 0, 0, 0, 999, 999);
+
+      await doc.set(<String, Object?>{'foo': date});
+
+      final snapshot = await doc.get();
+      final timestamp = snapshot.data()!['foo'] as Timestamp;
+
+      expect(timestamp, Timestamp.fromDate(date));
+      expect(timestamp.toDate(), date);
+    });
+
     test('updates a $Timestamp & returns', () async {
       DocumentReference<Map<String, dynamic>> doc =
           await initializeTest('geo-point-update');

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/utils/firestore_message_codec.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/utils/firestore_message_codec.dart
@@ -62,8 +62,10 @@ class FirestoreMessageCodec extends StandardMessageCodec {
   @override
   void writeValue(WriteBuffer buffer, dynamic value) {
     if (value is DateTime) {
-      buffer.putUint8(_kDateTime);
-      buffer.putInt64(value.millisecondsSinceEpoch);
+      final Timestamp timestamp = Timestamp.fromDate(value);
+      buffer.putUint8(_kTimestamp);
+      buffer.putInt64(timestamp.seconds);
+      buffer.putInt32(timestamp.nanoseconds);
     } else if (value is Timestamp) {
       buffer.putUint8(_kTimestamp);
       buffer.putInt64(value.seconds);

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/firestore_message_codec_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/firestore_message_codec_test.dart
@@ -1,0 +1,28 @@
+// Copyright 2026, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'utils/test_firestore_message_codec.dart';
+
+void main() {
+  const TestFirestoreMessageCodec codec = TestFirestoreMessageCodec();
+
+  test('encodes DateTime without losing microseconds', () {
+    final dates = <DateTime>[
+      DateTime.utc(2023, 11, 1, 0, 0, 0, 0, 1),
+      DateTime.utc(2023, 11, 1, 0, 0, 0, 1, 1),
+      DateTime.utc(2023, 11, 1, 0, 0, 0, 999, 999),
+      DateTime.utc(1969, 12, 31, 23, 59, 59, 999, 999),
+    ];
+
+    for (final date in dates) {
+      final encoded = codec.encodeMessage(date);
+      final decoded = codec.decodeMessage(encoded);
+
+      expect(decoded, Timestamp.fromDate(date));
+    }
+  });
+}

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/utils/utils.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/utils/utils.dart
@@ -73,13 +73,18 @@ JSAny? jsify(Object? dartObject) {
   }
 
   if (dartObject is DateTime) {
-    return TimestampJsImpl.fromMillis(dartObject.millisecondsSinceEpoch.toJS)
-        as JSAny;
+    final timestamp = Timestamp.fromDate(dartObject);
+    return TimestampJsImpl(
+      timestamp.seconds.toJS,
+      timestamp.nanoseconds.toJS,
+    ) as JSAny;
   }
 
   if (dartObject is Timestamp) {
-    return TimestampJsImpl.fromMillis(dartObject.millisecondsSinceEpoch.toJS)
-        as JSAny;
+    return TimestampJsImpl(
+      dartObject.seconds.toJS,
+      dartObject.nanoseconds.toJS,
+    ) as JSAny;
   }
 
   if (dartObject is DocumentReference) {


### PR DESCRIPTION

## ## Description

Implicit `DateTime` conversion truncated Firestore timestamps to milliseconds before serialization. This preserves microseconds by encoding `DateTime` values as Timestamp seconds and nanoseconds on native platforms and web, with unit and integration regression coverage.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/12102

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
