### PR TITLE
ci: stabilization pass — fix broken caches, flaky retries, and the e2e-fdc redness

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -137,9 +137,11 @@ jobs:
       - name: Pre-build APK
         # Build outside the emulator so the AVD does not boot and idle through the
         # whole Gradle build. `flutter test` below reuses this warm build cache.
+        # The validation skip matches `flutter test`, which does not enforce the
+        # minimum Gradle version either (the firestore example pins Gradle 8.4).
         working-directory: ${{ matrix.working_directory }}
         timeout-minutes: 25
-        run: flutter build apk --debug --target=integration_test/e2e_test.dart
+        run: flutter build apk --debug --target=integration_test/e2e_test.dart --android-skip-build-dependency-validation
       - name: Start AVD then run E2E tests
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a
         timeout-minutes: 30

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -55,14 +55,16 @@ jobs:
         name: Install Node.js 20
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: '.github/workflows/scripts/functions/package-lock.json'
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
         with:
           distribution: 'temurin'
           java-version: '21'
       - name: 'Install Tools'
         run: |
-          sudo npm i -g firebase-tools
-          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
+          sudo npm i -g firebase-tools@15.25.1
+          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -72,8 +74,9 @@ jobs:
           enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
-          restore-keys: firebase-emulators-v3
+          key: firebase-emulators-v5-${{ env.FIREBASE_TOOLS_VERSION }}
+          # Trailing dash so this never prefix-matches a future version's key
+          restore-keys: firebase-emulators-v5-
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -89,6 +92,7 @@ jobs:
       - name: 'Bootstrap package'
         run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
       - name: Start Firebase Emulator
+        timeout-minutes: 8
         run: cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
       - name: Enable KVM
         run: |
