### PR TITLE
fix(auth,macos): throw a clear error for unsupported provider sign-in flows

### DIFF
--- a/packages/firebase_auth/firebase_auth/example/integration_test/firebase_auth_instance_e2e_test.dart
+++ b/packages/firebase_auth/firebase_auth/example/integration_test/firebase_auth_instance_e2e_test.dart
@@ -916,6 +916,27 @@ void main() {
         );
       });
 
+      group('signInWithProvider()', () {
+        test(
+          'throws a clear error on macOS, where the provider flow is unsupported',
+          () async {
+            await expectLater(
+              FirebaseAuth.instance.signInWithProvider(MicrosoftAuthProvider()),
+              throwsA(
+                isA<FirebaseAuthException>().having(
+                  (e) => e.code,
+                  'code',
+                  'unsupported-platform',
+                ),
+              ),
+            );
+          },
+          // The Firebase Apple SDK only implements the OAuth web sign-in flow
+          // on iOS, so this only applies to macOS.
+          skip: kIsWeb || defaultTargetPlatform != TargetPlatform.macOS,
+        );
+      });
+
       group('signOut()', () {
         test('should sign out', () async {
           await ensureSignedIn(testEmail);

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.m
@@ -82,6 +82,25 @@ NSString *const kErrCodeInvalidCredential = @"invalid-credential";
 NSString *const kErrMsgInvalidCredential =
     @"The supplied auth credential is malformed, has expired or is not "
     @"currently supported.";
+NSString *const kErrCodeUnsupportedPlatform = @"unsupported-platform";
+
+#if TARGET_OS_OSX
+// The Firebase Apple SDK only builds the OAuth web sign-in flow
+// (`FIROAuthProvider getCredentialWithUIDelegate:completion:`) for iOS, so the
+// `*WithProvider()` APIs cannot be served on macOS. Sign in with Apple is
+// handled separately, before this error is built.
+static FlutterError *ProviderFlowUnsupportedOnMacOSError(NSString *methodName,
+                                                         NSString *providerId) {
+  return [FlutterError
+      errorWithCode:kErrCodeUnsupportedPlatform
+            message:[NSString stringWithFormat:@"%@ is not supported on macOS for the '%@' "
+                                               @"provider. The Firebase Apple SDK only implements "
+                                               @"the OAuth web sign-in flow on iOS. On macOS, only "
+                                               @"the '%@' provider is supported.",
+                                               methodName, providerId, kSignInMethodApple]
+            details:nil];
+}
+#endif
 
 // Used for caching credentials between Method Channel method calls.
 static NSMutableDictionary<NSNumber *, FIRAuthCredential *> *credentialsMap;
@@ -973,8 +992,8 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
            displayName:(nullable NSString *)displayName
             completion:(nonnull void (^)(FlutterError *_Nullable))completion {
 #if TARGET_OS_OSX
-  completion([FlutterError errorWithCode:@"unsupported-platform"
-                                 message:@"Phone authentication is not supported on macOS"
+  completion([FlutterError errorWithCode:kErrCodeUnsupportedPlatform
+                                 message:@"Phone authentication is not supported on macOS."
                                  details:nil]);
 #else
 
@@ -1750,9 +1769,8 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
     return;
   }
 #if TARGET_OS_OSX
-  NSLog(@"signInWithProvider is not supported on the "
-        @"MacOS platform.");
-  completion(nil, nil);
+  completion(nil,
+             ProviderFlowUnsupportedOnMacOSError(@"signInWithProvider", signInProvider.providerId));
 #else
   self.authProvider = [FIROAuthProvider providerWithProviderID:signInProvider.providerId auth:auth];
   NSArray *scopes = signInProvider.scopes;
@@ -1823,9 +1841,9 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
                   completion:
                       (nonnull void (^)(NSString *_Nullable, FlutterError *_Nullable))completion {
 #if TARGET_OS_OSX
-  NSLog(@"The Firebase Phone Authentication provider is not supported on the "
-        @"MacOS platform.");
-  completion(nil, nil);
+  completion(nil, [FlutterError errorWithCode:kErrCodeUnsupportedPlatform
+                                      message:@"Phone authentication is not supported on macOS."
+                                      details:nil]);
 #else
   FIRAuth *auth = [self getFIRAuthFromAppNameFromPigeon:app];
 
@@ -2006,9 +2024,8 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
     return;
   }
 #if TARGET_OS_OSX
-  NSLog(@"linkWithProvider is not supported on the "
-        @"MacOS platform.");
-  completion(nil, nil);
+  completion(nil,
+             ProviderFlowUnsupportedOnMacOSError(@"linkWithProvider", signInProvider.providerId));
 #else
   self.authProvider = [FIROAuthProvider providerWithProviderID:signInProvider.providerId];
   NSArray *scopes = signInProvider.scopes;
@@ -2107,9 +2124,8 @@ static void handleAppleAuthResult(FLTFirebaseAuthPlugin *object, AuthPigeonFireb
     return;
   }
 #if TARGET_OS_OSX
-  NSLog(@"reauthenticateWithProvider is not supported on the "
-        @"MacOS platform.");
-  completion(nil, nil);
+  completion(nil, ProviderFlowUnsupportedOnMacOSError(@"reauthenticateWithProvider",
+                                                      signInProvider.providerId));
 #else
   self.authProvider = [FIROAuthProvider providerWithProviderID:signInProvider.providerId];
   NSArray *scopes = signInProvider.scopes;

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -632,6 +632,10 @@ class FirebaseAuth extends FirebasePlugin implements FirebaseService {
 
   /// Signs in with an AuthProvider using native authentication flow.
   ///
+  /// On macOS, only [AppleAuthProvider] is supported: the Firebase Apple SDK
+  /// implements the OAuth web sign-in flow on iOS only. Any other provider
+  /// throws a [FirebaseAuthException] with the code `unsupported-platform`.
+  ///
   /// A [FirebaseAuthException] maybe thrown with the following error code:
   /// - **user-disabled**:
   ///  - Thrown if the user corresponding to the given email has been disabled.

--- a/packages/firebase_auth/firebase_auth/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/user.dart
@@ -199,6 +199,10 @@ class User {
   /// Links with an AuthProvider using native authentication flow.
   /// On web, you should use [linkWithPopup] or [linkWithRedirect] instead.
   ///
+  /// On macOS, only [AppleAuthProvider] is supported: the Firebase Apple SDK
+  /// implements the OAuth web sign-in flow on iOS only. Any other provider
+  /// throws a [FirebaseAuthException] with the code `unsupported-platform`.
+  ///
   /// A [FirebaseAuthException] maybe thrown with the following error code:
   /// - **provider-already-linked**:
   ///  - Thrown if the provider has already been linked to the user. This error
@@ -251,6 +255,10 @@ class User {
   ///
   /// Use before operations such as [User.updatePassword] that require tokens
   /// from recent sign-in attempts.
+  ///
+  /// On macOS, only [AppleAuthProvider] is supported: the Firebase Apple SDK
+  /// implements the OAuth web sign-in flow on iOS only. Any other provider
+  /// throws a [FirebaseAuthException] with the code `unsupported-platform`.
   ///
   /// A [FirebaseAuthException] maybe thrown with the following error code:
   /// - **user-mismatch**:


### PR DESCRIPTION
## Description

On macOS, `signInWithProvider()`, `linkWithProvider()` and `reauthenticateWithProvider()` logged a message to the native console and then called the Pigeon completion with `(nil, nil)`. Because the return value is non-null, Dart surfaced this as `FirebaseAuthException(code: 'null-error', message: 'Host platform returned null value for non-null return value.')`, which says nothing about what actually happened. `verifyPhoneNumber()` had the same silent-nil path.

These APIs cannot be implemented on macOS today: the Firebase Apple SDK builds the OAuth web sign-in flow (`FIROAuthProvider getCredentialWithUIDelegate:completion:`) inside `#if os(iOS)`, so it does not exist on macOS ([OAuthProvider.swift](https://github.com/firebase/firebase-ios-sdk/blob/main/FirebaseAuth/Sources/Swift/AuthProvider/OAuthProvider.swift)). This PR makes that explicit instead of failing obscurely:

```
FirebaseAuthException(
  code: unsupported-platform,
  message: signInWithProvider is not supported on macOS for the 'microsoft.com' provider.
           The Firebase Apple SDK only implements the OAuth web sign-in flow on iOS.
           On macOS, only the 'apple.com' provider is supported.
)
```

Sign in with Apple is handled before this branch and keeps working on macOS, so the behaviour change is limited to the providers that were already broken. The doc comments of the three Dart APIs now state the macOS limitation, and a macOS-only e2e test asserts the error code for `signInWithProvider()`. `linkWithProvider()` and `reauthenticateWithProvider()` share the same native path but cannot be covered on macOS CI: they need a signed-in `User`, and `signInAnonymously()` fails there with `keychain-error` for lack of the keychain sharing entitlement (https://github.com/firebase/flutterfire/issues/9538).

Not addressed here: the macOS OAuth flow itself, which needs support from the Firebase Apple SDK first. `initializeRecaptchaConfig()` also no-ops silently on macOS — that one is a best-effort optimisation, so it is left as is, and `PhoneAuthProvider.credential()` on macOS still reports `invalid-credential` from the shared credential helper.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/16960

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/

