### PR TITLE
fix(messaging,macos): unwrap UNNotificationResponse launch payload so getInitialMessage returns it

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
@@ -440,7 +440,15 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   NSDictionary *remoteNotification = nil;
   if ([launchNotification isKindOfClass:[NSDictionary class]]) {
     remoteNotification = launchNotification;
+  } else if ([launchNotification isKindOfClass:[UNNotificationResponse class]]) {
+    // UNNotificationResponse exposes the payload via its content, not a top-level `userInfo`,
+    // so it has to be unwrapped explicitly. Without this the payload is dropped and
+    // getInitialMessage() resolves with null when the app is launched by tapping a
+    // notification.
+    remoteNotification =
+        ((UNNotificationResponse *)launchNotification).notification.request.content.userInfo;
   } else if ([launchNotification respondsToSelector:@selector(userInfo)]) {
+    // Covers the deprecated NSUserNotification, which does expose `userInfo` directly.
     remoteNotification = [launchNotification userInfo];
   }
 #else


### PR DESCRIPTION
## Description

> [!NOTE]
> This fix was originally reported and written by @steffenhaak in #17231. All credit for
> diagnosing it goes to them. It is reopened here only because fork PRs receive 4 of the
> 46 CI checks on this repo, so the iOS and macOS jobs that exercise this code never ran
> on the original branch.

On macOS, `NSApplicationLaunchUserNotificationKey` can hold a `UNNotificationResponse`.
That class declares only two properties:

```objc
@interface UNNotificationResponse : NSObject <NSCopying, NSSecureCoding>
@property (readonly, copy) UNNotification *notification;
@property (readonly, copy) NSString *actionIdentifier;
```

The payload lives at `notification.request.content.userInfo`, so a `UNNotificationResponse`
does **not** respond to `userInfo` and fell through every branch in
`application_onDidFinishLaunchingNotification:`, leaving `remoteNotification` as `nil`.
`getInitialMessage()` then resolved with `null` whenever the app was launched by tapping a
notification.

#18457 fixed the related hang (a `nil` payload no longer blocks forever), but not the
extraction — so the payload was still being dropped.

This adds an explicit `UNNotificationResponse` branch ahead of the `respondsToSelector:`
check, leaving the existing `NSDictionary` and deprecated `NSUserNotification` paths
untouched. The original PR replaced those paths rather than extending them, which would
have regressed the cases #18457 deliberately handles.

Verified against the macOS 26.5 SDK at runtime:

| Class | responds to `userInfo` |
| --- | --- |
| `UNNotificationResponse` | **NO** — hence the dropped payload |
| `UNNotificationContent` | YES — the keypath used here |

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17230
- Supersedes https://github.com/firebase/flutterfire/pull/17231

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
