### PR TITLE
fix(sql_connect): non-subscribed queries should be tracked

### DIFF
--- a/packages/firebase_data_connect/firebase_data_connect/example/integration_test/listen_e2e.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/example/integration_test/listen_e2e.dart
@@ -102,7 +102,7 @@ void runListenTests() {
             expect(movies.length, 0,
                 reason: 'First emission should contain an empty list');
             isReady.complete();
-          } else {
+          } else if (count == 1) {
             expect(movies.length, 1,
                 reason: 'Second emission should contain one movie');
             expect(movies[0].title, 'The Matrix',

--- a/packages/firebase_data_connect/firebase_data_connect/example/integration_test/listen_e2e.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/example/integration_test/listen_e2e.dart
@@ -87,8 +87,8 @@ void runListenTests() {
         expect(initialValue.data.movies.length, 0,
             reason: 'Initial movie list should be empty');
 
-        final Completer<void> isReady = Completer<void>();
-        final Completer<bool> hasBeenListened = Completer<bool>();
+        final initialMovies = Completer<List<ListMoviesMovies>>();
+        final updatedMovies = Completer<List<ListMoviesMovies>>();
         int count = 0;
 
         final listener1 = MoviesConnector.instance
@@ -97,20 +97,14 @@ void runListenTests() {
             .subscribe()
             .listen((value) {
           final movies = value.data.movies;
-
-          if (count == 0) {
-            expect(movies.length, 0,
-                reason: 'First emission should contain an empty list');
-            isReady.complete();
-          } else if (count == 1) {
-            expect(movies.length, 1,
-                reason: 'Second emission should contain one movie');
-            expect(movies[0].title, 'The Matrix',
-                reason: 'The movie should be The Matrix');
-            hasBeenListened.complete(true);
+          if (count == 0 && !initialMovies.isCompleted) {
+            initialMovies.complete(movies);
+          } else if (count == 1 && !updatedMovies.isCompleted) {
+            updatedMovies.complete(movies);
           }
           count++;
         });
+
         int listener2Count = 0;
         final listener2 = MoviesConnector.instance
             .listMovies()
@@ -120,8 +114,10 @@ void runListenTests() {
           listener2Count++;
         });
 
-        // Wait for the listener to be ready
-        await isReady.future;
+        // Wait for the listener to receive initial empty list
+        final initial = await initialMovies.future.timeout(_listenTimeout);
+        expect(initial, isEmpty,
+            reason: 'First emission should contain an empty list');
 
         // Create the movie
         await MoviesConnector.instance
@@ -137,13 +133,16 @@ void runListenTests() {
         await MoviesConnector.instance.listMovies().ref().execute();
 
         // Wait for the listener to receive the movie update
-        final bool hasListenerReceived = await hasBeenListened.future;
+        final movies = await updatedMovies.future.timeout(_listenTimeout);
+        expect(movies, hasLength(1),
+            reason: 'Second emission should contain one movie');
+        expect(movies.single.title, 'The Matrix',
+            reason: 'The movie should be The Matrix');
 
-        // Cancel the listener and wait for it to finish
+        // Cancel listener1 and verify listener1 stops receiving events while listener2 continues
         await listener1.cancel();
-        expect(hasListenerReceived, isTrue,
-            reason: 'The stream should have emitted new data');
-        // Create the movie
+
+        // Create a second movie
         await MoviesConnector.instance
             .createMovie(
               genre: 'Adventure',
@@ -153,9 +152,15 @@ void runListenTests() {
             .rating(4.5)
             .ref()
             .execute();
-        await Future.delayed(const Duration(seconds: 5));
-        expect(count, equals(2));
-        expect(listener2Count, equals(3));
+
+        await MoviesConnector.instance.listMovies().ref().execute();
+        await Future.delayed(const Duration(seconds: 2));
+
+        expect(count, equals(2),
+            reason: 'listener1 should not receive events after cancellation');
+        expect(listener2Count, equals(3),
+            reason: 'listener2 should continue receiving events');
+
         await listener2.cancel();
       });
     },

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
@@ -144,7 +144,7 @@ class FirebaseDataConnect extends FirebasePlugin {
     if (ref != null) {
       return ref;
     } else {
-      return QueryRef<Data, Variables>(
+      final newRef = QueryRef<Data, Variables>(
         this,
         operationName,
         transport!,
@@ -153,6 +153,8 @@ class FirebaseDataConnect extends FirebasePlugin {
         varsSerializer,
         vars,
       );
+      _queryManager.trackedQueries[queryId] = newRef;
+      return newRef;
     }
   }
 

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
@@ -86,8 +86,7 @@ class RestTransport implements DataConnectTransport {
       'Accept': 'application/json',
       'x-goog-api-client': getGoogApiVal(sdkType, packageVersion),
       'x-firebase-client': getFirebaseClientVal(packageVersion),
-      'x-client-platform': 'flutter',
-      'x-client-version': packageVersion,
+      'x-client-version': packageVersion
     };
     String? appCheckToken;
     try {

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/websocket_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/websocket_transport.dart
@@ -200,7 +200,6 @@ class WebSocketTransport implements DataConnectTransport {
     Map<String, String> headers = {
       'x-goog-api-client': getGoogApiVal(sdkType, packageVersion),
       'x-firebase-client': getFirebaseClientVal(packageVersion),
-      'x-client-platform': 'flutter',
       'x-client-version': packageVersion
     };
     if (authToken != null) {

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/core/ref_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/core/ref_test.dart
@@ -101,6 +101,48 @@ void main() {
       expect(queryManager.trackedQueries.values.contains(ref), isTrue);
       expect(stream, isA<StreamController>());
     });
+
+    test(
+        'addQuery stream controller broadcast should remain active when one subscriber cancels and remove trackedQuery when all subscribers cancel',
+        () {
+      String deserializer(String data) => 'Deserialized Data';
+      String varSerializer(Object? _) => 'varsAsStr';
+
+      QueryRef ref = QueryRef(
+        mockDataConnect,
+        'testQuery',
+        MockDataConnectTransport(),
+        deserializer,
+        queryManager,
+        varSerializer,
+        'variables',
+      );
+
+      final controller = queryManager.addQuery(ref);
+      final stream = controller.stream;
+
+      int eventsReceived1 = 0;
+      int eventsReceived2 = 0;
+
+      final sub1 = stream.listen((_) {
+        eventsReceived1++;
+      });
+      final sub2 = stream.listen((_) {
+        eventsReceived2++;
+      });
+
+      expect(queryManager.trackedQueries[ref.operationId], equals(ref));
+
+      sub1.cancel();
+
+      // trackedQuery should still exist because sub2 is active
+      expect(queryManager.trackedQueries[ref.operationId], equals(ref));
+
+      sub2.cancel();
+
+      // now that all subscribers cancelled, trackedQuery should be removed
+      expect(queryManager.trackedQueries[ref.operationId], isNull);
+    });
   });
 
   group('MutationRef', () {

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/firebase_data_connect_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/firebase_data_connect_test.dart
@@ -127,7 +127,9 @@ void main() {
       expect(dataConnect.transport, isNotNull);
     });
 
-    test('query method returns QueryRef', () {
+    test(
+        'query method returns identical QueryRef instance for same operation and variables',
+        () {
       final dataConnect = FirebaseDataConnect(
         app: mockApp,
         connectorConfig: mockConnectorConfig,
@@ -135,14 +137,22 @@ void main() {
         appCheck: mockAppCheck,
       );
 
-      final queryRef = dataConnect.query(
+      final queryRef1 = dataConnect.query(
         'operationName',
         (json) => json,
         (variables) => variables.toString(),
         null,
       );
 
-      expect(queryRef, isA<QueryRef>());
+      final queryRef2 = dataConnect.query(
+        'operationName',
+        (json) => json,
+        (variables) => variables.toString(),
+        null,
+      );
+
+      expect(queryRef1, isA<QueryRef>());
+      expect(queryRef2, same(queryRef1));
     });
 
     test('mutation method returns MutationRef', () {


### PR DESCRIPTION
QueryRefs should be reused even if queries are non-subscribed. Previously we would only track if a user called subscribe, but that caused multiple queryrefs to be created.

Added new tests to validate fix. 
