### PR TITLE
fix(firestore,core,windows): per-engine BinaryMessenger, Firestore/Auth link order, Profile builds

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -63,6 +63,8 @@ jobs:
           npm install -g firebase-tools
       - name: "Build Windows (Release)"
         run: cd tests && flutter build windows --release
+      - name: "Build Windows (Profile)"
+        run: cd tests && flutter build windows --profile
       - name: Start Firebase Emulator and run tests
         run: cd ./.github/workflows/scripts && firebase emulators:exec --project flutterfire-e2e-tests "cd ../../../tests && flutter test .\integration_test\e2e_test.dart -d windows --verbose"
 

--- a/packages/cloud_firestore/cloud_firestore/windows/CMakeLists.txt
+++ b/packages/cloud_firestore/cloud_firestore/windows/CMakeLists.txt
@@ -66,7 +66,12 @@ target_compile_definitions(${PLUGIN_NAME} PRIVATE -DINTERNAL_EXPERIMENTAL=1)
 # Source include directories and library dependencies. Add any plugin-specific
 # dependencies here.
 set(MSVC_RUNTIME_MODE MD)
-set(firebase_libs firebase_core_plugin firebase_auth firebase_firestore)
+# firebase_auth must come after firebase_firestore: the Firestore desktop
+# credentials provider pulls symbols out of firebase_auth (e.g.
+# `firebase::g_auth_initializer`), the Firebase C++ SDK does not declare that
+# dependency between its imported targets, and MSVC resolves static libraries
+# in the order they appear on the link line.
+set(firebase_libs firebase_core_plugin firebase_firestore firebase_auth)
 set(ADDITIONAL_LIBS advapi32 ws2_32 crypt32 rpcrt4 ole32 shell32 Bcrypt.lib DbgHelp.lib)
 target_link_libraries(${PLUGIN_NAME} PRIVATE "${firebase_libs}" "${ADDITIONAL_LIBS}")
 

--- a/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.cpp
+++ b/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.cpp
@@ -255,7 +255,7 @@ void CloudFirestorePlugin::RegisterWithRegistrar(
 
   auto plugin = std::make_unique<CloudFirestorePlugin>();
 
-  messenger_ = registrar->messenger();
+  plugin->messenger_ = registrar->messenger();
 
   FirebaseFirestoreHostApi::SetUp(registrar->messenger(), plugin.get());
 
@@ -327,9 +327,6 @@ firebase::firestore::FieldValue CloudFirestorePlugin::ConvertToFieldValue(
   }
 }
 
-flutter::BinaryMessenger*
-    cloud_firestore_windows::CloudFirestorePlugin::messenger_ = nullptr;
-
 std::map<std::string,
          std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>>
     event_channels_;
@@ -343,12 +340,12 @@ std::map<std::string, std::unique_ptr<firebase::firestore::Firestore>>
     cloud_firestore_windows::CloudFirestorePlugin::firestoreInstances_;
 
 std::string RegisterEventChannelWithUUID(
-    std::string prefix, std::string uuid,
+    flutter::BinaryMessenger* messenger, std::string prefix, std::string uuid,
     std::unique_ptr<flutter::StreamHandler<flutter::EncodableValue>> handler) {
   std::string channelName = prefix + uuid;
   event_channels_[channelName] =
       std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
-          CloudFirestorePlugin::messenger_, channelName,
+          messenger, channelName,
           &flutter::StandardMethodCodec::GetInstance(
               &FirebaseFirestoreHostApiCodecSerializer::GetInstance()));
 
@@ -361,7 +358,7 @@ std::string RegisterEventChannelWithUUID(
 }
 
 std::string RegisterEventChannel(
-    std::string prefix,
+    flutter::BinaryMessenger* messenger, std::string prefix,
     std::unique_ptr<flutter::StreamHandler<flutter::EncodableValue>> handler) {
   UUID uuid;
   UuidCreate(&uuid);
@@ -371,7 +368,7 @@ std::string RegisterEventChannel(
   std::string channelName = prefix + str;
   event_channels_[channelName] =
       std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
-          CloudFirestorePlugin::messenger_, channelName,
+          messenger, channelName,
           &flutter::StandardMethodCodec::GetInstance(
               &FirebaseFirestoreHostApiCodecSerializer::GetInstance()));
   stream_handlers_[channelName] = std::move(handler);
@@ -831,7 +828,8 @@ void CloudFirestorePlugin::LoadBundle(
       std::make_unique<LoadBundleStreamHandler>(firestore, bundleConverted);
 
   std::string channelName = RegisterEventChannel(
-      "plugins.flutter.io/firebase_firestore/loadBundle/", std::move(handler));
+      messenger_, "plugins.flutter.io/firebase_firestore/loadBundle/",
+      std::move(handler));
 
   result(channelName);
 }
@@ -1029,7 +1027,7 @@ void CloudFirestorePlugin::SnapshotsInSyncSetup(
   std::string snapshotInSyncId(str);
 
   std::string channelName = RegisterEventChannelWithUUID(
-      "plugins.flutter.io/firebase_firestore/snapshotsInSync/",
+      messenger_, "plugins.flutter.io/firebase_firestore/snapshotsInSync/",
       snapshotInSyncId, std::move(handler));
   result(snapshotInSyncId);
 }
