### PR TITLE
feat(app_check): support Apple reCAPTCHA site keys

### DIFF
--- a/packages/firebase_app_check/firebase_app_check/android/src/main/kotlin/io/flutter/plugins/firebase/appcheck/FirebaseAppCheckPlugin.kt
+++ b/packages/firebase_app_check/firebase_app_check/android/src/main/kotlin/io/flutter/plugins/firebase/appcheck/FirebaseAppCheckPlugin.kt
@@ -53,6 +53,7 @@ class FirebaseAppCheckPlugin : FlutterFirebasePlugin, FlutterPlugin, FirebaseApp
       androidProvider: String?,
       appleProvider: String?,
       debugToken: String?,
+      appleProviderSiteKey: String?,
       callback: (Result<Unit>) -> Unit
   ) {
     try {

--- a/packages/firebase_app_check/firebase_app_check/android/src/main/kotlin/io/flutter/plugins/firebase/appcheck/GeneratedAndroidFirebaseAppCheck.g.kt
+++ b/packages/firebase_app_check/firebase_app_check/android/src/main/kotlin/io/flutter/plugins/firebase/appcheck/GeneratedAndroidFirebaseAppCheck.g.kt
@@ -257,6 +257,7 @@ interface FirebaseAppCheckHostApi {
       androidProvider: String?,
       appleProvider: String?,
       debugToken: String?,
+      appleProviderSiteKey: String?,
       callback: (Result<Unit>) -> Unit
   )
 
@@ -306,15 +307,20 @@ interface FirebaseAppCheckHostApi {
             val androidProviderArg = args[1] as String?
             val appleProviderArg = args[2] as String?
             val debugTokenArg = args[3] as String?
-            api.activate(appNameArg, androidProviderArg, appleProviderArg, debugTokenArg) {
-                result: Result<Unit> ->
-              val error = result.exceptionOrNull()
-              if (error != null) {
-                reply.reply(GeneratedAndroidFirebaseAppCheckPigeonUtils.wrapError(error))
-              } else {
-                reply.reply(GeneratedAndroidFirebaseAppCheckPigeonUtils.wrapResult(null))
-              }
-            }
+            val appleProviderSiteKeyArg = args[4] as String?
+            api.activate(
+                appNameArg,
+                androidProviderArg,
+                appleProviderArg,
+                debugTokenArg,
+                appleProviderSiteKeyArg) { result: Result<Unit> ->
+                  val error = result.exceptionOrNull()
+                  if (error != null) {
+                    reply.reply(GeneratedAndroidFirebaseAppCheckPigeonUtils.wrapError(error))
+                  } else {
+                    reply.reply(GeneratedAndroidFirebaseAppCheckPigeonUtils.wrapResult(null))
+                  }
+                }
           }
         } else {
           channel.setMessageHandler(null)

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FirebaseAppCheckMessages.g.swift
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FirebaseAppCheckMessages.g.swift
@@ -27,12 +27,13 @@ final class PigeonError: Error {
   }
 
   var localizedDescription: String {
-    "PigeonError(code: \(code), message: \(message ?? "<nil>"), details: \(details ?? "<nil>")"
+    return
+      "PigeonError(code: \(code), message: \(message ?? "<nil>"), details: \(details ?? "<nil>")"
   }
 }
 
 private func wrapResult(_ result: Any?) -> [Any?] {
-  [result]
+  return [result]
 }
 
 private func wrapError(_ error: Any) -> [Any?] {
@@ -58,7 +59,7 @@ private func wrapError(_ error: Any) -> [Any?] {
 }
 
 private func isNullish(_ value: Any?) -> Bool {
-  value is NSNull || value == nil
+  return value is NSNull || value == nil
 }
 
 private func nilOrValue<T>(_ value: Any?) -> T? {
@@ -67,7 +68,7 @@ private func nilOrValue<T>(_ value: Any?) -> T? {
 }
 
 private func doubleEqualsFirebaseAppCheckMessages(_ lhs: Double, _ rhs: Double) -> Bool {
-  (lhs.isNaN && rhs.isNaN) || lhs == rhs
+  return (lhs.isNaN && rhs.isNaN) || lhs == rhs
 }
 
 private func doubleHashFirebaseAppCheckMessages(_ value: Double, _ hasher: inout Hasher) {
@@ -144,7 +145,7 @@ func deepEqualsFirebaseAppCheckMessages(_ lhs: Any?, _ rhs: Any?) -> Bool {
 
 func deepHashFirebaseAppCheckMessages(value: Any?, hasher: inout Hasher) {
   let cleanValue = nilOrValue(value) as Any?
-  if let cleanValue {
+  if let cleanValue = cleanValue {
     if let doubleValue = cleanValue as? Double {
       doubleHashFirebaseAppCheckMessages(doubleValue, &hasher)
     } else if let valueList = cleanValue as? [Any?] {
@@ -178,7 +179,7 @@ func deepHashFirebaseAppCheckMessages(value: Any?, hasher: inout Hasher) {
 /// Generated class from Pigeon that represents data sent in messages.
 struct InternalAppCheckTokenResult: Hashable {
   var token: String
-  var expirationTimestamp: Int64?
+  var expirationTimestamp: Int64? = nil
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> InternalAppCheckTokenResult? {
@@ -190,23 +191,18 @@ struct InternalAppCheckTokenResult: Hashable {
       expirationTimestamp: expirationTimestamp
     )
   }
-
   func toList() -> [Any?] {
-    [
+    return [
       token,
       expirationTimestamp,
     ]
   }
-
   static func == (lhs: InternalAppCheckTokenResult, rhs: InternalAppCheckTokenResult) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
     return deepEqualsFirebaseAppCheckMessages(lhs.token, rhs.token)
-      && deepEqualsFirebaseAppCheckMessages(
-        lhs.expirationTimestamp,
-        rhs.expirationTimestamp
-      )
+      && deepEqualsFirebaseAppCheckMessages(lhs.expirationTimestamp, rhs.expirationTimestamp)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -220,7 +216,7 @@ private class FirebaseAppCheckMessagesPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
     case 129:
-      return InternalAppCheckTokenResult.fromList(readValue() as! [Any?])
+      return InternalAppCheckTokenResult.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -240,29 +236,26 @@ private class FirebaseAppCheckMessagesPigeonCodecWriter: FlutterStandardWriter {
 
 private class FirebaseAppCheckMessagesPigeonCodecReaderWriter: FlutterStandardReaderWriter {
   override func reader(with data: Data) -> FlutterStandardReader {
-    FirebaseAppCheckMessagesPigeonCodecReader(data: data)
+    return FirebaseAppCheckMessagesPigeonCodecReader(data: data)
   }
 
   override func writer(with data: NSMutableData) -> FlutterStandardWriter {
-    FirebaseAppCheckMessagesPigeonCodecWriter(data: data)
+    return FirebaseAppCheckMessagesPigeonCodecWriter(data: data)
   }
 }
 
 class FirebaseAppCheckMessagesPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendable {
-  static let shared =
-    FirebaseAppCheckMessagesPigeonCodec(
-      readerWriter: FirebaseAppCheckMessagesPigeonCodecReaderWriter()
-    )
+  static let shared = FirebaseAppCheckMessagesPigeonCodec(
+    readerWriter: FirebaseAppCheckMessagesPigeonCodecReaderWriter())
 }
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol FirebaseAppCheckHostApi {
   func activate(
-    appName: String, androidProvider: String?, appleProvider: String?,
-    debugToken: String?, completion: @escaping (Result<Void, Error>) -> Void)
+    appName: String, androidProvider: String?, appleProvider: String?, debugToken: String?,
+    appleProviderSiteKey: String?, completion: @escaping (Result<Void, Error>) -> Void)
   func getToken(
-    appName: String, forceRefresh: Bool,
-    completion: @escaping (Result<String?, Error>) -> Void)
+    appName: String, forceRefresh: Bool, completion: @escaping (Result<String?, Error>) -> Void)
   func getTokenResult(
     appName: String, forceRefresh: Bool,
     completion: @escaping (Result<InternalAppCheckTokenResult?, Error>) -> Void)
@@ -271,18 +264,13 @@ protocol FirebaseAppCheckHostApi {
     completion: @escaping (Result<Void, Error>) -> Void)
   func registerTokenListener(appName: String, completion: @escaping (Result<String, Error>) -> Void)
   func getLimitedUseAppCheckToken(
-    appName: String,
-    completion: @escaping (Result<String, Error>) -> Void)
+    appName: String, completion: @escaping (Result<String, Error>) -> Void)
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
 class FirebaseAppCheckHostApiSetup {
-  static var codec: FlutterStandardMessageCodec {
-    FirebaseAppCheckMessagesPigeonCodec.shared
-  }
-
-  /// Sets up an instance of `FirebaseAppCheckHostApi` to handle messages through the
-  /// `binaryMessenger`.
+  static var codec: FlutterStandardMessageCodec { FirebaseAppCheckMessagesPigeonCodec.shared }
+  /// Sets up an instance of `FirebaseAppCheckHostApi` to handle messages through the `binaryMessenger`.
   static func setUp(
     binaryMessenger: FlutterBinaryMessenger, api: FirebaseAppCheckHostApi?,
     messageChannelSuffix: String = ""
@@ -291,21 +279,18 @@ class FirebaseAppCheckHostApiSetup {
     let activateChannel = FlutterBasicMessageChannel(
       name:
         "dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.activate\(channelSuffix)",
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
-    if let api {
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
       activateChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let appNameArg = args[0] as! String
         let androidProviderArg: String? = nilOrValue(args[1])
         let appleProviderArg: String? = nilOrValue(args[2])
         let debugTokenArg: String? = nilOrValue(args[3])
+        let appleProviderSiteKeyArg: String? = nilOrValue(args[4])
         api.activate(
-          appName: appNameArg,
-          androidProvider: androidProviderArg,
-          appleProvider: appleProviderArg,
-          debugToken: debugTokenArg
+          appName: appNameArg, androidProvider: androidProviderArg, appleProvider: appleProviderArg,
+          debugToken: debugTokenArg, appleProviderSiteKey: appleProviderSiteKeyArg
         ) { result in
           switch result {
           case .success:
@@ -321,10 +306,8 @@ class FirebaseAppCheckHostApiSetup {
     let getTokenChannel = FlutterBasicMessageChannel(
       name:
         "dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getToken\(channelSuffix)",
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
-    if let api {
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
       getTokenChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let appNameArg = args[0] as! String
@@ -344,10 +327,8 @@ class FirebaseAppCheckHostApiSetup {
     let getTokenResultChannel = FlutterBasicMessageChannel(
       name:
         "dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getTokenResult\(channelSuffix)",
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
-    if let api {
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
       getTokenResultChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let appNameArg = args[0] as! String
@@ -367,17 +348,14 @@ class FirebaseAppCheckHostApiSetup {
     let setTokenAutoRefreshEnabledChannel = FlutterBasicMessageChannel(
       name:
         "dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.setTokenAutoRefreshEnabled\(channelSuffix)",
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
-    if let api {
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
       setTokenAutoRefreshEnabledChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let appNameArg = args[0] as! String
         let isTokenAutoRefreshEnabledArg = args[1] as! Bool
         api.setTokenAutoRefreshEnabled(
-          appName: appNameArg,
-          isTokenAutoRefreshEnabled: isTokenAutoRefreshEnabledArg
+          appName: appNameArg, isTokenAutoRefreshEnabled: isTokenAutoRefreshEnabledArg
         ) { result in
           switch result {
           case .success:
@@ -393,10 +371,8 @@ class FirebaseAppCheckHostApiSetup {
     let registerTokenListenerChannel = FlutterBasicMessageChannel(
       name:
         "dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.registerTokenListener\(channelSuffix)",
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
-    if let api {
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
       registerTokenListenerChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let appNameArg = args[0] as! String
@@ -415,10 +391,8 @@ class FirebaseAppCheckHostApiSetup {
     let getLimitedUseAppCheckTokenChannel = FlutterBasicMessageChannel(
       name:
         "dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getLimitedUseAppCheckToken\(channelSuffix)",
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
-    if let api {
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
       getLimitedUseAppCheckTokenChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let appNameArg = args[0] as! String

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FirebaseAppCheckPlugin.swift
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FirebaseAppCheckPlugin.swift
@@ -64,7 +64,7 @@ public class FirebaseAppCheckPlugin: NSObject, FlutterPlugin,
 
   func activate(
     appName: String, androidProvider: String?, appleProvider: String?,
-    debugToken: String?,
+    debugToken: String?, appleProviderSiteKey: String?,
     completion: @escaping (Result<Void, Error>) -> Void
   ) {
     guard let app = FLTFirebasePlugin.firebaseAppNamed(appName) else {
@@ -79,10 +79,24 @@ public class FirebaseAppCheckPlugin: NSObject, FlutterPlugin,
     }
     let provider = appleProvider ?? "deviceCheck"
 
+    if provider == "recaptcha", appleProviderSiteKey?.isEmpty ?? true {
+      completion(
+        .failure(
+          FlutterError(
+            code: "invalid-argument",
+            message: "A siteKey must be provided when using AppleReCaptchaProvider.",
+            details: nil
+          )
+        )
+      )
+      return
+    }
+
     providerFactory?.configure(
       app: app,
       providerName: provider,
-      debugToken: debugToken
+      debugToken: debugToken,
+      siteKey: appleProviderSiteKey
     )
 
     completion(.success(()))
@@ -319,7 +333,8 @@ class FlutterAppCheckProviderFactory: NSObject, AppCheckProviderFactory {
       wrapper.configure(
         app: app,
         providerName: "deviceCheck",
-        debugToken: nil
+        debugToken: nil,
+        siteKey: nil
       )
       providers[app.name] = wrapper
     }
@@ -329,7 +344,8 @@ class FlutterAppCheckProviderFactory: NSObject, AppCheckProviderFactory {
   func configure(
     app: FirebaseApp,
     providerName: String,
-    debugToken: String?
+    debugToken: String?,
+    siteKey: String?
   ) {
     if providers[app.name] == nil {
       providers[app.name] = AppCheckProviderWrapper()
@@ -337,7 +353,8 @@ class FlutterAppCheckProviderFactory: NSObject, AppCheckProviderFactory {
     providers[app.name]?.configure(
       app: app,
       providerName: providerName,
-      debugToken: debugToken
+      debugToken: debugToken,
+      siteKey: siteKey
     )
   }
 }
@@ -348,7 +365,8 @@ class AppCheckProviderWrapper: NSObject, AppCheckProvider {
   func configure(
     app: FirebaseApp,
     providerName: String,
-    debugToken: String?
+    debugToken: String?,
+    siteKey: String?
   ) {
     switch providerName {
     case "debug":
@@ -373,10 +391,12 @@ class AppCheckProviderWrapper: NSObject, AppCheckProvider {
       }
     case "recaptcha":
       #if os(iOS)
-        delegateProvider = RecaptchaProvider(app: app)
+        if let siteKey {
+          delegateProvider = RecaptchaProvider(app: app, siteKey: siteKey)
+        }
         if delegateProvider == nil {
           print(
-            "Firebase App Check: failed to initialize RecaptchaProvider. Ensure site key is in GoogleService-Info.plist."
+            "Firebase App Check: failed to initialize RecaptchaProvider. Ensure a valid site key is provided."
           )
         }
       #else

--- a/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
@@ -71,6 +71,7 @@ class FirebaseAppCheck extends FirebasePlugin implements FirebaseService {
   /// **iOS/macOS**: The default provider is "device check". Use `providerApple`
   /// to configure alternative providers such as "app attest", debug providers, or
   /// "app attest with fallback to device check" via `AppleAppCheckProvider`.
+  /// Apple reCAPTCHA requires passing a site key to `AppleReCaptchaProvider`.
   /// Note: App Attest is only available on iOS 14.0+ and macOS 14.0+.
   ///
   /// **Windows**: Only the debug provider is supported. You **must** supply a

--- a/packages/firebase_app_check/firebase_app_check/windows/firebase_app_check_plugin.cpp
+++ b/packages/firebase_app_check/firebase_app_check/windows/firebase_app_check_plugin.cpp
@@ -166,6 +166,7 @@ FirebaseAppCheckPlugin::~FirebaseAppCheckPlugin() {
 void FirebaseAppCheckPlugin::Activate(
     const std::string& app_name, const std::string* android_provider,
     const std::string* apple_provider, const std::string* debug_token,
+    const std::string* apple_provider_site_key,
     std::function<void(std::optional<FlutterError> reply)> result) {
   // On Windows/desktop, only the Debug provider is available.
   DebugAppCheckProviderFactory* factory =

--- a/packages/firebase_app_check/firebase_app_check/windows/firebase_app_check_plugin.h
+++ b/packages/firebase_app_check/firebase_app_check/windows/firebase_app_check_plugin.h
@@ -43,6 +43,7 @@ class FirebaseAppCheckPlugin : public flutter::Plugin,
   void Activate(
       const std::string& app_name, const std::string* android_provider,
       const std::string* apple_provider, const std::string* debug_token,
+      const std::string* apple_provider_site_key,
       std::function<void(std::optional<FlutterError> reply)> result) override;
   void GetToken(const std::string& app_name, bool force_refresh,
                 std::function<void(ErrorOr<std::optional<std::string>> reply)>

--- a/packages/firebase_app_check/firebase_app_check/windows/messages.g.cpp
+++ b/packages/firebase_app_check/firebase_app_check/windows/messages.g.cpp
@@ -396,8 +396,13 @@ void FirebaseAppCheckHostApi::SetUp(
               const auto& encodable_debug_token_arg = args.at(3);
               const auto* debug_token_arg =
                   std::get_if<std::string>(&encodable_debug_token_arg);
+              const auto& encodable_apple_provider_site_key_arg = args.at(4);
+              const auto* apple_provider_site_key_arg =
+                  std::get_if<std::string>(
+                      &encodable_apple_provider_site_key_arg);
               api->Activate(app_name_arg, android_provider_arg,
                             apple_provider_arg, debug_token_arg,
+                            apple_provider_site_key_arg,
                             [reply](std::optional<FlutterError>&& output) {
                               if (output.has_value()) {
                                 reply(WrapError(output.value()));

--- a/packages/firebase_app_check/firebase_app_check/windows/messages.g.h
+++ b/packages/firebase_app_check/firebase_app_check/windows/messages.g.h
@@ -118,6 +118,7 @@ class FirebaseAppCheckHostApi {
   virtual void Activate(
       const std::string& app_name, const std::string* android_provider,
       const std::string* apple_provider, const std::string* debug_token,
+      const std::string* apple_provider_site_key,
       std::function<void(std::optional<FlutterError> reply)> result) = 0;
   virtual void GetToken(
       const std::string& app_name, bool force_refresh,

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/apple_providers.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/apple_providers.dart
@@ -57,7 +57,10 @@ class AppleAppAttestWithDeviceCheckFallbackProvider
 
 /// reCAPTCHA provider for Apple platforms.
 ///
-/// The site key is retrieved automatically from GoogleService-Info.plist.
+/// Requires the reCAPTCHA site key from the Firebase console.
 class AppleReCaptchaProvider extends AppleAppCheckProvider {
-  const AppleReCaptchaProvider() : super('recaptcha');
+  const AppleReCaptchaProvider(this.siteKey) : super('recaptcha');
+
+  /// The reCAPTCHA site key for this Apple app.
+  final String siteKey;
 }

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/method_channel/method_channel_firebase_app_check.dart
@@ -133,6 +133,7 @@ class MethodChannelFirebaseAppCheck extends FirebaseAppCheckPlatform {
           providerApple: providerApple,
           providerWindows: providerWindows,
         ),
+        providerApple is AppleReCaptchaProvider ? providerApple.siteKey : null,
       );
     } on PlatformException catch (e, s) {
       convertPlatformException(e, s);

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/pigeon/messages.pigeon.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/pigeon/messages.pigeon.dart
@@ -13,9 +13,9 @@ import 'package:flutter/services.dart';
 import 'package:meta/meta.dart' show immutable, protected, visibleForTesting;
 
 Object? _extractReplyValueOrThrow(
-    List<Object?>? replyList,
-    String channelName, {
-    required bool isNullValid,
+  List<Object?>? replyList,
+  String channelName, {
+  required bool isNullValid,
 }) {
   if (replyList == null) {
     throw PlatformException(
@@ -99,7 +99,6 @@ int _deepHash(Object? value) {
   return value.hashCode;
 }
 
-
 class InternalAppCheckTokenResult {
   InternalAppCheckTokenResult({
     required this.token,
@@ -118,7 +117,8 @@ class InternalAppCheckTokenResult {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static InternalAppCheckTokenResult decode(Object result) {
     result as List<Object?>;
@@ -131,20 +131,21 @@ class InternalAppCheckTokenResult {
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! InternalAppCheckTokenResult || other.runtimeType != runtimeType) {
+    if (other is! InternalAppCheckTokenResult ||
+        other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(token, other.token) && _deepEquals(expirationTimestamp, other.expirationTimestamp);
+    return _deepEquals(token, other.token) &&
+        _deepEquals(expirationTimestamp, other.expirationTimestamp);
   }
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
 }
-
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -153,7 +154,7 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    }    else if (value is InternalAppCheckTokenResult) {
+    } else if (value is InternalAppCheckTokenResult) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
     } else {
@@ -176,124 +177,145 @@ class FirebaseAppCheckHostApi {
   /// Constructor for [FirebaseAppCheckHostApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  FirebaseAppCheckHostApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+  FirebaseAppCheckHostApi(
+      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
       : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+        pigeonVar_messageChannelSuffix =
+            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
 
   final String pigeonVar_messageChannelSuffix;
 
-  Future<void> activate(String appName, String? androidProvider, String? appleProvider, String? debugToken, String? appleProviderSiteKey) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.activate$pigeonVar_messageChannelSuffix';
+  Future<void> activate(
+      String appName,
+      String? androidProvider,
+      String? appleProvider,
+      String? debugToken,
+      String? appleProviderSiteKey) async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.activate$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[appName, androidProvider, appleProvider, debugToken, appleProviderSiteKey]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
+        .send(<Object?>[
+      appName,
+      androidProvider,
+      appleProvider,
+      debugToken,
+      appleProviderSiteKey
+    ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-    )
-    ;
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   Future<String?> getToken(String appName, bool forceRefresh) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getToken$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getToken$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[appName, forceRefresh]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[appName, forceRefresh]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-    )
-    ;
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
     return pigeonVar_replyValue as String?;
   }
 
-  Future<InternalAppCheckTokenResult?> getTokenResult(String appName, bool forceRefresh) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getTokenResult$pigeonVar_messageChannelSuffix';
+  Future<InternalAppCheckTokenResult?> getTokenResult(
+      String appName, bool forceRefresh) async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getTokenResult$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[appName, forceRefresh]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[appName, forceRefresh]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-    )
-    ;
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
     return pigeonVar_replyValue as InternalAppCheckTokenResult?;
   }
 
-  Future<void> setTokenAutoRefreshEnabled(String appName, bool isTokenAutoRefreshEnabled) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.setTokenAutoRefreshEnabled$pigeonVar_messageChannelSuffix';
+  Future<void> setTokenAutoRefreshEnabled(
+      String appName, bool isTokenAutoRefreshEnabled) async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.setTokenAutoRefreshEnabled$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[appName, isTokenAutoRefreshEnabled]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[appName, isTokenAutoRefreshEnabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-    )
-    ;
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   Future<String> registerTokenListener(String appName) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.registerTokenListener$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.registerTokenListener$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[appName]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[appName]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: false,
-    )
-    ;
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: false,
+    );
     return pigeonVar_replyValue! as String;
   }
 
   Future<String> getLimitedUseAppCheckToken(String appName) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getLimitedUseAppCheckToken$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getLimitedUseAppCheckToken$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[appName]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[appName]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: false,
-    )
-    ;
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: false,
+    );
     return pigeonVar_replyValue! as String;
   }
 }

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/pigeon/messages.pigeon.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/pigeon/messages.pigeon.dart
@@ -13,9 +13,9 @@ import 'package:flutter/services.dart';
 import 'package:meta/meta.dart' show immutable, protected, visibleForTesting;
 
 Object? _extractReplyValueOrThrow(
-  List<Object?>? replyList,
-  String channelName, {
-  required bool isNullValid,
+    List<Object?>? replyList,
+    String channelName, {
+    required bool isNullValid,
 }) {
   if (replyList == null) {
     throw PlatformException(
@@ -99,6 +99,7 @@ int _deepHash(Object? value) {
   return value.hashCode;
 }
 
+
 class InternalAppCheckTokenResult {
   InternalAppCheckTokenResult({
     required this.token,
@@ -117,8 +118,7 @@ class InternalAppCheckTokenResult {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static InternalAppCheckTokenResult decode(Object result) {
     result as List<Object?>;
@@ -131,21 +131,20 @@ class InternalAppCheckTokenResult {
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! InternalAppCheckTokenResult ||
-        other.runtimeType != runtimeType) {
+    if (other is! InternalAppCheckTokenResult || other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(token, other.token) &&
-        _deepEquals(expirationTimestamp, other.expirationTimestamp);
+    return _deepEquals(token, other.token) && _deepEquals(expirationTimestamp, other.expirationTimestamp);
   }
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
 }
+
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -154,7 +153,7 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    } else if (value is InternalAppCheckTokenResult) {
+    }    else if (value is InternalAppCheckTokenResult) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
     } else {
@@ -177,135 +176,124 @@ class FirebaseAppCheckHostApi {
   /// Constructor for [FirebaseAppCheckHostApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  FirebaseAppCheckHostApi(
-      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+  FirebaseAppCheckHostApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
       : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix =
-            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
 
   final String pigeonVar_messageChannelSuffix;
 
-  Future<void> activate(String appName, String? androidProvider,
-      String? appleProvider, String? debugToken) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.activate$pigeonVar_messageChannelSuffix';
+  Future<void> activate(String appName, String? androidProvider, String? appleProvider, String? debugToken, String? appleProviderSiteKey) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.activate$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
-        .send(<Object?>[appName, androidProvider, appleProvider, debugToken]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[appName, androidProvider, appleProvider, debugToken, appleProviderSiteKey]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
   }
 
   Future<String?> getToken(String appName, bool forceRefresh) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getToken$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getToken$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[appName, forceRefresh]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[appName, forceRefresh]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
     return pigeonVar_replyValue as String?;
   }
 
-  Future<InternalAppCheckTokenResult?> getTokenResult(
-      String appName, bool forceRefresh) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getTokenResult$pigeonVar_messageChannelSuffix';
+  Future<InternalAppCheckTokenResult?> getTokenResult(String appName, bool forceRefresh) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getTokenResult$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[appName, forceRefresh]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[appName, forceRefresh]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
     return pigeonVar_replyValue as InternalAppCheckTokenResult?;
   }
 
-  Future<void> setTokenAutoRefreshEnabled(
-      String appName, bool isTokenAutoRefreshEnabled) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.setTokenAutoRefreshEnabled$pigeonVar_messageChannelSuffix';
+  Future<void> setTokenAutoRefreshEnabled(String appName, bool isTokenAutoRefreshEnabled) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.setTokenAutoRefreshEnabled$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[appName, isTokenAutoRefreshEnabled]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[appName, isTokenAutoRefreshEnabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
   }
 
   Future<String> registerTokenListener(String appName) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.registerTokenListener$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.registerTokenListener$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[appName]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[appName]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as String;
   }
 
   Future<String> getLimitedUseAppCheckToken(String appName) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getLimitedUseAppCheckToken$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channelName = 'dev.flutter.pigeon.firebase_app_check_platform_interface.FirebaseAppCheckHostApi.getLimitedUseAppCheckToken$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[appName]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[appName]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as String;
   }
 }

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/platform_interface/platform_interface_firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/platform_interface/platform_interface_firebase_app_check.dart
@@ -65,6 +65,7 @@ abstract class FirebaseAppCheckPlatform extends PlatformInterface {
   /// **iOS/macOS**: The default provider is "device check". Use `providerApple`
   /// to configure alternative providers such as "app attest", debug providers, or
   /// "app attest with fallback to device check" via `AppleAppCheckProvider`.
+  /// Apple reCAPTCHA requires passing a site key to `AppleReCaptchaProvider`.
   /// Note: App Attest is only available on iOS 14.0+ and macOS 14.0+.
   ///
   /// **Windows**: Only the debug provider is supported. You **must** supply a

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/pigeons/messages.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/pigeons/messages.dart
@@ -40,6 +40,7 @@ abstract class FirebaseAppCheckHostApi {
     String? androidProvider,
     String? appleProvider,
     String? debugToken,
+    String? appleProviderSiteKey,
   );
 
   @async

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/test/method_channel_tests/method_channel_firebase_app_check_test.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/test/method_channel_tests/method_channel_firebase_app_check_test.dart
@@ -147,6 +147,7 @@ void main() {
 
         expect(calls, hasLength(1));
         expect(calls.single[3], 'apple-debug-token');
+        expect(calls.single[4], isNull);
       });
 
       test('passes the Android debug token on Android', () async {
@@ -179,6 +180,7 @@ void main() {
 
         expect(calls, hasLength(1));
         expect(calls.single[3], 'android-debug-token');
+        expect(calls.single[4], isNull);
       });
     });
 
@@ -207,6 +209,7 @@ void main() {
         expect(log.length, 1);
         expect(log[0][0], '[DEFAULT]'); // appName
         expect(log[0][1], 'recaptcha'); // androidProvider
+        expect(log[0][4], isNull); // appleProviderSiteKey
       });
 
       test('passes recaptcha on iOS', () async {
@@ -228,12 +231,13 @@ void main() {
         );
 
         await appCheck.activate(
-          providerApple: const AppleReCaptchaProvider(),
+          providerApple: const AppleReCaptchaProvider('apple-site-key'),
         );
 
         expect(log.length, 1);
         expect(log[0][0], '[DEFAULT]'); // appName
         expect(log[0][2], 'recaptcha'); // appleProvider
+        expect(log[0][4], 'apple-site-key'); // appleProviderSiteKey
       });
     });
   });


### PR DESCRIPTION
## Description

- Adds explicit `siteKey` support to `AppleReCaptchaProvider`.
- Passes the Apple reCAPTCHA site key through Pigeon to the iOS `RecaptchaProvider(app:siteKey:)` initializer required by Firebase iOS SDK 12.17.0.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
