### PR TITLE
fix(firestore,windows): Prevents lost Windows transaction responses

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/transaction_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/transaction_e2e.dart
@@ -69,6 +69,27 @@ void runTransactionTests() {
         expect(response, equals(randomValue));
       });
 
+      test(
+        'runs after reading a document',
+        () async {
+          final documentReference =
+              await initializeTest('transaction-after-get');
+          await documentReference.set({'value': 0});
+          await documentReference.get();
+
+          await firestore.runTransaction((transaction) async {
+            final snapshot = await transaction.get(documentReference);
+            transaction.update(documentReference, {
+              'value': snapshot.data()!['value'] + 1,
+            });
+          });
+
+          final snapshot = await documentReference.get();
+          expect(snapshot.data()!['value'], 1);
+        },
+        skip: defaultTargetPlatform != TargetPlatform.windows,
+      );
+
       test('should abort if thrown and not continue', () async {
         DocumentReference<Map<String, dynamic>> documentReference =
             await initializeTest('transaction-abort');

--- a/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.cpp
+++ b/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.cpp
@@ -44,6 +44,48 @@ namespace cloud_firestore_windows {
 
 static std::string kLibraryName = "flutter-fire-fst";
 
+void TransactionResponse::Reset() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  response_received_ = false;
+  commands_.clear();
+}
+
+void TransactionResponse::Complete(
+    InternalTransactionResult result,
+    std::vector<InternalTransactionCommand> commands) {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    result_ = result;
+    commands_ = std::move(commands);
+    response_received_ = true;
+  }
+  condition_.notify_one();
+}
+
+TransactionResponseStatus TransactionResponse::WaitFor(
+    std::chrono::milliseconds timeout, InternalTransactionResult& result,
+    std::vector<InternalTransactionCommand>& commands) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (!condition_.wait_for(
+          lock, timeout, [this] { return response_received_ || cancelled_; })) {
+    return TransactionResponseStatus::kTimedOut;
+  }
+  if (cancelled_) {
+    return TransactionResponseStatus::kCancelled;
+  }
+  result = result_;
+  commands = std::move(commands_);
+  return TransactionResponseStatus::kReceived;
+}
+
+void TransactionResponse::Cancel() {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    cancelled_ = true;
+  }
+  condition_.notify_one();
+}
+
 namespace {
 
 constexpr wchar_t kTaskRunnerWindowClassName[] =
@@ -996,10 +1038,7 @@ class TransactionStreamHandler
   void ReceiveTransactionResponse(
       InternalTransactionResult resultType,
       std::vector<InternalTransactionCommand> commands) {
-    std::lock_guard<std::mutex> lock(commands_mutex_);
-    resultType_ = resultType;
-    commands_ = commands;
-    cv_.notify_one();
+    response_.Complete(resultType, std::move(commands));
   }
 
   std::unique_ptr<flutter::StreamHandlerError<flutter::EncodableValue>>
@@ -1024,25 +1063,31 @@ class TransactionStreamHandler
 
               flutter::EncodableMap map;
               map.emplace("appName", firestore_->app()->name());
+              response_.Reset();
               SendSuccessOnPlatformThread(events_state_,
                                           flutter::EncodableValue(map));
 
-              std::unique_lock<std::mutex> lock(mtx_);
-              if (cv_.wait_for(lock, std::chrono::milliseconds(timeout_)) ==
-                  std::cv_status::timeout) {
-                SendErrorOnPlatformThread(events_state_, "Timeout",
-                                          "Transaction timed out.",
-                                          flutter::EncodableValue(), true);
-                return Error::kErrorDeadlineExceeded;
+              InternalTransactionResult resultType;
+              std::vector<InternalTransactionCommand> commands;
+              switch (response_.WaitFor(std::chrono::milliseconds(timeout_),
+                                        resultType, commands)) {
+                case TransactionResponseStatus::kTimedOut:
+                  SendErrorOnPlatformThread(events_state_, "Timeout",
+                                            "Transaction timed out.",
+                                            flutter::EncodableValue(), true);
+                  return Error::kErrorDeadlineExceeded;
+                case TransactionResponseStatus::kCancelled:
+                  return Error::kErrorCancelled;
+                case TransactionResponseStatus::kReceived:
+                  break;
               }
 
-              std::lock_guard<std::mutex> command_lock(commands_mutex_);
-              if (resultType_ == InternalTransactionResult::kFailure) {
+              if (resultType == InternalTransactionResult::kFailure) {
                 return Error::kErrorAborted;
               }
-              if (commands_.empty()) return Error::kErrorOk;
+              if (commands.empty()) return Error::kErrorOk;
 
-              for (InternalTransactionCommand& command : commands_) {
+              for (InternalTransactionCommand& command : commands) {
                 std::string path = command.path();
                 InternalTransactionType type = command.type();
                 if (path.empty() /* or some other invalid condition */) {
@@ -1114,8 +1159,7 @@ class TransactionStreamHandler
 
   std::unique_ptr<flutter::StreamHandlerError<flutter::EncodableValue>>
   OnCancelInternal(const flutter::EncodableValue* arguments) override {
-    std::unique_lock<std::mutex> lock(mtx_);
-    cv_.notify_one();
+    response_.Cancel();
     EndStreamOnPlatformThread(events_state_);
     return nullptr;
   }
@@ -1125,11 +1169,7 @@ class TransactionStreamHandler
   long timeout_;
   int maxAttempts_;
   std::string transactionId_;
-  std::vector<InternalTransactionCommand> commands_;
-  InternalTransactionResult resultType_ = InternalTransactionResult::kSuccess;
-  std::mutex mtx_;
-  std::mutex commands_mutex_;
-  std::condition_variable cv_;
+  TransactionResponse response_;
   std::shared_ptr<EventSinkState> events_state_;
 };
 

--- a/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.h
+++ b/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.h
@@ -11,7 +11,11 @@
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
 
+#include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
+#include <vector>
 
 #include "firebase/app.h"
 #include "firebase/firestore.h"
@@ -20,6 +24,31 @@
 #include "messages.g.h"
 
 namespace cloud_firestore_windows {
+
+enum class TransactionResponseStatus {
+  kReceived,
+  kTimedOut,
+  kCancelled,
+};
+
+class TransactionResponse {
+ public:
+  void Reset();
+  void Complete(InternalTransactionResult result,
+                std::vector<InternalTransactionCommand> commands);
+  TransactionResponseStatus WaitFor(
+      std::chrono::milliseconds timeout, InternalTransactionResult& result,
+      std::vector<InternalTransactionCommand>& commands);
+  void Cancel();
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable condition_;
+  bool response_received_ = false;
+  bool cancelled_ = false;
+  InternalTransactionResult result_ = InternalTransactionResult::kSuccess;
+  std::vector<InternalTransactionCommand> commands_;
+};
 
 class CloudFirestorePlugin : public flutter::Plugin,
                              public FirebaseFirestoreHostApi {


### PR DESCRIPTION
## Description

Firestore transactions on Windows could miss a Dart response when it arrived before the native thread began waiting, causing a timeout or crash. This uses a predicate-based synchronized response latch and adds native and integration regression coverage.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/13177

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
