### PR TITLE
fix(core, crashlytics): drop `flutter_test` from published dependencies

### DIFF
--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/pigeon/test_api.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/pigeon/test_api.dart
@@ -9,7 +9,7 @@ import 'dart:async';
 import 'dart:typed_data' show Float64List, Int32List, Int64List, Uint8List;
 import 'package:flutter/foundation.dart' show ReadBuffer, WriteBuffer;
 import 'package:flutter/services.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:firebase_core_platform_interface/test_binding.dart';
 
 import 'messages.pigeon.dart';
 

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/test_binding.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/test_binding.dart
@@ -1,0 +1,66 @@
+// Copyright 2026, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+
+/// A stand-in for `flutter_test`'s `TestDefaultBinaryMessengerBinding`, used by
+/// the generated Pigeon test APIs that ship in `lib/`.
+///
+/// Pigeon generates its test API against `flutter_test`, but a package cannot
+/// import a dev dependency from `lib/`, and depending on `flutter_test` for
+/// real pins `test_api` for every consumer of this package, which breaks
+/// version solving for apps that use `package:test`
+/// (https://github.com/firebase/flutterfire/issues/17001).
+///
+/// The generated files only ever need to install and remove mock handlers, so
+/// this reaches the test binary messenger through [ServicesBinding] instead.
+/// Callers already run inside `flutter_test` (that is where the test binding
+/// comes from), so the messenger is a `TestDefaultBinaryMessenger` at runtime
+/// and the dynamic call below resolves to `setMockMessageHandler`.
+class TestDefaultBinaryMessengerBinding {
+  const TestDefaultBinaryMessengerBinding._();
+
+  /// The current binding, mirroring
+  /// `TestDefaultBinaryMessengerBinding.instance`.
+  static TestDefaultBinaryMessengerBinding? get instance =>
+      const TestDefaultBinaryMessengerBinding._();
+
+  /// The mock-handler surface of the test binding's default binary messenger.
+  TestBinaryMessenger get defaultBinaryMessenger =>
+      TestBinaryMessenger._(ServicesBinding.instance.defaultBinaryMessenger);
+}
+
+/// The subset of `flutter_test`'s `TestDefaultBinaryMessenger` that generated
+/// Pigeon test APIs rely on.
+class TestBinaryMessenger {
+  const TestBinaryMessenger._(this._messenger);
+
+  final BinaryMessenger _messenger;
+
+  /// Intercepts messages sent on [channel], decoding them with the channel's
+  /// codec before handing them to [handler].
+  ///
+  /// Mirrors `TestDefaultBinaryMessenger.setMockDecodedMessageHandler`.
+  void setMockDecodedMessageHandler<T>(
+    BasicMessageChannel<T> channel,
+    Future<T> Function(T? message)? handler,
+  ) {
+    if (handler == null) {
+      _setMockMessageHandler(channel.name, null);
+      return;
+    }
+    _setMockMessageHandler(channel.name, (ByteData? message) async {
+      return channel.codec
+          .encodeMessage(await handler(channel.codec.decodeMessage(message)));
+    });
+  }
+
+  void _setMockMessageHandler(
+    String channel,
+    Future<ByteData?> Function(ByteData?)? handler,
+  ) {
+    // ignore: avoid_dynamic_calls
+    (_messenger as dynamic).setMockMessageHandler(channel, handler);
+  }
+}

--- a/packages/firebase_core/firebase_core_platform_interface/lib/test_binding.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/test_binding.dart
@@ -1,0 +1,12 @@
+// Copyright 2026, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// The test binding shim used by the Pigeon test APIs that FlutterFire
+/// packages ship in `lib/`.
+///
+/// This exists so those generated files do not have to import `flutter_test`
+/// from `lib/`. See `src/test_binding.dart` for the details.
+library;
+
+export 'package:firebase_core_platform_interface/src/test_binding.dart';

