### PR TITLE
fix(remote_config,windows): move CMake dependency from Core to Remote Config

### DIFF
--- a/packages/firebase_core/firebase_core/windows/CMakeLists.txt
+++ b/packages/firebase_core/firebase_core/windows/CMakeLists.txt
@@ -133,7 +133,7 @@ foreach(firebase_lib IN ITEMS ${FIREBASE_RELEASE_PATH_LIBS})
 endforeach()
 
 set(FIREBASE_LIBS firebase_app)
-set(ADDITIONAL_LIBS advapi32 ws2_32 crypt32 rpcrt4 ole32 icu)
+set(ADDITIONAL_LIBS advapi32 ws2_32 crypt32 rpcrt4 ole32)
 
 target_link_libraries(${PLUGIN_NAME} PUBLIC "${FIREBASE_LIBS}" "${ADDITIONAL_LIBS}")
 

--- a/packages/firebase_remote_config/firebase_remote_config/windows/CMakeLists.txt
+++ b/packages/firebase_remote_config/firebase_remote_config/windows/CMakeLists.txt
@@ -64,7 +64,7 @@ target_compile_definitions(${PLUGIN_NAME} PRIVATE -DINTERNAL_EXPERIMENTAL=1)
 # Source include directories and library dependencies. Add any plugin-specific
 # dependencies here.
 set(MSVC_RUNTIME_MODE MD)
-set(firebase_libs firebase_core_plugin firebase_remote_config)
+set(firebase_libs firebase_core_plugin firebase_remote_config icu)
 target_link_libraries(${PLUGIN_NAME} PRIVATE "${firebase_libs}")
 
 target_include_directories(${PLUGIN_NAME} INTERFACE


### PR DESCRIPTION
## Description

Stops `firebase_core` from publicly linking ICU on Windows, which caused core-only applications to fail when `icu.lib` was unavailable. ICU remains linked by `firebase_remote_config`, the Firebase C++ component that requires it.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/13394

## Local Verification

- `git diff --check` passed.
- Windows compilation was not run locally and remains for CI.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
