### PR TITLE
fix(ci): align Android toolchain and analyzer with Flutter 3.47

### DIFF
--- a/.github/workflows/e2e_tests_firestore.yaml
+++ b/.github/workflows/e2e_tests_firestore.yaml
@@ -103,6 +103,8 @@ jobs:
       package-path: 'packages/cloud_firestore/cloud_firestore'
       package-scope: 'cloud_firestore*'
       wasm: true
+      # Diagnostic pin: check whether the dart2wasm TFA startAfter failure is 3.47-only.
+      flutter-version: '3.44.0'
       drive-timeout: '300'
       max-attempts: '2'
       native-config-args: '--firestore-native'

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,6 +12,13 @@ analyzer:
     included_file_warning: ignore
   exclude:
     - packages/**/example/lib/generated_plugin_registrant.dart
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   rules:

--- a/packages/cloud_firestore/cloud_firestore/example/analysis_options.yaml
+++ b/packages/cloud_firestore/cloud_firestore/example/analysis_options.yaml
@@ -2,15 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
-analyzer:
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/cloud_firestore/cloud_firestore/example/analysis_options.yaml
+++ b/packages/cloud_firestore/cloud_firestore/example/analysis_options.yaml
@@ -2,6 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/cloud_firestore/cloud_firestore/pipeline_example/analysis_options.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pipeline_example/analysis_options.yaml
@@ -14,6 +14,13 @@ analyzer:
   # from analyze so analyze-ci passes.
   exclude:
     - integration_test/**
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/packages/cloud_firestore/cloud_firestore/pipeline_example/integration_test/pipeline/pipeline_expressions_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/pipeline_example/integration_test/pipeline/pipeline_expressions_e2e.dart
@@ -803,21 +803,17 @@ void runPipelineExpressionsTests() {
       ]);
     });
 
-    test(
-      'arraySum addFields succeeds on Android',
-      () async {
-        final snapshot = await firestore
-            .pipeline()
-            .collection('pipeline-e2e')
-            .where(Expression.field('test').equalValue('expressions'))
-            .addFields(Expression.array([1, 2, 3]).arraySum().as('x'))
-            .limit(1)
-            .execute();
-        expectResultCount(snapshot, 1);
-        expect(snapshot.result[0].data()!['x'], 6);
-      },
-      skip: defaultTargetPlatform != TargetPlatform.android,
-    );
+    test('arraySum addFields succeeds on Android', () async {
+      final snapshot = await firestore
+          .pipeline()
+          .collection('pipeline-e2e')
+          .where(Expression.field('test').equalValue('expressions'))
+          .addFields(Expression.array([1, 2, 3]).arraySum().as('x'))
+          .limit(1)
+          .execute();
+      expectResultCount(snapshot, 1);
+      expect(snapshot.result[0].data()!['x'], 6);
+    }, skip: defaultTargetPlatform != TargetPlatform.android);
 
     test(
       'unsupported expression returns parse-error with informative message',

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -495,12 +495,15 @@ class Query<T extends firestore_interop.QueryJsImpl>
   /// Creates a new Query from a [jsObject].
   Query.fromJsObject(T jsObject) : super.fromJsObject(jsObject);
 
+  // dart2wasm TFA can drop these JS-interop cursor helpers (Flutter 3.47+).
+  @pragma('wasm:entry-point')
   Query endAt({DocumentSnapshot? snapshot, List<dynamic>? fieldValues}) =>
       Query.fromJsObject(firestore_interop.query(
           jsObject,
           _createQueryConstraint(
               firestore_interop.endAt, snapshot, fieldValues)));
 
+  @pragma('wasm:entry-point')
   Query endBefore({DocumentSnapshot? snapshot, List<dynamic>? fieldValues}) =>
       Query.fromJsObject(firestore_interop.query(
           jsObject,
@@ -601,6 +604,7 @@ class Query<T extends firestore_interop.QueryJsImpl>
         firestore_interop.query(jsObject, jsObjectOrderBy));
   }
 
+  @pragma('wasm:entry-point')
   Query startAfter({DocumentSnapshot? snapshot, List<dynamic>? fieldValues}) =>
       Query.fromJsObject(
         firestore_interop.query(
@@ -613,6 +617,7 @@ class Query<T extends firestore_interop.QueryJsImpl>
         ),
       );
 
+  @pragma('wasm:entry-point')
   Query startAt({DocumentSnapshot? snapshot, List<dynamic>? fieldValues}) =>
       Query.fromJsObject(
         firestore_interop.query(
@@ -641,6 +646,7 @@ class Query<T extends firestore_interop.QueryJsImpl>
   /// [fieldValues].
   /// We need to call this method in all paginating methods to fix that Dart
   /// doesn't support varargs - we need to use [List] to call js function.
+  @pragma('wasm:entry-point')
   firestore_interop.QueryConstraintJsImpl _createQueryConstraint<S>(
       Object method, DocumentSnapshot? snapshot, List<dynamic>? fieldValues) {
     if (snapshot == null && fieldValues == null) {

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -495,15 +495,12 @@ class Query<T extends firestore_interop.QueryJsImpl>
   /// Creates a new Query from a [jsObject].
   Query.fromJsObject(T jsObject) : super.fromJsObject(jsObject);
 
-  // dart2wasm TFA can drop these JS-interop cursor helpers (Flutter 3.47+).
-  @pragma('wasm:entry-point')
   Query endAt({DocumentSnapshot? snapshot, List<dynamic>? fieldValues}) =>
       Query.fromJsObject(firestore_interop.query(
           jsObject,
           _createQueryConstraint(
               firestore_interop.endAt, snapshot, fieldValues)));
 
-  @pragma('wasm:entry-point')
   Query endBefore({DocumentSnapshot? snapshot, List<dynamic>? fieldValues}) =>
       Query.fromJsObject(firestore_interop.query(
           jsObject,
@@ -604,7 +601,6 @@ class Query<T extends firestore_interop.QueryJsImpl>
         firestore_interop.query(jsObject, jsObjectOrderBy));
   }
 
-  @pragma('wasm:entry-point')
   Query startAfter({DocumentSnapshot? snapshot, List<dynamic>? fieldValues}) =>
       Query.fromJsObject(
         firestore_interop.query(
@@ -617,7 +613,6 @@ class Query<T extends firestore_interop.QueryJsImpl>
         ),
       );
 
-  @pragma('wasm:entry-point')
   Query startAt({DocumentSnapshot? snapshot, List<dynamic>? fieldValues}) =>
       Query.fromJsObject(
         firestore_interop.query(
@@ -646,7 +641,6 @@ class Query<T extends firestore_interop.QueryJsImpl>
   /// [fieldValues].
   /// We need to call this method in all paginating methods to fix that Dart
   /// doesn't support varargs - we need to use [List] to call js function.
-  @pragma('wasm:entry-point')
   firestore_interop.QueryConstraintJsImpl _createQueryConstraint<S>(
       Object method, DocumentSnapshot? snapshot, List<dynamic>? fieldValues) {
     if (snapshot == null && fieldValues == null) {

--- a/packages/cloud_functions/cloud_functions/example/analysis_options.yaml
+++ b/packages/cloud_functions/cloud_functions/example/analysis_options.yaml
@@ -2,15 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
-analyzer:
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
 include: ../../../../analysis_options.yaml
 
 linter:

--- a/packages/cloud_functions/cloud_functions/example/analysis_options.yaml
+++ b/packages/cloud_functions/cloud_functions/example/analysis_options.yaml
@@ -2,6 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../../../analysis_options.yaml
 
 linter:

--- a/packages/firebase_ai/firebase_ai/example/analysis_options.yaml
+++ b/packages/firebase_ai/firebase_ai/example/analysis_options.yaml
@@ -2,15 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
-analyzer:
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_ai/firebase_ai/example/analysis_options.yaml
+++ b/packages/firebase_ai/firebase_ai/example/analysis_options.yaml
@@ -2,6 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_analytics/firebase_analytics/example/analysis_options.yaml
+++ b/packages/firebase_analytics/firebase_analytics/example/analysis_options.yaml
@@ -2,15 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
-analyzer:
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_analytics/firebase_analytics/example/analysis_options.yaml
+++ b/packages/firebase_analytics/firebase_analytics/example/analysis_options.yaml
@@ -2,6 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/lib/src/method_channel/method_channel_firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/lib/src/method_channel/method_channel_firebase_analytics.dart
@@ -85,7 +85,7 @@ class MethodChannelFirebaseAnalytics extends FirebaseAnalyticsPlatform {
     bool? securityStorageConsentGranted,
   }) async {
     try {
-      return _api.setConsent(<String, bool?>{
+      return await _api.setConsent(<String, bool?>{
         if (adStorageConsentGranted != null)
           'adStorageConsentGranted': adStorageConsentGranted,
         if (analyticsStorageConsentGranted != null)
@@ -106,7 +106,7 @@ class MethodChannelFirebaseAnalytics extends FirebaseAnalyticsPlatform {
     Map<String, Object?>? defaultParameters,
   ) async {
     try {
-      return _api.setDefaultEventParameters(defaultParameters);
+      return await _api.setDefaultEventParameters(defaultParameters);
     } catch (e, s) {
       convertPlatformException(e, s);
     }
@@ -168,7 +168,7 @@ class MethodChannelFirebaseAnalytics extends FirebaseAnalyticsPlatform {
   Future<void> setSessionTimeoutDuration(Duration timeout) async {
     try {
       if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
-        return _api.setSessionTimeoutDuration(timeout.inMilliseconds);
+        return await _api.setSessionTimeoutDuration(timeout.inMilliseconds);
       }
     } catch (e, s) {
       convertPlatformException(e, s);

--- a/packages/firebase_app_check/firebase_app_check/example/analysis_options.yaml
+++ b/packages/firebase_app_check/firebase_app_check/example/analysis_options.yaml
@@ -2,15 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
-analyzer:
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_app_check/firebase_app_check/example/analysis_options.yaml
+++ b/packages/firebase_app_check/firebase_app_check/example/analysis_options.yaml
@@ -2,6 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_app_installations/firebase_app_installations/example/analysis_options.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations/example/analysis_options.yaml
@@ -9,6 +9,16 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/packages/firebase_app_installations/firebase_app_installations_platform_interface/analysis_options.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations_platform_interface/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/packages/firebase_app_installations/firebase_app_installations_web/analysis_options.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations_web/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/packages/firebase_auth/firebase_auth/example/analysis_options.yaml
+++ b/packages/firebase_auth/firebase_auth/example/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../../../analysis_options.yaml
 
 linter:

--- a/packages/firebase_auth/firebase_auth/example/analysis_options.yaml
+++ b/packages/firebase_auth/firebase_auth/example/analysis_options.yaml
@@ -1,12 +1,3 @@
-analyzer:
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
 include: ../../../../analysis_options.yaml
 
 linter:

--- a/packages/firebase_core/firebase_core/example/analysis_options.yaml
+++ b/packages/firebase_core/firebase_core/example/analysis_options.yaml
@@ -2,15 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
-analyzer:
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_core/firebase_core/example/analysis_options.yaml
+++ b/packages/firebase_core/firebase_core/example/analysis_options.yaml
@@ -2,6 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/analysis_options.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/analysis_options.yaml
@@ -2,15 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
-analyzer:
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
 include: ../../../../analysis_options.yaml
 
 linter:

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/analysis_options.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/analysis_options.yaml
@@ -2,6 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../../../analysis_options.yaml
 
 linter:

--- a/packages/firebase_data_connect/firebase_data_connect/analysis_options.yaml
+++ b/packages/firebase_data_connect/firebase_data_connect/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml

--- a/packages/firebase_data_connect/firebase_data_connect/example/analysis_options.yaml
+++ b/packages/firebase_data_connect/firebase_data_connect/example/analysis_options.yaml
@@ -12,6 +12,13 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - lib/generated/**
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/packages/firebase_database/firebase_database/analysis_options.yaml
+++ b/packages/firebase_database/firebase_database/analysis_options.yaml
@@ -2,15 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
-analyzer:
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
 include: ../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_database/firebase_database/analysis_options.yaml
+++ b/packages/firebase_database/firebase_database/analysis_options.yaml
@@ -2,6 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_database/firebase_database/example/analysis_options.yaml
+++ b/packages/firebase_database/firebase_database/example/analysis_options.yaml
@@ -2,15 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
-analyzer:
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_database/firebase_database/example/analysis_options.yaml
+++ b/packages/firebase_database/firebase_database/example/analysis_options.yaml
@@ -2,6 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_database/firebase_database_web/analysis_options.yaml
+++ b/packages/firebase_database/firebase_database_web/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/example/analysis_options.yaml
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/example/analysis_options.yaml
@@ -2,15 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
-analyzer:
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/example/analysis_options.yaml
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/example/analysis_options.yaml
@@ -2,6 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_messaging/firebase_messaging/example/analysis_options.yaml
+++ b/packages/firebase_messaging/firebase_messaging/example/analysis_options.yaml
@@ -7,6 +7,14 @@ include: ../../../../analysis_options.yaml
 analyzer:
   errors:
     avoid_print: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   rules:

--- a/packages/firebase_messaging/firebase_messaging/example/analysis_options.yaml
+++ b/packages/firebase_messaging/firebase_messaging/example/analysis_options.yaml
@@ -7,14 +7,6 @@ include: ../../../../analysis_options.yaml
 analyzer:
   errors:
     avoid_print: ignore
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
 
 linter:
   rules:

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/example/analysis_options.yaml
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/example/analysis_options.yaml
@@ -9,6 +9,16 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/packages/firebase_performance/firebase_performance/example/analysis_options.yaml
+++ b/packages/firebase_performance/firebase_performance/example/analysis_options.yaml
@@ -2,15 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
-analyzer:
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_performance/firebase_performance/example/analysis_options.yaml
+++ b/packages/firebase_performance/firebase_performance/example/analysis_options.yaml
@@ -2,6 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # in the LICENSE file.
 
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../../../analysis_options.yaml
 linter:
   rules:

--- a/packages/firebase_remote_config/firebase_remote_config/example/analysis_options.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config/example/analysis_options.yaml
@@ -9,3 +9,11 @@ linter:
 analyzer:
   errors:
     public_member_api_docs: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/firebase_remote_config/firebase_remote_config/example/analysis_options.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config/example/analysis_options.yaml
@@ -9,11 +9,3 @@ linter:
 analyzer:
   errors:
     public_member_api_docs: ignore
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**

--- a/packages/firebase_storage/firebase_storage/example/analysis_options.yaml
+++ b/packages/firebase_storage/firebase_storage/example/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../../../../analysis_options.yaml
 
 linter:

--- a/packages/firebase_storage/firebase_storage/example/analysis_options.yaml
+++ b/packages/firebase_storage/firebase_storage/example/analysis_options.yaml
@@ -1,12 +1,3 @@
-analyzer:
-  exclude:
-    - build/**
-    - android/**
-    - ios/**
-    - web/**
-    - windows/**
-    - macos/**
-    - linux/**
 include: ../../../../analysis_options.yaml
 
 linter:

--- a/tests/android/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/tests/android/settings.gradle
+++ b/tests/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Description

Unpinned Flutter **3.47.0** on CI raised the Android dependency floors and enabled `unawaited_return_in_try_block`, which is currently failing `main` independently of feature PRs (`format`, `analyze`, `android-unit-tests`, `agp9-compatibility`).

- Bump the aggregate `tests/android` app to Gradle **8.14**, AGP **8.11.1**, and Kotlin **2.2.20** (Flutter 3.47 error thresholds).
- `return await` Pigeon HostApi calls in async `try` blocks in `firebase_analytics_platform_interface`.
- Add the native-dir `analyzer.exclude` entries that Flutter 3.47's `analysis_options.yaml` migrator writes (`build/**`, `android/**`, `ios/**`, `web/**`, `windows/**`, `macos/**`, `linux/**`) to each `analysis_options.yaml` it will open. The 3.47 migrator does not follow `include:`, so putting the list only on the repo root is not enough to keep format CI from rewriting nested files.
- dart-format the one pipeline e2e test CI rewrote.
- Temporarily pin the Firestore **web-wasm** e2e job to Flutter **3.44.0** (JS `web` stays on unpinned stable) to check whether the dart2wasm TFA `startAfter` failure is 3.47-specific.

## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/