### PR TITLE
docs(auth): update account-exists guidance after fetchSignInMethodsForEmail removal

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -466,12 +466,10 @@ class FirebaseAuth extends FirebasePlugin implements FirebaseService {
   /// A [FirebaseAuthException] maybe thrown with the following error code:
   /// - **account-exists-with-different-credential**:
   ///  - Thrown if there already exists an account with the email address
-  ///    asserted by the credential.
-  // ignore: deprecated_member_use_from_same_package
-  ///    Resolve this by asking
-  ///    the user to sign in using one of the returned providers.
-  ///    Once the user is signed in, the original credential can be linked to
-  ///    the user with [linkWithCredential].
+  ///    asserted by the credential. Resolve this by asking the user to sign in
+  ///    with a provider already linked to that email address. Once the user is
+  ///    signed in, the original credential can be linked to the user with
+  ///    [linkWithCredential].
   /// - **invalid-credential**:
   ///  - Thrown if the credential is malformed or has expired.
   /// - **operation-not-allowed**:

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/auth_credential.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/auth_credential.dart
@@ -23,8 +23,7 @@ class AuthCredential {
   final String providerId;
 
   /// The authentication sign in method for the credential. For example,
-  /// 'password', or 'emailLink'. This corresponds to the sign-in method
-  /// identifier returned in [fetchSignInMethodsForEmail].
+  /// 'password', or 'emailLink'.
   final String signInMethod;
 
   /// A token used to identify the AuthCredential on native platforms.

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_firebase_auth.dart
@@ -458,10 +458,10 @@ abstract class FirebaseAuthPlatform extends PlatformInterface {
   /// A [FirebaseAuthException] maybe thrown with the following error code:
   /// - **account-exists-with-different-credential**:
   ///  - Thrown if there already exists an account with the email address
-  ///    asserted by the credential. Resolve this by calling
-  ///    [fetchSignInMethodsForEmail] and then asking the user to sign in using
-  ///    one of the returned providers. Once the user is signed in, the original
-  ///    credential can be linked to the user with [linkWithCredential].
+  ///    asserted by the credential. Resolve this by asking the user to sign in
+  ///    with a provider already linked to that email address. Once the user is
+  ///    signed in, the original credential can be linked to the user with
+  ///    [linkWithCredential].
   /// - **invalid-credential**:
   ///  - Thrown if the credential is malformed or has expired.
   /// - **operation-not-allowed**:

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_user.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/platform_interface/platform_interface_user.dart
@@ -181,9 +181,9 @@ abstract class UserPlatform extends PlatformInterface {
   ///    user, an `email` and `credential` ([AuthCredential]) fields are also
   ///    provided. You have to link the credential to the existing user with
   ///    that email if you wish to continue signing in with that credential.
-  ///    To do so, call [fetchSignInMethodsForEmail], sign in to `email` via one
-  ///    of the providers returned and then [User.linkWithCredential] the
-  ///    original credential to that newly signed in user.
+  ///    To do so, sign in to `email` with a provider already linked to it, then
+  ///    [User.linkWithCredential] the original credential to that newly signed
+  ///    in user.
   /// - **operation-not-allowed**:
   ///  - Thrown if you have not enabled the provider in the Firebase Console. Go
   ///    to the Firebase Console for your project, in the Auth section and the
@@ -227,9 +227,9 @@ abstract class UserPlatform extends PlatformInterface {
   ///    user, an `email` and `credential` ([AuthCredential]) fields are also
   ///    provided. You have to link the credential to the existing user with
   ///    that email if you wish to continue signing in with that credential.
-  ///    To do so, call [fetchSignInMethodsForEmail], sign in to `email` via one
-  ///    of the providers returned and then [User.linkWithCredential] the
-  ///    original credential to that newly signed in user.
+  ///    To do so, sign in to `email` with a provider already linked to it, then
+  ///    [User.linkWithCredential] the original credential to that newly signed
+  ///    in user.
   /// - **operation-not-allowed**:
   ///  - Thrown if you have not enabled the provider in the Firebase Console. Go
   ///    to the Firebase Console for your project, in the Auth section and the
@@ -329,9 +329,9 @@ abstract class UserPlatform extends PlatformInterface {
   ///    user, an `email` and `credential` ([AuthCredential]) fields are also
   ///    provided. You have to link the credential to the existing user with
   ///    that email if you wish to continue signing in with that credential.
-  ///    To do so, call [fetchSignInMethodsForEmail], sign in to `email` via one
-  ///    of the providers returned and then [User.linkWithCredential] the
-  ///    original credential to that newly signed in user.
+  ///    To do so, sign in to `email` with a provider already linked to it, then
+  ///    [User.linkWithCredential] the original credential to that newly signed
+  ///    in user.
   /// - **operation-not-allowed**:
   ///  - Thrown if you have not enabled the provider in the Firebase Console. Go
   ///    to the Firebase Console for your project, in the Auth section and the
@@ -368,9 +368,9 @@ abstract class UserPlatform extends PlatformInterface {
   ///    user, an `email` and `credential` ([AuthCredential]) fields are also
   ///    provided. You have to link the credential to the existing user with
   ///    that email if you wish to continue signing in with that credential.
-  ///    To do so, call [fetchSignInMethodsForEmail], sign in to `email` via one
-  ///    of the providers returned and then [User.linkWithCredential] the
-  ///    original credential to that newly signed in user.
+  ///    To do so, sign in to `email` with a provider already linked to it, then
+  ///    [User.linkWithCredential] the original credential to that newly signed
+  ///    in user.
   /// - **operation-not-allowed**:
   ///  - Thrown if you have not enabled the provider in the Firebase Console. Go
   ///    to the Firebase Console for your project, in the Auth section and the


### PR DESCRIPTION
## Description

`FirebaseAuth.fetchSignInMethodsForEmail()` was removed in `firebase_auth` 6.0.0 (#17562, for email-enumeration security reasons), but the error-code documentation still instructs users to call it.

Existing behavior — the docs for `account-exists-with-different-credential` and `email-already-in-use` tell the reader to call `fetchSignInMethodsForEmail`, sign in with one of the providers it returns, and then link the original credential. That first step is no longer possible from the public API, so the recovery flow as documented cannot be followed.

This PR rewrites that guidance to the flow that still works: ask the user to sign in with a provider already linked to the email address, then link the original credential with `linkWithCredential`.

Two smaller cleanups from the same removal:

- `firebase_auth.dart` had a stray `// ignore: deprecated_member_use_from_same_package` left inside the `signInWithCredential` doc comment. The deprecated member it suppressed is gone, and it had been dropped in mid-sentence, leaving `Resolve this by asking the user to sign in using one of the returned providers` with nothing returning them.
- `AuthCredential.signInMethod` described itself as "the sign-in method identifier returned in `fetchSignInMethodsForEmail`". That trailing clause is dropped.

Six doc sites across three files, all `///` comments. No API, behavior, or signature changes.

Out of scope: `firebase_auth_web/lib/src/interop/auth_interop.dart` still references `firebase.auth.Auth.fetchSignInMethodsForEmail`, but that documents the underlying JS SDK method in the interop layer rather than the Dart API, so it is left alone.

## Related Issues

Fixes https://github.com/firebase/flutterfire/issues/12909

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
  - N/A — documentation-only change, no behavior to test.
- [ ] All existing and new tests are passing.
  - Not run locally; nothing executable changed. CI to confirm.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
