### PR TITLE
ci: extract shared workflow setup into a composite action (phase 2, step 1)

### DIFF
--- a/.github/actions/setup-flutterfire/action.yml
+++ b/.github/actions/setup-flutterfire/action.yml
@@ -118,8 +118,14 @@ runs:
         # Scopes are globs (e.g. `cloud_firestore*`); disable pathname expansion
         # so the shell does not resolve them against the working directory.
         set -f
+        # bash on Windows does not resolve `melos` to `melos.bat` the way
+        # PowerShell does.
+        MELOS_BIN="melos"
+        if [[ "${RUNNER_OS}" == "Windows" ]]; then
+          MELOS_BIN="melos.bat"
+        fi
         for scope in $BOOTSTRAP_SCOPES; do
           echo "::group::melos bootstrap --scope \"$scope\""
-          melos bootstrap --scope "$scope"
+          "$MELOS_BIN" bootstrap --scope "$scope"
           echo "::endgroup::"
         done

--- a/.github/actions/setup-flutterfire/action.yml
+++ b/.github/actions/setup-flutterfire/action.yml
@@ -1,0 +1,125 @@
+name: 'Setup FlutterFire'
+description: >-
+  Shared CI preamble: Node.js, Java, Flutter, Melos, optional firebase-tools and
+  optional scoped `melos bootstrap` runs. Requires actions/checkout to have run
+  first (a local action can only be resolved after the repository is checked out).
+
+inputs:
+  node:
+    description: "Set to 'false' to skip the Node.js setup step."
+    required: false
+    default: 'true'
+  node-version:
+    description: 'Node.js version to install.'
+    required: false
+    default: '20'
+  npm-cache:
+    description: >-
+      Set to 'false' to skip the npm cache. When enabled, the cache is keyed on
+      .github/workflows/scripts/functions/package-lock.json.
+    required: false
+    default: 'true'
+  java:
+    description: "Set to 'false' to skip the Java setup step."
+    required: false
+    default: 'true'
+  java-version:
+    description: 'Java (temurin) version to install.'
+    required: false
+    default: '21'
+  flutter-channel:
+    description: 'Flutter channel passed to subosito/flutter-action.'
+    required: false
+    default: 'stable'
+  flutter-version:
+    description: "Pinned Flutter version. Empty means unpinned (latest on the channel)."
+    required: false
+    default: ''
+  melos:
+    description: "Set to 'false' to skip installing Melos."
+    required: false
+    default: 'true'
+  melos-version:
+    description: 'Melos version to install.'
+    required: false
+    default: '5.3.0'
+  melos-run-bootstrap:
+    description: >-
+      Forwarded to melos-action's `run-bootstrap`. 'true' bootstraps the whole
+      workspace as part of the Melos install; leave 'false' and use
+      `bootstrap-scope` for scoped bootstraps.
+    required: false
+    default: 'false'
+  bootstrap-scope:
+    description: >-
+      Space-separated list of Melos scopes. Runs `melos bootstrap --scope "<s>"`
+      once per entry, in order. Empty means no scoped bootstrap.
+    required: false
+    default: ''
+  firebase-tools-version:
+    description: >-
+      When set, installs firebase-tools globally at this version and exports
+      FIREBASE_TOOLS_VERSION to $GITHUB_ENV (used as part of the Firebase
+      emulator cache key). Not usable on Windows runners (`sudo npm`).
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Node.js
+      if: inputs.node == 'true'
+      uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.npm-cache == 'true' && 'npm' || '' }}
+        cache-dependency-path: '.github/workflows/scripts/functions/package-lock.json'
+
+    - name: Install Java
+      if: inputs.java == 'true'
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
+      with:
+        distribution: 'temurin'
+        java-version: ${{ inputs.java-version }}
+
+    - name: Install Tools
+      # Exports FIREBASE_TOOLS_VERSION so later steps can key the emulator cache on it.
+      if: inputs.firebase-tools-version != ''
+      shell: bash
+      env:
+        FIREBASE_TOOLS_REQUESTED_VERSION: ${{ inputs.firebase-tools-version }}
+      run: |
+        sudo npm i -g "firebase-tools@${FIREBASE_TOOLS_REQUESTED_VERSION}"
+        echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
+
+    - name: Install Flutter
+      uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+      with:
+        channel: ${{ inputs.flutter-channel }}
+        flutter-version: ${{ inputs.flutter-version }}
+        cache: true
+        cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
+        pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
+
+    - name: Install Melos
+      if: inputs.melos == 'true'
+      uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
+      with:
+        run-bootstrap: ${{ inputs.melos-run-bootstrap }}
+        melos-version: ${{ inputs.melos-version }}
+
+    - name: Bootstrap packages
+      if: inputs.melos == 'true' && inputs.bootstrap-scope != ''
+      shell: bash
+      env:
+        BOOTSTRAP_SCOPES: ${{ inputs.bootstrap-scope }}
+      run: |
+        set -euo pipefail
+        # Scopes are globs (e.g. `cloud_firestore*`); disable pathname expansion
+        # so the shell does not resolve them against the working directory.
+        set -f
+        for scope in $BOOTSTRAP_SCOPES; do
+          echo "::group::melos bootstrap --scope \"$scope\""
+          melos bootstrap --scope "$scope"
+          echo "::endgroup::"
+        done

