### PR TITLE
fix(firestore,windows): reply on platform thread to prevent warnings

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.cpp
+++ b/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.cpp
@@ -173,6 +173,15 @@ class PlatformThreadDispatcher {
   std::queue<std::function<void()>> tasks_;
 };
 
+template <typename T>
+void ReplyOnPlatformThread(std::function<void(ErrorOr<T>)> result,
+                           ErrorOr<T> reply) {
+  PlatformThreadDispatcher::GetInstance().Post(
+      [result = std::move(result), reply = std::move(reply)]() mutable {
+        result(std::move(reply));
+      });
+}
+
 struct EventSinkState {
   std::mutex mutex;
   std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> events;
@@ -1603,11 +1612,14 @@ void CloudFirestorePlugin::QueryGet(
         if (completed_future.error() == firebase::firestore::kErrorOk) {
           const firebase::firestore::QuerySnapshot* querySnapshot =
               completed_future.result();
-          result(ParseQuerySnapshot(querySnapshot,
-                                    GetServerTimestampBehaviorFromPigeon(
-                                        options.server_timestamp_behavior())));
+          ReplyOnPlatformThread<InternalQuerySnapshot>(
+              result,
+              ParseQuerySnapshot(querySnapshot,
+                                 GetServerTimestampBehaviorFromPigeon(
+                                     options.server_timestamp_behavior())));
         } else {
-          result(CloudFirestorePlugin::ParseError(completed_future));
+          ReplyOnPlatformThread<InternalQuerySnapshot>(
+              result, CloudFirestorePlugin::ParseError(completed_future));
         }
       });
 }


### PR DESCRIPTION
## Description

Firestore `Query.get()` completions on Windows replied to Flutter directly from Firebase worker threads. Repeated paginated reads amplified this unsafe platform-channel path, which can cause data loss or crashes.

This routes both successful query snapshots and query errors through the existing Windows platform-thread dispatcher before sending the Pigeon reply.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17073
- Related to https://github.com/firebase/flutterfire/issues/11933

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
