### PR TITLE
fix(storage,windows): Windows list()/listAll() now throw unimplemented instead of returning misleading empty results

### DIFF
--- a/packages/firebase_storage/firebase_storage/windows/firebase_storage_plugin.cpp
+++ b/packages/firebase_storage/firebase_storage/windows/firebase_storage_plugin.cpp
@@ -470,22 +470,18 @@ void FirebaseStoragePlugin::ReferenceList(
     const InternalStorageReference& reference,
     const InternalListOptions& options,
     std::function<void(ErrorOr<InternalListResult> reply)> result) {
-  // C++ doesn't support list yet
-  flutter::EncodableList items = flutter::EncodableList();
-  flutter::EncodableList prefixs = flutter::EncodableList();
-  InternalListResult pigeon_result = InternalListResult(items, prefixs);
-  result(pigeon_result);
+  result(FlutterError(
+      "unimplemented",
+      "Listing files is not supported by the Firebase C++ SDK on Windows."));
 }
 
 void FirebaseStoragePlugin::ReferenceListAll(
     const InternalStorageFirebaseApp& app,
     const InternalStorageReference& reference,
     std::function<void(ErrorOr<InternalListResult> reply)> result) {
-  // C++ doesn't support listAll yet
-  flutter::EncodableList items = flutter::EncodableList();
-  flutter::EncodableList prefixs = flutter::EncodableList();
-  InternalListResult pigeon_result = InternalListResult(items, prefixs);
-  result(pigeon_result);
+  result(FlutterError(
+      "unimplemented",
+      "Listing files is not supported by the Firebase C++ SDK on Windows."));
 }
 
 void FirebaseStoragePlugin::ReferenceGetData(

--- a/tests/integration_test/firebase_storage/reference_e2e.dart
+++ b/tests/integration_test/firebase_storage/reference_e2e.dart
@@ -225,6 +225,28 @@ void setupReferenceTests() {
     );
 
     test(
+      'list operations report that they are unsupported on Windows',
+      () async {
+        final Reference ref = storage.ref('flutter-tests/list');
+        final unsupportedError = isA<FirebaseException>()
+            .having((error) => error.code, 'code', 'unimplemented')
+            .having(
+              (error) => error.message,
+              'message',
+              'Listing files is not supported by the Firebase C++ SDK on '
+                  'Windows.',
+            );
+
+        await expectLater(
+          ref.list(const ListOptions(maxResults: 25)),
+          throwsA(unsupportedError),
+        );
+        await expectLater(ref.listAll(), throwsA(unsupportedError));
+      },
+      skip: defaultTargetPlatform != TargetPlatform.windows,
+    );
+
+    test(
       'listAll',
       () async {
         Reference ref = storage.ref('flutter-tests/list');


### PR DESCRIPTION
## Description

Firebase Storage `list()` and `listAll()` silently returned empty results on Windows because listing is unsupported by the Firebase C++ SDK. This reports an explicit `unimplemented` error instead and adds native and integration regression coverage.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/11915

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
