### PR TITLE
test(firestore): bound and retry the bundle fixture fetch

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/load_bundle_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/load_bundle_e2e.dart
@@ -7,18 +7,44 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 
+/// Every test in this file loads its bundle fixture from an external endpoint.
+/// That request had no timeout, so a single stalled fetch consumed the whole
+/// five minute test budget and was reported as a `loadBundle()` failure — see
+/// `loadBundle(): LoadBundleTaskProgress stream snapshots` timing out on CI
+/// while the surrounding bundle tests passed.
+///
+/// Bound each attempt and retry the fetch. Only the network call is retried, so
+/// a genuine Firestore failure is still reported on the first run rather than
+/// being masked by a test-level `retry:`.
+const _fixtureTimeout = Duration(seconds: 20);
+const _fixtureAttempts = 3;
+
+Future<Uint8List> _fetchFixture(Uri url) async {
+  Object? lastError;
+  for (var attempt = 1; attempt <= _fixtureAttempts; attempt++) {
+    try {
+      final response = await http.get(url).timeout(_fixtureTimeout);
+      return Uint8List.fromList(response.body.codeUnits);
+    } catch (error) {
+      lastError = error;
+      if (attempt < _fixtureAttempts) {
+        await Future.delayed(Duration(seconds: attempt));
+      }
+    }
+  }
+  fail('Could not fetch $url after $_fixtureAttempts attempts: $lastError');
+}
+
 void runLoadBundleTests() {
   group('$DocumentReference', () {
     late FirebaseFirestore firestore;
 
-    Future<Uint8List> loadBundleSetup(int number) async {
+    Future<Uint8List> loadBundleSetup(int number) {
       // endpoint serves a bundle with 3 documents each containing
       // a 'number' property that increments in value 1-3.
-      final url =
-          Uri.https('api.rnfirebase.io', '/firestore/e2e-tests/bundle-$number');
-      final response = await http.get(url);
-      String string = response.body;
-      return Uint8List.fromList(string.codeUnits);
+      return _fetchFixture(
+        Uri.https('api.rnfirebase.io', '/firestore/e2e-tests/bundle-$number'),
+      );
     }
 
     setUp(() async {
@@ -80,13 +106,12 @@ void runLoadBundleTests() {
       test(
         'loadBundle(): error handling for malformed bundle',
         () async {
-          final url = Uri.https(
-            'api.rnfirebase.io',
-            '/firestore/e2e-tests/malformed-bundle',
+          final Uint8List buffer = await _fetchFixture(
+            Uri.https(
+              'api.rnfirebase.io',
+              '/firestore/e2e-tests/malformed-bundle',
+            ),
           );
-          final response = await http.get(url);
-          String string = response.body;
-          Uint8List buffer = Uint8List.fromList(string.codeUnits);
 
           LoadBundleTask task = firestore.loadBundle(buffer);
 


### PR DESCRIPTION
## Description

`loadBundle(): LoadBundleTaskProgress stream snapshots` intermittently fails the `android (packages/cloud_firestore/cloud_firestore/example)` job with `TimeoutException after 0:05:00`. It failed on the release commit `93523fbf8` (351 passed, 1 failed) but passed on `ce1f6e05e` and `e14403429` with the same 352-test suite, so it is flaky rather than broken.

Every test in `load_bundle_e2e.dart` loads its fixture from `https://api.rnfirebase.io`, and that `http.get` had no timeout. The endpoint normally answers in ~0.2s (I measured all five fixtures at 0.11–0.25s, HTTP 200), so a single stalled fetch silently consumed the whole five minute test budget and surfaced as a `loadBundle()` failure instead of as a network stall — which is why the surrounding bundle tests passed in the same run.

This bounds each attempt to 20s and retries up to 3 times with a short backoff, so the worst case is ~60s rather than exhausting the budget, and a genuinely unreachable endpoint now fails with the URL and the underlying error.

Only the network call is retried, not the test. A test-level `retry:` would also re-run the Firestore assertions and could mask a real regression.

## Related Issues

None; found while triaging red jobs on `main`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/