### PR TITLE
feat(sql_connect): merge "X-Client-Platform" header into "X-Client-Version"

### DIFF
--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/rest_transport.dart
@@ -86,8 +86,7 @@ class RestTransport implements DataConnectTransport {
       'Accept': 'application/json',
       'x-goog-api-client': getGoogApiVal(sdkType, packageVersion),
       'x-firebase-client': getFirebaseClientVal(packageVersion),
-      'x-client-platform': 'flutter',
-      'x-client-version': packageVersion,
+      'x-client-version': 'flutter/$packageVersion',
     };
     String? appCheckToken;
     try {

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/websocket_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/websocket_transport.dart
@@ -200,8 +200,7 @@ class WebSocketTransport implements DataConnectTransport {
     Map<String, String> headers = {
       'x-goog-api-client': getGoogApiVal(sdkType, packageVersion),
       'x-firebase-client': getFirebaseClientVal(packageVersion),
-      'x-client-platform': 'flutter',
-      'x-client-version': packageVersion
+      'x-client-version': 'flutter/$packageVersion',
     };
     if (authToken != null) {
       headers['X-Firebase-Auth-Token'] = authToken;

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/network/rest_transport_test.dart
@@ -276,41 +276,6 @@ void main() {
       ).called(1);
     });
 
-    test('invokeOperation should include x-client-platform headers', () async {
-      final mockResponse = http.Response('{"data": {"key": "value"}}', 200);
-      when(
-        mockHttpClient.post(
-          any,
-          headers: anyNamed('headers'),
-          body: anyNamed('body'),
-        ),
-      ).thenAnswer((_) async => mockResponse);
-
-      String deserializer(String data) => 'Deserialized Data';
-
-      await transport.invokeOperation(
-        'testQuery',
-        'executeQuery',
-        deserializer,
-        null,
-        null,
-        'authToken123',
-      );
-
-      verify(
-        mockHttpClient.post(
-          any,
-          headers: argThat(
-            allOf(
-              containsPair('x-client-platform', 'flutter'),
-            ),
-            named: 'headers',
-          ),
-          body: anyNamed('body'),
-        ),
-      ).called(1);
-    });
-
     test('invokeOperation should include x-client-version headers', () async {
       final mockResponse = http.Response('{"data": {"key": "value"}}', 200);
       when(
@@ -337,7 +302,7 @@ void main() {
           any,
           headers: argThat(
             allOf(
-              containsPair('x-client-version', packageVersion),
+              containsPair('x-client-version', 'flutter/$packageVersion'),
             ),
             named: 'headers',
           ),


### PR DESCRIPTION
This PR updates the gRPC metadata in `firebase_data_connect ` by merging the `X-Client-Platform` header into the `X-Client-Version` header (formatting as `flutter/<version>`) and removing the standalone `X-Client-Platform` header.

This is an update to PR https://github.com/firebase/flutterfire/pull/18484 which was merged yesterday and added both of these headers. This update was made to accommodate the firebase-js-sdk because the "X-Client-Platform" header causes the CORS OPTIONS preflight request to fail with a 403 "Permission Denied" error due to that header being absent from Google's list of whitelisted CORS headers. See https://github.com/firebase/firebase-js-sdk/pull/10217 for a few more details, if interested. Note that this exact problem affects this flutter sdk when running in a web browser, so the fix is critical here in this repository too.

### Highlights

* **Header Consolidation**: Merged the platform identifier into the `X-Client-Version` header (e.g. `flutter/<version>`) and removed the separate `X-Client-Platform` (`x-client-platform`) header.
* **Test Updates**: Updated test suites to verify the new `X-Client-Version` header value format.