--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -27,15 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          melos-version: '5.3.0'
+          node: 'false'
+          java: 'false'
+          # This job needs the whole workspace bootstrapped, which melos-action does itself.
+          melos-run-bootstrap: 'true'
       - name: 'Validate Generated SPM Versions'
         run: |
           dart run scripts/generate_versions_spm.dart
@@ -56,15 +53,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          melos-version: '5.3.0'
+          node: 'false'
+          java: 'false'
+          # This job needs the whole workspace bootstrapped, which melos-action does itself.
+          melos-run-bootstrap: 'true'
       - name: 'Pub Check'
         run: |
           melos exec -c 1 --no-private --ignore="*example*" -- \
@@ -75,15 +69,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          melos-version: '5.3.0'
+          node: 'false'
+          java: 'false'
+          # This job needs the whole workspace bootstrapped, which melos-action does itself.
+          melos-run-bootstrap: 'true'
       - name: 'Flutter Pub Get'
         run: |
           melos exec -c 1 --scope="*example*" -- \
@@ -145,16 +136,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          channel: 'stable'
+          node: 'false'
+          java: 'false'
           flutter-version: '3.41.9'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          melos-version: '5.3.0'
+          # This job needs the whole workspace bootstrapped, which melos-action does itself.
+          melos-run-bootstrap: 'true'
       - name: 'Build Examples'
         run: |
           dart ./.github/workflows/scripts/generate-dummy-firebase-configs.dart
@@ -168,19 +156,16 @@ jobs:
       PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          flutter-version: '3.41.9'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
       - name: Xcode
         # Firebase iOS SDK: minimum Xcode 26.2.
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
-      - uses: bluefireteam/melos-action@705015c3d2bc4ab94201ac24accb2bbe070cf533
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          melos-version: '5.3.0'
+          node: 'false'
+          java: 'false'
+          flutter-version: '3.41.9'
+          # This job needs the whole workspace bootstrapped, which melos-action does itself.
+          melos-run-bootstrap: 'true'
       - name: Setup firebase_core example app to test Swift integration
         # Run after melos bootstrap so workspace pubspec_overrides resolve unpublished package versions.
         run: |
@@ -199,15 +184,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          melos-version: '5.3.0'
+          node: 'false'
+          java: 'false'
+          # This job needs the whole workspace bootstrapped, which melos-action does itself.
+          melos-run-bootstrap: 'true'
       - name: 'Flutter Test'
         run: melos run test --no-select
       - name: 'Flutter Test - Web'
