### PR TITLE
fix(firestore): prevent duplicate transaction completion

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_firestore.dart
@@ -287,8 +287,12 @@ class MethodChannelFirebaseFirestore extends FirebaseFirestorePlatform {
             null,
           );
 
-          // Allow the [runTransaction] method to listen to an error.
+          // Native may report an error while the result is being stored.
+          if (completer.isCompleted) {
+            return;
+          }
 
+          // Allow the [runTransaction] method to listen to an error.
           completer.completeError(error, stack);
 
           return;

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_firestore_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_firestore_test.dart
@@ -1,0 +1,138 @@
+// Copyright 2017, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:cloud_firestore_platform_interface/src/method_channel/method_channel_firestore.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_platform_interface/test.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import 'pigeon/test_api.dart';
+
+class _MockFirebaseFirestoreHostApi extends Mock
+    implements TestFirebaseFirestoreHostApi {
+  final Completer<void> storeResultCalled = Completer<void>();
+  final Completer<void> releaseStoreResult = Completer<void>();
+
+  @override
+  Future<String> transactionCreate(
+    FirestorePigeonFirebaseApp app,
+    int timeout,
+    int maxAttempts,
+  ) async {
+    return 'transaction-id';
+  }
+
+  @override
+  Future<void> transactionStoreResult(
+    String transactionId,
+    InternalTransactionResult resultType,
+    List<InternalTransactionCommand?>? commands,
+  ) async {
+    storeResultCalled.complete();
+    await releaseStoreResult.future;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setupFirebaseCoreMocks();
+
+  const transactionId = 'transaction-id';
+  const channelName =
+      'plugins.flutter.io/firebase_firestore/transaction/$transactionId';
+  const codec = StandardMethodCodec(PigeonCodec());
+
+  late TestDefaultBinaryMessenger messenger;
+  late _MockFirebaseFirestoreHostApi hostApi;
+  late Completer<void> eventChannelListened;
+  late FirebaseApp app;
+
+  setUpAll(() async {
+    app = await Firebase.initializeApp(
+      name: 'test-app',
+      options: const FirebaseOptions(
+        apiKey: 'api-key',
+        appId: 'app-id',
+        messagingSenderId: 'sender-id',
+        projectId: 'project-id',
+      ),
+    );
+  });
+
+  setUp(() {
+    messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    hostApi = _MockFirebaseFirestoreHostApi();
+    eventChannelListened = Completer<void>();
+
+    TestFirebaseFirestoreHostApi.setUp(hostApi);
+    messenger.setMockMessageHandler(channelName, (ByteData? message) async {
+      if (!eventChannelListened.isCompleted) {
+        eventChannelListened.complete();
+      }
+      return codec.encodeSuccessEnvelope(null);
+    });
+  });
+
+  tearDown(() {
+    TestFirebaseFirestoreHostApi.setUp(null);
+    messenger.setMockMessageHandler(channelName, null);
+  });
+
+  test(
+    'does not complete the transaction future twice when native reports an '
+    'error while storing a failure',
+    () async {
+      final firestore = MethodChannelFirebaseFirestore(
+        app: app,
+        databaseId: '(default)',
+      );
+
+      final transactionFuture = firestore.runTransaction<void>(
+        (_) => throw StateError('handler failed'),
+      );
+
+      await eventChannelListened.future;
+      unawaited(
+        messenger.handlePlatformMessage(
+          channelName,
+          codec.encodeSuccessEnvelope(<String, Object?>{
+            'appName': 'test-app',
+          }),
+          (_) {},
+        ),
+      );
+      await hostApi.storeResultCalled.future;
+
+      unawaited(
+        messenger.handlePlatformMessage(
+          channelName,
+          codec.encodeSuccessEnvelope(<String, Object?>{
+            'error': <String, Object?>{
+              'code': 'deadline-exceeded',
+              'message': 'Transaction timed out',
+            },
+          }),
+          (_) {},
+        ),
+      );
+
+      await expectLater(
+        transactionFuture,
+        throwsA(
+          isA<FirebaseException>()
+              .having((error) => error.code, 'code', 'deadline-exceeded'),
+        ),
+      );
+
+      hostApi.releaseStoreResult.complete();
+      await Future<void>.delayed(Duration.zero);
+    },
+  );
+}


### PR DESCRIPTION
## Description

Prevents `runTransaction` from completing its result future a second time when native reports a transaction error while Dart is awaiting `transactionStoreResult` for a handler failure. A deterministic platform-channel regression test covers the race and previously failed with `Bad state: Future already completed`.

Verified with the full `cloud_firestore_platform_interface` test suite and package-level `dart analyze`.

## Related Issues

Fixes https://github.com/firebase/flutterfire/issues/18551

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
