### PR TITLE
fix(core, web): load firebase-app.js before component bundles to avoid WebKit import race

### DIFF
--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -208,28 +208,47 @@ class FirebaseCoreWeb extends FirebasePlatform {
     String version = firebaseSDKVersion;
     List<String> ignored = _ignoredServiceScripts;
 
-    await Future.wait(
-      _services.values.map((service) {
-        if (ignored.contains(service.override ?? service.name)) {
-          return Future.value();
-        }
+    Future<void> injectService(FirebaseWebService service) {
+      if (ignored.contains(service.override ?? service.name)) {
+        return Future.value();
+      }
 
-        const firestoreServiceName = 'firestore';
+      const firestoreServiceName = 'firestore';
 
-        if (service.name == firestoreServiceName) {
-          // Inject the Firestore Pipelines script. This bundle supports both
-          // Pipeline operations (Enterprise edition) and standard Firestore queries.
-          return injectSrcScript(
-            'https://www.gstatic.com/firebasejs/$version/firebase-firestore-pipelines.js',
-            'firebase_$firestoreServiceName',
-          );
-        }
-
+      if (service.name == firestoreServiceName) {
+        // Inject the Firestore Pipelines script. This bundle supports both
+        // Pipeline operations (Enterprise edition) and standard Firestore queries.
         return injectSrcScript(
-          'https://www.gstatic.com/firebasejs/$version/firebase-${service.name}.js',
-          'firebase_${service.override ?? service.name}',
+          'https://www.gstatic.com/firebasejs/$version/firebase-firestore-pipelines.js',
+          'firebase_$firestoreServiceName',
         );
-      }),
+      }
+
+      return injectSrcScript(
+        'https://www.gstatic.com/firebasejs/$version/firebase-${service.name}.js',
+        'firebase_${service.override ?? service.name}',
+      );
+    }
+
+    // Every component bundle (firebase-auth.js, firebase-messaging.js, ...)
+    // statically imports from firebase-app.js. Loading all services with
+    // concurrent dynamic import()s makes those imports race on the shared
+    // firebase-app.js module, which trips a WebKit module-evaluation defect:
+    // the returned namespace can still have its top-level bindings in the
+    // temporal dead zone, so reading firebase.SDK_VERSION right afterwards
+    // throws "ReferenceError: Cannot access 'SDK_VERSION' before
+    // initialization" (Safari/WKWebView only). Load firebase-app.js first,
+    // then fan out to the component bundles in parallel.
+    // https://github.com/firebase/flutterfire/issues/18436
+    final coreService = _services['core'];
+    if (coreService != null) {
+      await injectService(coreService);
+    }
+
+    await Future.wait(
+      _services.values
+          .where((service) => !identical(service, coreService))
+          .map(injectService),
     );
     registerLibraryVersion(_libraryName, packageVersion);
     _registerAllLibraryVersions();


### PR DESCRIPTION
## Description

Fixes #18436.

On Flutter web, `Firebase.initializeApp()` intermittently throws `ReferenceError: Cannot access 'SDK_VERSION' before initialization` in WebKit-based browsers (Safari, WKWebView, and every iOS browser), leaving apps that await it before `runApp()` on a blank page. The linked issue includes production Sentry data: 968 events across 941 users in ~2 months, 100% of them WebKit.

### Root cause

`_initializeCore()` injects one script per registered service and awaits them all in parallel with `Future.wait`. Each injection performs a dynamic `import()`, and every component bundle (`firebase-auth.js`, `firebase-messaging.js`, …) statically imports from the shared `firebase-app.js`. With N services registered, N concurrent dynamic imports converge on that shared module, and WebKit has a long-standing module-evaluation defect in exactly this situation: it can hand back a namespace whose top-level bindings are still in the temporal dead zone. Reading `firebase.SDK_VERSION` right afterwards then throws. V8 and SpiderMonkey evaluate the shared dependency correctly, which matches the zero non-WebKit events in the report.

### Fix

Load `firebase-app.js` (the `core` service) first and only then fan out to the component bundles in parallel — option 3 from the issue. This keeps the parallel loading of component bundles (no measurable startup cost) while guaranteeing the shared dependency has fully evaluated before any dependent bundle's import starts, which removes the race entirely.

The per-service injection logic is unchanged — it is only extracted into a local `injectService` closure so the core service and the remaining services go through the identical path.

### Testing

- `dart analyze` and `dart format` clean.
- `flutter test --platform chrome` passes (existing Trusted Types + exception suites).
- The race itself is probabilistic WebKit-only startup behavior and isn't reproducible in the unit harness; the fix makes the ordering deterministic by construction (a dependent bundle's import can no longer start before `firebase-app.js` has evaluated).

## Related Issues

Fixes #18436 (likely also the root cause behind the older WebKit reports #13107 / #11243).

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes a description of the change / issue fixed.
- [x] All existing and new tests are passing.