@@ -224,18 +206,11 @@ jobs:
       # Go is used by addlicense command (addlicense is used in melos run
       # check-license-header)
       - run: go install github.com/google/addlicense@latest
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+      # Running `melos bootstrap` is not needed because we use Melos just for the
+      # `check-license-header` script, so no `bootstrap-scope` is passed here.
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - name: Install Melos
-        uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          # Running `melos bootstrap` is not needed because we use Melos just
-          # for the `check-license-header` script.
-          run-bootstrap: false
-          melos-version: '5.3.0'
+          node: 'false'
+          java: 'false'
       - name: Check license header
         run: melos run check-license-header

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -51,20 +51,11 @@ jobs:
       AVD_TARGET: google_apis
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: '.github/workflows/scripts/functions/package-lock.json'
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools@15.25.1
-          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
+          firebase-tools-version: '15.25.1'
+          # Each matrix leg bootstraps only the packages it exercises.
+          bootstrap-scope: ${{ matrix.working_directory == 'tests' && 'tests' || 'cloud_firestore*' }}
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -77,20 +68,8 @@ jobs:
           key: firebase-emulators-v5-${{ env.FIREBASE_TOOLS_VERSION }}
           # Trailing dash so this never prefix-matches a future version's key
           restore-keys: firebase-emulators-v5-
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
       - name: Generate dummy Firebase configs
         run: dart ./.github/workflows/scripts/generate-dummy-firebase-configs.dart --firestore-native
-      - name: 'Bootstrap package'
-        run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
       - name: Start Firebase Emulator
         timeout-minutes: 8
         run: cd ./.github/workflows/scripts && ./start-firebase-emulator.sh
@@ -194,22 +173,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          distribution: 'temurin'
-          java-version: '21'
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
-      - name: 'Bootstrap tests package'
-        run: melos bootstrap --scope tests
+          node: 'false'
+          bootstrap-scope: 'tests'
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@90ddb51e90a5fd9ba75f40cf85156b7b41bf76a3
       - name: 'Build tests app with AGP 9'

--- a/.github/workflows/android_unit_tests.yaml
+++ b/.github/workflows/android_unit_tests.yaml
@@ -29,22 +29,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          distribution: 'temurin'
-          java-version: '21'
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
-      - name: 'Bootstrap tests package'
-        run: melos bootstrap --scope tests
+          node: 'false'
+          bootstrap-scope: 'tests'
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@90ddb51e90a5fd9ba75f40cf85156b7b41bf76a3
       - name: 'Generate Gradle build files'

--- a/.github/workflows/e2e_tests_fdc.yaml
+++ b/.github/workflows/e2e_tests_fdc.yaml
@@ -41,18 +41,13 @@ jobs:
       AVD_TARGET: google_apis
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          node-version: '20'
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools@15.25.1
-          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
+          npm-cache: 'false'
+          firebase-tools-version: '15.25.1'
+          bootstrap-scope: 'firebase_data_connect*'
+      - name: Setup PostgreSQL for Linux/macOS/Windows
+        uses: ikalnytskyi/action-setup-postgres@c4dda34aae1c821e3a771b68b73b13af3198a7ee
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -61,22 +56,8 @@ jobs:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-v4-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - name: Setup PostgreSQL for Linux/macOS/Windows
-        uses: ikalnytskyi/action-setup-postgres@c4dda34aae1c821e3a771b68b73b13af3198a7ee
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
       - name: Generate dummy Firebase configs
         run: dart ./.github/workflows/scripts/generate-dummy-firebase-configs.dart
-      - name: 'Bootstrap package'
-        run: melos bootstrap --scope "firebase_data_connect*"
       - name: Start Firebase Emulator
         run: |
           cd ./packages/firebase_data_connect/firebase_data_connect/example
@@ -159,17 +140,14 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
-        with:
-          node-version: '20'
       - name: Xcode
         # Firebase iOS SDK: minimum Xcode 26.2.
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
-      - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          npm-cache: 'false'
+          firebase-tools-version: '15.25.1'
+          bootstrap-scope: 'firebase_data_connect*'
       - name: Setup PostgreSQL for Linux/macOS/Windows
         uses: ikalnytskyi/action-setup-postgres@c4dda34aae1c821e3a771b68b73b13af3198a7ee
       - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03
