### PR TITLE
docs(messaging): improve explanation around token refresh behavior

### DIFF
--- a/docs/cloud-messaging/client.md
+++ b/docs/cloud-messaging/client.md
@@ -120,24 +120,32 @@ see [Application server keys](https://developers.google.com/web/fundamentals/pus
 
 To send a message to a specific device, you need to know the device
 registration token. To retrieve the current registration token for an app instance, call
-`getToken()`. If notification permission has not been granted, this method will
-ask the user for notification permissions. Otherwise, it returns a token or
-rejects the future due to an error.
-
-Warning: In iOS SDK 10.4.0 and higher, it is required that the APNs token
-is available before making API requests. The APNs token is not guaranteed to
-have been received before making FCM plugin API requests.
+`getToken()`. This method does not request notification permission. If your app
+displays notifications, request permission explicitly:
 
 ```dart
-// You may set the permission requests to "provisional" which allows the user to choose what type
-// of notifications they would like to receive once the user receives a notification.
-final notificationSettings = await FirebaseMessaging.instance.requestPermission(provisional: true);
+final notificationSettings =
+    await FirebaseMessaging.instance.requestPermission(provisional: true);
+```
 
-// For apple platforms, ensure the APNS token is available before making any FCM plugin API calls
+Warning: In iOS SDK 10.4.0 and higher, it is required that the APNs token
+is available before retrieving the FCM token. The APNs token is not guaranteed
+to be available immediately after permission is granted. If `getAPNSToken()`
+returns `null`, wait for APNs registration to complete and try again later.
+
+```dart
+// On Apple platforms, ensure the APNs token is available before retrieving
+// the FCM token.
 final apnsToken = await FirebaseMessaging.instance.getAPNSToken();
 if (apnsToken != null) {
- // APNS token is available, make FCM plugin API requests...
+  final fcmToken = await FirebaseMessaging.instance.getToken();
 }
+```
+
+On other native platforms, retrieve the token directly:
+
+```dart
+final fcmToken = await FirebaseMessaging.instance.getToken();
 ```
 
 On web platforms, pass your VAPID public key to `getToken()`:
@@ -154,8 +162,7 @@ FirebaseMessaging.instance.onTokenRefresh
     .listen((fcmToken) {
       // TODO: If necessary send token to application server.
 
-      // Note: This callback is fired at each app startup and whenever a new
-      // token is generated.
+      // This callback is fired whenever a new token is generated.
     })
     .onError((err) {
       // Error getting token.

--- a/docs/cloud-messaging/client.md
+++ b/docs/cloud-messaging/client.md
@@ -120,13 +120,19 @@ see [Application server keys](https://developers.google.com/web/fundamentals/pus
 
 To send a message to a specific device, you need to know the device
 registration token. To retrieve the current registration token for an app instance, call
-`getToken()`. This method does not request notification permission. If your app
-displays notifications, request permission explicitly:
+`getToken()`.
+
+On Apple and Android platforms, `getToken()` does not request notification
+permission. If your app displays notifications, request permission explicitly:
 
 ```dart
 final notificationSettings =
     await FirebaseMessaging.instance.requestPermission(provisional: true);
 ```
+
+On web, `getToken()` asks for notification permission if it has not already
+been granted. You can call `requestPermission()` first if you want to control
+when the browser displays the permission prompt.
 
 Warning: In iOS SDK 10.4.0 and higher, it is required that the APNs token
 is available before retrieving the FCM token. The APNs token is not guaranteed
@@ -154,15 +160,16 @@ On web platforms, pass your VAPID public key to `getToken()`:
 final fcmToken = await FirebaseMessaging.instance.getToken(vapidKey: "BKagOny0KF_2pCJQ3m....moL0ewzQ8rZu");
 ```
 
-To be notified whenever the token is updated, subscribe to the `onTokenRefresh`
-stream:
+On Apple and Android platforms, subscribe to the `onTokenRefresh` stream to be
+notified whenever a token is generated or refreshed. The stream does not emit
+at every app startup. On web, `onTokenRefresh` is a no-op stream.
 
 ```dart
 FirebaseMessaging.instance.onTokenRefresh
     .listen((fcmToken) {
       // TODO: If necessary send token to application server.
 
-      // This callback is fired whenever a new token is generated.
+      // This callback is fired whenever a token is generated or refreshed.
     })
     .onError((err) {
       // Error getting token.

--- a/docs/cloud-messaging/first-message.md
+++ b/docs/cloud-messaging/first-message.md
@@ -53,10 +53,12 @@ Notifications console to complete this tutorial, make sure to copy the token
 or securely store it after you retrieve it.
 
 To retrieve the current registration token for an app instance, call
-`getToken()`. This method does not request notification permission. Call
-`requestPermission()` explicitly before retrieving the token if your app
-displays notifications. On Apple platforms, also ensure that `getAPNSToken()`
-returns a non-null APNs token before calling `getToken()`.
+`getToken()`. On Apple and Android platforms, this method does not request
+notification permission. On web, it requests permission if permission has not
+already been granted. To keep the flow explicit and consistent across
+platforms, call `requestPermission()` before retrieving the token. On Apple
+platforms, also ensure that `getAPNSToken()` returns a non-null APNs token
+before calling `getToken()`.
 
 ```dart
 await FirebaseMessaging.instance.requestPermission();

--- a/docs/cloud-messaging/first-message.md
+++ b/docs/cloud-messaging/first-message.md
@@ -53,11 +53,14 @@ Notifications console to complete this tutorial, make sure to copy the token
 or securely store it after you retrieve it.
 
 To retrieve the current registration token for an app instance, call
-`getToken()`. If notification permission has not been granted, this method will
-ask the user for notification permissions. Otherwise, it returns a token or
-rejects the future due to an error.
+`getToken()`. This method does not request notification permission. Call
+`requestPermission()` explicitly before retrieving the token if your app
+displays notifications. On Apple platforms, also ensure that `getAPNSToken()`
+returns a non-null APNs token before calling `getToken()`.
 
 ```dart
+await FirebaseMessaging.instance.requestPermission();
+// On Apple platforms, run this only after getAPNSToken() returns non-null.
 final fcmToken = await FirebaseMessaging.instance.getToken();
 ```
 


### PR DESCRIPTION
## Description

The FCM guides incorrectly stated that `getToken()` requests notification permission and that `onTokenRefresh` fires at every app startup. This documents the explicit permission flow, Apple APNs token prerequisite, and actual token refresh behavior.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/12676

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
