### PR TITLE
fix(auth,ios): Generic OAuth credentials on iOS passed a missing access token through a non-nullable Firebase SDK selector

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
@@ -896,11 +896,18 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
   // OAuth
   if ([signInMethod isEqualToString:kSignInMethodOAuth]) {
     NSString *providerId = arguments[kArgumentProviderId];
-    completion([FIROAuthProvider credentialWithProviderID:providerId
-                                                  IDToken:idToken
-                                                 rawNonce:rawNonce
-                                              accessToken:accessToken],
-               nil);
+    FIRAuthCredential *credential;
+    if (accessToken == nil) {
+      credential = [FIROAuthProvider credentialWithProviderID:providerId
+                                                      IDToken:idToken
+                                                     rawNonce:rawNonce];
+    } else {
+      credential = [FIROAuthProvider credentialWithProviderID:providerId
+                                                      IDToken:idToken
+                                                     rawNonce:rawNonce
+                                                  accessToken:accessToken];
+    }
+    completion(credential, nil);
     return;
   }
 


### PR DESCRIPTION
## Description

Generic OAuth credentials on iOS passed a missing access token through a non-nullable Firebase SDK selector, which converted it to an empty string. This uses the selector that omits the access token when it is absent while preserving credentials that provide one.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18445

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
