### PR TITLE
feat(sql_connect): add "X-Client-Platform" and "X-Client-Version" headers

### DIFF
--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
@@ -85,7 +85,9 @@ class RestTransport implements DataConnectTransport {
       'Content-Type': 'application/json',
       'Accept': 'application/json',
       'x-goog-api-client': getGoogApiVal(sdkType, packageVersion),
-      'x-firebase-client': getFirebaseClientVal(packageVersion)
+      'x-firebase-client': getFirebaseClientVal(packageVersion),
+      'x-client-platform': 'flutter',
+      'x-client-version': packageVersion,
     };
     String? appCheckToken;
     try {

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/websocket_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/websocket_transport.dart
@@ -192,10 +192,16 @@ class WebSocketTransport implements DataConnectTransport {
 
   bool get isConnected => _channel != null;
 
+  @visibleForTesting
+  Map<String, String> buildHeaders(String? authToken, String? appCheckToken) =>
+      _buildHeaders(authToken, appCheckToken);
+
   Map<String, String> _buildHeaders(String? authToken, String? appCheckToken) {
     Map<String, String> headers = {
       'x-goog-api-client': getGoogApiVal(sdkType, packageVersion),
-      'x-firebase-client': getFirebaseClientVal(packageVersion)
+      'x-firebase-client': getFirebaseClientVal(packageVersion),
+      'x-client-platform': 'flutter',
+      'x-client-version': packageVersion
     };
     if (authToken != null) {
       headers['X-Firebase-Auth-Token'] = authToken;

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.dart
@@ -277,6 +277,80 @@ void main() {
     });
 
     test(
+        'invokeOperation should include x-client-platform headers',
+        () async {
+      final mockResponse = http.Response('{"data": {"key": "value"}}', 200);
+      when(
+        mockHttpClient.post(
+          any,
+          headers: anyNamed('headers'),
+          body: anyNamed('body'),
+        ),
+      ).thenAnswer((_) async => mockResponse);
+
+      String deserializer(String data) => 'Deserialized Data';
+
+      await transport.invokeOperation(
+        'testQuery',
+        'executeQuery',
+        deserializer,
+        null,
+        null,
+        'authToken123',
+      );
+
+      verify(
+        mockHttpClient.post(
+          any,
+          headers: argThat(
+            allOf(
+              containsPair('x-client-platform', 'flutter'),
+            ),
+            named: 'headers',
+          ),
+          body: anyNamed('body'),
+        ),
+      ).called(1);
+    });
+
+    test(
+        'invokeOperation should include x-client-version headers',
+        () async {
+      final mockResponse = http.Response('{"data": {"key": "value"}}', 200);
+      when(
+        mockHttpClient.post(
+          any,
+          headers: anyNamed('headers'),
+          body: anyNamed('body'),
+        ),
+      ).thenAnswer((_) async => mockResponse);
+
+      String deserializer(String data) => 'Deserialized Data';
+
+      await transport.invokeOperation(
+        'testQuery',
+        'executeQuery',
+        deserializer,
+        null,
+        null,
+        'authToken123',
+      );
+
+      verify(
+        mockHttpClient.post(
+          any,
+          headers: argThat(
+            allOf(
+              containsPair('x-client-version', packageVersion),
+            ),
+            named: 'headers',
+          ),
+          body: anyNamed('body'),
+        ),
+      ).called(1);
+    });
+
+    test(
         'regression #17290 - invokeOperation should correctly decode UTF-8 response with international characters',
         () async {
       // Simulate a server response with Korean characters, where the

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.dart
@@ -276,9 +276,7 @@ void main() {
       ).called(1);
     });
 
-    test(
-        'invokeOperation should include x-client-platform headers',
-        () async {
+    test('invokeOperation should include x-client-platform headers', () async {
       final mockResponse = http.Response('{"data": {"key": "value"}}', 200);
       when(
         mockHttpClient.post(
@@ -313,9 +311,7 @@ void main() {
       ).called(1);
     });
 
-    test(
-        'invokeOperation should include x-client-version headers',
-        () async {
+    test('invokeOperation should include x-client-version headers', () async {
       final mockResponse = http.Response('{"data": {"key": "value"}}', 200);
       when(
         mockHttpClient.post(


### PR DESCRIPTION
This PR adds `x-client-platform` and `x-client-version` request headers to `firebase_data_connect`. These headers supply the client platform (`flutter`) and SDK version (`packageVersion`) to enable metrics collection in Cloud Monitoring.

**NOTE**: Shortly after merging this PR, it was decided to delete the `x-client-platform` header and merge its value into `x-client-version`. See https://github.com/firebase/flutterfire/pull/18502 for details.

### Highlights

* **New Metadata Headers**: Added `x-client-platform` (set to `"flutter"`) and `x-client-version` (set to `packageVersion`) request headers across REST (`rest_transport.dart`) and WebSocket (`websocket_transport.dart`) transports.
* **Unit Tests**: Added unit tests in `rest_transport_test.dart` to verify `x-client-platform` and `x-client-version` headers are attached on outgoing requests.

<details>

<summary><b>Changelog</b></summary>

* **rest_transport.dart**
  * Added `x-client-platform` and `x-client-version` headers to `invokeOperation`.
* **websocket_transport.dart**
  * Added `x-client-platform` and `x-client-version` headers to `_buildHeaders` and exposed `buildHeaders` for testing.
* **rest_transport_test.dart**
  * Added unit tests asserting `x-client-platform` and `x-client-version` headers are included in REST requests.
</details>