@@ -190,10 +168,6 @@ jobs:
           # native SDK version instead.
           key: ${{ runner.os }}-fdc-pods-v2-${{ hashFiles('packages/firebase_data_connect/firebase_data_connect/example/ios/Podfile', 'packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb') }}
           restore-keys: ${{ runner.os }}-fdc-pods-v2-
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools@15.25.1
-          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -202,20 +176,8 @@ jobs:
           # Must match the save path exactly
           path: ~/.cache/firebase/emulators
           key: firebase-emulators-v4-${{ runner.os }}-${{ env.FIREBASE_TOOLS_VERSION }}
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
       - name: Generate dummy Firebase configs
         run: dart ./.github/workflows/scripts/generate-dummy-firebase-configs.dart
-      - name: 'Bootstrap package'
-        run: melos bootstrap --scope "firebase_data_connect*"
       - name: 'Build Application'
         working-directory: 'packages/firebase_data_connect/firebase_data_connect/example'
         run: |
@@ -285,34 +247,15 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          node-version: '20'
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
-        with:
-          distribution: 'temurin'
-          java-version: '21'
+          npm-cache: 'false'
+          firebase-tools-version: '15.25.1'
+          bootstrap-scope: 'firebase_data_connect*'
       - name: Setup PostgreSQL for Linux/macOS/Windows
         uses: ikalnytskyi/action-setup-postgres@c4dda34aae1c821e3a771b68b73b13af3198a7ee
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
       - name: Generate dummy Firebase configs
         run: dart ./.github/workflows/scripts/generate-dummy-firebase-configs.dart
-      - name: 'Bootstrap package'
-        run: melos bootstrap --scope "firebase_data_connect*"
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools@15.25.1
-          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -359,34 +302,15 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          node-version: '20'
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
-        with:
-          distribution: 'temurin'
-          java-version: '21'
+          npm-cache: 'false'
+          firebase-tools-version: '15.25.1'
+          bootstrap-scope: 'firebase_data_connect*'
       - name: Setup PostgreSQL for Linux/macOS/Windows
         uses: ikalnytskyi/action-setup-postgres@c4dda34aae1c821e3a771b68b73b13af3198a7ee
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
       - name: Generate dummy Firebase configs
         run: dart ./.github/workflows/scripts/generate-dummy-firebase-configs.dart
-      - name: 'Bootstrap package'
-        run: melos bootstrap --scope "firebase_data_connect*"
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools@15.25.1
-          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9

--- a/.github/workflows/e2e_tests_pipeline.yaml
+++ b/.github/workflows/e2e_tests_pipeline.yaml
@@ -46,25 +46,11 @@ jobs:
       AVD_TARGET: google_apis
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          node-version: '20'
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
+          npm-cache: 'false'
           flutter-version: '3.41.9'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@705015c3d2bc4ab94201ac24accb2bbe070cf533
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
+          bootstrap-scope: 'cloud_firestore*'
       - name: Inject Firebase config for pipeline E2E
         env:
           FIREBASE_OPTIONS_DART: ${{ secrets.PIPELINE_E2E_FIREBASE_OPTIONS_DART }}
@@ -78,8 +64,6 @@ jobs:
           echo "$FIREBASE_OPTIONS_DART" > packages/cloud_firestore/cloud_firestore/pipeline_example/lib/firebase_options.dart
           echo "$GOOGLE_SERVICES_JSON" > packages/cloud_firestore/cloud_firestore/pipeline_example/android/app/google-services.json
           echo "$GOOGLE_SERVICE_INFO_PLIST" > packages/cloud_firestore/cloud_firestore/pipeline_example/ios/Runner/GoogleService-Info.plist
