### PR TITLE
fix(ci): stop `e2e-fdc / web-wasm` hanging until the job timeout

### DIFF
--- a/.github/workflows/e2e_tests_fdc.yaml
+++ b/.github/workflows/e2e_tests_fdc.yaml
@@ -317,17 +317,22 @@ jobs:
         # Web devices are not supported for the `flutter test` command yet. As a
         # workaround we can use the `flutter drive` command. Tracking issue:
         # https://github.com/flutter/flutter/issues/66264
+        # WASM runs can hang after building but before the test harness
+        # connects, which the 15 minute job timeout then reports as a
+        # cancellation. The retry script covers that failure class: it owns the
+        # chromedriver lifecycle, applies a per-attempt timeout, retries only
+        # infrastructure startup failures, and performs the `[E]` check. It also
+        # defaults the device to `web-server` rather than `chrome`, so
+        # chromedriver launches the browser headlessly instead of the flutter
+        # tool needing a display server.
         run: |
-          chromedriver --port=4444 --trace-buffer-size=100000 &
           mv ./web/wasm_index.html ./web/index.html
-          flutter drive --target=./integration_test/e2e_test.dart --driver=./test_driver/integration_test.dart -d chrome --wasm --dart-define=CI=true | tee output.log
-          # We have to check the output for failed tests matching the string "[E]"
-          output=$(<output.log)
-          if [[ "$output" =~ \[E\] ]]; then
-          # You will see "All tests passed." in the logs even when tests failed.
-          echo "All tests did not pass. Please check the logs for more information."
-          exit 1
-          fi
+          FLUTTER_DRIVE_TARGET="./integration_test/e2e_test.dart" \
+          FLUTTER_DRIVE_DRIVER="./test_driver/integration_test.dart" \
+          FLUTTER_DRIVE_EXTRA_ARGS="--wasm --dart-define=CI=true" \
+          FLUTTER_DRIVE_TIMEOUT_SECONDS="300" \
+          FLUTTER_DRIVE_MAX_ATTEMPTS="2" \
+          "${GITHUB_WORKSPACE}/.github/workflows/scripts/flutter-drive-web-retry.sh"
         shell: bash
       - name: Save Firestore Emulator Cache
         # Branches can read main cache but main cannot read branch cache. Avoid LRU eviction with main-only cache.


### PR DESCRIPTION
## Description

`e2e-fdc`'s `web-wasm` job was the last web e2e job still invoking `flutter drive` directly, with `-d chrome` and no timeout or retry. It compiles, prints `✓ Built build/web`, then emits nothing for ~12.5 minutes until the 15 minute job timeout fires — which GitHub reports as **"Cancelled after 15m"** rather than a failure, so it reads like flake rather than a reproducible hang.

It is not flake, and it is not caused by any one PR. On `main`:

| date | `web-wasm` | `web` / `android` / `ios` |
|---|---|---|
| 2026-08-11 | success, 3m | pass |
| 2026-08-14 | **cancelled, 15m** | pass |
| 2026-08-18 | **cancelled, 15m** | pass |

Two independent attempts on the same commit died at 15m21s and 15m18s, so re-running cannot clear it. This currently blocks every PR that runs the Data Connect suite (e.g. #18575, which is approved and otherwise green).

### Fix

Route the job through `.github/workflows/scripts/flutter-drive-web-retry.sh`, exactly as `web` in this same workflow and `web-wasm` in `e2e-smoke` already are. The script:

- owns the chromedriver lifecycle (so the manual `chromedriver --port=4444 &` goes away),
- applies a per-attempt timeout and retries **only** infrastructure startup failures (timeouts, `AppConnectionException`, `Failed to exit Chromium`) — real test and compile failures still fail fast,
- performs the `[E]` output check that was inlined here, plus a guard against `flutter drive` exiting 0 without running any test,
- defaults the device to `-d web-server`, so chromedriver launches the browser headlessly instead of the flutter tool needing a display server.

`reusable_e2e_web.yaml` already documents this precise failure class for WASM ("WASM runs can additionally hang after building but before the test harness connects"); the per-product suites were migrated and `e2e_tests_fdc.yaml`, which defines its own jobs, was left behind.

`FLUTTER_DRIVE_TIMEOUT_SECONDS=300` / `FLUTTER_DRIVE_MAX_ATTEMPTS=2` match `e2e-smoke`'s WASM job, keeping the worst case inside the existing 15 minute job timeout. The `mv ./web/wasm_index.html ./web/index.html` step is preserved.

## Related Issues

Unblocks #18575.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/