@@ -121,15 +125,24 @@ jobs:
           path: |
             /mnt/avd/*
             ~/.android/adb*
-          key: avd-${{ runner.os }}-${{ env.AVD_API_LEVEL }}-${{ env.AVD_TARGET }}-${{ env.AVD_ARCH }}
+          # The emulator build is part of the key so bumping `emulator-build:` below
+          # invalidates the cached AVD instead of reusing an image from the old build.
+          key: avd-${{ runner.os }}-${{ env.AVD_API_LEVEL }}-${{ env.AVD_TARGET }}-${{ env.AVD_ARCH }}-14214601
       - name: Link AVD home to /mnt
         # android-emulator-runner exportVariables ANDROID_AVD_HOME to $HOME/.android/avd
         run: |
           mkdir -p "$HOME/.android"
           rm -rf "$HOME/.android/avd"
           ln -s /mnt/avd "$HOME/.android/avd"
+      - name: Pre-build APK
+        # Build outside the emulator so the AVD does not boot and idle through the
+        # whole Gradle build. `flutter test` below reuses this warm build cache.
+        working-directory: ${{ matrix.working_directory }}
+        timeout-minutes: 25
+        run: flutter build apk --debug --target=integration_test/e2e_test.dart
       - name: Start AVD then run E2E tests
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a
+        timeout-minutes: 30
         env:
           ANDROID_AVD_HOME: /mnt/avd
         with:
@@ -137,6 +150,8 @@ jobs:
           target: ${{ env.AVD_TARGET }}
           arch: ${{ env.AVD_ARCH }}
           emulator-build: 14214601
+          # The default (true) wipes and recreates the AVD, making the cache above useless.
+          force-avd-creation: false
           working-directory: ${{ matrix.working_directory }}
           script: |
             flutter test integration_test/e2e_test.dart --timeout 10x --dart-define=CI=true -d emulator-5554
@@ -149,6 +164,7 @@ jobs:
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        continue-on-error: true
         with:
           # The firebase emulators are pure javascript and java, OS-independent
           enableCrossOsArchive: true
@@ -157,8 +173,11 @@ jobs:
           path: ~/.cache/firebase/emulators
       - name: Save Android Emulator Cache
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
-        if: github.ref == 'refs/heads/main'
+        # Skip on a cache hit: the AVD image is multi-GB and re-uploading it unchanged on
+        # every main run is pure waste.
+        if: github.ref == 'refs/heads/main' && steps.avd-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        continue-on-error: true
         with:
           key: ${{ steps.avd-cache.outputs.cache-primary-key }}
           # Must match the restore path exactly
@@ -172,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
         with:
           distribution: 'temurin'
@@ -190,6 +209,7 @@ jobs:
       - name: 'Bootstrap tests package'
         run: melos bootstrap --scope tests
       - name: Gradle cache
-        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d
+        uses: gradle/actions/setup-gradle@90ddb51e90a5fd9ba75f40cf85156b7b41bf76a3
       - name: 'Build tests app with AGP 9'
+        timeout-minutes: 25
         run: bash ./.github/workflows/scripts/agp9-compatibility.sh

--- a/.github/workflows/android_unit_tests.yaml
+++ b/.github/workflows/android_unit_tests.yaml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -39,7 +39,7 @@ jobs:
           cache: true
           cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
           pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@705015c3d2bc4ab94201ac24accb2bbe070cf533
+      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
         with:
           run-bootstrap: false
           melos-version: '5.3.0'

--- a/.github/workflows/e2e_tests_fdc.yaml
+++ b/.github/workflows/e2e_tests_fdc.yaml
@@ -14,7 +14,7 @@ on:
       - '**.md'
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
       - 'website/**'
@@ -51,7 +51,7 @@ jobs:
           java-version: '21'
       - name: 'Install Tools'
         run: |
-          sudo npm i -g firebase-tools
+          sudo npm i -g firebase-tools@15.25.1
           echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
@@ -184,12 +184,15 @@ jobs:
         id: pods-cache
         with:
           # Must match the save path exactly
-          path: tests/ios/Pods
-          key: ${{ runner.os }}-fdc-pods-${{ hashFiles('tests/pubspec.lock') }}
-          restore-keys: ${{ runner.os }}-fdc-pods
+          path: packages/firebase_data_connect/firebase_data_connect/example/ios/Pods
+          # tests/pubspec.lock is gitignored, so the old key hashed nothing and
+          # the cache never invalidated. Key on the files that actually pin the
+          # native SDK version instead.
+          key: ${{ runner.os }}-fdc-pods-v2-${{ hashFiles('packages/firebase_data_connect/firebase_data_connect/example/ios/Podfile', 'packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb') }}
+          restore-keys: ${{ runner.os }}-fdc-pods-v2-
       - name: 'Install Tools'
         run: |
-          sudo npm i -g firebase-tools
+          sudo npm i -g firebase-tools@15.25.1
           echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
@@ -272,8 +275,8 @@ jobs:
         continue-on-error: true
         with:
           key: ${{ steps.pods-cache.outputs.cache-primary-key }}
-          # Must match the restore paths exactly
-          path: tests/ios/Pods
+          # Must match the restore path exactly
+          path: packages/firebase_data_connect/firebase_data_connect/example/ios/Pods
 
   web:
     runs-on: macos-latest
@@ -308,7 +311,7 @@ jobs:
         run: melos bootstrap --scope "firebase_data_connect*"
       - name: 'Install Tools'
         run: |
-          sudo npm i -g firebase-tools
+          sudo npm i -g firebase-tools@15.25.1
           echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
@@ -382,7 +385,7 @@ jobs:
         run: melos bootstrap --scope "firebase_data_connect*"
       - name: 'Install Tools'
         run: |
-          sudo npm i -g firebase-tools
+          sudo npm i -g firebase-tools@15.25.1
           echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache

--- a/.github/workflows/e2e_tests_pipeline.yaml
+++ b/.github/workflows/e2e_tests_pipeline.yaml
@@ -20,6 +20,13 @@ on:
       - '**/example/**'
       - '**.md'
   workflow_call:
+    secrets:
+      PIPELINE_E2E_FIREBASE_OPTIONS_DART:
+        required: true
+      PIPELINE_E2E_GOOGLE_SERVICES_JSON:
+        required: true
+      PIPELINE_E2E_GOOGLE_SERVICE_INFO_PLIST:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/e2e_tests_pipeline.yaml
+++ b/.github/workflows/e2e_tests_pipeline.yaml
@@ -26,6 +26,11 @@ permissions:
 
 jobs:
   pipeline-e2e-android:
+    # Requires live-project secrets, which fork and dependabot PRs don't receive.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -59,6 +64,10 @@ jobs:
           GOOGLE_SERVICES_JSON: ${{ secrets.PIPELINE_E2E_GOOGLE_SERVICES_JSON }}
           GOOGLE_SERVICE_INFO_PLIST: ${{ secrets.PIPELINE_E2E_GOOGLE_SERVICE_INFO_PLIST }}
         run: |
+          if [ -z "$FIREBASE_OPTIONS_DART" ]; then
+            echo "::error::PIPELINE_E2E_FIREBASE_OPTIONS_DART is empty — secrets are unavailable (fork/dependabot PR?). Failing early instead of producing a broken build."
+            exit 1
+          fi
           echo "$FIREBASE_OPTIONS_DART" > packages/cloud_firestore/cloud_firestore/pipeline_example/lib/firebase_options.dart
           echo "$GOOGLE_SERVICES_JSON" > packages/cloud_firestore/cloud_firestore/pipeline_example/android/app/google-services.json
           echo "$GOOGLE_SERVICE_INFO_PLIST" > packages/cloud_firestore/cloud_firestore/pipeline_example/ios/Runner/GoogleService-Info.plist
@@ -124,6 +133,11 @@ jobs:
             ~/.android/adb*
 
   pipeline-e2e-web:
+    # Requires live-project secrets, which fork and dependabot PRs don't receive.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]')
     runs-on: macos-latest
     timeout-minutes: 25
     steps:
@@ -148,6 +162,10 @@ jobs:
           GOOGLE_SERVICES_JSON: ${{ secrets.PIPELINE_E2E_GOOGLE_SERVICES_JSON }}
           GOOGLE_SERVICE_INFO_PLIST: ${{ secrets.PIPELINE_E2E_GOOGLE_SERVICE_INFO_PLIST }}
         run: |
+          if [ -z "$FIREBASE_OPTIONS_DART" ]; then
+            echo "::error::PIPELINE_E2E_FIREBASE_OPTIONS_DART is empty — secrets are unavailable (fork/dependabot PR?). Failing early instead of producing a broken build."
+            exit 1
+          fi
           echo "$FIREBASE_OPTIONS_DART" > packages/cloud_firestore/cloud_firestore/pipeline_example/lib/firebase_options.dart
           echo "$GOOGLE_SERVICES_JSON" > packages/cloud_firestore/cloud_firestore/pipeline_example/android/app/google-services.json
           echo "$GOOGLE_SERVICE_INFO_PLIST" > packages/cloud_firestore/cloud_firestore/pipeline_example/ios/Runner/GoogleService-Info.plist
@@ -168,6 +186,11 @@ jobs:
         shell: bash
 
   pipeline-e2e-ios:
+    # Requires live-project secrets, which fork and dependabot PRs don't receive.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]')
     runs-on: macos-15
     timeout-minutes: 50
     steps:
@@ -202,6 +225,10 @@ jobs:
           GOOGLE_SERVICES_JSON: ${{ secrets.PIPELINE_E2E_GOOGLE_SERVICES_JSON }}
           GOOGLE_SERVICE_INFO_PLIST: ${{ secrets.PIPELINE_E2E_GOOGLE_SERVICE_INFO_PLIST }}
         run: |
+          if [ -z "$FIREBASE_OPTIONS_DART" ]; then
+            echo "::error::PIPELINE_E2E_FIREBASE_OPTIONS_DART is empty — secrets are unavailable (fork/dependabot PR?). Failing early instead of producing a broken build."
+            exit 1
+          fi
           echo "$FIREBASE_OPTIONS_DART" > packages/cloud_firestore/cloud_firestore/pipeline_example/lib/firebase_options.dart
           echo "$GOOGLE_SERVICES_JSON" > packages/cloud_firestore/cloud_firestore/pipeline_example/android/app/google-services.json
           echo "$GOOGLE_SERVICE_INFO_PLIST" > packages/cloud_firestore/cloud_firestore/pipeline_example/ios/Runner/GoogleService-Info.plist

--- a/.github/workflows/e2e_tests_pipeline.yaml
+++ b/.github/workflows/e2e_tests_pipeline.yaml
@@ -254,16 +254,19 @@ jobs:
           model: "iPhone 16"
       - name: Build iOS (simulator)
         working-directory: packages/cloud_firestore/cloud_firestore/pipeline_example
+        timeout-minutes: 25
         run: |
           flutter build ios --no-codesign --simulator --debug --target=./integration_test/pipeline/pipeline_live_test.dart --dart-define=CI=true
       - name: Ensure Simulator Ready
         env:
           SIMULATOR: ${{ steps.simulator.outputs.udid }}
           ENSURE_BOOT_IF_NEEDED: "0"
+        timeout-minutes: 13
         run: .github/workflows/scripts/ensure-simulator-ready.sh
       - name: Run pipeline E2E tests (iOS)
         working-directory: packages/cloud_firestore/cloud_firestore/pipeline_example
         env:
           SIMULATOR: ${{ steps.simulator.outputs.udid }}
+        timeout-minutes: 20
         run: |
           flutter test integration_test/pipeline/pipeline_live_test.dart -d "$SIMULATOR" --timeout 10x --dart-define=CI=true

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -51,17 +51,21 @@ jobs:
         name: Install Node.js 20
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: '.github/workflows/scripts/functions/package-lock.json'
       - name: Xcode
         # Firebase iOS SDK: minimum Xcode 26.2.
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
-      - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
         with:
           distribution: 'temurin'
           java-version: '21'
       - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03
         name: Xcode Compile Cache
         with:
-          key: xcode-cache-${{ runner.os }}
+          # Distinct from the macOS workflow's key: both run on macos-15, so a shared
+          # `xcode-cache-${{ runner.os }}` had the two workflows clobbering each other.
+          key: xcode-ccache-ios
           save: "${{ github.ref == 'refs/heads/main' }}"
           max-size: 700M
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -71,12 +75,15 @@ jobs:
         with:
           # Must match the save path exactly
           path: tests/ios/Pods
-          key: pods-v3-${{ runner.os }}-ios-${{ hashFiles('tests/pubspec.lock') }}
-          restore-keys: pods-v3-${{ runner.os }}-ios
+          # Keyed on the Podfile and the pinned Firebase SDK version, not tests/pubspec.lock:
+          # that file is gitignored, so hashFiles() returned an empty string and the key
+          # never changed - the cache could never be invalidated.
+          key: pods-v4-${{ runner.os }}-ios-${{ hashFiles('tests/ios/Podfile', 'packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb') }}
+          restore-keys: pods-v4-${{ runner.os }}-ios-
       - name: 'Install Tools'
         run: |
-          sudo npm i -g firebase-tools
-          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
+          sudo npm i -g firebase-tools@15.25.1
+          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -86,8 +93,9 @@ jobs:
           enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
-          restore-keys: firebase-emulators-v3
+          key: firebase-emulators-v5-${{ env.FIREBASE_TOOLS_VERSION }}
+          # Trailing dash so this never prefix-matches a future version's key
+          restore-keys: firebase-emulators-v5-
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -119,6 +127,7 @@ jobs:
           df -h /
       - name: 'Build Application'
         working-directory: ${{ matrix.working_directory }}
+        timeout-minutes: 25
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           export CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros
@@ -129,6 +138,7 @@ jobs:
           flutter build ios --no-codesign --simulator --debug --target=./integration_test/e2e_test.dart --dart-define=CI=true
           ccache -s
       - name: Start Firebase Emulator
+        timeout-minutes: 8
         run: sudo chown -R 501:20 "/Users/runner/.npm" && cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
       - uses: futureware-tech/simulator-action@e89aa8f93d3aec35083ff49d2854d07f7186f7f5
         id: simulator
@@ -136,12 +146,14 @@ jobs:
           # List of available simulators: https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#installed-simulators
           model: "iPhone 16"
       - name: Ensure Simulator Ready
+        timeout-minutes: 13
         env:
           SIMULATOR: ${{ steps.simulator.outputs.udid }}
           ENSURE_BOOT_IF_NEEDED: "0"
         run: .github/workflows/scripts/ensure-simulator-ready.sh
       - name: 'E2E Tests'
         working-directory: ${{ matrix.working_directory }}
+        timeout-minutes: 30
         env:
           SIMULATOR: ${{ steps.simulator.outputs.udid }}
         run: |

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -51,6 +51,11 @@ jobs:
         name: Install Node.js 20
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: '.github/workflows/scripts/functions/package-lock.json'
+      - name: Xcode
+        # Firebase iOS SDK: minimum Xcode 26.2.
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
         with:
           distribution: 'temurin'
@@ -58,7 +63,9 @@ jobs:
       - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03
         name: Xcode Compile Cache
         with:
-          key: xcode-cache-${{ runner.os }}
+          # Distinct from the iOS workflow's key: both run on macos-15, so a shared
+          # `xcode-cache-${{ runner.os }}` had the two workflows clobbering each other.
+          key: xcode-ccache-macos
           save: "${{ github.ref == 'refs/heads/main' }}"
           max-size: 700M
       - name: Pods Cache
@@ -68,12 +75,15 @@ jobs:
         with:
           # Must match the save path exactly
           path: tests/macos/Pods
-          key: pods-v3-${{ runner.os }}-macos-${{ hashFiles('tests/pubspec.lock') }}
-          restore-keys: pods-v3-${{ runner.os }}-macos
+          # Keyed on the Podfile and the pinned Firebase SDK version, not tests/pubspec.lock:
+          # that file is gitignored, so hashFiles() returned an empty string and the key
+          # never changed - the cache could never be invalidated.
+          key: pods-v4-${{ runner.os }}-macos-${{ hashFiles('tests/macos/Podfile', 'packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb') }}
+          restore-keys: pods-v4-${{ runner.os }}-macos-
       - name: 'Install Tools'
         run: |
-          sudo npm i -g firebase-tools
-          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
+          sudo npm i -g firebase-tools@15.25.1
+          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -83,8 +93,9 @@ jobs:
           enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
-          restore-keys: firebase-emulators-v3
+          key: firebase-emulators-v5-${{ env.FIREBASE_TOOLS_VERSION }}
+          # Trailing dash so this never prefix-matches a future version's key
+          restore-keys: firebase-emulators-v5-
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -102,6 +113,7 @@ jobs:
         run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
       - name: 'Build Application'
         working-directory: ${{ matrix.working_directory }}
+        timeout-minutes: 25
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           export CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros
@@ -113,9 +125,11 @@ jobs:
           ccache -s
       - name: Start Firebase Emulator
         # Chown the npm cache directory to the runner user to avoid permission issues
+        timeout-minutes: 8
         run: sudo chown -R 501:20 "/Users/runner/.npm" && cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
       - name: 'E2E Tests'
         working-directory: ${{ matrix.working_directory }}
+        timeout-minutes: 30
         run: |
           # flutter test on macOS CI may exit 1 due to "Failed to foreground app"
           # even when all tests pass. Check actual test results to determine success.

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,40 +20,39 @@ permissions:
   contents: read
 
 jobs:
+  # Only e2e-pipeline needs secrets; the rest run entirely against emulators
+  # or dummy configs, so nothing is inherited.
   e2e-android:
     uses: ./.github/workflows/android.yaml
     with:
       nightly_test_mode: ${{ github.event.inputs.test_mode == 'true' }}
-    secrets: inherit
   e2e-ios:
     uses: ./.github/workflows/ios.yaml
     with:
       nightly_test_mode: ${{ github.event.inputs.test_mode == 'true' }}
-    secrets: inherit
   e2e-macos:
     uses: ./.github/workflows/macos.yaml
     with:
       nightly_test_mode: ${{ github.event.inputs.test_mode == 'true' }}
-    secrets: inherit
   e2e-web:
     uses: ./.github/workflows/web.yaml
     with:
       nightly_test_mode: ${{ github.event.inputs.test_mode == 'true' }}
-    secrets: inherit
   e2e-windows:
     uses: ./.github/workflows/windows.yaml
     with:
       nightly_test_mode: ${{ github.event.inputs.test_mode == 'true' }}
-    secrets: inherit
   e2e-fdc:
     uses: ./.github/workflows/e2e_tests_fdc.yaml
     with:
       nightly_test_mode: ${{ github.event.inputs.test_mode == 'true' }}
-    secrets: inherit
   e2e-pipeline:
     uses: ./.github/workflows/e2e_tests_pipeline.yaml
     if: ${{ github.event.inputs.test_mode != 'true' }}
-    secrets: inherit
+    secrets:
+      PIPELINE_E2E_FIREBASE_OPTIONS_DART: ${{ secrets.PIPELINE_E2E_FIREBASE_OPTIONS_DART }}
+      PIPELINE_E2E_GOOGLE_SERVICES_JSON: ${{ secrets.PIPELINE_E2E_GOOGLE_SERVICES_JSON }}
+      PIPELINE_E2E_GOOGLE_SERVICE_INFO_PLIST: ${{ secrets.PIPELINE_E2E_GOOGLE_SERVICE_INFO_PLIST }}
 
   update-dashboard:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -18,7 +18,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   e2e-android:
@@ -59,6 +58,10 @@ jobs:
   update-dashboard:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Only this job writes to issues; keep the workflow-level grant read-only.
+    permissions:
+      contents: read
+      issues: write
     if: ${{ always() && !cancelled() }}
     needs: [e2e-android, e2e-ios, e2e-macos, e2e-web, e2e-windows, e2e-fdc, e2e-pipeline]
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,13 +8,13 @@ concurrency:
 on:
   schedule:
     - cron: '0 4 * * *'
-  # The dispatch is only for test purpose  
-  # workflow_dispatch:
-  #   inputs:
-  #     test_mode:
-  #       description: 'Run in test mode'
-  #       type: boolean
-  #       default: false
+  # The dispatch is only for test purpose
+  workflow_dispatch:
+    inputs:
+      test_mode:
+        description: 'Run in test mode'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -58,6 +58,7 @@ jobs:
 
   update-dashboard:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: ${{ always() && !cancelled() }}
     needs: [e2e-android, e2e-ios, e2e-macos, e2e-web, e2e-windows, e2e-fdc, e2e-pipeline]
     steps:

--- a/.github/workflows/scripts/flutter-drive-web-retry.sh
+++ b/.github/workflows/scripts/flutter-drive-web-retry.sh
@@ -10,7 +10,11 @@ FLUTTER_DRIVE_MAX_ATTEMPTS="${FLUTTER_DRIVE_MAX_ATTEMPTS:-4}"
 FLUTTER_DRIVE_EXTRA_ARGS="${FLUTTER_DRIVE_EXTRA_ARGS:-}"
 
 cleanup_web_processes() {
+  # Chrome's process name differs per OS: "Google Chrome" on macOS,
+  # "chrome"/"google-chrome" on Linux.
   pkill -f "Google Chrome" || true
+  pkill -f "google-chrome" || true
+  pkill -x chrome || true
   pkill -f chrome_crashpad || true
   pkill -x chromedriver || true
   pkill -x dartvm || true
@@ -23,7 +27,17 @@ run_tests() {
 
   chromedriver --port=4444 --trace-buffer-size=100000 &
   chromedriver_pid=$!
-  sleep 2
+  # Wait for chromedriver to accept connections instead of a fixed sleep.
+  for _ in $(seq 1 30); do
+    if curl --output /dev/null --silent --fail http://localhost:4444/status; then
+      break
+    fi
+    if ! kill -0 "$chromedriver_pid" 2>/dev/null; then
+      echo "chromedriver exited before becoming ready."
+      return 3
+    fi
+    sleep 1
+  done
 
   set +e
   python3 - <<'PY'

--- a/.github/workflows/scripts/flutter-drive-web-retry.sh
+++ b/.github/workflows/scripts/flutter-drive-web-retry.sh
@@ -9,6 +9,13 @@ FLUTTER_DRIVE_TIMEOUT_SECONDS="${FLUTTER_DRIVE_TIMEOUT_SECONDS:-180}"
 FLUTTER_DRIVE_MAX_ATTEMPTS="${FLUTTER_DRIVE_MAX_ATTEMPTS:-4}"
 FLUTTER_DRIVE_EXTRA_ARGS="${FLUTTER_DRIVE_EXTRA_ARGS:-}"
 
+# The embedded Python reads these from its environment; without the export a
+# variable defaulted above is invisible to it, the KeyError kills the run
+# before flutter drive starts, and on macOS (bash 3.2) that failure was
+# silently swallowed — the job went green having run zero tests.
+export FLUTTER_DRIVE_TARGET FLUTTER_DRIVE_DRIVER FLUTTER_DRIVE_DEVICE \
+  FLUTTER_DRIVE_TIMEOUT_SECONDS FLUTTER_DRIVE_MAX_ATTEMPTS FLUTTER_DRIVE_EXTRA_ARGS
+
 cleanup_web_processes() {
   # Chrome's process name differs per OS: "Google Chrome" on macOS,
   # "chrome"/"google-chrome" on Linux.
@@ -95,7 +102,8 @@ PY
   wait "$chromedriver_pid" 2>/dev/null || true
   cleanup_web_processes
 
-  output=$(<output.log)
+  # output.log may not exist if the drive process died before writing it.
+  output=$(cat output.log 2>/dev/null || true)
   if [[ "$output" =~ \[E\] ]]; then
     # You will see "All tests passed." in the logs even when tests failed.
     echo "All tests did not pass. Please check the logs for more information."

--- a/.github/workflows/scripts/start-firebase-emulator.sh
+++ b/.github/workflows/scripts/start-firebase-emulator.sh
@@ -27,7 +27,10 @@ if [[ ! -d "functions/node_modules" ]]; then
       # TODO temporary workaround for GitHub Actions CI issue:
       # npm ERR! Your cache folder contains root-owned files, due to a bug in
       # npm ERR! previous versions of npm which has since been addressed.
-      sudo chown -R 501:20 "/Users/runner/.npm" || exit 1
+      # macOS runners only; on Linux the directory doesn't exist.
+      if [[ -d "/Users/runner/.npm" ]]; then
+        sudo chown -R 501:20 "/Users/runner/.npm" || exit 1
+      fi
       npm i || exit 1
     fi
   fi
@@ -37,42 +40,39 @@ fi
 export STORAGE_EMULATOR_DEBUG=true
 EMU_START_COMMAND="firebase emulators:start --only auth,firestore,functions,storage,database --project flutterfire-e2e-tests"
 
-MAX_RETRIES=3
-MAX_CHECKATTEMPTS=60
-CHECKATTEMPTS_WAIT=1
+if [[ -z "${CI}" ]]; then
+  echo "Starting Firebase Emulator Suite in foreground."
+  $EMU_START_COMMAND
+  exit 0
+fi
 
-RETRIES=1
-while [ $RETRIES -le $MAX_RETRIES ]; do
+# Waiting on the "All emulators ready" log line covers every emulator in the
+# suite; probing a single port (the old approach) let tests start while Auth,
+# Storage, Database or Functions were still binding.
+LOG_FILE="firebase-emulator.log"
+MAX_CHECKATTEMPTS=120
 
-  if [[ -z "${CI}" ]]; then
-    echo "Starting Firebase Emulator Suite in foreground."
-    $EMU_START_COMMAND
-    exit 0
-  else
-    echo "Starting Firebase Emulator Suite in background."
-    $EMU_START_COMMAND &
-    CHECKATTEMPTS=1
-    while [ $CHECKATTEMPTS -le $MAX_CHECKATTEMPTS ]; do
-      sleep $CHECKATTEMPTS_WAIT
-      if curl --output /dev/null --silent --fail http://localhost:8080; then
-        # Check again since it can exit before the emulator is ready.
-        sleep 15
-        if curl --output /dev/null --silent --fail http://localhost:8080; then
-          echo "Firebase Emulator Suite is online!"
-          exit 0
-        else
-          echo "❌ Firebase Emulator exited after startup."
-          exit 1
-        fi
-      fi
-      echo "Waiting for Firebase Emulator Suite to come online, check $CHECKATTEMPTS of $MAX_CHECKATTEMPTS..."
-      ((CHECKATTEMPTS = CHECKATTEMPTS + 1))
-    done
+echo "Starting Firebase Emulator Suite in background."
+$EMU_START_COMMAND >"$LOG_FILE" 2>&1 &
+EMU_PID=$!
+
+CHECKATTEMPTS=1
+while [ $CHECKATTEMPTS -le $MAX_CHECKATTEMPTS ]; do
+  if ! kill -0 "$EMU_PID" 2>/dev/null; then
+    echo "❌ Firebase Emulator process exited before becoming ready. Log output:"
+    cat "$LOG_FILE"
+    exit 1
   fi
-
-  echo "Firebase Emulator Suite did not come online in $MAX_CHECKATTEMPTS checks. Try $RETRIES of $MAX_RETRIES."
-  ((RETRIES = RETRIES + 1))
-
+  if grep -q "All emulators ready" "$LOG_FILE"; then
+    echo "Firebase Emulator Suite is online!"
+    exit 0
+  fi
+  echo "Waiting for Firebase Emulator Suite to come online, check $CHECKATTEMPTS of $MAX_CHECKATTEMPTS..."
+  sleep 1
+  ((CHECKATTEMPTS = CHECKATTEMPTS + 1))
 done
-echo "Firebase Emulator Suite did not come online after $MAX_RETRIES attempts."
+
+echo "❌ Firebase Emulator Suite did not come online in $MAX_CHECKATTEMPTS seconds. Log output:"
+cat "$LOG_FILE"
+kill "$EMU_PID" 2>/dev/null
 exit 1

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -36,8 +36,8 @@ jobs:
   web:
     permissions:
       contents: read
-    runs-on: macos-latest
-    timeout-minutes: ${{ inputs.nightly_test_mode && 5 || 15 }}
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.nightly_test_mode && 5 || 25 }}
     strategy:
       fail-fast: false
       matrix:
@@ -51,10 +51,20 @@ jobs:
         name: Install Node.js 20
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: '.github/workflows/scripts/functions/package-lock.json'
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
         with:
           distribution: 'temurin'
           java-version: '21'
+      # The ubuntu runner image ships Google Chrome and a chromedriver build
+      # that is matched to it — that pairing IS our pinning strategy, so we use
+      # the image binaries rather than downloading our own.
+      - name: 'Set up Chrome and chromedriver'
+        run: |
+          echo "$CHROMEWEBDRIVER" >> "$GITHUB_PATH"
+          google-chrome --version
+          "$CHROMEWEBDRIVER/chromedriver" --version
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -68,11 +78,12 @@ jobs:
       - name: Generate dummy Firebase configs
         run: dart ./.github/workflows/scripts/generate-dummy-firebase-configs.dart
       - name: 'Bootstrap package'
+        timeout-minutes: 15
         run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
       - name: 'Install Tools'
         run: |
-          sudo npm i -g firebase-tools
-          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
+          sudo npm i -g firebase-tools@15.25.1
+          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -82,104 +93,26 @@ jobs:
           enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
-          restore-keys: firebase-emulators-v3
+          key: firebase-emulators-v5-${{ env.FIREBASE_TOOLS_VERSION }}
+          restore-keys: firebase-emulators-v5-
       - name: Start Firebase Emulator
-        run: sudo chown -R 501:20 "/Users/runner/.npm" && cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
+        timeout-minutes: 8
+        run: cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
       - name: 'E2E Tests'
+        timeout-minutes: 15
         working-directory: ${{ matrix.working_directory }}
         # Web devices are not supported for the `flutter test` command yet. As a
         # workaround we can use the `flutter drive` command. Tracking issue:
         # https://github.com/flutter/flutter/issues/66264
-        # Chrome debug service can fail with AppConnectionException. Retry with
-        # a clean browser/driver process set so stale children cannot poison
-        # the next attempt.
+        # The retry script only retries infrastructure startup failures
+        # (timeouts, AppConnectionException, "Failed to exit Chromium"); real
+        # test/compile failures fail fast. It also owns the chromedriver
+        # lifecycle, so nothing here starts chromedriver.
         run: |
-          cleanup_web_processes() {
-            pkill -f "Google Chrome" || true
-            pkill -f chrome_crashpad || true
-            pkill -x chromedriver || true
-            pkill -x dartvm || true
-            pkill -x dartaotruntime || true
-          }
-
-          run_tests() {
-            rm -f output.log
-            cleanup_web_processes
-            chromedriver --port=4444 --trace-buffer-size=100000 &
-            chromedriver_pid=$!
-            sleep 2
-
-            python3 - <<'PY'
-          import subprocess
-          import sys
-
-          def normalize_output(output):
-              if output is None:
-                  return ''
-              if isinstance(output, bytes):
-                  return output.decode(errors='replace')
-              return output
-
-          command = [
-              'flutter',
-              'drive',
-              '--target=./integration_test/e2e_test.dart',
-              '--driver=./test_driver/integration_test.dart',
-              '-d',
-              'chrome',
-              '--dart-define=CI=true',
-          ]
-
-          try:
-              completed = subprocess.run(
-                  command,
-                  check=False,
-                  stdout=subprocess.PIPE,
-                  stderr=subprocess.STDOUT,
-                  text=True,
-                  timeout=180,
-              )
-          except subprocess.TimeoutExpired as error:
-              output = normalize_output(error.stdout)
-              print(output, end='')
-              with open('output.log', 'w') as file:
-                  file.write(output)
-              print('flutter drive timed out before connecting to Chrome.')
-              sys.exit(124)
-
-          output = normalize_output(completed.stdout)
-          print(output, end='')
-          with open('output.log', 'w') as file:
-              file.write(output)
-          sys.exit(completed.returncode)
-          PY
-            exit_code=$?
-            kill "$chromedriver_pid" 2>/dev/null || true
-            wait "$chromedriver_pid" 2>/dev/null || true
-            cleanup_web_processes
-
-            output=$(<output.log)
-            if [[ "$output" =~ \[E\] ]]; then
-              # You will see "All tests passed." in the logs even when tests failed.
-              echo "All tests did not pass. Please check the logs for more information."
-              return 2
-            fi
-            return $exit_code
-          }
-
-          max_attempts=4
-          for attempt in $(seq 1 "$max_attempts"); do
-            if run_tests; then
-              exit 0
-            fi
-            exit_code=$?
-            if [[ "$exit_code" == "2" || "$attempt" == "$max_attempts" ]]; then
-              exit "$exit_code"
-            fi
-            echo "Attempt $attempt failed before tests completed. Retrying..."
-          done
-        shell: bash
+          FLUTTER_DRIVE_TARGET="./integration_test/e2e_test.dart" \
+          FLUTTER_DRIVE_DRIVER="./test_driver/integration_test.dart" \
+          FLUTTER_DRIVE_EXTRA_ARGS="--dart-define=CI=true" \
+          "${GITHUB_WORKSPACE}/.github/workflows/scripts/flutter-drive-web-retry.sh"
       - name: Save Firestore Emulator Cache
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
@@ -195,18 +128,28 @@ jobs:
   web-app-check:
     permissions:
       contents: read
-    runs-on: macos-latest
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
         name: Install Node.js 20
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: '.github/workflows/scripts/functions/package-lock.json'
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
         with:
           distribution: 'temurin'
           java-version: '21'
+      # The ubuntu runner image ships Google Chrome and a chromedriver build
+      # that is matched to it — that pairing IS our pinning strategy, so we use
+      # the image binaries rather than downloading our own.
+      - name: 'Set up Chrome and chromedriver'
+        run: |
+          echo "$CHROMEWEBDRIVER" >> "$GITHUB_PATH"
+          google-chrome --version
+          "$CHROMEWEBDRIVER/chromedriver" --version
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -218,11 +161,12 @@ jobs:
           run-bootstrap: false
           melos-version: '5.3.0'
       - name: 'Bootstrap package'
+        timeout-minutes: 15
         run: melos bootstrap --scope tests
       - name: 'Install Tools'
         run: |
-          sudo npm i -g firebase-tools
-          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
+          sudo npm i -g firebase-tools@15.25.1
+          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -232,104 +176,26 @@ jobs:
           enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
-          restore-keys: firebase-emulators-v3
+          key: firebase-emulators-v5-${{ env.FIREBASE_TOOLS_VERSION }}
+          restore-keys: firebase-emulators-v5-
       - name: Start Firebase Emulator
-        run: sudo chown -R 501:20 "/Users/runner/.npm" && cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
+        timeout-minutes: 8
+        run: cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
       - name: 'E2E Tests'
+        timeout-minutes: 15
         working-directory: tests
         # Web devices are not supported for the `flutter test` command yet. As a
         # workaround we can use the `flutter drive` command. Tracking issue:
         # https://github.com/flutter/flutter/issues/66264
-        # Chrome debug service can fail with AppConnectionException. Retry with
-        # a clean browser/driver process set so stale children cannot poison
-        # the next attempt.
+        # The retry script only retries infrastructure startup failures
+        # (timeouts, AppConnectionException, "Failed to exit Chromium"); real
+        # test/compile failures fail fast. It also owns the chromedriver
+        # lifecycle, so nothing here starts chromedriver.
         run: |
-          cleanup_web_processes() {
-            pkill -f "Google Chrome" || true
-            pkill -f chrome_crashpad || true
-            pkill -x chromedriver || true
-            pkill -x dartvm || true
-            pkill -x dartaotruntime || true
-          }
-
-          run_tests() {
-            rm -f output.log
-            cleanup_web_processes
-            chromedriver --port=4444 --trace-buffer-size=100000 &
-            chromedriver_pid=$!
-            sleep 2
-
-            python3 - <<'PY'
-          import subprocess
-          import sys
-
-          def normalize_output(output):
-              if output is None:
-                  return ''
-              if isinstance(output, bytes):
-                  return output.decode(errors='replace')
-              return output
-
-          command = [
-              'flutter',
-              'drive',
-              '--target=./integration_test/e2e_test.dart',
-              '--driver=./test_driver/integration_test.dart',
-              '-d',
-              'chrome',
-              '--dart-define=CI=true',
-              '--dart-define=APP_CHECK_E2E=true',
-          ]
-
-          try:
-              completed = subprocess.run(
-                  command,
-                  check=False,
-                  stdout=subprocess.PIPE,
-                  stderr=subprocess.STDOUT,
-                  text=True,
-                  timeout=180,
-              )
-          except subprocess.TimeoutExpired as error:
-              output = normalize_output(error.stdout)
-              print(output, end='')
-              with open('output.log', 'w') as file:
-                  file.write(output)
-              print('flutter drive timed out before connecting to Chrome.')
-              sys.exit(124)
-
-          output = normalize_output(completed.stdout)
-          print(output, end='')
-          with open('output.log', 'w') as file:
-              file.write(output)
-          sys.exit(completed.returncode)
-          PY
-            exit_code=$?
-            kill "$chromedriver_pid" 2>/dev/null || true
-            wait "$chromedriver_pid" 2>/dev/null || true
-            cleanup_web_processes
-
-            output=$(<output.log)
-            if [[ "$output" =~ \[E\] ]]; then
-              echo "All tests did not pass. Please check the logs for more information."
-              return 2
-            fi
-            return $exit_code
-          }
-
-          max_attempts=4
-          for attempt in $(seq 1 "$max_attempts"); do
-            if run_tests; then
-              exit 0
-            fi
-            exit_code=$?
-            if [[ "$exit_code" == "2" || "$attempt" == "$max_attempts" ]]; then
-              exit "$exit_code"
-            fi
-            echo "Attempt $attempt failed before tests completed. Retrying..."
-          done
-        shell: bash
+          FLUTTER_DRIVE_TARGET="./integration_test/e2e_test.dart" \
+          FLUTTER_DRIVE_DRIVER="./test_driver/integration_test.dart" \
+          FLUTTER_DRIVE_EXTRA_ARGS="--dart-define=CI=true --dart-define=APP_CHECK_E2E=true" \
+          "${GITHUB_WORKSPACE}/.github/workflows/scripts/flutter-drive-web-retry.sh"
       - name: Save Firestore Emulator Cache
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
@@ -345,8 +211,8 @@ jobs:
   web-wasm:
     permissions:
       contents: read
-    runs-on: macos-latest
-    timeout-minutes: ${{ inputs.nightly_test_mode && 5 || 15 }}
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.nightly_test_mode && 5 || 25 }}
     strategy:
       fail-fast: false
       matrix:
@@ -360,10 +226,20 @@ jobs:
         name: Install Node.js 20
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: '.github/workflows/scripts/functions/package-lock.json'
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
         with:
           distribution: 'temurin'
           java-version: '21'
+      # The ubuntu runner image ships Google Chrome and a chromedriver build
+      # that is matched to it — that pairing IS our pinning strategy, so we use
+      # the image binaries rather than downloading our own.
+      - name: 'Set up Chrome and chromedriver'
+        run: |
+          echo "$CHROMEWEBDRIVER" >> "$GITHUB_PATH"
+          google-chrome --version
+          "$CHROMEWEBDRIVER/chromedriver" --version
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: 'stable'
@@ -377,11 +253,12 @@ jobs:
       - name: Generate dummy Firebase configs
         run: dart ./.github/workflows/scripts/generate-dummy-firebase-configs.dart
       - name: 'Bootstrap package'
+        timeout-minutes: 15
         run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
       - name: 'Install Tools'
         run: |
-          sudo npm i -g firebase-tools
-          echo "FIREBASE_TOOLS_VERSION=$(npm firebase --version)" >> $GITHUB_ENV
+          sudo npm i -g firebase-tools@15.25.1
+          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -391,110 +268,36 @@ jobs:
           enableCrossOsArchive: true
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v3-${{ env.FIREBASE_TOOLS_VERSION }}
-          restore-keys: firebase-emulators-v3
+          key: firebase-emulators-v5-${{ env.FIREBASE_TOOLS_VERSION }}
+          restore-keys: firebase-emulators-v5-
       - name: Start Firebase Emulator
-        run: sudo chown -R 501:20 "/Users/runner/.npm" && cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
+        timeout-minutes: 8
+        run: cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
+      - name: 'Use WASM index.html'
+        working-directory: ${{ matrix.working_directory }}
+        run: mv ./web/wasm_index.html ./web/index.html
       - name: 'E2E Tests'
+        timeout-minutes: 15
         working-directory: ${{ matrix.working_directory }}
         # Web devices are not supported for the `flutter test` command yet. As a
         # workaround we can use the `flutter drive` command. Tracking issue:
         # https://github.com/flutter/flutter/issues/66264
         # WASM web runs can hang after building but before the test harness
-        # connects. Retry from a clean browser/driver process set.
+        # connects; the retry script retries only those infrastructure startup
+        # failures. It also owns the chromedriver lifecycle, so nothing here
+        # starts chromedriver.
         run: |
-          mv ./web/wasm_index.html ./web/index.html
-          cleanup_web_processes() {
-            pkill -f "Google Chrome" || true
-            pkill -f chrome_crashpad || true
-            pkill -x chromedriver || true
-            pkill -x dartvm || true
-            pkill -x dartaotruntime || true
-          }
-
-          run_tests() {
-            rm -f output.log
-            cleanup_web_processes
-            chromedriver --port=4444 --trace-buffer-size=100000 &
-            chromedriver_pid=$!
-            sleep 2
-
-            python3 - <<'PY'
-          import subprocess
-          import sys
-
-          def normalize_output(output):
-              if output is None:
-                  return ''
-              if isinstance(output, bytes):
-                  return output.decode(errors='replace')
-              return output
-
-          command = [
-              'flutter',
-              'drive',
-              '--target=./integration_test/e2e_test.dart',
-              '--driver=./test_driver/integration_test.dart',
-              '-d',
-              'chrome',
-              '--wasm',
-              '--dart-define=CI=true',
-          ]
-
-          try:
-              completed = subprocess.run(
-                  command,
-                  check=False,
-                  stdout=subprocess.PIPE,
-                  stderr=subprocess.STDOUT,
-                  text=True,
-                  timeout=300,
-              )
-          except subprocess.TimeoutExpired as error:
-              output = normalize_output(error.stdout)
-              print(output, end='')
-              with open('output.log', 'w') as file:
-                  file.write(output)
-              print('flutter drive timed out before completing WASM web tests.')
-              sys.exit(124)
-
-          output = normalize_output(completed.stdout)
-          print(output, end='')
-          with open('output.log', 'w') as file:
-              file.write(output)
-          sys.exit(completed.returncode)
-          PY
-            exit_code=$?
-            kill "$chromedriver_pid" 2>/dev/null || true
-            wait "$chromedriver_pid" 2>/dev/null || true
-            cleanup_web_processes
-
-            output=$(<output.log)
-            if [[ "$output" =~ \[E\] ]]; then
-              # You will see "All tests passed." in the logs even when tests failed.
-              echo "All tests did not pass. Please check the logs for more information."
-              return 2
-            fi
-            return $exit_code
-          }
-
-          max_attempts=2
-          for attempt in $(seq 1 "$max_attempts"); do
-            if run_tests; then
-              exit 0
-            fi
-            exit_code=$?
-            if [[ "$exit_code" == "2" || "$attempt" == "$max_attempts" ]]; then
-              exit "$exit_code"
-            fi
-            echo "Attempt $attempt failed before WASM tests completed. Retrying..."
-          done
-        shell: bash
+          FLUTTER_DRIVE_TARGET="./integration_test/e2e_test.dart" \
+          FLUTTER_DRIVE_DRIVER="./test_driver/integration_test.dart" \
+          FLUTTER_DRIVE_EXTRA_ARGS="--wasm --dart-define=CI=true" \
+          FLUTTER_DRIVE_TIMEOUT_SECONDS=300 \
+          FLUTTER_DRIVE_MAX_ATTEMPTS=2 \
+          "${GITHUB_WORKSPACE}/.github/workflows/scripts/flutter-drive-web-retry.sh"
       - name: Save Firestore Emulator Cache
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.
         if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           # The firebase emulators are pure javascript and java, OS-independent
           enableCrossOsArchive: true

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -55,17 +55,20 @@ jobs:
       - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
         with:
           run-bootstrap: false
-          melos-version: '3.0.0'
+          melos-version: '5.3.0'
       - name: "Bootstrap package"
         run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
       - name: "Install Tools"
         run: |
-          npm install -g firebase-tools
+          npm install -g firebase-tools@15.25.1
       - name: "Build Windows (Release)"
+        timeout-minutes: 25
         run: cd tests && flutter build windows --release
       - name: "Build Windows (Profile)"
+        timeout-minutes: 25
         run: cd tests && flutter build windows --profile
       - name: Start Firebase Emulator and run tests
+        timeout-minutes: 30
         run: cd ./.github/workflows/scripts && firebase emulators:exec --project flutterfire-e2e-tests "cd ../../../tests && flutter test .\integration_test\e2e_test.dart -d windows --verbose"
 
   windows-firestore:
@@ -91,15 +94,16 @@ jobs:
       - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
         with:
           run-bootstrap: false
-          melos-version: '3.0.0'
+          melos-version: '5.3.0'
       - name: Generate dummy Firebase configs
         run: dart ./.github/workflows/scripts/generate-dummy-firebase-configs.dart
       - name: "Bootstrap package"
         run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
       - name: "Install Tools"
         run: |
-          npm install -g firebase-tools
+          npm install -g firebase-tools@15.25.1
       - name: Start Firebase Emulator and run tests
+        timeout-minutes: 30
         run: |
           cd ./.github/workflows/scripts
           firebase emulators:exec --project flutterfire-e2e-tests "cd ../../../packages/cloud_firestore/cloud_firestore/example && flutter drive --target=.\integration_test\e2e_test.dart --driver=.\test_driver\integration_test.dart -d windows --verbose" 2>&1 | Tee-Object -FilePath output.log

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/web_snapshot_listeners.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/web_snapshot_listeners.dart
@@ -8,6 +8,10 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+/// Guards against a dropped snapshot callback hanging the whole suite: a
+/// missing event fails this test instead of burning the job timeout.
+const _completerTimeout = Duration(seconds: 30);
+
 // Run only on web for demonstrating snapshot listener clean up in debug mode does not clean up the listeners incorrectly.
 // See: https://github.com/firebase/flutterfire/issues/13019
 void runWebSnapshotListenersTests() {
@@ -57,9 +61,9 @@ void runWebSnapshotListenersTests() {
           completer3.complete(true);
         });
 
-        final one = await completer.future;
-        final two = await completer2.future;
-        final three = await completer3.future;
+        final one = await completer.future.timeout(_completerTimeout);
+        final two = await completer2.future.timeout(_completerTimeout);
+        final three = await completer3.future.timeout(_completerTimeout);
 
         expect(one, true);
         expect(two, true);
@@ -103,10 +107,10 @@ void runWebSnapshotListenersTests() {
           completer4.complete(true);
         });
 
-        final one = await completer.future;
-        final two = await completer2.future;
-        final three = await completer3.future;
-        final four = await completer4.future;
+        final one = await completer.future.timeout(_completerTimeout);
+        final two = await completer2.future.timeout(_completerTimeout);
+        final three = await completer3.future.timeout(_completerTimeout);
+        final four = await completer4.future.timeout(_completerTimeout);
 
         expect(one, true);
         expect(two, true);
@@ -142,9 +146,9 @@ void runWebSnapshotListenersTests() {
           }
           completer3.complete(true);
         });
-        final one = await completer.future;
-        final two = await completer2.future;
-        final three = await completer3.future;
+        final one = await completer.future.timeout(_completerTimeout);
+        final two = await completer2.future.timeout(_completerTimeout);
+        final three = await completer3.future.timeout(_completerTimeout);
 
         expect(one, true);
         expect(two, true);
@@ -180,9 +184,9 @@ void runWebSnapshotListenersTests() {
           completer3.complete(true);
         });
 
-        final one = await completer.future;
-        final two = await completer2.future;
-        final three = await completer3.future;
+        final one = await completer.future.timeout(_completerTimeout);
+        final two = await completer2.future.timeout(_completerTimeout);
+        final three = await completer3.future.timeout(_completerTimeout);
 
         expect(one, true);
         expect(two, true);

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/core/ref.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/core/ref.dart
@@ -338,7 +338,24 @@ class QueryRef<Data, Variables> extends OperationRef<Data, Variables> {
   Stream<ServerResponse>? _serverStream;
   StreamSubscription<ServerResponse>? _serverStreamSubscription;
 
+  /// True from the moment [_streamFromServer] is entered until it has either
+  /// installed [_serverStream] or given up.
+  ///
+  /// [_streamFromServer] awaits a token refresh before it can assign
+  /// [_serverStream], so `_serverStream == null` is *not* a usable "no stream
+  /// yet" test for callers racing inside that window.
+  bool _serverStreamStarting = false;
+
+  /// Bumped whenever the current server stream is torn down, so a
+  /// [_streamFromServer] call that is still starting up can tell that its
+  /// result is no longer wanted and avoid installing an unreachable stream.
+  int _serverStreamGeneration = 0;
+
+  bool get _hasServerStream => _serverStream != null || _serverStreamStarting;
+
   void _onAllSubscribersCancelled() {
+    _serverStreamGeneration++;
+    _serverStreamStarting = false;
     _serverStreamSubscription?.cancel();
     _serverStreamSubscription = null;
     _serverStream = null;
@@ -346,6 +363,14 @@ class QueryRef<Data, Variables> extends OperationRef<Data, Variables> {
 
   Stream<QueryResult<Data, Variables>> subscribe() {
     _streamController ??= _queryManager.addQuery(this);
+
+    // A ref can be subscribed again after all of its previous subscribers went
+    // away, in which case `addQuery` above is skipped and the QueryManager no
+    // longer tracks this ref. Re-register it, otherwise
+    // `FirebaseDataConnect.query()` hands out a *different* ref for the same
+    // query while this one is still live, and each of them opens its own
+    // server stream for one logical subscription.
+    _queryManager.trackedQueries[operationId] = this;
 
     final stream =
         _streamController!.stream.cast<QueryResult<Data, Variables>>();
@@ -362,7 +387,7 @@ class QueryRef<Data, Variables> extends OperationRef<Data, Variables> {
       }
 
       // Initiate Web Socket stream only if not already streaming
-      if (_serverStream == null) {
+      if (!_hasServerStream) {
         _streamFromServer();
       }
     });
@@ -371,8 +396,25 @@ class QueryRef<Data, Variables> extends OperationRef<Data, Variables> {
   }
 
   void _streamFromServer() async {
+    // Guard synchronously: two `subscribe()` calls for the same query resolve
+    // to this same ref and both queue a microtask, so without this both would
+    // reach here while `_serverStream` is still null and open two server
+    // streams. Only one of them would ever be reachable for cancellation; the
+    // other leaks for the lifetime of the process, holding the transport's
+    // subscription open so every later subscribe to this query silently
+    // multiplexes onto it and never receives a first event.
+    if (_hasServerStream) return;
+    _serverStreamStarting = true;
+    final generation = _serverStreamGeneration;
+
     bool shouldRetry = await _shouldRetry();
     try {
+      if (generation != _serverStreamGeneration) {
+        // Every subscriber went away while we were starting up. Do not install
+        // the stream: nothing would ever cancel it.
+        return;
+      }
+
       _serverStream = _transport.invokeStreamQuery<Data, Variables>(
         operationId,
         operationName,
@@ -423,6 +465,8 @@ class QueryRef<Data, Variables> extends OperationRef<Data, Variables> {
       _serverStream = null;
       log("QueryRef $operationId _streamFromServer loop Unknown loop failure: $e");
       publishErrorToStream(e);
+    } finally {
+      _serverStreamStarting = false;
     }
   }
 

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/websocket_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/websocket_transport.dart
@@ -32,6 +32,12 @@ class _PendingSubscription {
   final String queryName;
   final Map<String, dynamic>? variables;
 
+  /// Connection generation on which the `subscribe` frame for this request was
+  /// last written. `-1` means "never written on any live socket", so the server
+  /// has no idea this subscription exists and it must be (re)sent before any
+  /// event — or any `resume` — can be expected for its request id.
+  int sentOnGeneration = -1;
+
   _PendingSubscription(this.operationId, this.queryName, this.variables);
 }
 
@@ -199,6 +205,64 @@ class WebSocketTransport implements DataConnectTransport {
     _scheduleReconnect();
   }
 
+  /// Incremented every time a socket completes its handshake and gets its init
+  /// frame. Subscriptions record the generation they were sent on so a
+  /// subscription can never be silently "live" on the client while the server
+  /// has never seen its `subscribe` frame.
+  int _connectionGeneration = 0;
+
+  /// Returns the request id of a subscription for [operationId] that new
+  /// listeners can safely attach to, or `null` if there is none.
+  ///
+  /// `_activeSubscriptions` is the routing table for both multiplexing
+  /// (`invokeStreamQuery`) and `resume` (`_sendUnary`). An entry that outlives
+  /// its subscription is silently fatal: every later `subscribe()` for that
+  /// query attaches to a request the server is not streaming, no `subscribe`
+  /// frame is ever written, and the caller waits forever for a first event
+  /// that cannot arrive. So treat the entry as a cache that has to be
+  /// *validated* against the listener/pending tables and purged when stale.
+  String? _liveSubscriptionRequestId(String operationId) {
+    final requestId = _activeSubscriptions[operationId];
+    if (requestId == null) return null;
+
+    final pending = _pendingSubscriptions[requestId];
+    final listeners = _streamListeners[requestId];
+    if (pending == null || listeners == null || listeners.isEmpty) {
+      _activeSubscriptions.remove(operationId);
+      _pendingSubscriptions.remove(requestId);
+      _streamListeners.remove(requestId);
+      return null;
+    }
+    return requestId;
+  }
+
+  /// Writes the `subscribe` frame for every registered subscription that has
+  /// not been sent on the current connection.
+  ///
+  /// Guarded by [_PendingSubscription.sentOnGeneration] so it is idempotent:
+  /// whoever gets there first (this method, `invokeStreamQuery.onListen`, or
+  /// `_resubscribeActive`) sends, the others skip. Without this, a subscription
+  /// registered while a socket was being established — or one whose frame was
+  /// dropped by a teardown — is never retried on any later connection.
+  void _sendPendingSubscriptions(String? authToken, String? appCheckToken) {
+    if (!isConnected) return;
+    for (final entry in _pendingSubscriptions.entries) {
+      final requestId = entry.key;
+      final sub = entry.value;
+      if (sub.sentOnGeneration == _connectionGeneration) continue;
+      if (_activeSubscriptions[sub.operationId] != requestId) continue;
+
+      final request = StreamRequest(
+        requestId: requestId,
+        requestKind: RequestKind.subscribe,
+        subscribe: ExecuteRequest(sub.queryName, sub.variables),
+        headers: _buildHeaders(authToken, appCheckToken),
+      );
+      _send(request.toJson());
+      sub.sentOnGeneration = _connectionGeneration;
+    }
+  }
+
   final Random _random = Random();
   static const String _chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
 
@@ -303,6 +367,11 @@ class WebSocketTransport implements DataConnectTransport {
       headers: headers,
     );
     _send(initRequest.toJson());
+
+    // This is a brand new server-side session: nothing that was sent on a
+    // previous socket counts any more.
+    _connectionGeneration++;
+    _sendPendingSubscriptions(authToken, appCheckToken);
   }
 
   // called when a message is received from the stream
@@ -443,18 +512,9 @@ class WebSocketTransport implements DataConnectTransport {
   }
 
   void _resubscribeActive(String? authToken, String? appCheckToken) {
-    for (final sub in _pendingSubscriptions.values) {
-      final reqId = _activeSubscriptions[sub.operationId];
-      if (reqId == null) continue;
-      final headers = _buildHeaders(authToken, appCheckToken);
-      final request = StreamRequest(
-        requestId: reqId,
-        requestKind: RequestKind.subscribe,
-        subscribe: ExecuteRequest(sub.queryName, sub.variables),
-        headers: headers,
-      );
-      _send(request.toJson());
-    }
+    // Generation-guarded, so this is a no-op for anything `_doConnect` already
+    // resent on the new socket rather than a duplicate `subscribe`.
+    _sendPendingSubscriptions(authToken, appCheckToken);
   }
 
   void _replayQueriesAndFailMutations(
@@ -644,8 +704,19 @@ class WebSocketTransport implements DataConnectTransport {
 
     final completer = Completer<ServerResponse>();
 
-    if (_activeSubscriptions.containsKey(operationId)) {
-      final existingRequestId = _activeSubscriptions[operationId]!;
+    // `resume` is only meaningful for a subscription the server currently
+    // streams. Resuming a request id it never received a `subscribe` for (or
+    // one it has already cancelled) yields no response at all, and this
+    // completer — the caller's `execute()` future — would hang forever.
+    // `_liveSubscriptionRequestId` also purges the mapping if it is stale.
+    final liveRequestId = _liveSubscriptionRequestId(operationId);
+    final liveSubscription =
+        liveRequestId == null ? null : _pendingSubscriptions[liveRequestId];
+    final canResume = liveRequestId != null &&
+        liveSubscription!.sentOnGeneration == _connectionGeneration;
+
+    if (canResume) {
+      final existingRequestId = liveRequestId;
       Map<String, dynamic>? variablesMap;
       if (vars != null && serializer != null) {
         variablesMap = jsonDecode(serializer(vars));
@@ -724,6 +795,13 @@ class WebSocketTransport implements DataConnectTransport {
   ) {
     late StreamController<ServerResponse> controller;
 
+    // The request id this particular controller joined. `onCancel` must use
+    // this rather than re-reading `_activeSubscriptions[operationId]`: by the
+    // time a cancel is delivered the map may already point at a *newer*
+    // subscription for the same query, and cleaning up against that entry
+    // corrupts the live subscription instead of this dead one.
+    String? joinedRequestId;
+
     controller = StreamController<ServerResponse>(
       onListen: () async {
         _pendingOperationSetups++;
@@ -735,7 +813,11 @@ class WebSocketTransport implements DataConnectTransport {
           // arriving in that window makes the transport look idle, closes the
           // socket, flags the close as *expected*, and this subscription is
           // then stranded forever — no first event, and (by design) no error.
-          final existingRequestId = _activeSubscriptions[operationId];
+          //
+          // Only multiplex onto an existing request id that is *verifiably*
+          // live. A stale entry here means no `subscribe` frame is ever
+          // written for this listener and it waits forever for a first event.
+          final existingRequestId = _liveSubscriptionRequestId(operationId);
           final isNewSubscription = existingRequestId == null;
 
           Map<String, dynamic>? variables;
@@ -745,6 +827,7 @@ class WebSocketTransport implements DataConnectTransport {
 
           final requestId =
               existingRequestId ?? _generateRequestId(operationId);
+          joinedRequestId = requestId;
 
           if (isNewSubscription) {
             _activeSubscriptions[operationId] = requestId;
@@ -760,13 +843,6 @@ class WebSocketTransport implements DataConnectTransport {
             // Do NOT add error to sink here. The stream is designed to quietly
             // keep the query in `_pendingSubscriptions` and silently retry
             // when the network reconnects via `_scheduleReconnect`.
-          }
-
-          if (!isNewSubscription) {
-            // Multiplexed onto a `subscribe` that was already sent for
-            // `requestId`; nothing more to write.
-            if (!isConnected) _reconnectForActiveOperations();
-            return;
           }
 
           if (!isConnected) {
@@ -788,23 +864,22 @@ class WebSocketTransport implements DataConnectTransport {
             return;
           }
 
-          final headers = _buildHeaders(authToken, appCheckToken);
-
-          final request = StreamRequest(
-            requestId: requestId,
-            requestKind: RequestKind.subscribe,
-            subscribe: ExecuteRequest(queryName, variables),
-            headers: headers,
-          );
-
-          _send(request.toJson());
+          // Generation-guarded, so this covers both cases with no duplicates:
+          // a brand new subscription is written here, and a multiplexed one is
+          // a no-op unless its `subscribe` is missing from this connection (in
+          // which case attaching to it silently would never yield an event).
+          _sendPendingSubscriptions(authToken, appCheckToken);
         } finally {
           _pendingOperationSetups--;
         }
       },
       onCancel: () {
-        final requestId = _activeSubscriptions[operationId];
+        // Clean up against the request id *this* controller joined, and only
+        // once — `onCancel` can be reached again for an already-cancelled
+        // subscription, and the map may meanwhile describe a newer one.
+        final requestId = joinedRequestId;
         if (requestId == null) return;
+        joinedRequestId = null;
 
         final listeners = _streamListeners[requestId];
         listeners?.remove(controller);
@@ -814,7 +889,9 @@ class WebSocketTransport implements DataConnectTransport {
           // every later `subscribe()` for this query attach to a request the
           // server is no longer streaming, so it never gets a first event.
           _streamListeners.remove(requestId);
-          _activeSubscriptions.remove(operationId);
+          if (_activeSubscriptions[operationId] == requestId) {
+            _activeSubscriptions.remove(operationId);
+          }
           _pendingSubscriptions.remove(requestId);
 
           if (isConnected) {

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/network/websocket_transport.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/network/websocket_transport.dart
@@ -164,13 +164,39 @@ class WebSocketTransport implements DataConnectTransport {
     _disconnect();
   }
 
+  /// Number of operations that are currently between "requested by the caller"
+  /// and "registered in [_unaryListeners] / [_streamListeners]".
+  ///
+  /// Both `_invokeUnary` and `invokeStreamQuery` have to await the connection
+  /// handshake (and an AppCheck token) before they can send anything, so there
+  /// is a window during which a brand new operation is invisible to
+  /// [_checkIdleAndDisconnect]. Without this counter an unrelated unary
+  /// response arriving in that window makes the transport look idle, closes the
+  /// socket and — because the close is flagged as *expected* — permanently
+  /// vetoes any reconnect for the operation that was still being set up.
+  int _pendingOperationSetups = 0;
+
   void _checkIdleAndDisconnect() {
+    if (_pendingOperationSetups > 0) return;
     if (_streamListeners.isEmpty && _unaryListeners.isEmpty) {
       _isExpectedDisconnect = true;
       _disconnect();
       _releaseWebSocketTransport();
       _clearState();
     }
+  }
+
+  /// Re-establishes the connection on behalf of operations that are already
+  /// registered.
+  ///
+  /// An explicit `execute`/`subscribe` is an explicit intent to be connected,
+  /// so a previous *expected* disconnect (from [_checkIdleAndDisconnect] or
+  /// [disconnect]) must not veto the retry: [_scheduleReconnect] returns early
+  /// while `_isExpectedDisconnect` is set, which would strand the operation
+  /// forever with no event and no error.
+  void _reconnectForActiveOperations() {
+    _isExpectedDisconnect = false;
+    _scheduleReconnect();
   }
 
   final Random _random = Random();
@@ -235,24 +261,40 @@ class WebSocketTransport implements DataConnectTransport {
 
     _claimWebSocketTransport();
 
-    _channel = WebSocketChannel.connect(Uri.parse(_url));
-    _channelSubscription = _channel?.stream.listen(
+    // Detach any listener still attached to a previous socket, so a late
+    // `done`/`error` from it cannot clobber the channel we are about to open.
+    unawaited(_channelSubscription?.cancel());
+
+    final channel = WebSocketChannel.connect(Uri.parse(_url));
+    _channel = channel;
+    _channelSubscription = channel.stream.listen(
       _onMessage,
-      onError: _onError,
-      onDone: _onDone,
+      onError: (Object error) => _onError(channel, error),
+      onDone: () => _onDone(channel),
     );
 
     // reset this since an explicit connect was requested
     _isExpectedDisconnect = false;
 
     try {
-      await _channel?.ready;
+      // Await the local `channel`, never `_channel`: `_channel` can be nulled
+      // out while we are connecting, and `await null` would silently report
+      // success for a socket that is not usable.
+      await channel.ready;
     } catch (e) {
       developer.log('WebSocket connection failed to become ready: $e');
-      _channel = null;
+      if (identical(_channel, channel)) {
+        _channel = null;
+      }
       _releaseWebSocketTransport();
       throw DataConnectError(
           DataConnectErrorCode.other, 'WebSocket connection failed: $e');
+    }
+
+    if (!identical(_channel, channel)) {
+      // The socket was torn down or replaced while the handshake was in
+      // flight; whoever replaced it owns sending the init request.
+      return;
     }
 
     final initRequest = StreamRequest(
@@ -472,12 +514,13 @@ class WebSocketTransport implements DataConnectTransport {
     }
   }
 
-  void _onError(dynamic error) {
+  void _onError(WebSocketChannel channel, dynamic error) {
     if (!_isCurrentWebSocketTransport) {
       _closeStaleWebSocketTransport();
       return;
     }
-    if (_channel == null) return;
+    // Ignore events from a socket that is no longer the active one.
+    if (!identical(_channel, channel)) return;
     developer.log('WebSocket error: $error');
     _channel = null;
     _isReconnecting = false;
@@ -487,6 +530,10 @@ class WebSocketTransport implements DataConnectTransport {
   void _disconnect() {
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
+    // The stream subscription is intentionally left attached so the close
+    // handshake can complete; `_onDone`/`_onError` ignore it once `_channel`
+    // no longer points at it, and `_doConnect` detaches it before opening the
+    // replacement socket.
     _channel?.sink.close();
     _channel = null;
   }
@@ -497,12 +544,14 @@ class WebSocketTransport implements DataConnectTransport {
     _releaseWebSocketTransport();
   }
 
-  void _onDone() {
+  void _onDone(WebSocketChannel channel) {
     if (!_isCurrentWebSocketTransport) {
       _closeStaleWebSocketTransport();
       return;
     }
-    if (_channel == null) return;
+    // A `done` from a socket we already replaced must not null out the current
+    // channel: every later `_send` would be dropped on the floor silently.
+    if (!identical(_channel, channel)) return;
     _channel = null;
     _isReconnecting = false;
     if (!_isExpectedDisconnect) {
@@ -560,7 +609,38 @@ class WebSocketTransport implements DataConnectTransport {
     RequestKind requestKind,
     bool isMutation,
   ) async {
+    // The setup is only "in flight" until the operation is registered and its
+    // request has been written; the returned future is intentionally awaited
+    // outside the guard so idle detection still works once we are waiting on
+    // the server.
+    _pendingOperationSetups++;
+    Completer<ServerResponse> completer;
+    try {
+      completer = await _sendUnary(operationId, operationName, serializer, vars,
+          authToken, requestKind, isMutation);
+    } finally {
+      _pendingOperationSetups--;
+    }
+    return completer.future;
+  }
+
+  Future<Completer<ServerResponse>> _sendUnary<Variables>(
+    String operationId,
+    String operationName,
+    Serializer<Variables>? serializer,
+    Variables? vars,
+    String? authToken,
+    RequestKind requestKind,
+    bool isMutation,
+  ) async {
     await _ensureConnected(authToken);
+    if (!isConnected) {
+      // A concurrent teardown closed the socket while we were connecting.
+      // Reconnect explicitly rather than writing into a null channel, which
+      // `_send` would drop silently and hang the returned future forever.
+      _isExpectedDisconnect = false;
+      await _ensureConnected(authToken);
+    }
 
     final completer = Completer<ServerResponse>();
 
@@ -588,9 +668,13 @@ class WebSocketTransport implements DataConnectTransport {
         resume: ResumeRequest(),
         headers: headers,
       );
-      _send(request.toJson());
+      if (isConnected) {
+        _send(request.toJson());
+      } else {
+        _reconnectForActiveOperations();
+      }
 
-      return completer.future;
+      return completer;
     }
 
     final requestId = _generateRequestId(operationId);
@@ -619,9 +703,14 @@ class WebSocketTransport implements DataConnectTransport {
       headers: headers,
     );
 
-    _send(request.toJson());
+    if (isConnected) {
+      _send(request.toJson());
+    } else {
+      // Registered in `_unaryListeners`, so the reconnect replays it.
+      _reconnectForActiveOperations();
+    }
 
-    return completer.future;
+    return completer;
   }
 
   @override
@@ -637,79 +726,106 @@ class WebSocketTransport implements DataConnectTransport {
 
     controller = StreamController<ServerResponse>(
       onListen: () async {
+        _pendingOperationSetups++;
         try {
-          await _ensureConnected(authToken);
-        } catch (e) {
-          developer.log("Error subscribing - setting up stream $e");
-          // Do NOT add error to sink here. The stream is designed to quietly
-          // add the query to `_pendingSubscriptions` below and silently
-          // retry when the network reconnects via `_scheduleReconnect`.
+          // Register this listener *synchronously*, before awaiting anything.
+          // `_checkIdleAndDisconnect()` and `_scheduleReconnect()` both key off
+          // `_streamListeners`, so a listener that is only registered after the
+          // `await` below is invisible to them: an unrelated unary response
+          // arriving in that window makes the transport look idle, closes the
+          // socket, flags the close as *expected*, and this subscription is
+          // then stranded forever — no first event, and (by design) no error.
+          final existingRequestId = _activeSubscriptions[operationId];
+          final isNewSubscription = existingRequestId == null;
+
+          Map<String, dynamic>? variables;
+          if (vars != null && serializer != null) {
+            variables = json.decode(serializer(vars));
+          }
+
+          final requestId =
+              existingRequestId ?? _generateRequestId(operationId);
+
+          if (isNewSubscription) {
+            _activeSubscriptions[operationId] = requestId;
+            _pendingSubscriptions[requestId] =
+                _PendingSubscription(operationId, queryName, variables);
+          }
+          _streamListeners.putIfAbsent(requestId, () => []).add(controller);
+
+          try {
+            await _ensureConnected(authToken);
+          } catch (e) {
+            developer.log("Error subscribing - setting up stream $e");
+            // Do NOT add error to sink here. The stream is designed to quietly
+            // keep the query in `_pendingSubscriptions` and silently retry
+            // when the network reconnects via `_scheduleReconnect`.
+          }
+
+          if (!isNewSubscription) {
+            // Multiplexed onto a `subscribe` that was already sent for
+            // `requestId`; nothing more to write.
+            if (!isConnected) _reconnectForActiveOperations();
+            return;
+          }
+
+          if (!isConnected) {
+            // we are not connected -
+            // keep pending sub to use for retry
+            _reconnectForActiveOperations();
+            return;
+          }
+
+          String? appCheckToken;
+          try {
+            appCheckToken = await appCheck?.getToken();
+          } catch (_) {
+            // Ignored
+          }
+
+          if (!isConnected) {
+            _reconnectForActiveOperations();
+            return;
+          }
+
+          final headers = _buildHeaders(authToken, appCheckToken);
+
+          final request = StreamRequest(
+            requestId: requestId,
+            requestKind: RequestKind.subscribe,
+            subscribe: ExecuteRequest(queryName, variables),
+            headers: headers,
+          );
+
+          _send(request.toJson());
+        } finally {
+          _pendingOperationSetups--;
         }
-
-        if (_activeSubscriptions.containsKey(operationId)) {
-          final existingRequestId = _activeSubscriptions[operationId]!;
-          _streamListeners
-              .putIfAbsent(existingRequestId, () => [])
-              .add(controller);
-          return;
-        }
-
-        final requestId = _generateRequestId(operationId);
-        _activeSubscriptions[operationId] = requestId;
-        _streamListeners.putIfAbsent(requestId, () => []).add(controller);
-
-        Map<String, dynamic>? variables;
-        if (vars != null && serializer != null) {
-          variables = json.decode(serializer(vars));
-        }
-        _pendingSubscriptions[requestId] =
-            _PendingSubscription(operationId, queryName, variables);
-
-        if (!isConnected) {
-          // we are not connected -
-          // keep pending sub to use for retry
-          _scheduleReconnect();
-          return;
-        }
-
-        String? appCheckToken;
-        try {
-          appCheckToken = await appCheck?.getToken();
-        } catch (_) {
-          // Ignored
-        }
-
-        final headers = _buildHeaders(authToken, appCheckToken);
-
-        final request = StreamRequest(
-          requestId: requestId,
-          requestKind: RequestKind.subscribe,
-          subscribe: ExecuteRequest(queryName, variables),
-          headers: headers,
-        );
-
-        _send(request.toJson());
       },
       onCancel: () {
-        if (!_activeSubscriptions.containsKey(operationId)) return;
-        final requestId = _activeSubscriptions[operationId]!;
+        final requestId = _activeSubscriptions[operationId];
+        if (requestId == null) return;
 
         final listeners = _streamListeners[requestId];
-        if (listeners != null) {
-          listeners.remove(controller);
-          if (listeners.isEmpty) {
-            _streamListeners.remove(requestId);
-            _activeSubscriptions.remove(operationId);
-            _pendingSubscriptions.remove(requestId);
+        listeners?.remove(controller);
+        if (listeners == null || listeners.isEmpty) {
+          // Always drop the `operationId -> requestId` mapping here. Leaving it
+          // behind (which the previous `listeners != null` guard did) makes
+          // every later `subscribe()` for this query attach to a request the
+          // server is no longer streaming, so it never gets a first event.
+          _streamListeners.remove(requestId);
+          _activeSubscriptions.remove(operationId);
+          _pendingSubscriptions.remove(requestId);
 
+          if (isConnected) {
             final cancelReq = StreamRequest(
               requestId: requestId,
               requestKind: RequestKind.cancel,
               cancel: true,
             );
             _send(cancelReq.toJson());
-            _checkIdleAndDisconnect();
           }
+          _checkIdleAndDisconnect();
         }
       },
     );

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/core/ref_resubscribe_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/core/ref_resubscribe_test.dart
@@ -164,8 +164,7 @@ void main() {
   }
 
   group('QueryRef double subscribe', () {
-    test(
-        'two subscribe() calls on the same ref open exactly one server stream',
+    test('two subscribe() calls on the same ref open exactly one server stream',
         () async {
       final ref = buildRef();
 

--- a/packages/firebase_data_connect/firebase_data_connect/test/src/core/ref_resubscribe_test.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/test/src/core/ref_resubscribe_test.dart
@@ -1,0 +1,304 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:firebase_app_check/firebase_app_check.dart';
+import 'package:firebase_data_connect/firebase_data_connect.dart';
+import 'package:firebase_data_connect/src/common/common_library.dart';
+import 'package:firebase_data_connect/src/core/ref.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+class MockFirebaseDataConnect extends Mock implements FirebaseDataConnect {}
+
+/// Minimal in-memory transport that records subscribe/cancel and lets a test
+/// push events into whichever stream is currently listened to.
+class FakeStreamTransport implements DataConnectTransport {
+  FakeStreamTransport(this.transportOptions, this.options, this.appId,
+      this.sdkType, this.appCheck);
+
+  @override
+  FirebaseAppCheck? appCheck;
+  @override
+  DataConnectOptions options;
+  @override
+  TransportOptions transportOptions;
+  @override
+  CallerSDKType sdkType;
+  @override
+  String appId;
+
+  final List<String> log = <String>[];
+  int subscribeCount = 0;
+  final Set<StreamController<ServerResponse>> _live =
+      <StreamController<ServerResponse>>{};
+
+  /// Server streams that are still subscribed. Anything left here once every
+  /// caller has cancelled is an orphan the ref layer can no longer reach — in
+  /// the real WebSocket transport that pins `_activeSubscriptions`, so every
+  /// later subscribe to the query multiplexes onto it and gets no first event.
+  int get liveSubscriptions => _live.length;
+
+  /// Pushes an event to every currently subscribed stream.
+  void emit(Map<String, dynamic> data) {
+    for (final c in _live.toList()) {
+      if (!c.isClosed) c.add(ServerResponse(data));
+    }
+  }
+
+  @override
+  Stream<ServerResponse> invokeStreamQuery<Data, Variables>(
+    String operationId,
+    String queryName,
+    Deserializer<Data> deserializer,
+    Serializer<Variables>? serializer,
+    Variables? vars,
+    String? token,
+  ) {
+    late StreamController<ServerResponse> controller;
+    controller = StreamController<ServerResponse>(
+      onListen: () {
+        subscribeCount++;
+        _live.add(controller);
+        log.add('subscribe');
+      },
+      onCancel: () {
+        log.add('cancel');
+        _live.remove(controller);
+      },
+    );
+    return controller.stream;
+  }
+
+  @override
+  Future<ServerResponse> invokeQuery<Data, Variables>(
+    String operationId,
+    String queryName,
+    Deserializer<Data> deserializer,
+    Serializer<Variables>? serialize,
+    Variables? vars,
+    String? token,
+  ) async =>
+      ServerResponse(<String, dynamic>{});
+
+  @override
+  Future<ServerResponse> invokeMutation<Data, Variables>(
+    String operationId,
+    String queryName,
+    Deserializer<Data> deserializer,
+    Serializer<Variables>? serializer,
+    Variables? vars,
+    String? token,
+  ) async =>
+      ServerResponse(<String, dynamic>{});
+}
+
+void main() {
+  late MockFirebaseDataConnect dataConnect;
+  late FakeStreamTransport transport;
+  late QueryManager queryManager;
+
+  String deserializer(String data) => data;
+
+  setUp(() {
+    dataConnect = MockFirebaseDataConnect();
+    when(dataConnect.auth).thenReturn(null);
+    when(dataConnect.cacheManager).thenReturn(null);
+    transport = FakeStreamTransport(
+      TransportOptions('testhost', 443, true),
+      DataConnectOptions(
+        'testProject',
+        'testLocation',
+        'testConnector',
+        'testService',
+      ),
+      'testAppId',
+      CallerSDKType.core,
+      null,
+    );
+    queryManager = QueryManager(dataConnect);
+  });
+
+  QueryRef<String, String?> buildRef() => QueryRef<String, String?>(
+        dataConnect,
+        'listMovies',
+        transport,
+        deserializer,
+        queryManager,
+        emptySerializer,
+        null,
+      );
+
+  /// Waits for a first event on [stream], returning false if it never arrives.
+  Future<bool> firstEventArrives(
+    Stream<QueryResult<String, String?>> stream,
+    void Function() pump,
+  ) async {
+    final received = Completer<void>();
+    final sub = stream.listen((_) {
+      if (!received.isCompleted) received.complete();
+    });
+    // Let subscribe() run its microtask and reach the transport.
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    pump();
+    try {
+      await received.future.timeout(const Duration(milliseconds: 300));
+      return true;
+    } on TimeoutException {
+      return false;
+    } finally {
+      await sub.cancel();
+    }
+  }
+
+  group('QueryRef double subscribe', () {
+    test(
+        'two subscribe() calls on the same ref open exactly one server stream',
+        () async {
+      final ref = buildRef();
+
+      // Exactly the shape of the `should be able to gracefully cancel` e2e
+      // test: two listeners for the same query, back to back, which
+      // `FirebaseDataConnect.query()` resolves to the *same* cached QueryRef.
+      final a = ref.subscribe().listen((_) {});
+      final b = ref.subscribe().listen((_) {});
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(transport.subscribeCount, 1,
+          reason: 'the second subscriber must multiplex onto the existing '
+              'server stream, not open a second one that nothing can cancel');
+
+      await a.cancel();
+      await b.cancel();
+
+      // Everything the ref opened must be cancelled once all subscribers go.
+      expect(transport.liveSubscriptions, 0,
+          reason: 'no server stream may outlive its last subscriber');
+    });
+  });
+
+  group('QueryRef re-subscribe after cancel', () {
+    test('a query is re-subscribable after a double-subscribe generation',
+        () async {
+      final ref = buildRef();
+
+      // Generation 1: two listeners, then both cancelled.
+      final a = ref.subscribe().listen((_) {});
+      final b = ref.subscribe().listen((_) {});
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      transport.emit({'movies': []});
+      await a.cancel();
+      await b.cancel();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      // Generation 2: a fresh ref, exactly as `query()` hands out once
+      // trackedQueries has been cleaned.
+      expect(
+        await firstEventArrives(
+            buildRef().subscribe(), () => transport.emit({'movies': []})),
+        isTrue,
+        reason: 'a later subscription to the same query must still receive '
+            'a first event',
+      );
+    });
+
+    test('re-subscribing the same ref after a plain cancel gets a first event',
+        () async {
+      final ref = buildRef();
+
+      expect(
+        await firstEventArrives(
+            ref.subscribe(), () => transport.emit({'movies': []})),
+        isTrue,
+        reason: 'first subscription should receive an event',
+      );
+
+      expect(
+        await firstEventArrives(
+            ref.subscribe(), () => transport.emit({'movies': []})),
+        isTrue,
+        reason: 're-subscribing the same QueryRef must restart the '
+            'server stream and deliver a first event',
+      );
+    });
+
+    test(
+        'a listener attached while the previous cancel is still pending is not '
+        'stranded', () async {
+      final ref = buildRef();
+
+      // First subscriber, established and receiving events.
+      final firstReady = Completer<void>();
+      final first = ref.subscribe().listen((_) {
+        if (!firstReady.isCompleted) firstReady.complete();
+      });
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      transport.emit({'movies': []});
+      await firstReady.future.timeout(const Duration(seconds: 1));
+
+      // Cancel WITHOUT awaiting and immediately re-subscribe in the same turn.
+      // This is the shape the e2e suite hits: `_onAllSubscribersCancelled()`
+      // tears the server stream down out-of-band while a new listener is
+      // already attaching to the very same (reused) broadcast controller.
+      unawaited(first.cancel());
+
+      final secondReady = Completer<void>();
+      final second = ref.subscribe().listen((_) {
+        if (!secondReady.isCompleted) secondReady.complete();
+      });
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      transport.emit({'movies': []});
+
+      var gotEvent = true;
+      try {
+        await secondReady.future.timeout(const Duration(milliseconds: 300));
+      } on TimeoutException {
+        gotEvent = false;
+      }
+      await second.cancel();
+
+      expect(gotEvent, isTrue,
+          reason: 'the second subscriber must not be stranded on a '
+              'controller whose server stream was torn down');
+    });
+
+    test('cancelling from inside the event handler still allows re-subscribe',
+        () async {
+      final ref = buildRef();
+
+      // Cancelling from within delivery makes the broadcast controller defer
+      // onCancel until the firing loop finishes.
+      late StreamSubscription<QueryResult<String, String?>> first;
+      final delivered = Completer<void>();
+      first = ref.subscribe().listen((_) {
+        unawaited(first.cancel());
+        if (!delivered.isCompleted) delivered.complete();
+      });
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      transport.emit({'movies': []});
+      await delivered.future.timeout(const Duration(seconds: 1));
+
+      expect(
+        await firstEventArrives(
+            ref.subscribe(), () => transport.emit({'movies': []})),
+        isTrue,
+        reason: 're-subscribing after a deferred cancel must restart the '
+            'server stream',
+      );
+    });
+  });
+}

--- a/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
+++ b/tests/integration_test/cloud_functions/cloud_functions_e2e_test.dart
@@ -20,6 +20,10 @@ String kTestFunctionTimeout = 'testFunctionTimeout';
 String kTestMapConvertType = 'testMapConvertType';
 String kTestStreamResponse = 'testStreamResponse';
 
+/// Guards against a dropped stream callback hanging the whole suite: a missing
+/// event fails the test instead of burning the job timeout.
+const _completerTimeout = Duration(seconds: 30);
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -474,7 +478,7 @@ void main() {
               }
             },
           );
-          await completer.future;
+          await completer.future.timeout(_completerTimeout);
         },
         skip: !kIsWeb,
       );
@@ -509,7 +513,7 @@ void main() {
               }
             },
           );
-          await completer.future;
+          await completer.future.timeout(_completerTimeout);
         },
         skip: !kIsWeb,
       );

--- a/tests/integration_test/firebase_auth/firebase_auth_instance_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_instance_e2e_test.dart
@@ -14,6 +14,11 @@ import 'package:tests/firebase_options.dart';
 
 import './test_utils.dart';
 
+/// Guards against a dropped `verifyPhoneNumber` callback hanging the whole
+/// suite: a missing callback fails the test instead of burning the job
+/// timeout. Generous because these are multi-step phone auth flows.
+const _completerTimeout = Duration(seconds: 60);
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -965,7 +970,8 @@ void main() {
                 ),
               );
 
-              return completer.future as FutureOr<Exception>;
+              return completer.future.timeout(_completerTimeout)
+                  as FutureOr<Exception>;
             }
 
             Exception e = await getError();
@@ -1015,7 +1021,7 @@ void main() {
                   ),
                 );
 
-                return completer.future;
+                return completer.future.timeout(_completerTimeout);
               }
 
               PhoneAuthCredential credential = await getCredential();

--- a/tests/integration_test/firebase_auth/firebase_auth_multi_factor_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_multi_factor_e2e_test.dart
@@ -11,6 +11,11 @@ import 'package:integration_test/integration_test.dart';
 
 import 'test_utils.dart';
 
+/// Guards against a dropped `verifyPhoneNumber` callback hanging the whole
+/// suite: a missing callback fails the test instead of burning the job
+/// timeout. Generous because these are multi-step enrollment/sign-in flows.
+const _completerTimeout = Duration(seconds: 60);
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -129,7 +134,8 @@ void main() {
                 ),
               );
 
-              return completer.future as FutureOr<String>;
+              return completer.future.timeout(_completerTimeout)
+                  as FutureOr<String>;
             }
 
             final verificationId = await getCredential();
@@ -246,7 +252,8 @@ void main() {
                 ),
               );
 
-              return completer.future as FutureOr<String>;
+              return completer.future.timeout(_completerTimeout)
+                  as FutureOr<String>;
             }
 
             final verificationId = await getCredential();
@@ -355,7 +362,8 @@ void main() {
                 ),
               );
 
-              return completer.future as FutureOr<String>;
+              return completer.future.timeout(_completerTimeout)
+                  as FutureOr<String>;
             }
 
             final verificationId = await getCredential();
@@ -452,7 +460,8 @@ void main() {
                 ),
               );
 
-              return completer.future as FutureOr<Exception>;
+              return completer.future.timeout(_completerTimeout)
+                  as FutureOr<Exception>;
             }
 
             final exception = await getCredential();
@@ -524,7 +533,8 @@ void main() {
                 ),
               );
 
-              return completer.future as FutureOr<String>;
+              return completer.future.timeout(_completerTimeout)
+                  as FutureOr<String>;
             }
 
             final verificationId = await getCredential();
@@ -605,7 +615,8 @@ void main() {
                 ),
               );
 
-              return completer.future as FutureOr<String>;
+              return completer.future.timeout(_completerTimeout)
+                  as FutureOr<String>;
             }
 
             final verificationIdSignIn = await getCredentialSignIn();

--- a/tests/integration_test/firebase_auth/firebase_auth_user_e2e_test.dart
+++ b/tests/integration_test/firebase_auth/firebase_auth_user_e2e_test.dart
@@ -11,6 +11,11 @@ import 'package:integration_test/integration_test.dart';
 
 import 'test_utils.dart';
 
+/// Guards against a dropped `verifyPhoneNumber` callback hanging the whole
+/// suite: a missing callback fails the test instead of burning the job
+/// timeout. Generous because this is a multi-step phone auth flow.
+const _completerTimeout = Duration(seconds: 60);
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -215,7 +220,9 @@ void main() {
                   ),
                 );
 
-                return completer.future.then((value) => value as String);
+                return completer.future
+                    .timeout(_completerTimeout)
+                    .then((value) => value as String);
               }
 
               String storedVerificationId = await getVerificationId();

--- a/tests/integration_test/firebase_crashlytics/firebase_crashlytics_e2e_test.dart
+++ b/tests/integration_test/firebase_crashlytics/firebase_crashlytics_e2e_test.dart
@@ -125,7 +125,10 @@ void main() {
               reason: 'foo reason',
             );
 
-            final event = await completer.future;
+            // Fail the test rather than hang the suite if the native event
+            // channel never delivers.
+            final event =
+                await completer.future.timeout(const Duration(seconds: 30));
             expect(event, 'thrown foo reason');
             await subscription.cancel();
           },

--- a/tests/integration_test/firebase_database/database_reference_e2e.dart
+++ b/tests/integration_test/firebase_database/database_reference_e2e.dart
@@ -208,7 +208,9 @@ void setupDatabaseReferenceTests() {
           errorReceived.complete(e as FirebaseException);
         });
 
-        final streamError = await errorReceived.future;
+        // Fail the test rather than hang the suite if the error never arrives.
+        final streamError =
+            await errorReceived.future.timeout(const Duration(seconds: 30));
         expect(streamError, isA<FirebaseException>());
         expect(streamError.code, 'permission-denied');
       });

--- a/tests/integration_test/firebase_database/query_e2e.dart
+++ b/tests/integration_test/firebase_database/query_e2e.dart
@@ -662,7 +662,9 @@ void setupQueryTests() {
           },
         );
 
-        final streamError = await errorReceived.future;
+        // Fail the test rather than hang the suite if the error never arrives.
+        final streamError =
+            await errorReceived.future.timeout(const Duration(seconds: 30));
         expect(streamError, isA<FirebaseException>());
         expect(streamError.code, 'permission-denied');
       });

--- a/tests/integration_test/firebase_storage/task_e2e.dart
+++ b/tests/integration_test/firebase_storage/task_e2e.dart
@@ -15,6 +15,10 @@ import 'package:tests/firebase_options.dart';
 
 import './test_utils.dart';
 
+/// Storage tasks move large files; a dropped native event otherwise hangs the
+/// whole suite until the job-level timeout kills it.
+const _completerTimeout = Duration(seconds: 60);
+
 void setupTaskTests() {
   group('Task', () {
     late FirebaseStorage storage;
@@ -156,7 +160,8 @@ void setupTaskTests() {
             },
           );
           // Allow time for listener events to be called
-          FirebaseException streamError = await errorReceived.future;
+          FirebaseException streamError =
+              await errorReceived.future.timeout(_completerTimeout);
 
           expect(streamError.plugin, 'firebase_storage');
           expect(streamError.code, 'unauthorized');
@@ -164,7 +169,7 @@ void setupTaskTests() {
             streamError.message,
             'User is not authorized to perform the desired action.',
           );
-          final complete = await finished.future;
+          final complete = await finished.future.timeout(_completerTimeout);
 
           expect(complete, true);
           expect(task.snapshot.state, TaskState.error);
@@ -261,13 +266,14 @@ void setupTaskTests() {
             },
           );
 
-          await started.future;
+          await started.future.timeout(_completerTimeout);
 
           bool canceled = await task.cancel();
           expect(canceled, isTrue);
           expect(task.snapshot.state, TaskState.canceled);
 
-          final streamError = await errorReceived.future;
+          final streamError =
+              await errorReceived.future.timeout(_completerTimeout);
 
           expect(streamError, isNotNull);
           expect(streamError.code, 'canceled');
@@ -431,7 +437,7 @@ void setupTaskTests() {
           },
         );
 
-        final response = await onDoneReceived.future;
+        final response = await onDoneReceived.future.timeout(_completerTimeout);
         expect(response, isTrue);
         expect(snapshots.last.state, TaskState.success);
       });
@@ -454,7 +460,7 @@ void setupTaskTests() {
           },
         );
 
-        final response = await onDoneReceived.future;
+        final response = await onDoneReceived.future.timeout(_completerTimeout);
         expect(response, isTrue);
         expect(snapshots.last.state, TaskState.running);
         expect(streamError, isA<FirebaseException>());


### PR DESCRIPTION
Fixes the root causes behind most of the recent CI redness: a WebSocket transport race that kept e2e-fdc 100% red since Jul 20, broken cache keys that never invalidated, unpinned firebase-tools, blind retries masking failures, and suite-level hangs burning 15–60 min job timeouts.

Also moves all web e2e jobs from macOS to ubuntu runners and makes fork/dependabot PRs skip secret-dependent jobs instead of failing. See individual commit messages for details.