### PR TITLE
fix(sql_connect): queries are not single instanced for execute

### DIFF
--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/core/ref.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/core/ref.dart
@@ -359,6 +359,7 @@ class QueryRef<Data, Variables> extends OperationRef<Data, Variables> {
     _serverStreamSubscription?.cancel();
     _serverStreamSubscription = null;
     _serverStream = null;
+    _streamController = null;
   }
 
   Stream<QueryResult<Data, Variables>> subscribe() {

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/firebase_data_connect.dart
@@ -144,7 +144,7 @@ class FirebaseDataConnect extends FirebasePlugin {
     if (ref != null) {
       return ref;
     } else {
-      return QueryRef<Data, Variables>(
+      final newRef = QueryRef<Data, Variables>(
         this,
         operationName,
         transport!,
@@ -153,6 +153,8 @@ class FirebaseDataConnect extends FirebasePlugin {
         varsSerializer,
         vars,
       );
+      _queryManager.trackedQueries[queryId] = newRef;
+      return newRef;
     }
   }
 

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/firebase_data_connect_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/firebase_data_connect_test.dart
@@ -254,5 +254,38 @@ void main() {
       expect(routingTransport.websocket.auth, equals(mockAuth));
       expect(routingTransport.websocket.appCheck, equals(mockAppCheck));
     });
+
+    test('query returns identical QueryRef instance for identical queries', () {
+      final dynamicApp = DynamicMockFirebaseApp(
+        name: 'queryRefAppName',
+        options: const FirebaseOptions(
+          apiKey: 'fake_api_key',
+          appId: 'fake_app_id',
+          messagingSenderId: 'fake_messaging_sender_id',
+          projectId: 'fake_project_id',
+        ),
+      );
+
+      final instance = FirebaseDataConnect(
+        app: dynamicApp,
+        connectorConfig: mockConnectorConfig,
+      );
+
+      final ref1 = instance.query(
+        'listMovies',
+        (json) => json,
+        emptySerializer,
+        null,
+      );
+
+      final ref2 = instance.query(
+        'listMovies',
+        (json) => json,
+        emptySerializer,
+        null,
+      );
+
+      expect(identical(ref1, ref2), isTrue);
+    });
   });
 }


### PR DESCRIPTION
QueryRefs are not single instanced when calling execute so queryrefs get overwritten when first subscribe is called resulting in orphaned queryrefs created for execute. 