@@ -1202,8 +1200,8 @@ void CloudFirestorePlugin::TransactionCreate(
 
   // Register the event channel.
   std::string channelName = RegisterEventChannelWithUUID(
-      "plugins.flutter.io/firebase_firestore/transaction/", transactionId,
-      std::move(handler));
+      messenger_, "plugins.flutter.io/firebase_firestore/transaction/",
+      transactionId, std::move(handler));
 
   // Return the result (assumed to be transaction ID in this example).
   result(transactionId);
@@ -1864,9 +1862,9 @@ void CloudFirestorePlugin::QuerySnapshot(
       GetServerTimestampBehaviorFromPigeon(
           options.server_timestamp_behavior()));
 
-  std::string channelName =
-      RegisterEventChannel("plugins.flutter.io/firebase_firestore/query/",
-                           std::move(query_snapshot_handler));
+  std::string channelName = RegisterEventChannel(
+      messenger_, "plugins.flutter.io/firebase_firestore/query/",
+      std::move(query_snapshot_handler));
 
   result(channelName);
 }
@@ -1962,9 +1960,9 @@ void CloudFirestorePlugin::DocumentReferenceSnapshot(
           GetServerTimestampBehaviorFromPigeon(
               *parameters.server_timestamp_behavior()));
 
-  std::string channelName =
-      RegisterEventChannel("plugins.flutter.io/firebase_firestore/document/",
-                           std::move(document_snapshot_handler));
+  std::string channelName = RegisterEventChannel(
+      messenger_, "plugins.flutter.io/firebase_firestore/document/",
+      std::move(document_snapshot_handler));
   result(channelName);
 }
 

--- a/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.h
+++ b/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.h
@@ -176,7 +176,12 @@ class CloudFirestorePlugin : public flutter::Plugin,
       std::function<void(ErrorOr<InternalPipelineSnapshot> reply)> result)
       override;
 
-  static flutter::BinaryMessenger* messenger_;
+  // Per-registration messenger. A Windows app can host several Flutter engines
+  // in the same process (e.g. via `desktop_multi_window`), and each one
+  // registers the plugin with its own registrar. Keeping this per instance
+  // means every channel is built on the messenger of the engine that asked for
+  // it, instead of whichever engine registered last.
+  flutter::BinaryMessenger* messenger_ = nullptr;
   static std::map<
       std::string,
       std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>>

--- a/packages/firebase_core/firebase_core/windows/CMakeLists.txt
+++ b/packages/firebase_core/firebase_core/windows/CMakeLists.txt
@@ -126,9 +126,17 @@ set(FIREBASE_RELEASE_PATH_LIBS firebase_app firebase_auth firebase_remote_config
 foreach(firebase_lib IN ITEMS ${FIREBASE_RELEASE_PATH_LIBS})
     get_target_property(firebase_lib_path ${firebase_lib} IMPORTED_LOCATION)
     string(REPLACE "Debug" "Release" firebase_lib_release_path ${firebase_lib_path})
+    # Flutter builds Windows apps in Debug, Profile or Release. Profile uses the
+    # release CRT (Flutter maps its compiler/linker flags onto Release), so it
+    # must pick the release libraries too - without an explicit mapping CMake
+    # falls back to plain IMPORTED_LOCATION, which the SDK points at Debug, and
+    # linking fails with unresolved __imp__CrtDbgReport / __imp__invalid_parameter.
     set_target_properties(${firebase_lib} PROPERTIES
       IMPORTED_LOCATION_DEBUG "${firebase_lib_path}"
       IMPORTED_LOCATION_RELEASE "${firebase_lib_release_path}"
+      IMPORTED_LOCATION_PROFILE "${firebase_lib_release_path}"
+      IMPORTED_LOCATION_RELWITHDEBINFO "${firebase_lib_release_path}"
+      IMPORTED_LOCATION_MINSIZEREL "${firebase_lib_release_path}"
     )
 endforeach()
 


### PR DESCRIPTION
## Description

Fixes three Windows bugs.

**1. `cloud_firestore`'s `BinaryMessenger` was a class-level static**, reassigned on every `RegisterWithRegistrar`. In an app hosting several Flutter engines (e.g. `desktop_multi_window`), the last engine to register owned the messenger process-wide: snapshot listeners opened from any other engine were delivered to the wrong isolate and silently never fired, and once that engine was destroyed the dangling pointer crashed the next snapshot call. It is now a per-instance member, passed to `RegisterEventChannel` / `RegisterEventChannelWithUUID`.

**2. `firebase_auth` was linked before `firebase_firestore`.** MSVC resolves static libraries in link-line order and the SDK declares no dependency between the two imported targets, so Firestore's `create_credentials_provider_desktop.obj` failed on `unresolved external symbol "void * firebase::g_auth_initializer"` unless the app also depended on `firebase_auth` (which put the lib back on the line, later). Reordered. Kept in `cloud_firestore`'s own `CMakeLists.txt` rather than on the imported target in Core, following #18498.

**3. Only `DEBUG` and `RELEASE` had an `IMPORTED_LOCATION`.** The SDK never sets `IMPORTED_CONFIGURATIONS`, so every other configuration fell back to the Debug libraries. Flutter maps Profile's flags onto Release, so a Profile build compiled against the release CRT and linked debug-CRT libraries, failing on `__imp__CrtDbgReport` / `__imp__invalid_parameter`. `PROFILE`, `RELWITHDEBINFO` and `MINSIZEREL` now resolve to the release libraries — same class of bug as #18073, which fixed Release only. The `windows` job gained a `--profile` build so it cannot regress.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18508
- Fixes https://github.com/firebase/flutterfire/issues/18514
- Fixes https://github.com/firebase/flutterfire/issues/12051

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
