### PR TITLE
fix(core,web): preserve non-JavaScript app errors

### DIFF
--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -386,16 +386,16 @@ class FirebaseCoreWeb extends FirebasePlatform {
           measurementId: options.measurementId,
         );
       } catch (e) {
-        // ignore: invalid_runtime_check_with_js_interop_types
-        if (e is! JSError) {
+        if (!e.isA<JSObject>()) {
           rethrow;
         }
 
-        if (_getJSErrorCode(e) == 'app/duplicate-app') {
+        final jsError = e as JSError;
+        if (_getJSErrorCode(jsError) == 'app/duplicate-app') {
           throw duplicateApp(name);
         }
 
-        throw _catchJSError(e);
+        throw _catchJSError(jsError);
       }
     }
 
@@ -432,16 +432,16 @@ class FirebaseCoreWeb extends FirebasePlatform {
       app = guardNotInitialized(() => firebase.app(name));
       return _createFromJsApp(app);
     } catch (e) {
-      // ignore: invalid_runtime_check_with_js_interop_types
-      if (e is! JSError) {
+      if (!e.isA<JSObject>()) {
         rethrow;
       }
 
-      if (_getJSErrorCode(e) == 'app/no-app') {
+      final jsError = e as JSError;
+      if (_getJSErrorCode(jsError) == 'app/no-app') {
         throw noAppExists(name);
       }
 
-      throw _catchJSError(e);
+      throw _catchJSError(jsError);
     }
   }
 }

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -386,7 +386,12 @@ class FirebaseCoreWeb extends FirebasePlatform {
           measurementId: options.measurementId,
         );
       } catch (e) {
-        if (_getJSErrorCode(e as JSError) == 'app/duplicate-app') {
+        // ignore: invalid_runtime_check_with_js_interop_types
+        if (e is! JSError) {
+          rethrow;
+        }
+
+        if (_getJSErrorCode(e) == 'app/duplicate-app') {
           throw duplicateApp(name);
         }
 
@@ -427,7 +432,12 @@ class FirebaseCoreWeb extends FirebasePlatform {
       app = guardNotInitialized(() => firebase.app(name));
       return _createFromJsApp(app);
     } catch (e) {
-      if (_getJSErrorCode(e as JSError) == 'app/no-app') {
+      // ignore: invalid_runtime_check_with_js_interop_types
+      if (e is! JSError) {
+        rethrow;
+      }
+
+      if (_getJSErrorCode(e) == 'app/no-app') {
         throw noAppExists(name);
       }
 

--- a/packages/firebase_core/firebase_core_web/test/firebase_core_web_exceptions_test.dart
+++ b/packages/firebase_core/firebase_core_web/test/firebase_core_web_exceptions_test.dart
@@ -4,6 +4,9 @@
 // found in the LICENSE file.
 
 @TestOn('browser')
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
 import 'package:firebase_core_web/firebase_core_web.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -47,6 +50,31 @@ void main() {
 
     test('should return empty list when Firebase is not initialized', () {
       expect(FirebasePlatform.instance.apps, isEmpty);
+    });
+  });
+
+  group('.app()', () {
+    test('preserves core-not-initialized errors', () {
+      JSObject throwDartError() {
+        throw StateError('Cannot read properties of undefined');
+      }
+
+      final firebaseCore = JSObject();
+      firebaseCore['getApp'] = throwDartError.toJS;
+      globalContext['firebase_core'] = firebaseCore;
+
+      expect(
+        () => FirebaseCoreWeb().app(),
+        throwsA(
+          isA<FirebaseException>()
+              .having((error) => error.plugin, 'plugin', 'core')
+              .having(
+                (error) => error.code,
+                'code',
+                'not-initialized',
+              ),
+        ),
+      );
     });
   });
 }


### PR DESCRIPTION
## Description

`FirebaseCoreWeb.app()` and secondary-app initialization cast every caught exception to `JSError`, which could mask Dart exceptions produced by `guardNotInitialized` with an unrelated `TypeError`. This change rethrows non-JavaScript exceptions unchanged while preserving the existing Firebase JavaScript error mapping, and adds a browser regression test for `[core/not-initialized]`.

Verified with `flutter test --platform chrome` and `flutter analyze` in `packages/firebase_core/firebase_core_web`.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18548

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/