### PR TITLE
fix(appcheck,macos): fix how appAttestWithDeviceCheckFallback is working on fallback

### DIFF
--- a/packages/firebase_app_check/firebase_app_check/example/integration_test/e2e_test.dart
+++ b/packages/firebase_app_check/firebase_app_check/example/integration_test/e2e_test.dart
@@ -141,6 +141,35 @@ void main() {
       );
 
       test(
+        'appAttestWithDeviceCheckFallback falls back rather than erroring',
+        () async {
+          await FirebaseAppCheck.instance.activate(
+            providerApple:
+                const AppleAppAttestWithDeviceCheckFallbackProvider(),
+          );
+
+          // On devices without App Attest support — most Macs — the provider
+          // has to fall back to DeviceCheck. It used to pick App Attest purely
+          // on OS version and fail with "The attestation provider
+          // AppAttestProvider is not supported on current platform and OS
+          // version", so that specific error must not come back.
+          try {
+            await FirebaseAppCheck.instance.getToken(true);
+          } on FirebaseException catch (e) {
+            expect(
+              '${e.message}',
+              isNot(contains('is not supported on current platform')),
+              reason: 'the DeviceCheck fallback did not engage',
+            );
+          }
+        },
+        skip: defaultTargetPlatform != TargetPlatform.macOS &&
+                defaultTargetPlatform != TargetPlatform.iOS
+            ? 'Apple platforms only.'
+            : null,
+      );
+
+      test(
         'uses Apple debug token when both Android and Apple debug tokens are configured',
         () async {
           await FirebaseAppCheck.instance.activate(

--- a/packages/firebase_app_check/firebase_app_check/example/integration_test/e2e_test.dart
+++ b/packages/firebase_app_check/firebase_app_check/example/integration_test/e2e_test.dart
@@ -148,17 +148,20 @@ void main() {
                 const AppleAppAttestWithDeviceCheckFallbackProvider(),
           );
 
-          // On devices without App Attest support — most Macs — the provider
-          // has to fall back to DeviceCheck. It used to pick App Attest purely
-          // on OS version and fail with "The attestation provider
-          // AppAttestProvider is not supported on current platform and OS
-          // version", so that specific error must not come back.
+          // On devices without App Attest support — most Macs, and every
+          // simulator — the provider has to fall back to DeviceCheck. It used
+          // to pick App Attest purely on OS version and fail with "The
+          // attestation provider AppAttestProvider is not supported on current
+          // platform and OS version", so App Attest must not be the provider
+          // named in any error. Fetching a token can still fail beyond that
+          // (simulators do not support DeviceCheck either, and there is no
+          // debug token configured), which is fine here.
           try {
             await FirebaseAppCheck.instance.getToken(true);
           } on FirebaseException catch (e) {
             expect(
               '${e.message}',
-              isNot(contains('is not supported on current platform')),
+              isNot(contains('AppAttestProvider')),
               reason: 'the DeviceCheck fallback did not engage',
             );
           }

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FirebaseAppCheckPlugin.swift
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FirebaseAppCheckPlugin.swift
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import DeviceCheck
 import FirebaseAppCheck
 import FirebaseCore
 
@@ -371,11 +372,16 @@ class AppCheckProviderWrapper: NSObject, AppCheckProvider {
         delegateProvider = AppCheckDebugProvider(app: app)
       }
     case "appAttestWithDeviceCheckFallback":
-      if #available(iOS 14.0, macOS 14.0, *) {
-        delegateProvider = AppAttestProvider(app: app)
-      } else {
-        delegateProvider = DeviceCheckProvider(app: app)
+      // A new enough OS is not sufficient: the device must also support App
+      // Attest, which is often false on macOS. The SDK only reports that when a
+      // token is first requested, so check the same capability it checks —
+      // otherwise this provider never actually falls back. Typed as the
+      // protocol to keep the availability-annotated type inside `#available`.
+      var appAttestProvider: (any AppCheckProvider)?
+      if #available(iOS 14.0, macOS 14.0, *), DCAppAttestService.shared.isSupported {
+        appAttestProvider = AppAttestProvider(app: app)
       }
+      delegateProvider = appAttestProvider ?? DeviceCheckProvider(app: app)
     case "recaptcha":
       #if os(iOS)
         if let recaptchaSiteKey {


### PR DESCRIPTION
## Description

`AppleProvider.appAttestWithDeviceCheckFallback` chose its provider on OS version alone, so on macOS 14+ it always installed `AppAttestProvider` and never fell back to DeviceCheck. Since App Attest also requires device support — commonly absent on macOS — every token request then failed with "The attestation provider AppAttestProvider is not supported on current platform and OS version", raised by the SDK at `getToken` time rather than at activation. `AppAttestProvider(app:)` is declared nullable but never returns nil in the current SDK, so nothing surfaced the problem earlier either.

The fix checks `DCAppAttestService.shared.isSupported` — the same capability the SDK checks — before selecting App Attest, and falls back to `DeviceCheckProvider` otherwise:

```swift
var appAttestProvider: (any AppCheckProvider)?
if #available(iOS 14.0, macOS 14.0, *), DCAppAttestService.shared.isSupported {
  appAttestProvider = AppAttestProvider(app: app)
}
delegateProvider = appAttestProvider ?? DeviceCheckProvider(app: app)
```

The `??` also covers the nullable initializer, so the fallback holds if a future SDK version starts returning nil. iOS behaviour is unchanged where App Attest is supported. Callers can drop `Platform.isMacOS` special-casing after this.

Not addressed here: DeviceCheck being unreliable on some macOS versions is upstream ([firebase-ios-sdk#10095](https://github.com/firebase/firebase-ios-sdk/issues/10095), still open). Separately, the `appAttest` case immediately above silently substitutes `AppCheckDebugProvider` when the OS is too old — shipping a debug provider in a release build seems worse than a clear error, but that is a behaviour change and is left out of this PR deliberately.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17057

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
