### PR TITLE
fix(remote_config): restores the Apple error mapping and accepts both throttling status spellings

### DIFF
--- a/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Sources/firebase_remote_config/FirebaseRemoteConfigPlugin.swift
+++ b/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Sources/firebase_remote_config/FirebaseRemoteConfigPlugin.swift
@@ -289,7 +289,7 @@ public class FirebaseRemoteConfigPlugin: NSObject, FlutterPlugin, FlutterStreamH
     return FlutterError(
       code: "firebase_remote_config",
       message: nsError.localizedDescription,
-      details: nsError.userInfo["details"]
+      details: FLTFirebaseRemoteConfigUtils.errorCodeAndMessage(from: nsError)
     )
   }
 

--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/lib/src/method_channel/method_channel_firebase_remote_config.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/lib/src/method_channel/method_channel_firebase_remote_config.dart
@@ -94,6 +94,7 @@ class MethodChannelFirebaseRemoteConfig extends FirebaseRemoteConfigPlatform {
       case 'failure':
         return RemoteConfigFetchStatus.failure;
       case 'throttle':
+      case 'throttled':
         return RemoteConfigFetchStatus.throttle;
       default:
         return RemoteConfigFetchStatus.noFetchYet;

--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/test/method_channel/method_channel_firebase_remote_config_test.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/test/method_channel/method_channel_firebase_remote_config_test.dart
@@ -1,0 +1,20 @@
+// Copyright 2026, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:firebase_remote_config_platform_interface/firebase_remote_config_platform_interface.dart';
+import 'package:firebase_remote_config_platform_interface/src/method_channel/method_channel_firebase_remote_config.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('parses native throttled fetch status', () {
+    final remoteConfig =
+        MethodChannelFirebaseRemoteConfig.instance.setInitialValues(
+      remoteConfigValues: <String, Object?>{
+        'lastFetchStatus': 'throttled',
+      },
+    );
+
+    expect(remoteConfig.lastFetchStatus, RemoteConfigFetchStatus.throttle);
+  });
+}


### PR DESCRIPTION
## Description

The Apple Pigeon migration stopped attaching Remote Config's structured error details, causing native errors to reach Dart with an `unknown` code. Native Apple and Android implementations also emit `"throttled"` while the Dart platform interface only recognized `"throttle"`.

This restores the Apple error mapping and accepts both throttling status spellings so callers can reliably handle or filter fetch failures.

## Related Issues

- Relates to https://github.com/firebase/flutterfire/issues/10904

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
