### PR TITLE
fix(core, web): keep App Check registered for secondary Firebase apps

### DIFF
--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -57,6 +57,14 @@ class FirebaseCoreWeb extends FirebasePlatform {
     );
   }
 
+  /// Whether [service] is still registered for per-app initialization.
+  ///
+  /// Used by tests to ensure App Check is not removed after the first
+  /// [initializeApp] (secondary apps must re-run ensurePluginInitialized).
+  @visibleForTesting
+  static bool isServiceRegistered(String service) =>
+      _services.containsKey(service);
+
   static const String _libraryName = 'flutter-fire-core';
 
   /// Registers that [FirebaseCoreWeb] is the platform implementation.
@@ -394,15 +402,22 @@ class FirebaseCoreWeb extends FirebasePlatform {
       }
     }
 
-    final appCheck = _services.remove('app-check');
-    if (appCheck != null) {
-      // Activate app check first
-      await appCheck.ensurePluginInitialized!(app!);
+    // Activate App Check before other services so Auth/etc. attach tokens.
+    // Do NOT remove 'app-check' from [_services]: secondary (named) apps also
+    // need ensurePluginInitialized on each Firebase.initializeApp() call.
+    // Removing it caused App Check to skip reactivation for named apps on
+    // reload, so accounts:lookup ran without X-Firebase-AppCheck (#18556).
+    final appCheck = _services['app-check'];
+    final appCheckEnsureInitialized = appCheck?.ensurePluginInitialized;
+    if (appCheckEnsureInitialized != null) {
+      await appCheckEnsureInitialized(app!);
     }
 
     await Future.wait(
-      _services.values.map((service) {
-        final ensureInitializedFunction = service.ensurePluginInitialized;
+      _services.entries
+          .where((entry) => entry.key != 'app-check')
+          .map((entry) {
+        final ensureInitializedFunction = entry.value.ensurePluginInitialized;
 
         if (ensureInitializedFunction == null || app == null) {
           return Future.value();

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -414,9 +414,7 @@ class FirebaseCoreWeb extends FirebasePlatform {
     }
 
     await Future.wait(
-      _services.entries
-          .where((entry) => entry.key != 'app-check')
-          .map((entry) {
+      _services.entries.where((entry) => entry.key != 'app-check').map((entry) {
         final ensureInitializedFunction = entry.value.ensurePluginInitialized;
 
         if (ensureInitializedFunction == null || app == null) {

--- a/packages/firebase_core/firebase_core_web/test/firebase_core_web_app_check_multi_app_test.dart
+++ b/packages/firebase_core/firebase_core_web/test/firebase_core_web_app_check_multi_app_test.dart
@@ -1,0 +1,67 @@
+// Copyright 2026 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
+import 'package:firebase_core_web/firebase_core_web.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('App Check multi-app initialization', () {
+    setUp(() async {
+      FirebasePlatform.instance = FirebaseCoreWeb();
+    });
+
+    test(
+      'keeps app-check registered and re-runs ensurePluginInitialized for named apps',
+      () async {
+        final initializedAppNames = <String>[];
+
+        FirebaseCoreWeb.registerService(
+          'app-check',
+          productNameOverride: 'app_check',
+          ensurePluginInitialized: (firebaseApp) async {
+            initializedAppNames.add(firebaseApp.name);
+          },
+        );
+
+        expect(FirebaseCoreWeb.isServiceRegistered('app-check'), isTrue);
+
+        const options = FirebaseOptions(
+          apiKey: 'fake-api-key',
+          appId: '1:1234567890:web:fake',
+          messagingSenderId: '1234567890',
+          projectId: 'fake-project',
+          authDomain: 'fake-project.firebaseapp.com',
+        );
+
+        final coreWeb = FirebaseCoreWeb();
+        final version = coreWeb.firebaseSDKVersion;
+        await coreWeb.injectSrcScript(
+          'https://www.gstatic.com/firebasejs/$version/firebase-app.js',
+          'firebase_core',
+        );
+
+        await FirebasePlatform.instance.initializeApp(options: options);
+
+        // Must still be registered so a secondary app can reactivate App Check.
+        expect(FirebaseCoreWeb.isServiceRegistered('app-check'), isTrue);
+        expect(initializedAppNames, contains('[DEFAULT]'));
+
+        await FirebasePlatform.instance.initializeApp(
+          name: 'prod',
+          options: options,
+        );
+
+        expect(FirebaseCoreWeb.isServiceRegistered('app-check'), isTrue);
+        expect(
+          initializedAppNames,
+          containsAll(['[DEFAULT]', 'prod']),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description

On web, `Firebase.initializeApp()` activates App Check before other services so Auth can attach `X-Firebase-AppCheck`. The #11625 implementation did that with `_services.remove('app-check')`, which permanently dropped App Check from the registry after the **first** app.

For a secondary named app, Auth still ran `ensurePluginInitialized` (and `accounts:lookup`) without App Check being reactivated, so the App Check header was missing on reload when Auth enforcement was enabled.

This change keeps `app-check` registered, awaits its `ensurePluginInitialized` on every `initializeApp`, and still skips it in the parallel `Future.wait` so ordering is preserved.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18556

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/