### PR TITLE
fix(firestore, android): clean up Android transaction listeners on completion

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -277,6 +277,28 @@ public class FlutterFirebaseFirestorePlugin
     return identifier;
   }
 
+  private void removeEventListener(String identifier) {
+    synchronized (eventChannels) {
+      EventChannel eventChannel = eventChannels.remove(identifier);
+      if (eventChannel != null) {
+        eventChannel.setStreamHandler(null);
+      }
+    }
+
+    synchronized (streamHandlers) {
+      StreamHandler streamHandler = streamHandlers.remove(identifier);
+      if (streamHandler != null) {
+        streamHandler.onCancel(null);
+      }
+    }
+  }
+
+  private void removeTransaction(String transactionId) {
+    transactions.remove(transactionId);
+    removeEventListener(transactionId);
+    transactionHandlers.remove(transactionId);
+  }
+
   private void removeEventListeners() {
     synchronized (eventChannels) {
       for (String identifier : eventChannels.keySet()) {
@@ -292,6 +314,7 @@ public class FlutterFirebaseFirestorePlugin
       streamHandlers.clear();
     }
 
+    transactions.clear();
     transactionHandlers.clear();
   }
 
@@ -560,6 +583,7 @@ public class FlutterFirebaseFirestorePlugin
     final TransactionStreamHandler handler =
         new TransactionStreamHandler(
             transaction -> transactions.put(transactionId, transaction),
+            this::removeTransaction,
             firestore,
             transactionId,
             timeout,

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -600,8 +600,13 @@ public class FlutterFirebaseFirestorePlugin
       @NonNull GeneratedAndroidFirebaseFirestore.InternalTransactionResult resultType,
       @Nullable List<GeneratedAndroidFirebaseFirestore.InternalTransactionCommand> commands,
       @NonNull GeneratedAndroidFirebaseFirestore.VoidResult result) {
-    Objects.requireNonNull(transactionHandlers.get(transactionId))
-        .receiveTransactionResponse(resultType, commands);
+    OnTransactionResultListener handler = transactionHandlers.get(transactionId);
+    if (handler == null) {
+      result.success();
+      return;
+    }
+
+    handler.receiveTransactionResponse(resultType, commands);
     result.success();
   }
 

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/TransactionStreamHandler.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/TransactionStreamHandler.java
@@ -38,7 +38,13 @@ public class TransactionStreamHandler implements OnTransactionResultListener, St
     void onStarted(Transaction transaction);
   }
 
+  /** Callback when the transaction has reached a terminal state. */
+  public interface OnTransactionCompleteListener {
+    void onComplete(String transactionId);
+  }
+
   final OnTransactionStartedListener onTransactionStartedListener;
+  final OnTransactionCompleteListener onTransactionCompleteListener;
   final FirebaseFirestore firestore;
   final String transactionId;
   final Long timeout;
@@ -47,11 +53,13 @@ public class TransactionStreamHandler implements OnTransactionResultListener, St
 
   public TransactionStreamHandler(
       OnTransactionStartedListener onTransactionStartedListener,
+      OnTransactionCompleteListener onTransactionCompleteListener,
       FirebaseFirestore firestore,
       String transactionId,
       Long timeout,
       Long maxAttempts) {
     this.onTransactionStartedListener = onTransactionStartedListener;
+    this.onTransactionCompleteListener = onTransactionCompleteListener;
     this.firestore = firestore;
     this.transactionId = transactionId;
     this.timeout = timeout;
@@ -178,6 +186,7 @@ public class TransactionStreamHandler implements OnTransactionResultListener, St
                   () -> {
                     events.success(map);
                     events.endOfStream();
+                    onTransactionCompleteListener.onComplete(transactionId);
                   });
             });
   }

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/transaction_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/transaction_e2e.dart
@@ -214,6 +214,35 @@ void runTransactionTests() {
       });
 
       test(
+        'runs many sequential transactions with large payloads',
+        () async {
+          DocumentReference<Map<String, dynamic>> doc =
+              await initializeTest('transaction-cleanup-stress');
+          final payload = <String, Object?>{
+            for (var i = 0; i < 100; i++) 'field_$i': 'x' * 100,
+          };
+
+          await doc.set({'count': 0, ...payload});
+
+          for (var i = 0; i < 100; i++) {
+            await firestore.runTransaction((transaction) async {
+              final snapshot = await transaction.get(doc);
+              final count = snapshot.data()!['count'] as int;
+
+              transaction.update(doc, {
+                'count': count + 1,
+                ...payload,
+              });
+            });
+          }
+
+          final snapshot = await doc.get();
+          expect(snapshot.data()!['count'], 100);
+        },
+        skip: kIsWeb,
+      );
+
+      test(
         'should abort if timeout is exceeded',
         () async {
           await expectLater(

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_firestore.dart
@@ -246,16 +246,20 @@ class MethodChannelFirebaseFirestore extends FirebaseFirestorePlatform {
     ).listen(
       (event) async {
         if (event['error'] != null) {
-          completer.completeError(
-            FirebaseException(
-              plugin: 'cloud_firestore',
-              code: event['error']['code'],
-              message: event['error']['message'],
-            ),
-          );
+          if (!completer.isCompleted) {
+            completer.completeError(
+              FirebaseException(
+                plugin: 'cloud_firestore',
+                code: event['error']['code'],
+                message: event['error']['message'],
+              ),
+            );
+          }
           return;
         } else if (event['complete'] == true) {
-          completer.complete(result);
+          if (!completer.isCompleted) {
+            completer.complete(result);
+          }
           return;
         }
 
@@ -271,6 +275,10 @@ class MethodChannelFirebaseFirestore extends FirebaseFirestorePlatform {
         try {
           result = await transactionHandler(transaction) as T;
         } catch (error, stack) {
+          if (completer.isCompleted) {
+            return;
+          }
+
           // Signal native that a user error occurred, and finish the
           // transaction
           await pigeonChannel.transactionStoreResult(
@@ -283,6 +291,10 @@ class MethodChannelFirebaseFirestore extends FirebaseFirestorePlatform {
 
           completer.completeError(error, stack);
 
+          return;
+        }
+
+        if (completer.isCompleted) {
           return;
         }
 


### PR DESCRIPTION
## Description

Fixes an Android memory leak in `cloud_firestore` transactions where native transaction state was retained after `runTransaction` completed.
Previously, each Android transaction registered transaction-specific state including an `EventChannel`, `StreamHandler`, transaction handler, and transaction reference, but that state was only cleared during full plugin cleanup. Apps that ran many transactions over time could therefore retain completed transaction resources indefinitely.
This change adds per-transaction cleanup when the transaction stream completes, removing the associated transaction, event channel, stream handler, and transaction result handler.

## Related Issues
Fixes https://github.com/firebase/flutterfire/issues/18474

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
