### PR TITLE
fix(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after #18505

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Package.swift
+++ b/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "6.7.1"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "cloud_firestore",

--- a/packages/cloud_firestore/cloud_firestore/macos/cloud_firestore/Package.swift
+++ b/packages/cloud_firestore/cloud_firestore/macos/cloud_firestore/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "6.7.1"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "cloud_firestore",

--- a/packages/cloud_functions/cloud_functions/ios/cloud_functions/Package.swift
+++ b/packages/cloud_functions/cloud_functions/ios/cloud_functions/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "cloud_functions",

--- a/packages/cloud_functions/cloud_functions/macos/cloud_functions/Package.swift
+++ b/packages/cloud_functions/cloud_functions/macos/cloud_functions/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "cloud_functions",

--- a/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics/Package.swift
+++ b/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics/Package.swift
@@ -8,7 +8,7 @@
 import Foundation
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 // Set FIREBASE_ANALYTICS_WITHOUT_ADID=true to use FirebaseAnalyticsCore.
 // e.g. FIREBASE_ANALYTICS_WITHOUT_ADID=true flutter build ios

--- a/packages/firebase_analytics/firebase_analytics/macos/firebase_analytics/Package.swift
+++ b/packages/firebase_analytics/firebase_analytics/macos/firebase_analytics/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_analytics",

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Package.swift
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_app_check",

--- a/packages/firebase_app_check/firebase_app_check/macos/firebase_app_check/Package.swift
+++ b/packages/firebase_app_check/firebase_app_check/macos/firebase_app_check/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_app_check",

--- a/packages/firebase_app_check/firebase_app_check/windows/firebase_app_check_plugin.cpp
+++ b/packages/firebase_app_check/firebase_app_check/windows/firebase_app_check_plugin.cpp
@@ -166,7 +166,11 @@ FirebaseAppCheckPlugin::~FirebaseAppCheckPlugin() {
 void FirebaseAppCheckPlugin::Activate(
     const std::string& app_name, const std::string* android_provider,
     const std::string* apple_provider, const std::string* debug_token,
+    const std::string* recaptcha_site_key,
     std::function<void(std::optional<FlutterError> reply)> result) {
+  // reCAPTCHA is a mobile-only provider, so the site key is unused here.
+  (void)recaptcha_site_key;
+
   // On Windows/desktop, only the Debug provider is available.
   DebugAppCheckProviderFactory* factory =
       DebugAppCheckProviderFactory::GetInstance();

--- a/packages/firebase_app_check/firebase_app_check/windows/firebase_app_check_plugin.h
+++ b/packages/firebase_app_check/firebase_app_check/windows/firebase_app_check_plugin.h
@@ -43,6 +43,7 @@ class FirebaseAppCheckPlugin : public flutter::Plugin,
   void Activate(
       const std::string& app_name, const std::string* android_provider,
       const std::string* apple_provider, const std::string* debug_token,
+      const std::string* recaptcha_site_key,
       std::function<void(std::optional<FlutterError> reply)> result) override;
   void GetToken(const std::string& app_name, bool force_refresh,
                 std::function<void(ErrorOr<std::optional<std::string>> reply)>

--- a/packages/firebase_app_installations/firebase_app_installations/ios/firebase_app_installations/Package.swift
+++ b/packages/firebase_app_installations/firebase_app_installations/ios/firebase_app_installations/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_app_installations",

--- a/packages/firebase_app_installations/firebase_app_installations/macos/firebase_app_installations/Package.swift
+++ b/packages/firebase_app_installations/firebase_app_installations/macos/firebase_app_installations/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_app_installations",

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Package.swift
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "6.5.6"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_auth",

--- a/packages/firebase_auth/firebase_auth/macos/firebase_auth/Package.swift
+++ b/packages/firebase_auth/firebase_auth/macos/firebase_auth/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "6.5.6"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_auth",

--- a/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
+++ b/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersionString = "4.12.1"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_core",

--- a/packages/firebase_core/firebase_core/macos/firebase_core/Package.swift
+++ b/packages/firebase_core/firebase_core/macos/firebase_core/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersionString = "4.12.1"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_core",

--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics/Package.swift
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "5.2.6"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_crashlytics",

--- a/packages/firebase_crashlytics/firebase_crashlytics/macos/firebase_crashlytics/Package.swift
+++ b/packages/firebase_crashlytics/firebase_crashlytics/macos/firebase_crashlytics/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "5.2.6"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_crashlytics",

--- a/packages/firebase_database/firebase_database/ios/firebase_database/Package.swift
+++ b/packages/firebase_database/firebase_database/ios/firebase_database/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "12.4.6"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_database",

--- a/packages/firebase_database/firebase_database/macos/firebase_database/Package.swift
+++ b/packages/firebase_database/firebase_database/macos/firebase_database/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "12.4.6"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_database",

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/firebase_in_app_messaging/Package.swift
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/firebase_in_app_messaging/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "0.9.2-6"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_in_app_messaging",

--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Package.swift
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "16.4.3"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_messaging",

--- a/packages/firebase_messaging/firebase_messaging/macos/firebase_messaging/Package.swift
+++ b/packages/firebase_messaging/firebase_messaging/macos/firebase_messaging/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "16.4.3"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_messaging",

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/ios/firebase_ml_model_downloader/Package.swift
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/ios/firebase_ml_model_downloader/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_ml_model_downloader",

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/macos/firebase_ml_model_downloader/Package.swift
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/macos/firebase_ml_model_downloader/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_ml_model_downloader",

--- a/packages/firebase_performance/firebase_performance/ios/firebase_performance/Package.swift
+++ b/packages/firebase_performance/firebase_performance/ios/firebase_performance/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "0.11.4-5"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_performance",

--- a/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Package.swift
+++ b/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_remote_config",

--- a/packages/firebase_remote_config/firebase_remote_config/macos/firebase_remote_config/Package.swift
+++ b/packages/firebase_remote_config/firebase_remote_config/macos/firebase_remote_config/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_remote_config",

--- a/packages/firebase_storage/firebase_storage/ios/firebase_storage/Package.swift
+++ b/packages/firebase_storage/firebase_storage/ios/firebase_storage/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "13.4.5"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_storage",

--- a/packages/firebase_storage/firebase_storage/macos/firebase_storage/Package.swift
+++ b/packages/firebase_storage/firebase_storage/macos/firebase_storage/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "13.4.5"
-let firebaseSdkVersion: Version = "12.16.0"
+let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(
   name: "firebase_storage",


### PR DESCRIPTION
## Description

Follow-up to #18505, which is now merged. Two pieces it needed but didn't include are still missing on `main`, and they break two jobs.

Rebased onto `main` — this PR is now just those two fixes (28 `Package.swift` version lines + 2 Windows files).

### 1. SPM `Package.swift` pins were never synced to 12.17.0

#18489 bumped only the CocoaPods pin (`firebase_sdk_version.rb` → 12.17.0). The 28 SPM `Package.swift` files are still at **12.16.0** — syncing them is a separate follow-up step (#18487 did it for 12.16.0) that was missed this time.

Now that #18505 has landed, the code passes a `siteKey` to the reCAPTCHA provider, which only exists in 12.17.0. So the SPM build compiles new code against the old SDK:

| build path | pin | result on current `main` |
|---|---|---|
| CocoaPods (`ios`) | 12.17.0 | ok |
| SPM (`swift-integration`) | **12.16.0** | `Extra argument 'siteKey' in call` |

Regenerated with `dart run scripts/generate_versions_spm.dart` (verified idempotent — a second run is a no-op, and no `Package.swift` is left at 12.16.0).

### 2. Windows `Activate` override no longer matches its base declaration

#18505 regenerated `windows/messages.g.h`, so `FirebaseAppCheckHostApi::Activate` now takes a 5th `recaptcha_site_key` parameter. The hand-written override in `firebase_app_check_plugin.h/.cpp` was not updated, so on current `main`:

```
firebase_app_check_plugin.h(43,8): error C3668:
  'FirebaseAppCheckPlugin::Activate': method with override specifier 'override'
  did not override any base class methods
```

reCAPTCHA is a mobile-only provider, so the site key is unused on Windows.

## Verification

Both target jobs already passed on this branch's previous run, which carried the same two fixes:

- ✅ `swift-integration` — pass (was failing with `Extra argument 'siteKey'`)
- ✅ `windows` — pass (was failing with `error C3668`)
- ✅ `agp9-compatibility`, `windows-firestore`, `format`, `analyze`, `test`, `build_examples_dart`, `pub_dry_run`, `pub_get_check` — pass

Locally: `clang-format` clean, and the override signature now matches the generated declaration exactly.

### Unrelated failures

These fail independently of this change and reproduce on other branches:

- `web-wasm` / `e2e-fdc` — `firebase_data_connect` websocket + listen e2e timeouts (pre-existing; identical on unrelated dependabot branches)
- `macos (tests)` — transient `pod install` failure, `github.com/firebase/firebase-ios-sdk.git` returned HTTP 503
- `android (cloud_firestore example)` — `TimeoutException after 0:05:00` test timeout
- `ios (tests)` — 2 `firebase_storage` download-cancel tests (351 passed / 2 failed). This job builds via CocoaPods, which was already pinned to 12.17.0 before this PR, so a change to SPM pins and Windows C++ cannot affect it.

## Related Issues

- Follows up #18505, #18489
- SPM sync precedent: #18487

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

Build fixes only — no API surface change. (The breaking `recaptchaSiteKey` move landed in #18505.)

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/