### PR TITLE
fix(firestore, android): defer transaction cleanup until stream cancellation

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -277,26 +277,21 @@ public class FlutterFirebaseFirestorePlugin
     return identifier;
   }
 
-  private void removeEventListener(String identifier) {
+  private void removeTransaction(String transactionId) {
+    transactions.remove(transactionId);
+    transactionHandlers.remove(transactionId);
+
+    // onCancel invokes this method, so remove the handler without cancelling it again.
+    synchronized (streamHandlers) {
+      streamHandlers.remove(transactionId);
+    }
+
     synchronized (eventChannels) {
-      EventChannel eventChannel = eventChannels.remove(identifier);
+      EventChannel eventChannel = eventChannels.remove(transactionId);
       if (eventChannel != null) {
         eventChannel.setStreamHandler(null);
       }
     }
-
-    synchronized (streamHandlers) {
-      StreamHandler streamHandler = streamHandlers.remove(identifier);
-      if (streamHandler != null) {
-        streamHandler.onCancel(null);
-      }
-    }
-  }
-
-  private void removeTransaction(String transactionId) {
-    transactions.remove(transactionId);
-    removeEventListener(transactionId);
-    transactionHandlers.remove(transactionId);
   }
 
   private void removeEventListeners() {

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/TransactionStreamHandler.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/TransactionStreamHandler.java
@@ -38,13 +38,13 @@ public class TransactionStreamHandler implements OnTransactionResultListener, St
     void onStarted(Transaction transaction);
   }
 
-  /** Callback when the transaction has reached a terminal state. */
-  public interface OnTransactionCompleteListener {
-    void onComplete(String transactionId);
+  /** Callback when Dart cancels the transaction event stream. */
+  public interface OnTransactionCancelledListener {
+    void onCancelled(String transactionId);
   }
 
   final OnTransactionStartedListener onTransactionStartedListener;
-  final OnTransactionCompleteListener onTransactionCompleteListener;
+  final OnTransactionCancelledListener onTransactionCancelledListener;
   final FirebaseFirestore firestore;
   final String transactionId;
   final Long timeout;
@@ -53,13 +53,13 @@ public class TransactionStreamHandler implements OnTransactionResultListener, St
 
   public TransactionStreamHandler(
       OnTransactionStartedListener onTransactionStartedListener,
-      OnTransactionCompleteListener onTransactionCompleteListener,
+      OnTransactionCancelledListener onTransactionCancelledListener,
       FirebaseFirestore firestore,
       String transactionId,
       Long timeout,
       Long maxAttempts) {
     this.onTransactionStartedListener = onTransactionStartedListener;
-    this.onTransactionCompleteListener = onTransactionCompleteListener;
+    this.onTransactionCancelledListener = onTransactionCancelledListener;
     this.firestore = firestore;
     this.transactionId = transactionId;
     this.timeout = timeout;
@@ -186,7 +186,6 @@ public class TransactionStreamHandler implements OnTransactionResultListener, St
                   () -> {
                     events.success(map);
                     events.endOfStream();
-                    onTransactionCompleteListener.onComplete(transactionId);
                   });
             });
   }
@@ -194,6 +193,11 @@ public class TransactionStreamHandler implements OnTransactionResultListener, St
   @Override
   public void onCancel(Object arguments) {
     semaphore.release();
+    // FlutterFirebaseFirestorePlugin passes null when disposing all listeners and clears the
+    // listener maps itself. A non-null value identifies Dart's EventChannel cancellation.
+    if (arguments != null) {
+      onTransactionCancelledListener.onCancelled(transactionId);
+    }
   }
 
   @Override

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/transaction_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/transaction_e2e.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void runTransactionTests() {
@@ -68,6 +69,47 @@ void runTransactionTests() {
         });
         expect(response, equals(randomValue));
       });
+
+      test(
+        'does not report an error when the transaction stream is cancelled',
+        () async {
+          final List<Object> reportedErrors = <Object>[];
+          final FlutterExceptionHandler? previousOnError = FlutterError.onError;
+          FlutterError.onError = (FlutterErrorDetails details) {
+            reportedErrors.add(details.exception);
+          };
+          addTearDown(() {
+            FlutterError.onError = previousOnError;
+          });
+
+          final DocumentReference<Map<String, dynamic>> doc =
+              await initializeTest('transaction-cancel-cleanup');
+
+          await firestore.runTransaction((Transaction transaction) async {
+            transaction.set(doc, {
+              'updatedAt': DateTime.now().toIso8601String(),
+            });
+          });
+
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+
+          final Iterable<Object> transactionCancelErrors =
+              reportedErrors.where((Object error) {
+            final String text = error.toString();
+            return error is MissingPluginException &&
+                text.contains('firebase_firestore/transaction');
+          });
+
+          expect(
+            transactionCancelErrors,
+            isEmpty,
+            reason: 'Unexpected FlutterError(s): $reportedErrors',
+          );
+        },
+        skip: kIsWeb || defaultTargetPlatform != TargetPlatform.android
+            ? 'Android-only EventChannel teardown race'
+            : false,
+      );
 
       test(
         'runs after reading a document',


### PR DESCRIPTION
## Description

On Android, transaction event channels were unregistered immediately after native completion, so Dart's subsequent stream cancellation reached no handler and reported a `MissingPluginException` even though the transaction succeeded. This PR defers transaction cleanup until the Dart `EventChannel` subscription is cancelled, avoids recursive cancellation during plugin-wide listener disposal, and adds Android integration coverage for the teardown path.

The targeted regression test and the complete transaction integration group pass on Android.

## Related Issues

Fixes #18546

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/