-      - name: Bootstrap package
-        run: melos bootstrap --scope "cloud_firestore*"
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -149,20 +133,11 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          node-version: '20'
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@705015c3d2bc4ab94201ac24accb2bbe070cf533
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
+          npm-cache: 'false'
+          java: 'false'
+          bootstrap-scope: 'cloud_firestore*'
       - name: Inject Firebase config for pipeline E2E
         env:
           FIREBASE_OPTIONS_DART: ${{ secrets.PIPELINE_E2E_FIREBASE_OPTIONS_DART }}
@@ -176,8 +151,6 @@ jobs:
           echo "$FIREBASE_OPTIONS_DART" > packages/cloud_firestore/cloud_firestore/pipeline_example/lib/firebase_options.dart
           echo "$GOOGLE_SERVICES_JSON" > packages/cloud_firestore/cloud_firestore/pipeline_example/android/app/google-services.json
           echo "$GOOGLE_SERVICE_INFO_PLIST" > packages/cloud_firestore/cloud_firestore/pipeline_example/ios/Runner/GoogleService-Info.plist
-      - name: Bootstrap package
-        run: melos bootstrap --scope "cloud_firestore*"
       - name: Run pipeline E2E tests (Chrome)
         working-directory: packages/cloud_firestore/cloud_firestore/pipeline_example
         # Web devices are not supported for the `flutter test` command yet. As a
@@ -202,30 +175,16 @@ jobs:
     timeout-minutes: 50
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
-        with:
-          node-version: '20'
       - name: Xcode
         # Firebase iOS SDK: minimum Xcode 26.2.
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
-      - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          distribution: 'temurin'
-          java-version: '21'
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
+          npm-cache: 'false'
           flutter-version: '3.41.9'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
+          bootstrap-scope: 'cloud_firestore*'
       - name: Enable Swift Package Manager for iOS
         run: flutter config --enable-swift-package-manager
-      - uses: bluefireteam/melos-action@705015c3d2bc4ab94201ac24accb2bbe070cf533
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
       - name: Inject Firebase config for pipeline E2E
         env:
           FIREBASE_OPTIONS_DART: ${{ secrets.PIPELINE_E2E_FIREBASE_OPTIONS_DART }}
@@ -239,8 +198,6 @@ jobs:
           echo "$FIREBASE_OPTIONS_DART" > packages/cloud_firestore/cloud_firestore/pipeline_example/lib/firebase_options.dart
           echo "$GOOGLE_SERVICES_JSON" > packages/cloud_firestore/cloud_firestore/pipeline_example/android/app/google-services.json
           echo "$GOOGLE_SERVICE_INFO_PLIST" > packages/cloud_firestore/cloud_firestore/pipeline_example/ios/Runner/GoogleService-Info.plist
-      - name: Bootstrap package
-        run: melos bootstrap --scope "cloud_firestore*"
       - name: Prepare iOS project for Swift Package Manager
         working-directory: packages/cloud_firestore/cloud_firestore/pipeline_example/ios
         run: |

