### PR TITLE
test(storage): keep test file under the storage emulator's upload limit

### DIFF
--- a/tests/integration_test/firebase_storage/test_utils.dart
+++ b/tests/integration_test/firebase_storage/test_utils.dart
@@ -33,10 +33,16 @@ const int testEmulatorPort = 9199;
 
 // Creates a test file with a specified name to
 // a locally directory
+//
+// The default size is deliberately large so download tasks are still running
+// when a test cancels or pauses them, but it has to stay under the storage
+// emulator's resumable upload limit. The emulator rejects a resumable upload
+// body over ~128MB with `413`, which surfaces as
+// `[firebase_storage/unknown] Unexpected 413 code from backend`.
 Future<File> createFile(
   String name, {
   String? string,
-  int sizeInBytes = 209715200,
+  int sizeInBytes = 104857600,
 }) async {
   final Directory systemTempDir = Directory.systemTemp;
   final File file = await File('${systemTempDir.path}/$name').create();
@@ -46,7 +52,7 @@ Future<File> createFile(
     return file;
   }
 
-  // Create a 200MB file by writing data in chunks to avoid memory issues
+  // Write the file in chunks to avoid memory issues
   const chunkSize = 1024 * 1024; // 1MB chunks
   final chunk = Uint8List(chunkSize);
 


### PR DESCRIPTION
## Description

`ios (tests)` fails on two `firebase_storage` tests with `[firebase_storage/unknown] Unexpected 413 code from backend`. Both already use `retry: 2`, so it is a deterministic failure, and it reproduces on every `main` run going back to at least 2026-07-30.

`createFile()` defaults to 200MB (set in #17596 so `cancel()` has a download still in flight). These two tests are the only callers that `putFile()` the generated file — every other caller passes `string:` or uses it only as a `writeToFile()` destination. `putFile()` uses a resumable upload, and the storage emulator rejects a resumable body over ~128MB with 413.

Measured against the emulator on firebase-tools 15.14.0: resumable 120MB → 200, 150MB → 413, and simple media 200MB → 200 (which is why only the `putFile()` path was affected). This lowers the default to 100MB, keeping headroom under the cap while staying large enough to cancel mid-download. No test asserts an absolute byte count.

Verified on this PR: `ios (tests)` now reports **353 passed, 0 failed** (was 351 passed, 2 failed).

## Related Issues

Follows up #17596, which introduced the 200MB default.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/