--- a/packages/firebase_core/firebase_core_platform_interface/pigeons/messages.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/pigeons/messages.dart
@@ -8,6 +8,9 @@ import 'package:pigeon/pigeon.dart';
   PigeonOptions(
     dartOut: 'lib/src/pigeon/messages.pigeon.dart',
     // We export in the lib folder to expose the class to other packages.
+    // `melos run generate:pigeon` rewrites the generated `flutter_test` import
+    // to `package:firebase_core_platform_interface/test_binding.dart`, because
+    // `flutter_test` cannot be a dependency of a published package.
     dartTestOut: 'lib/src/pigeon/test_api.dart',
     dartPackageName: 'firebase_core_platform_interface',
     javaOut:

--- a/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
@@ -15,12 +15,15 @@ dependencies:
   collection: ^1.0.0
   flutter:
     sdk: flutter
-  # Needed to export the mocks
-  flutter_test:
-    sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
+  # `flutter_test` must stay a dev dependency: as a regular dependency it pins
+  # `test_api` for every consumer of this package, which breaks version solving
+  # for apps that use `package:test` (see #17001). `lib/src/test_binding.dart`
+  # exists so the generated Pigeon test API does not need it.
+  flutter_test:
+    sdk: flutter
   mockito: ^5.4.0
   pigeon: 26.3.4

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/pigeon/test_api.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/pigeon/test_api.dart
@@ -9,7 +9,7 @@ import 'dart:async';
 import 'dart:typed_data' show Float64List, Int32List, Int64List, Uint8List;
 import 'package:flutter/foundation.dart' show ReadBuffer, WriteBuffer;
 import 'package:flutter/services.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:firebase_core_platform_interface/test_binding.dart';
 
 import 'messages.pigeon.dart';
 

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pigeons/messages.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pigeons/messages.dart
@@ -8,6 +8,9 @@ import 'package:pigeon/pigeon.dart';
   PigeonOptions(
     dartOut: 'lib/src/pigeon/messages.pigeon.dart',
     // Exported via lib/test.dart so firebase_crashlytics package tests can mock it.
+    // `melos run generate:pigeon` rewrites the generated `flutter_test` import
+    // to `package:firebase_core_platform_interface/test_binding.dart`, because
+    // `flutter_test` cannot be a dependency of a published package.
     dartTestOut: 'lib/src/pigeon/test_api.dart',
     dartPackageName: 'firebase_crashlytics_platform_interface',
     kotlinOut:

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pubspec.yaml
@@ -13,15 +13,17 @@ dependencies:
   _flutterfire_internals: ^1.3.76
   collection: ^1.15.0
   firebase_core: ^4.13.0
+  # The generated Pigeon test API in `lib/` imports the test binding shim from
+  # this package, so it has to be a regular dependency. It is already in the
+  # dependency graph through firebase_core.
+  firebase_core_platform_interface: ^8.1.0
   flutter:
-    sdk: flutter
-  # Needed to export the pigeon test HostApi via lib/test.dart
-  flutter_test:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  flutter_test:
+    sdk: flutter
   mockito: ^5.0.0
   pigeon: 26.3.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -465,10 +465,22 @@ melos:
         melos exec -- "flutter pub run pigeon --input ./pigeons/messages.dart" && \
         melos run generate:pigeon:macos --no-select && \
         melos run generate:pigeon:android --no-select && \
+        melos run generate:pigeon:dart-test --no-select && \
         melos run format-ci --no-select
       packageFilters:
         fileExists: 'pigeons/messages.dart'
       description: Generate the pigeon messages for all the supported packages.
+
+    generate:pigeon:dart-test:
+      run: |
+        melos exec -- "sed -i '' \"s;import 'package:flutter_test/flutter_test.dart';import 'package:firebase_core_platform_interface/test_binding.dart';g\" lib/src/pigeon/test_api.dart"
+      packageFilters:
+        fileExists: 'lib/src/pigeon/test_api.dart'
+      description: |
+        The generated test API lives in lib/ so other packages can use it, but
+        pigeon generates it against flutter_test, which cannot be a dependency
+        of a published package (it pins test_api for every consumer, see #17001).
+        Point it at the test binding shim instead.
 
     generate:pigeon:macos:
       run: |

--- a/scripts/validate_workspace.dart
+++ b/scripts/validate_workspace.dart
@@ -15,7 +15,8 @@
 // ignore_for_file: avoid_print
 
 /// Validates that all packages in the repository are listed in the root
-/// pubspec.yaml workspace.
+/// pubspec.yaml workspace, and that no package declares `flutter_test` as a
+/// regular dependency.
 library;
 
 import 'dart:io';
@@ -94,6 +95,26 @@ void main() {
     hasError = true;
   }
 
+  final flutterTestDependents = foundPackages
+      .where((path) => _dependsOnFlutterTest(p.join(rootDir, path)))
+      .toList();
+
+  if (flutterTestDependents.isNotEmpty) {
+    print(
+      '\nDeclaring `flutter_test` in `dependencies` pins `test_api` for every '
+      'consumer of the package, which breaks version solving for apps that use '
+      '`package:test` (https://github.com/firebase/flutterfire/issues/17001).\n'
+      'Move it to `dev_dependencies`. If a generated Pigeon test API in `lib/` '
+      'needs it, import '
+      '`package:firebase_core_platform_interface/test_binding.dart` instead.\n'
+      '\n`flutter_test` declared as a regular dependency:',
+    );
+    for (final path in flutterTestDependents) {
+      print(' - $path');
+    }
+    hasError = true;
+  }
+
   if (hasError) {
     exitCode = 1;
   } else {
@@ -101,15 +122,36 @@ void main() {
   }
 }
 
+/// Whether the published package at [packageDir] lists `flutter_test` in
+/// `dependencies`.
+///
+/// Unpublished packages (example apps, test fixtures) are skipped: their
+/// dependencies never reach a consumer's version solving.
+bool _dependsOnFlutterTest(String packageDir) {
+  final yaml =
+      loadYaml(File(p.join(packageDir, 'pubspec.yaml')).readAsStringSync());
+  if (yaml is! YamlMap) return false;
+  if (yaml['publish_to'] == 'none') return false;
+  final dependencies = yaml['dependencies'];
+  return dependencies is YamlMap && dependencies.containsKey('flutter_test');
+}
+
+/// Walks [dir] for package pubspecs, pruning [_ignoredDirectories] as it
+/// descends rather than filtering them out afterwards, so generated build
+/// output is never entered.
+///
+/// Symlinks are not followed: the `.symlinks` directories that CocoaPods
+/// creates in example apps point back into `packages`, so following them turns
+/// the walk into a cycle.
 Iterable<String> _findPackages(Directory dir, String rootDir) sync* {
-  for (final entity in dir.listSync(recursive: true)) {
-    if (entity is File && p.basename(entity.path) == 'pubspec.yaml') {
-      final path = entity.path;
-      final components = p.split(path);
-      if (components.any(_ignoredDirectories.contains)) {
+  for (final entity in dir.listSync(followLinks: false)) {
+    if (entity is Directory) {
+      if (_ignoredDirectories.contains(p.basename(entity.path))) {
         continue;
       }
-      final relPath = p.relative(p.dirname(path), from: rootDir);
+      yield* _findPackages(entity, rootDir);
+    } else if (entity is File && p.basename(entity.path) == 'pubspec.yaml') {
+      final relPath = p.relative(p.dirname(entity.path), from: rootDir);
       if (relPath != '.') {
         yield relPath;
       }


### PR DESCRIPTION
## Description

- `firebase_core_platform_interface` and `firebase_crashlytics_platform_interface` declared `flutter_test` as a regular dependency, which pins `test_api` for every consumer and breaks version solving for apps that also use `package:test`. It is now a dev dependency: the Pigeon test API shipped in `lib/` imports a small `test_binding.dart` shim instead, `melos run generate:pigeon` rewrites the generated import, and `scripts/validate_workspace.dart` fails if a published package declares `flutter_test` again.
- Drive-by: that script's package walk no longer follows symlinks and prunes ignored directories as it descends, so it stops cycling through the CocoaPods `.symlinks` directories in example apps and actually completes when run locally.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/17001

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
