### PR TITLE
docs: fix code snippets that do not compile

### DIFF
--- a/docs/auth/email-link-auth.md
+++ b/docs/auth/email-link-auth.md
@@ -99,7 +99,6 @@ To initiate the authentication flow, present an interface that prompts the user 
             email: emailAuth, actionCodeSettings: acs)
         .catchError((onError) => print('Error sending email verification $onError'))
         .then((value) => print('Successfully sent email verification'));
-    });
     ```
 
 

--- a/docs/perf-mon/_custom-code-traces.md
+++ b/docs/perf-mon/_custom-code-traces.md
@@ -151,7 +151,7 @@ Note the following:
   not use this type of custom attribute in your app):
 
   ```dart
-  customTrace.putAttribute(("email", user.getEmailAddress());  // Don't do this!
+  customTrace.putAttribute("email", user.getEmailAddress());  // Don't do this!
   ```
 
   Data that exposes any personally identifiable information is subject to

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase_app.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase_app.dart
@@ -11,7 +11,7 @@ part of '../../firebase_core_platform_interface.dart';
 /// instance, for example:
 ///
 /// ```dart
-/// Firebase.app('SecondaryApp`);
+/// Firebase.app('SecondaryApp');
 /// ```
 class MethodChannelFirebaseApp extends FirebaseAppPlatform {
   // ignore: public_member_api_docs

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_app_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_app_web.dart
@@ -7,11 +7,11 @@ part of '../firebase_core_web.dart';
 
 /// The entry point for accessing a Firebase app instance.
 ///
-/// To get an instance, call the the `app` method on the [FirebaseCore]
+/// To get an instance, call the `app` method on the [FirebaseCore]
 /// instance, for example:
 ///
 /// ```dart
-/// Firebase.app('SecondaryApp`);
+/// Firebase.app('SecondaryApp');
 /// ```
 class FirebaseAppWeb extends FirebaseAppPlatform {
   FirebaseAppWeb._(String name, FirebaseOptions options) : super(name, options);


### PR DESCRIPTION
Four documentation snippets do not parse as written. Each was verified with `dart format --output=none`: the block fails to parse before the change and parses after it.

### Dartdoc — unterminated string

`packages/firebase_core/firebase_core_web/lib/src/firebase_app_web.dart:14`
`packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase_app.dart:14`

```diff
-/// Firebase.app('SecondaryApp`);
+/// Firebase.app('SecondaryApp');
```

Both files close the string with a backtick instead of `'`. Same line, same typo, presumably copied between the two.

The web file also says "call **the the** `app` method" one line above, fixed here too.

### `docs/perf-mon/_custom-code-traces.md:154` — doubled paren

```diff
-customTrace.putAttribute(("email", user.getEmailAddress());  // Don't do this!
+customTrace.putAttribute("email", user.getEmailAddress());  // Don't do this!
```

To be explicit about intent: the "Don't do this!" warning is about putting personally identifiable information in an attribute, not about the syntax — the "OK" example seven lines above is `putAttribute("experiment", "A");` with a single paren. The extra `(` is unintended.

### `docs/auth/email-link-auth.md:102` — leftover closing

```diff
     .then((value) => print('Successfully sent email verification'));
-});
```

The statement already terminates with `;` on the previous line; the `});` has no matching opener inside the block.

### How I found them

I extracted every fenced code block and `///` doc comment across the repo and checked paren/bracket balance outside strings and comments, then read each hit in context to separate real typos from intentional fragments. Docs-only change — no behaviour, no tests affected.