--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -47,19 +47,15 @@ jobs:
           - working_directory: ${{ inputs.nightly_test_mode && 'packages/cloud_firestore/cloud_firestore/example' || 'none' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: '.github/workflows/scripts/functions/package-lock.json'
       - name: Xcode
         # Firebase iOS SDK: minimum Xcode 26.2.
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          flutter-version: '3.41.9'
+          firebase-tools-version: '15.25.1'
+          # Each matrix leg bootstraps only the packages it exercises.
+          bootstrap-scope: ${{ matrix.working_directory == 'tests' && 'tests' || 'cloud_firestore*' }}
       - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03
         name: Xcode Compile Cache
         with:
@@ -80,10 +76,6 @@ jobs:
           # never changed - the cache could never be invalidated.
           key: pods-v4-${{ runner.os }}-ios-${{ hashFiles('tests/ios/Podfile', 'packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb') }}
           restore-keys: pods-v4-${{ runner.os }}-ios-
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools@15.25.1
-          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -96,21 +88,8 @@ jobs:
           key: firebase-emulators-v5-${{ env.FIREBASE_TOOLS_VERSION }}
           # Trailing dash so this never prefix-matches a future version's key
           restore-keys: firebase-emulators-v5-
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          cache: true
-          flutter-version: '3.41.9'
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
       - name: Generate dummy Firebase configs
         run: dart ./.github/workflows/scripts/generate-dummy-firebase-configs.dart --firestore-native
-      - name: 'Bootstrap package'
-        run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
       - name: 'Free up space'
         run: |
           sudo rm -rf \

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -47,19 +47,15 @@ jobs:
           - working_directory: ${{ inputs.nightly_test_mode && 'packages/cloud_firestore/cloud_firestore/example' || 'none' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: '.github/workflows/scripts/functions/package-lock.json'
       - name: Xcode
         # Firebase iOS SDK: minimum Xcode 26.2.
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          flutter-version: '3.41.9'
+          firebase-tools-version: '15.25.1'
+          # Each matrix leg bootstraps only the packages it exercises.
+          bootstrap-scope: ${{ matrix.working_directory == 'tests' && 'tests' || 'cloud_firestore*' }}
       - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03
         name: Xcode Compile Cache
         with:
@@ -80,10 +76,6 @@ jobs:
           # never changed - the cache could never be invalidated.
           key: pods-v4-${{ runner.os }}-macos-${{ hashFiles('tests/macos/Podfile', 'packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb') }}
           restore-keys: pods-v4-${{ runner.os }}-macos-
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools@15.25.1
-          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -96,21 +88,8 @@ jobs:
           key: firebase-emulators-v5-${{ env.FIREBASE_TOOLS_VERSION }}
           # Trailing dash so this never prefix-matches a future version's key
           restore-keys: firebase-emulators-v5-
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          flutter-version: '3.41.9'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
       - name: Generate dummy Firebase configs
         run: dart ./.github/workflows/scripts/generate-dummy-firebase-configs.dart --firestore-native
-      - name: 'Bootstrap package'
-        run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
       - name: 'Build Application'
         working-directory: ${{ matrix.working_directory }}
         timeout-minutes: 25

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -47,16 +47,12 @@ jobs:
           - working_directory: ${{ inputs.nightly_test_mode && 'packages/cloud_firestore/cloud_firestore/example' || 'none' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
+      - uses: ./.github/actions/setup-flutterfire
+        timeout-minutes: 15
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: '.github/workflows/scripts/functions/package-lock.json'
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
-        with:
-          distribution: 'temurin'
-          java-version: '21'
+          firebase-tools-version: '15.25.1'
+          # Each matrix leg bootstraps only the packages it exercises.
+          bootstrap-scope: ${{ matrix.working_directory == 'tests' && 'tests' || 'cloud_firestore*' }}
       # The ubuntu runner image ships Google Chrome and a chromedriver build
       # that is matched to it — that pairing IS our pinning strategy, so we use
       # the image binaries rather than downloading our own.
@@ -65,25 +61,8 @@ jobs:
           echo "$CHROMEWEBDRIVER" >> "$GITHUB_PATH"
           google-chrome --version
           "$CHROMEWEBDRIVER/chromedriver" --version
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
       - name: Generate dummy Firebase configs
         run: dart ./.github/workflows/scripts/generate-dummy-firebase-configs.dart
-      - name: 'Bootstrap package'
-        timeout-minutes: 15
-        run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools@15.25.1
-          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -132,16 +111,11 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
+      - uses: ./.github/actions/setup-flutterfire
+        timeout-minutes: 15
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: '.github/workflows/scripts/functions/package-lock.json'
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
-        with:
-          distribution: 'temurin'
-          java-version: '21'
+          firebase-tools-version: '15.25.1'
+          bootstrap-scope: 'tests'
       # The ubuntu runner image ships Google Chrome and a chromedriver build
       # that is matched to it — that pairing IS our pinning strategy, so we use
       # the image binaries rather than downloading our own.
@@ -150,23 +124,6 @@ jobs:
           echo "$CHROMEWEBDRIVER" >> "$GITHUB_PATH"
           google-chrome --version
           "$CHROMEWEBDRIVER/chromedriver" --version
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
-      - name: 'Bootstrap package'
-        timeout-minutes: 15
-        run: melos bootstrap --scope tests
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools@15.25.1
-          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -222,16 +179,12 @@ jobs:
           - working_directory: ${{ inputs.nightly_test_mode && 'packages/cloud_firestore/cloud_firestore/example' || 'none' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
+      - uses: ./.github/actions/setup-flutterfire
+        timeout-minutes: 15
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: '.github/workflows/scripts/functions/package-lock.json'
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
-        with:
-          distribution: 'temurin'
-          java-version: '21'
+          firebase-tools-version: '15.25.1'
+          # Each matrix leg bootstraps only the packages it exercises.
+          bootstrap-scope: ${{ matrix.working_directory == 'tests' && 'tests' || 'cloud_firestore*' }}
       # The ubuntu runner image ships Google Chrome and a chromedriver build
       # that is matched to it — that pairing IS our pinning strategy, so we use
       # the image binaries rather than downloading our own.
@@ -240,25 +193,8 @@ jobs:
           echo "$CHROMEWEBDRIVER" >> "$GITHUB_PATH"
           google-chrome --version
           "$CHROMEWEBDRIVER/chromedriver" --version
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
       - name: Generate dummy Firebase configs
         run: dart ./.github/workflows/scripts/generate-dummy-firebase-configs.dart
-      - name: 'Bootstrap package'
-        timeout-minutes: 15
-        run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
-      - name: 'Install Tools'
-        run: |
-          sudo npm i -g firebase-tools@15.25.1
-          echo "FIREBASE_TOOLS_VERSION=$(firebase --version)" >> $GITHUB_ENV
       - name: Firebase Emulator Cache
         id: firebase-emulator-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -38,27 +38,13 @@ jobs:
     timeout-minutes: ${{ inputs.nightly_test_mode && 5 || 45 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          distribution: 'temurin'
-          java-version: '21'
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
-        with:
-          node-version: "20"
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
-      - name: "Bootstrap package"
-        run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
+          npm-cache: 'false'
+          bootstrap-scope: 'tests cloud_firestore*'
       - name: "Install Tools"
+        # Not the composite action's firebase-tools install: that one uses `sudo npm`,
+        # which does not exist on the Windows runners.
         run: |
           npm install -g firebase-tools@15.25.1
       - name: "Build Windows (Release)"
@@ -77,29 +63,15 @@ jobs:
     timeout-minutes: ${{ inputs.nightly_test_mode && 5 || 45 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
+      - uses: ./.github/actions/setup-flutterfire
         with:
-          distribution: 'temurin'
-          java-version: '21'
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
-        name: Install Node.js 20
-        with:
-          node-version: "20"
-      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: 'stable'
-          cache: true
-          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
-      - uses: bluefireteam/melos-action@2982f8e4fc92440a219490009d6d05195cb1a6a5
-        with:
-          run-bootstrap: false
-          melos-version: '5.3.0'
+          npm-cache: 'false'
+          bootstrap-scope: 'tests cloud_firestore*'
       - name: Generate dummy Firebase configs
         run: dart ./.github/workflows/scripts/generate-dummy-firebase-configs.dart
-      - name: "Bootstrap package"
-        run: melos bootstrap --scope tests && melos bootstrap --scope "cloud_firestore*"
       - name: "Install Tools"
+        # Not the composite action's firebase-tools install: that one uses `sudo npm`,
+        # which does not exist on the Windows runners.
         run: |
           npm install -g firebase-tools@15.25.1
       - name: Start Firebase Emulator and run tests


### PR DESCRIPTION
First step of the CI rework (follow-up to #18532): the 22 copies of the setup preamble become one composite action, and matrixed jobs now bootstrap only the scope their leg needs. Pure refactor — no behavior changes. Shrinks every subsequent CI PR's diff.