### PR TITLE
feat(in_app_messaging): expose the message lifecycle events

### DIFF
--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/README.md
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/README.md
@@ -14,6 +14,20 @@ To get started with Firebase In-App Messaging for Flutter, please [see the docum
 
 To use this plugin, please visit the [Firebase In-App Messaging Usage documentation](https://firebase.google.com/docs/in-app-messaging/get-started?platform=flutter)
 
+### Message lifecycle events
+
+Listen to the streams below to react to what happens to the messages of your
+campaigns, for example to handle the URL of the button a user tapped yourself:
+
+```dart
+FirebaseInAppMessaging.instance.onMessageClicked.listen((event) {
+  print('${event.campaignMetadata.campaignName} -> ${event.action.actionUrl}');
+});
+```
+
+`onMessageImpression`, `onMessageDismissed` and `onMessageDisplayError` report
+the rest of the message lifecycle.
+
 ## Issues and feedback
 
 Please file FlutterFire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/firebase/flutterfire/issues/new).

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/android/src/main/kotlin/io/flutter/plugins/firebase/inappmessaging/FirebaseInAppMessagingPlugin.kt
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/android/src/main/kotlin/io/flutter/plugins/firebase/inappmessaging/FirebaseInAppMessagingPlugin.kt
@@ -3,24 +3,61 @@
 // found in the LICENSE file.
 package io.flutter.plugins.firebase.inappmessaging
 
+import android.os.Handler
+import android.os.Looper
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.TaskCompletionSource
 import com.google.firebase.FirebaseApp
 import com.google.firebase.inappmessaging.FirebaseInAppMessaging
+import com.google.firebase.inappmessaging.FirebaseInAppMessagingClickListener
+import com.google.firebase.inappmessaging.FirebaseInAppMessagingDismissListener
+import com.google.firebase.inappmessaging.FirebaseInAppMessagingDisplayErrorListener
+import com.google.firebase.inappmessaging.FirebaseInAppMessagingImpressionListener
+import com.google.firebase.inappmessaging.model.InAppMessage
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugins.firebase.core.FlutterFirebasePlugin
 import io.flutter.plugins.firebase.core.FlutterFirebasePluginRegistry
+import java.util.concurrent.Executor
 
 /** FirebaseInAppMessagingPlugin */
 class FirebaseInAppMessagingPlugin :
     FlutterFirebasePlugin, FlutterPlugin, FirebaseInAppMessagingHostApi {
   private var binaryMessenger: BinaryMessenger? = null
+  private var flutterApi: FirebaseInAppMessagingFlutterApi? = null
+
+  // The listeners below forward events to Dart, which has to happen on the main
+  // thread, so they are registered with a main thread executor.
+  private val mainThreadExecutor = Executor { command ->
+    Handler(Looper.getMainLooper()).post(command)
+  }
+
+  private val clickListener = FirebaseInAppMessagingClickListener { inAppMessage, action ->
+    flutterApi?.onMessageClicked(
+        campaignMetadata(inAppMessage), FiamAction(action.actionUrl, action.button?.text?.text)) {}
+  }
+
+  private val impressionListener = FirebaseInAppMessagingImpressionListener { inAppMessage ->
+    flutterApi?.onMessageImpression(campaignMetadata(inAppMessage)) {}
+  }
+
+  private val dismissListener = FirebaseInAppMessagingDismissListener { inAppMessage ->
+    // The Android SDK does not report how a message was dismissed.
+    flutterApi?.onMessageDismissed(campaignMetadata(inAppMessage), FiamDismissType.UNKNOWN) {}
+  }
+
+  private val displayErrorListener =
+      FirebaseInAppMessagingDisplayErrorListener { inAppMessage, errorReason ->
+        flutterApi?.onMessageDisplayError(campaignMetadata(inAppMessage), errorReason.name) {}
+      }
+
+  private var eventListenersAdded = false
 
   private fun initInstance(messenger: BinaryMessenger) {
     FlutterFirebasePluginRegistry.registerPlugin(METHOD_CHANNEL_NAME, this)
     binaryMessenger = messenger
+    flutterApi = FirebaseInAppMessagingFlutterApi(messenger)
     FirebaseInAppMessagingHostApi.setUp(messenger, this)
   }
 
@@ -29,8 +66,47 @@ class FirebaseInAppMessagingPlugin :
   }
 
   override fun onDetachedFromEngine(binding: FlutterPluginBinding) {
+    removeEventListeners()
     binaryMessenger = null
+    flutterApi = null
     FirebaseInAppMessagingHostApi.setUp(binding.binaryMessenger, null)
+  }
+
+  private fun campaignMetadata(inAppMessage: InAppMessage): FiamCampaignMetadata {
+    val metadata = inAppMessage.campaignMetadata
+    return FiamCampaignMetadata(
+        metadata?.campaignId ?: "", metadata?.campaignName ?: "", metadata?.isTestMessage ?: false)
+  }
+
+  private fun removeEventListeners() {
+    if (!eventListenersAdded) return
+    eventListenersAdded = false
+
+    FirebaseInAppMessaging.getInstance().apply {
+      removeClickListener(clickListener)
+      removeImpressionListener(impressionListener)
+      removeDismissListener(dismissListener)
+      removeDisplayErrorListener(displayErrorListener)
+    }
+  }
+
+  override fun addEventListeners(appName: String, callback: (Result<Unit>) -> Unit) {
+    FlutterFirebasePlugin.cachedThreadPool.execute {
+      try {
+        if (!eventListenersAdded) {
+          FirebaseInAppMessaging.getInstance().apply {
+            addClickListener(clickListener, mainThreadExecutor)
+            addImpressionListener(impressionListener, mainThreadExecutor)
+            addDismissListener(dismissListener, mainThreadExecutor)
+            addDisplayErrorListener(displayErrorListener, mainThreadExecutor)
+          }
+          eventListenersAdded = true
+        }
+        callback(Result.success(Unit))
+      } catch (exception: Exception) {
+        handleFailure(callback, exception)
+      }
+    }
   }
 
   override fun triggerEvent(appName: String, eventName: String, callback: (Result<Unit>) -> Unit) {

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/android/src/main/kotlin/io/flutter/plugins/firebase/inappmessaging/GeneratedAndroidFirebaseInAppMessaging.g.kt
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/android/src/main/kotlin/io/flutter/plugins/firebase/inappmessaging/GeneratedAndroidFirebaseInAppMessaging.g.kt
@@ -17,6 +17,11 @@ import java.nio.ByteBuffer
 
 private object GeneratedAndroidFirebaseInAppMessagingPigeonUtils {
 
+  fun createConnectionError(channelName: String): FlutterError {
+    return FlutterError(
+        "channel-error", "Unable to establish connection on channel: '$channelName'.", "")
+  }
+
   fun wrapResult(result: Any?): List<Any?> {
     return listOf(result)
   }
@@ -29,6 +34,150 @@ private object GeneratedAndroidFirebaseInAppMessagingPigeonUtils {
           exception.javaClass.simpleName,
           exception.toString(),
           "Cause: " + exception.cause + ", Stacktrace: " + Log.getStackTraceString(exception))
+    }
+  }
+
+  fun doubleEquals(a: Double, b: Double): Boolean {
+    // Normalize -0.0 to 0.0 and handle NaN equality.
+    return (if (a == 0.0) 0.0 else a) == (if (b == 0.0) 0.0 else b) || (a.isNaN() && b.isNaN())
+  }
+
+  fun floatEquals(a: Float, b: Float): Boolean {
+    // Normalize -0.0 to 0.0 and handle NaN equality.
+    return (if (a == 0.0f) 0.0f else a) == (if (b == 0.0f) 0.0f else b) || (a.isNaN() && b.isNaN())
+  }
+
+  fun doubleHash(d: Double): Int {
+    // Normalize -0.0 to 0.0 and handle NaN to ensure consistent hash codes.
+    val normalized = if (d == 0.0) 0.0 else d
+    val bits = java.lang.Double.doubleToLongBits(normalized)
+    return (bits xor (bits ushr 32)).toInt()
+  }
+
+  fun floatHash(f: Float): Int {
+    // Normalize -0.0 to 0.0 and handle NaN to ensure consistent hash codes.
+    val normalized = if (f == 0.0f) 0.0f else f
+    return java.lang.Float.floatToIntBits(normalized)
+  }
+
+  fun deepEquals(a: Any?, b: Any?): Boolean {
+    if (a === b) {
+      return true
+    }
+    if (a == null || b == null) {
+      return false
+    }
+    if (a is ByteArray && b is ByteArray) {
+      return a.contentEquals(b)
+    }
+    if (a is IntArray && b is IntArray) {
+      return a.contentEquals(b)
+    }
+    if (a is LongArray && b is LongArray) {
+      return a.contentEquals(b)
+    }
+    if (a is DoubleArray && b is DoubleArray) {
+      if (a.size != b.size) return false
+      for (i in a.indices) {
+        if (!doubleEquals(a[i], b[i])) return false
+      }
+      return true
+    }
+    if (a is FloatArray && b is FloatArray) {
+      if (a.size != b.size) return false
+      for (i in a.indices) {
+        if (!floatEquals(a[i], b[i])) return false
+      }
+      return true
+    }
+    if (a is Array<*> && b is Array<*>) {
+      if (a.size != b.size) return false
+      for (i in a.indices) {
+        if (!deepEquals(a[i], b[i])) return false
+      }
+      return true
+    }
+    if (a is List<*> && b is List<*>) {
+      if (a.size != b.size) return false
+      val iterA = a.iterator()
+      val iterB = b.iterator()
+      while (iterA.hasNext() && iterB.hasNext()) {
+        if (!deepEquals(iterA.next(), iterB.next())) return false
+      }
+      return true
+    }
+    if (a is Map<*, *> && b is Map<*, *>) {
+      if (a.size != b.size) return false
+      for (entry in a) {
+        val key = entry.key
+        var found = false
+        for (bEntry in b) {
+          if (deepEquals(key, bEntry.key)) {
+            if (deepEquals(entry.value, bEntry.value)) {
+              found = true
+              break
+            } else {
+              return false
+            }
+          }
+        }
+        if (!found) return false
+      }
+      return true
+    }
+    if (a is Double && b is Double) {
+      return doubleEquals(a, b)
+    }
+    if (a is Float && b is Float) {
+      return floatEquals(a, b)
+    }
+    return a == b
+  }
+
+  fun deepHash(value: Any?): Int {
+    return when (value) {
+      null -> 0
+      is ByteArray -> value.contentHashCode()
+      is IntArray -> value.contentHashCode()
+      is LongArray -> value.contentHashCode()
+      is DoubleArray -> {
+        var result = 1
+        for (item in value) {
+          result = 31 * result + doubleHash(item)
+        }
+        result
+      }
+      is FloatArray -> {
+        var result = 1
+        for (item in value) {
+          result = 31 * result + floatHash(item)
+        }
+        result
+      }
+      is Array<*> -> {
+        var result = 1
+        for (item in value) {
+          result = 31 * result + deepHash(item)
+        }
+        result
+      }
+      is List<*> -> {
+        var result = 1
+        for (item in value) {
+          result = 31 * result + deepHash(item)
+        }
+        result
+      }
+      is Map<*, *> -> {
+        var result = 0
+        for (entry in value) {
+          result += ((deepHash(entry.key) * 31) xor deepHash(entry.value))
+        }
+        result
+      }
+      is Double -> doubleHash(value)
+      is Float -> floatHash(value)
+      else -> value.hashCode()
     }
   }
 }
@@ -46,13 +195,159 @@ class FlutterError(
     val details: Any? = null
 ) : RuntimeException()
 
+/** How an in-app message was dismissed. */
+enum class FiamDismissType(val raw: Int) {
+  /** The message was swiped away. Only reported on iOS, for banner messages. */
+  SWIPE(0),
+  /** The user tapped a button to close the message. */
+  CLICKED_CANCEL(1),
+  /** The message was dismissed automatically. Only reported on iOS, for banner messages. */
+  AUTO(2),
+  /**
+   * The way the message was dismissed is unknown. Always reported on Android, which does not expose
+   * a dismiss type.
+   */
+  UNKNOWN(3);
+
+  companion object {
+    fun ofRaw(raw: Int): FiamDismissType? {
+      return values().firstOrNull { it.raw == raw }
+    }
+  }
+}
+
+/**
+ * Metadata of the campaign an in-app message belongs to.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class FiamCampaignMetadata(
+    val campaignId: String,
+    val campaignName: String,
+    val isTestMessage: Boolean
+) {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): FiamCampaignMetadata {
+      val campaignId = pigeonVar_list[0] as String
+      val campaignName = pigeonVar_list[1] as String
+      val isTestMessage = pigeonVar_list[2] as Boolean
+      return FiamCampaignMetadata(campaignId, campaignName, isTestMessage)
+    }
+  }
+
+  fun toList(): List<Any?> {
+    return listOf(
+        campaignId,
+        campaignName,
+        isTestMessage,
+    )
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    val other = other as FiamCampaignMetadata
+    return GeneratedAndroidFirebaseInAppMessagingPigeonUtils.deepEquals(
+        this.campaignId, other.campaignId) &&
+        GeneratedAndroidFirebaseInAppMessagingPigeonUtils.deepEquals(
+            this.campaignName, other.campaignName) &&
+        GeneratedAndroidFirebaseInAppMessagingPigeonUtils.deepEquals(
+            this.isTestMessage, other.isTestMessage)
+  }
+
+  override fun hashCode(): Int {
+    var result = javaClass.hashCode()
+    result =
+        31 * result + GeneratedAndroidFirebaseInAppMessagingPigeonUtils.deepHash(this.campaignId)
+    result =
+        31 * result + GeneratedAndroidFirebaseInAppMessagingPigeonUtils.deepHash(this.campaignName)
+    result =
+        31 * result + GeneratedAndroidFirebaseInAppMessagingPigeonUtils.deepHash(this.isTestMessage)
+    return result
+  }
+}
+
+/**
+ * The action attached to the button a user tapped on an in-app message.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class FiamAction(val actionUrl: String? = null, val buttonText: String? = null) {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): FiamAction {
+      val actionUrl = pigeonVar_list[0] as String?
+      val buttonText = pigeonVar_list[1] as String?
+      return FiamAction(actionUrl, buttonText)
+    }
+  }
+
+  fun toList(): List<Any?> {
+    return listOf(
+        actionUrl,
+        buttonText,
+    )
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    val other = other as FiamAction
+    return GeneratedAndroidFirebaseInAppMessagingPigeonUtils.deepEquals(
+        this.actionUrl, other.actionUrl) &&
+        GeneratedAndroidFirebaseInAppMessagingPigeonUtils.deepEquals(
+            this.buttonText, other.buttonText)
+  }
+
+  override fun hashCode(): Int {
+    var result = javaClass.hashCode()
+    result =
+        31 * result + GeneratedAndroidFirebaseInAppMessagingPigeonUtils.deepHash(this.actionUrl)
+    result =
+        31 * result + GeneratedAndroidFirebaseInAppMessagingPigeonUtils.deepHash(this.buttonText)
+    return result
+  }
+}
+
 private open class GeneratedAndroidFirebaseInAppMessagingPigeonCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
-    return super.readValueOfType(type, buffer)
+    return when (type) {
+      129.toByte() -> {
+        return (readValue(buffer) as Long?)?.let { FiamDismissType.ofRaw(it.toInt()) }
+      }
+      130.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let { FiamCampaignMetadata.fromList(it) }
+      }
+      131.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let { FiamAction.fromList(it) }
+      }
+      else -> super.readValueOfType(type, buffer)
+    }
   }
 
   override fun writeValue(stream: ByteArrayOutputStream, value: Any?) {
-    super.writeValue(stream, value)
+    when (value) {
+      is FiamDismissType -> {
+        stream.write(129)
+        writeValue(stream, value.raw.toLong())
+      }
+      is FiamCampaignMetadata -> {
+        stream.write(130)
+        writeValue(stream, value.toList())
+      }
+      is FiamAction -> {
+        stream.write(131)
+        writeValue(stream, value.toList())
+      }
+      else -> super.writeValue(stream, value)
+    }
   }
 }
 
@@ -67,6 +362,11 @@ interface FirebaseInAppMessagingHostApi {
       enabled: Boolean,
       callback: (Result<Unit>) -> Unit
   )
+  /**
+   * Attaches the native message lifecycle listeners that forward events to
+   * [FirebaseInAppMessagingFlutterApi]. Calling this more than once is a no-op.
+   */
+  fun addEventListeners(appName: String, callback: (Result<Unit>) -> Unit)
 
   companion object {
     /** The codec used by FirebaseInAppMessagingHostApi. */
@@ -154,6 +454,142 @@ interface FirebaseInAppMessagingHostApi {
         } else {
           channel.setMessageHandler(null)
         }
+      }
+      run {
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingHostApi.addEventListeners$separatedMessageChannelSuffix",
+                codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val appNameArg = args[0] as String
+            api.addEventListeners(appNameArg) { result: Result<Unit> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(GeneratedAndroidFirebaseInAppMessagingPigeonUtils.wrapError(error))
+              } else {
+                reply.reply(GeneratedAndroidFirebaseInAppMessagingPigeonUtils.wrapResult(null))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+    }
+  }
+}
+/** Generated class from Pigeon that represents Flutter messages that can be called from Kotlin. */
+class FirebaseInAppMessagingFlutterApi(
+    private val binaryMessenger: BinaryMessenger,
+    private val messageChannelSuffix: String = ""
+) {
+  companion object {
+    /** The codec used by FirebaseInAppMessagingFlutterApi. */
+    val codec: MessageCodec<Any?> by lazy { GeneratedAndroidFirebaseInAppMessagingPigeonCodec() }
+  }
+
+  fun onMessageClicked(
+      campaignMetadataArg: FiamCampaignMetadata,
+      actionArg: FiamAction,
+      callback: (Result<Unit>) -> Unit
+  ) {
+    val separatedMessageChannelSuffix =
+        if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName =
+        "dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingFlutterApi.onMessageClicked$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(campaignMetadataArg, actionArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(
+            Result.failure(
+                GeneratedAndroidFirebaseInAppMessagingPigeonUtils.createConnectionError(
+                    channelName)))
+      }
+    }
+  }
+
+  fun onMessageImpression(
+      campaignMetadataArg: FiamCampaignMetadata,
+      callback: (Result<Unit>) -> Unit
+  ) {
+    val separatedMessageChannelSuffix =
+        if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName =
+        "dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingFlutterApi.onMessageImpression$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(campaignMetadataArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(
+            Result.failure(
+                GeneratedAndroidFirebaseInAppMessagingPigeonUtils.createConnectionError(
+                    channelName)))
+      }
+    }
+  }
+
+  fun onMessageDismissed(
+      campaignMetadataArg: FiamCampaignMetadata,
+      dismissTypeArg: FiamDismissType,
+      callback: (Result<Unit>) -> Unit
+  ) {
+    val separatedMessageChannelSuffix =
+        if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName =
+        "dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingFlutterApi.onMessageDismissed$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(campaignMetadataArg, dismissTypeArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(
+            Result.failure(
+                GeneratedAndroidFirebaseInAppMessagingPigeonUtils.createConnectionError(
+                    channelName)))
+      }
+    }
+  }
+
+  fun onMessageDisplayError(
+      campaignMetadataArg: FiamCampaignMetadata,
+      errorMessageArg: String?,
+      callback: (Result<Unit>) -> Unit
+  ) {
+    val separatedMessageChannelSuffix =
+        if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName =
+        "dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingFlutterApi.onMessageDisplayError$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(campaignMetadataArg, errorMessageArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(
+            Result.failure(
+                GeneratedAndroidFirebaseInAppMessagingPigeonUtils.createConnectionError(
+                    channelName)))
       }
     }
   }

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/example/lib/main.dart
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/example/lib/main.dart
@@ -38,6 +38,7 @@ class MyApp extends StatelessWidget {
                 children: <Widget>[
                   AnalyticsEventExample(),
                   ProgrammaticTriggersExample(),
+                  MessageEventsExample(),
                 ],
               ),
             );
@@ -81,6 +82,81 @@ class ProgrammaticTriggersExample extends StatelessWidget {
                 style: const TextStyle(color: Colors.white),
               ),
             )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class MessageEventsExample extends StatefulWidget {
+  @override
+  State<MessageEventsExample> createState() => _MessageEventsExampleState();
+}
+
+class _MessageEventsExampleState extends State<MessageEventsExample> {
+  final List<StreamSubscription<Object>> _subscriptions =
+      <StreamSubscription<Object>>[];
+  String _lastEvent = 'No message event yet';
+
+  @override
+  void initState() {
+    super.initState();
+
+    _subscriptions.addAll(<StreamSubscription<Object>>[
+      MyApp.fiam.onMessageClicked.listen((InAppMessagingClickEvent event) {
+        _log('clicked ${event.campaignMetadata.campaignName}, '
+            'action url: ${event.action.actionUrl}');
+      }),
+      MyApp.fiam.onMessageImpression
+          .listen((InAppMessagingImpressionEvent event) {
+        _log('impression for ${event.campaignMetadata.campaignName}');
+      }),
+      MyApp.fiam.onMessageDismissed.listen((InAppMessagingDismissEvent event) {
+        _log('dismissed ${event.campaignMetadata.campaignName} '
+            '(${event.dismissType.name})');
+      }),
+      MyApp.fiam.onMessageDisplayError
+          .listen((InAppMessagingDisplayErrorEvent event) {
+        _log('display error for ${event.campaignMetadata.campaignName}: '
+            '${event.errorMessage}');
+      }),
+    ]);
+  }
+
+  @override
+  void dispose() {
+    for (final StreamSubscription<Object> subscription in _subscriptions) {
+      subscription.cancel();
+    }
+    super.dispose();
+  }
+
+  void _log(String message) {
+    if (!mounted) return;
+    setState(() {
+      _lastEvent = message;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: <Widget>[
+            const Text(
+              'Message events',
+              style: TextStyle(
+                fontStyle: FontStyle.italic,
+                fontSize: 18,
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text('Last event received from the campaign'),
+            const SizedBox(height: 8),
+            Text(_lastEvent, textAlign: TextAlign.center),
           ],
         ),
       ),

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/firebase_in_app_messaging/Sources/firebase_in_app_messaging/FirebaseInAppMessagingMessages.g.swift
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/firebase_in_app_messaging/Sources/firebase_in_app_messaging/FirebaseInAppMessagingMessages.g.swift
@@ -57,6 +57,13 @@ private func wrapError(_ error: Any) -> [Any?] {
   ]
 }
 
+private func createConnectionError(withChannelName channelName: String) -> PigeonError {
+  PigeonError(
+    code: "channel-error", message: "Unable to establish connection on channel: '\(channelName)'.",
+    details: ""
+  )
+}
+
 private func isNullish(_ value: Any?) -> Bool {
   value is NSNull || value == nil
 }
@@ -66,9 +73,250 @@ private func nilOrValue<T>(_ value: Any?) -> T? {
   return value as! T?
 }
 
-private class FirebaseInAppMessagingMessagesPigeonCodecReader: FlutterStandardReader {}
+private func doubleEqualsFirebaseInAppMessagingMessages(_ lhs: Double, _ rhs: Double) -> Bool {
+  (lhs.isNaN && rhs.isNaN) || lhs == rhs
+}
 
-private class FirebaseInAppMessagingMessagesPigeonCodecWriter: FlutterStandardWriter {}
+private func doubleHashFirebaseInAppMessagingMessages(_ value: Double, _ hasher: inout Hasher) {
+  if value.isNaN {
+    hasher.combine(0x7FF8_0000_0000_0000)
+  } else {
+    // Normalize -0.0 to 0.0
+    hasher.combine(value == 0 ? 0 : value)
+  }
+}
+
+func deepEqualsFirebaseInAppMessagingMessages(_ lhs: Any?, _ rhs: Any?) -> Bool {
+  let cleanLhs = nilOrValue(lhs) as Any?
+  let cleanRhs = nilOrValue(rhs) as Any?
+  switch (cleanLhs, cleanRhs) {
+  case (nil, nil):
+    return true
+
+  case (nil, _), (_, nil):
+    return false
+
+  case (let lhs as AnyObject, let rhs as AnyObject) where lhs === rhs:
+    return true
+
+  case is (Void, Void):
+    return true
+
+  case (let lhsArray, let rhsArray) as ([Any?], [Any?]):
+    guard lhsArray.count == rhsArray.count else { return false }
+    for (index, element) in lhsArray.enumerated() {
+      if !deepEqualsFirebaseInAppMessagingMessages(element, rhsArray[index]) {
+        return false
+      }
+    }
+    return true
+
+  case (let lhsArray, let rhsArray) as ([Double], [Double]):
+    guard lhsArray.count == rhsArray.count else { return false }
+    for (index, element) in lhsArray.enumerated() {
+      if !doubleEqualsFirebaseInAppMessagingMessages(element, rhsArray[index]) {
+        return false
+      }
+    }
+    return true
+
+  case (let lhsDictionary, let rhsDictionary) as ([AnyHashable: Any?], [AnyHashable: Any?]):
+    guard lhsDictionary.count == rhsDictionary.count else { return false }
+    for (lhsKey, lhsValue) in lhsDictionary {
+      var found = false
+      for (rhsKey, rhsValue) in rhsDictionary {
+        if deepEqualsFirebaseInAppMessagingMessages(lhsKey, rhsKey) {
+          if deepEqualsFirebaseInAppMessagingMessages(lhsValue, rhsValue) {
+            found = true
+            break
+          } else {
+            return false
+          }
+        }
+      }
+      if !found { return false }
+    }
+    return true
+
+  case (let lhs as Double, let rhs as Double):
+    return doubleEqualsFirebaseInAppMessagingMessages(lhs, rhs)
+
+  case (let lhsHashable, let rhsHashable) as (AnyHashable, AnyHashable):
+    return lhsHashable == rhsHashable
+
+  default:
+    return false
+  }
+}
+
+func deepHashFirebaseInAppMessagingMessages(value: Any?, hasher: inout Hasher) {
+  let cleanValue = nilOrValue(value) as Any?
+  if let cleanValue {
+    if let doubleValue = cleanValue as? Double {
+      doubleHashFirebaseInAppMessagingMessages(doubleValue, &hasher)
+    } else if let valueList = cleanValue as? [Any?] {
+      for item in valueList {
+        deepHashFirebaseInAppMessagingMessages(value: item, hasher: &hasher)
+      }
+    } else if let valueList = cleanValue as? [Double] {
+      for item in valueList {
+        doubleHashFirebaseInAppMessagingMessages(item, &hasher)
+      }
+    } else if let valueDict = cleanValue as? [AnyHashable: Any?] {
+      var result = 0
+      for (key, value) in valueDict {
+        var entryKeyHasher = Hasher()
+        deepHashFirebaseInAppMessagingMessages(value: key, hasher: &entryKeyHasher)
+        var entryValueHasher = Hasher()
+        deepHashFirebaseInAppMessagingMessages(value: value, hasher: &entryValueHasher)
+        result = result &+ ((entryKeyHasher.finalize() &* 31) ^ entryValueHasher.finalize())
+      }
+      hasher.combine(result)
+    } else if let hashableValue = cleanValue as? AnyHashable {
+      hasher.combine(hashableValue)
+    } else {
+      hasher.combine(String(describing: cleanValue))
+    }
+  } else {
+    hasher.combine(0)
+  }
+}
+
+/// How an in-app message was dismissed.
+enum FiamDismissType: Int {
+  /// The message was swiped away. Only reported on iOS, for banner messages.
+  case swipe = 0
+  /// The user tapped a button to close the message.
+  case clickedCancel = 1
+  /// The message was dismissed automatically. Only reported on iOS, for banner
+  /// messages.
+  case auto = 2
+  /// The way the message was dismissed is unknown. Always reported on Android,
+  /// which does not expose a dismiss type.
+  case unknown = 3
+}
+
+/// Metadata of the campaign an in-app message belongs to.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct FiamCampaignMetadata: Hashable {
+  var campaignId: String
+  var campaignName: String
+  var isTestMessage: Bool
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> FiamCampaignMetadata? {
+    let campaignId = pigeonVar_list[0] as! String
+    let campaignName = pigeonVar_list[1] as! String
+    let isTestMessage = pigeonVar_list[2] as! Bool
+
+    return FiamCampaignMetadata(
+      campaignId: campaignId,
+      campaignName: campaignName,
+      isTestMessage: isTestMessage
+    )
+  }
+
+  func toList() -> [Any?] {
+    [
+      campaignId,
+      campaignName,
+      isTestMessage,
+    ]
+  }
+
+  static func == (lhs: FiamCampaignMetadata, rhs: FiamCampaignMetadata) -> Bool {
+    if Swift.type(of: lhs) != Swift.type(of: rhs) {
+      return false
+    }
+    return deepEqualsFirebaseInAppMessagingMessages(lhs.campaignId, rhs.campaignId)
+      && deepEqualsFirebaseInAppMessagingMessages(lhs.campaignName, rhs.campaignName)
+      && deepEqualsFirebaseInAppMessagingMessages(lhs.isTestMessage, rhs.isTestMessage)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine("FiamCampaignMetadata")
+    deepHashFirebaseInAppMessagingMessages(value: campaignId, hasher: &hasher)
+    deepHashFirebaseInAppMessagingMessages(value: campaignName, hasher: &hasher)
+    deepHashFirebaseInAppMessagingMessages(value: isTestMessage, hasher: &hasher)
+  }
+}
+
+/// The action attached to the button a user tapped on an in-app message.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct FiamAction: Hashable {
+  var actionUrl: String?
+  var buttonText: String?
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> FiamAction? {
+    let actionUrl: String? = nilOrValue(pigeonVar_list[0])
+    let buttonText: String? = nilOrValue(pigeonVar_list[1])
+
+    return FiamAction(
+      actionUrl: actionUrl,
+      buttonText: buttonText
+    )
+  }
+
+  func toList() -> [Any?] {
+    [
+      actionUrl,
+      buttonText,
+    ]
+  }
+
+  static func == (lhs: FiamAction, rhs: FiamAction) -> Bool {
+    if Swift.type(of: lhs) != Swift.type(of: rhs) {
+      return false
+    }
+    return deepEqualsFirebaseInAppMessagingMessages(lhs.actionUrl, rhs.actionUrl)
+      && deepEqualsFirebaseInAppMessagingMessages(lhs.buttonText, rhs.buttonText)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine("FiamAction")
+    deepHashFirebaseInAppMessagingMessages(value: actionUrl, hasher: &hasher)
+    deepHashFirebaseInAppMessagingMessages(value: buttonText, hasher: &hasher)
+  }
+}
+
+private class FirebaseInAppMessagingMessagesPigeonCodecReader: FlutterStandardReader {
+  override func readValue(ofType type: UInt8) -> Any? {
+    switch type {
+    case 129:
+      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
+      if let enumResultAsInt {
+        return FiamDismissType(rawValue: enumResultAsInt)
+      }
+      return nil
+    case 130:
+      return FiamCampaignMetadata.fromList(readValue() as! [Any?])
+    case 131:
+      return FiamAction.fromList(readValue() as! [Any?])
+    default:
+      return super.readValue(ofType: type)
+    }
+  }
+}
+
+private class FirebaseInAppMessagingMessagesPigeonCodecWriter: FlutterStandardWriter {
+  override func writeValue(_ value: Any) {
+    if let value = value as? FiamDismissType {
+      super.writeByte(129)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? FiamCampaignMetadata {
+      super.writeByte(130)
+      super.writeValue(value.toList())
+    } else if let value = value as? FiamAction {
+      super.writeByte(131)
+      super.writeValue(value.toList())
+    } else {
+      super.writeValue(value)
+    }
+  }
+}
 
 private class FirebaseInAppMessagingMessagesPigeonCodecReaderWriter: FlutterStandardReaderWriter {
   override func reader(with data: Data) -> FlutterStandardReader {
@@ -97,6 +345,9 @@ protocol FirebaseInAppMessagingHostApi {
   func setAutomaticDataCollectionEnabled(
     appName: String, enabled: Bool,
     completion: @escaping (Result<Void, Error>) -> Void)
+  /// Attaches the native message lifecycle listeners that forward events to
+  /// [FirebaseInAppMessagingFlutterApi]. Calling this more than once is a no-op.
+  func addEventListeners(appName: String, completion: @escaping (Result<Void, Error>) -> Void)
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -177,6 +428,164 @@ class FirebaseInAppMessagingHostApiSetup {
       }
     } else {
       setAutomaticDataCollectionEnabledChannel.setMessageHandler(nil)
+    }
+    // Attaches the native message lifecycle listeners that forward events to
+    // [FirebaseInAppMessagingFlutterApi]. Calling this more than once is a no-op.
+    let addEventListenersChannel = FlutterBasicMessageChannel(
+      name:
+        "dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingHostApi.addEventListeners\(channelSuffix)",
+      binaryMessenger: binaryMessenger, codec: codec
+    )
+    if let api {
+      addEventListenersChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let appNameArg = args[0] as! String
+        api.addEventListeners(appName: appNameArg) { result in
+          switch result {
+          case .success:
+            reply(wrapResult(nil))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      addEventListenersChannel.setMessageHandler(nil)
+    }
+  }
+}
+
+/// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
+protocol FirebaseInAppMessagingFlutterApiProtocol {
+  func onMessageClicked(
+    campaignMetadata campaignMetadataArg: FiamCampaignMetadata,
+    action actionArg: FiamAction,
+    completion: @escaping (Result<Void, PigeonError>) -> Void)
+  func onMessageImpression(
+    campaignMetadata campaignMetadataArg: FiamCampaignMetadata,
+    completion: @escaping (Result<Void, PigeonError>) -> Void)
+  func onMessageDismissed(
+    campaignMetadata campaignMetadataArg: FiamCampaignMetadata,
+    dismissType dismissTypeArg: FiamDismissType,
+    completion: @escaping (Result<Void, PigeonError>) -> Void)
+  func onMessageDisplayError(
+    campaignMetadata campaignMetadataArg: FiamCampaignMetadata,
+    errorMessage errorMessageArg: String?,
+    completion: @escaping (Result<Void, PigeonError>) -> Void)
+}
+
+class FirebaseInAppMessagingFlutterApi: FirebaseInAppMessagingFlutterApiProtocol {
+  private let binaryMessenger: FlutterBinaryMessenger
+  private let messageChannelSuffix: String
+  init(binaryMessenger: FlutterBinaryMessenger, messageChannelSuffix: String = "") {
+    self.binaryMessenger = binaryMessenger
+    self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
+  }
+
+  var codec: FirebaseInAppMessagingMessagesPigeonCodec {
+    FirebaseInAppMessagingMessagesPigeonCodec.shared
+  }
+
+  func onMessageClicked(
+    campaignMetadata campaignMetadataArg: FiamCampaignMetadata,
+    action actionArg: FiamAction,
+    completion: @escaping (Result<Void, PigeonError>) -> Void
+  ) {
+    let channelName =
+      "dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingFlutterApi.onMessageClicked\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName, binaryMessenger: binaryMessenger, codec: codec
+    )
+    channel.sendMessage([campaignMetadataArg, actionArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+
+  func onMessageImpression(
+    campaignMetadata campaignMetadataArg: FiamCampaignMetadata,
+    completion: @escaping (Result<Void, PigeonError>) -> Void
+  ) {
+    let channelName =
+      "dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingFlutterApi.onMessageImpression\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName, binaryMessenger: binaryMessenger, codec: codec
+    )
+    channel.sendMessage([campaignMetadataArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+
+  func onMessageDismissed(
+    campaignMetadata campaignMetadataArg: FiamCampaignMetadata,
+    dismissType dismissTypeArg: FiamDismissType,
+    completion: @escaping (Result<Void, PigeonError>) -> Void
+  ) {
+    let channelName =
+      "dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingFlutterApi.onMessageDismissed\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName, binaryMessenger: binaryMessenger, codec: codec
+    )
+    channel.sendMessage([campaignMetadataArg, dismissTypeArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+
+  func onMessageDisplayError(
+    campaignMetadata campaignMetadataArg: FiamCampaignMetadata,
+    errorMessage errorMessageArg: String?,
+    completion: @escaping (Result<Void, PigeonError>) -> Void
+  ) {
+    let channelName =
+      "dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingFlutterApi.onMessageDisplayError\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName, binaryMessenger: binaryMessenger, codec: codec
+    )
+    channel.sendMessage([campaignMetadataArg, errorMessageArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
     }
   }
 }

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/firebase_in_app_messaging/Sources/firebase_in_app_messaging/FirebaseInAppMessagingPlugin.swift
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/firebase_in_app_messaging/Sources/firebase_in_app_messaging/FirebaseInAppMessagingPlugin.swift
@@ -21,6 +21,8 @@ let kFLTFirebaseInAppMessagingChannelName = "plugins.flutter.io/firebase_in_app_
 public class FirebaseInAppMessagingPlugin: NSObject, FLTFirebasePluginProtocol, FlutterPlugin,
   FirebaseInAppMessagingHostApi
 {
+  private var flutterApi: FirebaseInAppMessagingFlutterApi?
+
   public static func register(with registrar: FlutterPluginRegistrar) {
     let binaryMessenger: FlutterBinaryMessenger
 
@@ -31,6 +33,7 @@ public class FirebaseInAppMessagingPlugin: NSObject, FLTFirebasePluginProtocol, 
     #endif
 
     let instance = FirebaseInAppMessagingPlugin()
+    instance.flutterApi = FirebaseInAppMessagingFlutterApi(binaryMessenger: binaryMessenger)
     FLTFirebasePluginRegistry.sharedInstance().register(instance)
     FirebaseInAppMessagingHostApiSetup.setUp(binaryMessenger: binaryMessenger, api: instance)
   }
@@ -85,5 +88,81 @@ public class FirebaseInAppMessagingPlugin: NSObject, FLTFirebasePluginProtocol, 
     let inAppMessaging = InAppMessaging.inAppMessaging()
     inAppMessaging.automaticDataCollectionEnabled = enabled
     completion(.success(()))
+  }
+
+  public func addEventListeners(
+    appName: String,
+    completion: @escaping (Result<Void, Error>) -> Void
+  ) {
+    // `delegate` is a weak reference, this instance is retained by
+    // `FLTFirebasePluginRegistry`.
+    InAppMessaging.inAppMessaging().delegate = self
+    completion(.success(()))
+  }
+}
+
+/// The delegate callbacks are documented as being called on the main thread,
+/// which is also where the Pigeon channels have to be used.
+extension FirebaseInAppMessagingPlugin: InAppMessagingDisplayDelegate {
+  public func messageClicked(
+    _ inAppMessage: InAppMessagingDisplayMessage,
+    with action: InAppMessagingAction
+  ) {
+    flutterApi?.onMessageClicked(
+      campaignMetadata: Self.campaignMetadata(inAppMessage),
+      action: FiamAction(
+        actionUrl: action.actionURL?.absoluteString,
+        buttonText: action.actionText
+      )
+    ) { _ in }
+  }
+
+  public func impressionDetected(for inAppMessage: InAppMessagingDisplayMessage) {
+    flutterApi?.onMessageImpression(
+      campaignMetadata: Self.campaignMetadata(inAppMessage)
+    ) { _ in }
+  }
+
+  public func messageDismissed(
+    _ inAppMessage: InAppMessagingDisplayMessage,
+    dismissType: InAppMessagingDismissType
+  ) {
+    flutterApi?.onMessageDismissed(
+      campaignMetadata: Self.campaignMetadata(inAppMessage),
+      dismissType: Self.dismissType(dismissType)
+    ) { _ in }
+  }
+
+  public func displayError(
+    for inAppMessage: InAppMessagingDisplayMessage,
+    error: Error
+  ) {
+    flutterApi?.onMessageDisplayError(
+      campaignMetadata: Self.campaignMetadata(inAppMessage),
+      errorMessage: error.localizedDescription
+    ) { _ in }
+  }
+
+  private static func campaignMetadata(_ inAppMessage: InAppMessagingDisplayMessage)
+    -> FiamCampaignMetadata
+  {
+    FiamCampaignMetadata(
+      campaignId: inAppMessage.campaignInfo.messageID,
+      campaignName: inAppMessage.campaignInfo.campaignName,
+      isTestMessage: inAppMessage.campaignInfo.renderAsTestMessage
+    )
+  }
+
+  private static func dismissType(_ dismissType: InAppMessagingDismissType) -> FiamDismissType {
+    switch dismissType {
+    case .typeUserSwipe:
+      return .swipe
+    case .typeUserTapClose:
+      return .clickedCancel
+    case .typeAuto:
+      return .auto
+    default:
+      return .unknown
+    }
   }
 }

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/lib/firebase_in_app_messaging.dart
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/lib/firebase_in_app_messaging.dart
@@ -7,6 +7,16 @@ import 'package:firebase_core_platform_interface/firebase_core_platform_interfac
     show FirebasePlugin;
 import 'package:firebase_in_app_messaging_platform_interface/firebase_in_app_messaging_platform_interface.dart';
 
+export 'package:firebase_in_app_messaging_platform_interface/firebase_in_app_messaging_platform_interface.dart'
+    show
+        InAppMessagingAction,
+        InAppMessagingCampaignMetadata,
+        InAppMessagingClickEvent,
+        InAppMessagingDismissEvent,
+        InAppMessagingDismissType,
+        InAppMessagingDisplayErrorEvent,
+        InAppMessagingImpressionEvent;
+
 class FirebaseInAppMessaging extends FirebasePlugin {
   FirebaseInAppMessaging._({required this.app})
       : super(app.name, 'plugins.flutter.io/firebase_in_app_messaging');
@@ -63,4 +73,34 @@ class FirebaseInAppMessaging extends FirebasePlugin {
   Future<void> setAutomaticDataCollectionEnabled(bool enabled) {
     return _delegate.setAutomaticDataCollectionEnabled(enabled);
   }
+
+  /// Notifies when the user taps the action button of an in-app message.
+  ///
+  /// Use [InAppMessagingClickEvent.action] to know which URL the campaign
+  /// asked to open, and [InAppMessagingClickEvent.campaignMetadata] to know
+  /// which campaign the message came from.
+  ///
+  /// Listening to any of the message lifecycle streams makes the plugin become
+  /// the `InAppMessaging` display delegate on iOS. If your app also sets that
+  /// delegate from native code, the one set last wins.
+  Stream<InAppMessagingClickEvent> get onMessageClicked =>
+      _delegate.onMessageClicked;
+
+  /// Notifies when an in-app message has been displayed long enough to count
+  /// as an impression.
+  Stream<InAppMessagingImpressionEvent> get onMessageImpression =>
+      _delegate.onMessageImpression;
+
+  /// Notifies when an in-app message is dismissed.
+  ///
+  /// [InAppMessagingDismissEvent.dismissType] is always
+  /// [InAppMessagingDismissType.unknown] on Android, which does not report how
+  /// a message was dismissed.
+  Stream<InAppMessagingDismissEvent> get onMessageDismissed =>
+      _delegate.onMessageDismissed;
+
+  /// Notifies when an in-app message could not be rendered, for example
+  /// because its image failed to download.
+  Stream<InAppMessagingDisplayErrorEvent> get onMessageDisplayError =>
+      _delegate.onMessageDisplayError;
 }

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/test/firebase_in_app_messaging_test.dart
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/test/firebase_in_app_messaging_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/test.dart';
 import 'package:firebase_in_app_messaging/firebase_in_app_messaging.dart';
@@ -63,6 +65,85 @@ void main() {
       await fiam.setAutomaticDataCollectionEnabled(false);
       verify(mockFiam.setAutomaticDataCollectionEnabled(false));
     });
+
+    test('onMessageClicked', () async {
+      final controller = StreamController<InAppMessagingClickEvent>();
+      addTearDown(controller.close);
+      when(mockFiam.onMessageClicked).thenAnswer((_) => controller.stream);
+
+      const event = InAppMessagingClickEvent(
+        campaignMetadata: InAppMessagingCampaignMetadata(
+          campaignId: 'campaign-id',
+          campaignName: 'campaign-name',
+          isTestMessage: false,
+        ),
+        action: InAppMessagingAction(actionUrl: 'https://example.com'),
+      );
+
+      final emitted = fiam.onMessageClicked.first;
+      controller.add(event);
+
+      expect(await emitted, event);
+    });
+
+    test('onMessageImpression', () async {
+      final controller = StreamController<InAppMessagingImpressionEvent>();
+      addTearDown(controller.close);
+      when(mockFiam.onMessageImpression).thenAnswer((_) => controller.stream);
+
+      const event = InAppMessagingImpressionEvent(
+        campaignMetadata: InAppMessagingCampaignMetadata(
+          campaignId: 'campaign-id',
+          campaignName: 'campaign-name',
+          isTestMessage: false,
+        ),
+      );
+
+      final emitted = fiam.onMessageImpression.first;
+      controller.add(event);
+
+      expect(await emitted, event);
+    });
+
+    test('onMessageDismissed', () async {
+      final controller = StreamController<InAppMessagingDismissEvent>();
+      addTearDown(controller.close);
+      when(mockFiam.onMessageDismissed).thenAnswer((_) => controller.stream);
+
+      const event = InAppMessagingDismissEvent(
+        campaignMetadata: InAppMessagingCampaignMetadata(
+          campaignId: 'campaign-id',
+          campaignName: 'campaign-name',
+          isTestMessage: false,
+        ),
+        dismissType: InAppMessagingDismissType.swipe,
+      );
+
+      final emitted = fiam.onMessageDismissed.first;
+      controller.add(event);
+
+      expect(await emitted, event);
+    });
+
+    test('onMessageDisplayError', () async {
+      final controller = StreamController<InAppMessagingDisplayErrorEvent>();
+      addTearDown(controller.close);
+      when(mockFiam.onMessageDisplayError).thenAnswer((_) => controller.stream);
+
+      const event = InAppMessagingDisplayErrorEvent(
+        campaignMetadata: InAppMessagingCampaignMetadata(
+          campaignId: 'campaign-id',
+          campaignName: 'campaign-name',
+          isTestMessage: false,
+        ),
+        errorMessage: 'IMAGE_FETCH_ERROR',
+      );
+
+      final emitted = fiam.onMessageDisplayError.first;
+      controller.add(event);
+
+      expect(await emitted, event);
+    });
   });
 }
 
@@ -111,6 +192,45 @@ class MockFirebaseInAppMessaging extends Mock
       Invocation.method(#triggerEvent, [eventName]),
       returnValue: Future<void>.value(),
       returnValueForMissingStub: Future<void>.value(),
+    );
+  }
+
+  @override
+  Stream<InAppMessagingClickEvent> get onMessageClicked {
+    return super.noSuchMethod(
+      Invocation.getter(#onMessageClicked),
+      returnValue: const Stream<InAppMessagingClickEvent>.empty(),
+      returnValueForMissingStub: const Stream<InAppMessagingClickEvent>.empty(),
+    );
+  }
+
+  @override
+  Stream<InAppMessagingImpressionEvent> get onMessageImpression {
+    return super.noSuchMethod(
+      Invocation.getter(#onMessageImpression),
+      returnValue: const Stream<InAppMessagingImpressionEvent>.empty(),
+      returnValueForMissingStub:
+          const Stream<InAppMessagingImpressionEvent>.empty(),
+    );
+  }
+
+  @override
+  Stream<InAppMessagingDismissEvent> get onMessageDismissed {
+    return super.noSuchMethod(
+      Invocation.getter(#onMessageDismissed),
+      returnValue: const Stream<InAppMessagingDismissEvent>.empty(),
+      returnValueForMissingStub:
+          const Stream<InAppMessagingDismissEvent>.empty(),
+    );
+  }
+
+  @override
+  Stream<InAppMessagingDisplayErrorEvent> get onMessageDisplayError {
+    return super.noSuchMethod(
+      Invocation.getter(#onMessageDisplayError),
+      returnValue: const Stream<InAppMessagingDisplayErrorEvent>.empty(),
+      returnValueForMissingStub:
+          const Stream<InAppMessagingDisplayErrorEvent>.empty(),
     );
   }
 }

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/lib/firebase_in_app_messaging_platform_interface.dart
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/lib/firebase_in_app_messaging_platform_interface.dart
@@ -2,4 +2,5 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+export 'src/events.dart';
 export 'src/platform_interface/platform_interface_firebase_in_app_messaging.dart';

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/lib/src/events.dart
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/lib/src/events.dart
@@ -1,0 +1,137 @@
+// Copyright 2026, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// How an in-app message was dismissed.
+enum InAppMessagingDismissType {
+  /// The message was swiped away.
+  ///
+  /// Only reported on iOS, for banner messages.
+  swipe,
+
+  /// The user tapped a button to close the message.
+  clickedCancel,
+
+  /// The message was dismissed automatically after being displayed.
+  ///
+  /// Only reported on iOS, for banner messages.
+  auto,
+
+  /// The way the message was dismissed is unknown.
+  ///
+  /// Always reported on Android, as the Android SDK does not expose how a
+  /// message was dismissed.
+  unknown,
+}
+
+/// Metadata of the campaign an in-app message belongs to.
+class InAppMessagingCampaignMetadata {
+  const InAppMessagingCampaignMetadata({
+    required this.campaignId,
+    required this.campaignName,
+    required this.isTestMessage,
+  });
+
+  /// The identifier of the campaign this message belongs to.
+  ///
+  /// This maps to `messageID` on iOS.
+  final String campaignId;
+
+  /// The name of the campaign, as entered in the Firebase console.
+  final String campaignName;
+
+  /// Whether the message was rendered as a test message ("Test on device").
+  final bool isTestMessage;
+
+  @override
+  String toString() => 'InAppMessagingCampaignMetadata('
+      'campaignId: $campaignId, '
+      'campaignName: $campaignName, '
+      'isTestMessage: $isTestMessage)';
+}
+
+/// The action attached to the button the user tapped on an in-app message.
+class InAppMessagingAction {
+  const InAppMessagingAction({this.actionUrl, this.buttonText});
+
+  /// The URL the campaign asked to open, if the message defines one.
+  final String? actionUrl;
+
+  /// The text of the button that was tapped, if the message defines one.
+  final String? buttonText;
+
+  @override
+  String toString() =>
+      'InAppMessagingAction(actionUrl: $actionUrl, buttonText: $buttonText)';
+}
+
+/// Emitted when the user taps the action button of an in-app message.
+class InAppMessagingClickEvent {
+  const InAppMessagingClickEvent({
+    required this.campaignMetadata,
+    required this.action,
+  });
+
+  /// Metadata of the campaign the clicked message belongs to.
+  final InAppMessagingCampaignMetadata campaignMetadata;
+
+  /// The action that was triggered by the tap.
+  final InAppMessagingAction action;
+
+  @override
+  String toString() => 'InAppMessagingClickEvent('
+      'campaignMetadata: $campaignMetadata, action: $action)';
+}
+
+/// Emitted when an in-app message has been displayed long enough to count as
+/// an impression.
+class InAppMessagingImpressionEvent {
+  const InAppMessagingImpressionEvent({required this.campaignMetadata});
+
+  /// Metadata of the campaign the displayed message belongs to.
+  final InAppMessagingCampaignMetadata campaignMetadata;
+
+  @override
+  String toString() =>
+      'InAppMessagingImpressionEvent(campaignMetadata: $campaignMetadata)';
+}
+
+/// Emitted when an in-app message is dismissed.
+class InAppMessagingDismissEvent {
+  const InAppMessagingDismissEvent({
+    required this.campaignMetadata,
+    required this.dismissType,
+  });
+
+  /// Metadata of the campaign the dismissed message belongs to.
+  final InAppMessagingCampaignMetadata campaignMetadata;
+
+  /// How the message was dismissed.
+  final InAppMessagingDismissType dismissType;
+
+  @override
+  String toString() => 'InAppMessagingDismissEvent('
+      'campaignMetadata: $campaignMetadata, dismissType: $dismissType)';
+}
+
+/// Emitted when an in-app message could not be rendered.
+class InAppMessagingDisplayErrorEvent {
+  const InAppMessagingDisplayErrorEvent({
+    required this.campaignMetadata,
+    this.errorMessage,
+  });
+
+  /// Metadata of the campaign whose message failed to render.
+  final InAppMessagingCampaignMetadata campaignMetadata;
+
+  /// A description of what went wrong.
+  ///
+  /// On Android this is the name of the underlying
+  /// `InAppMessagingErrorReason` (for example `IMAGE_FETCH_ERROR`), on iOS the
+  /// localized description of the error reported by the SDK.
+  final String? errorMessage;
+
+  @override
+  String toString() => 'InAppMessagingDisplayErrorEvent('
+      'campaignMetadata: $campaignMetadata, errorMessage: $errorMessage)';
+}

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/lib/src/method_channel/method_channel_firebase_in_app_messaging.dart
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/lib/src/method_channel/method_channel_firebase_in_app_messaging.dart
@@ -2,13 +2,97 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_in_app_messaging_platform_interface/firebase_in_app_messaging_platform_interface.dart';
 import 'package:firebase_in_app_messaging_platform_interface/src/pigeon/messages.pigeon.dart'
     as pigeon;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'utils/exception.dart';
+
+/// Receives the message lifecycle events sent by the native SDKs and forwards
+/// them to the streams exposed by [MethodChannelFirebaseInAppMessaging].
+class _FirebaseInAppMessagingFlutterApi
+    implements pigeon.FirebaseInAppMessagingFlutterApi {
+  @override
+  void onMessageClicked(
+    pigeon.FiamCampaignMetadata campaignMetadata,
+    pigeon.FiamAction action,
+  ) {
+    MethodChannelFirebaseInAppMessaging.clickedController.add(
+      InAppMessagingClickEvent(
+        campaignMetadata: _campaignMetadata(campaignMetadata),
+        action: InAppMessagingAction(
+          actionUrl: action.actionUrl,
+          buttonText: action.buttonText,
+        ),
+      ),
+    );
+  }
+
+  @override
+  void onMessageImpression(pigeon.FiamCampaignMetadata campaignMetadata) {
+    MethodChannelFirebaseInAppMessaging.impressionController.add(
+      InAppMessagingImpressionEvent(
+        campaignMetadata: _campaignMetadata(campaignMetadata),
+      ),
+    );
+  }
+
+  @override
+  void onMessageDismissed(
+    pigeon.FiamCampaignMetadata campaignMetadata,
+    pigeon.FiamDismissType dismissType,
+  ) {
+    MethodChannelFirebaseInAppMessaging.dismissedController.add(
+      InAppMessagingDismissEvent(
+        campaignMetadata: _campaignMetadata(campaignMetadata),
+        dismissType: _dismissType(dismissType),
+      ),
+    );
+  }
+
+  @override
+  void onMessageDisplayError(
+    pigeon.FiamCampaignMetadata campaignMetadata,
+    String? errorMessage,
+  ) {
+    MethodChannelFirebaseInAppMessaging.displayErrorController.add(
+      InAppMessagingDisplayErrorEvent(
+        campaignMetadata: _campaignMetadata(campaignMetadata),
+        errorMessage: errorMessage,
+      ),
+    );
+  }
+
+  static InAppMessagingCampaignMetadata _campaignMetadata(
+    pigeon.FiamCampaignMetadata metadata,
+  ) {
+    return InAppMessagingCampaignMetadata(
+      campaignId: metadata.campaignId,
+      campaignName: metadata.campaignName,
+      isTestMessage: metadata.isTestMessage,
+    );
+  }
+
+  static InAppMessagingDismissType _dismissType(
+    pigeon.FiamDismissType dismissType,
+  ) {
+    switch (dismissType) {
+      case pigeon.FiamDismissType.swipe:
+        return InAppMessagingDismissType.swipe;
+      case pigeon.FiamDismissType.clickedCancel:
+        return InAppMessagingDismissType.clickedCancel;
+      case pigeon.FiamDismissType.auto:
+        return InAppMessagingDismissType.auto;
+      case pigeon.FiamDismissType.unknown:
+        return InAppMessagingDismissType.unknown;
+    }
+  }
+}
 
 class MethodChannelFirebaseInAppMessaging
     extends FirebaseInAppMessagingPlatform {
@@ -26,6 +110,30 @@ class MethodChannelFirebaseInAppMessaging
   );
 
   static final pigeonChannel = pigeon.FirebaseInAppMessagingHostApi();
+
+  // The message lifecycle controllers live as long as the app does, they are
+  // never closed.
+  @visibleForTesting
+  // ignore: close_sinks
+  static final clickedController =
+      StreamController<InAppMessagingClickEvent>.broadcast();
+
+  @visibleForTesting
+  // ignore: close_sinks
+  static final impressionController =
+      StreamController<InAppMessagingImpressionEvent>.broadcast();
+
+  @visibleForTesting
+  // ignore: close_sinks
+  static final dismissedController =
+      StreamController<InAppMessagingDismissEvent>.broadcast();
+
+  @visibleForTesting
+  // ignore: close_sinks
+  static final displayErrorController =
+      StreamController<InAppMessagingDisplayErrorEvent>.broadcast();
+
+  static bool _eventListenersAdded = false;
 
   /// Returns a stub instance to allow the platform interface to access
   /// the class instance statically.
@@ -63,5 +171,59 @@ class MethodChannelFirebaseInAppMessaging
     } catch (e, s) {
       convertPlatformException(e, s);
     }
+  }
+
+  @override
+  Stream<InAppMessagingClickEvent> get onMessageClicked {
+    _ensureEventListeners();
+    return clickedController.stream;
+  }
+
+  @override
+  Stream<InAppMessagingImpressionEvent> get onMessageImpression {
+    _ensureEventListeners();
+    return impressionController.stream;
+  }
+
+  @override
+  Stream<InAppMessagingDismissEvent> get onMessageDismissed {
+    _ensureEventListeners();
+    return dismissedController.stream;
+  }
+
+  @override
+  Stream<InAppMessagingDisplayErrorEvent> get onMessageDisplayError {
+    _ensureEventListeners();
+    return displayErrorController.stream;
+  }
+
+  /// The message lifecycle listeners are attached natively the first time one
+  /// of the event streams is used, so that apps which never listen keep the
+  /// previous behavior - most notably they keep ownership of the iOS
+  /// `InAppMessaging` display delegate.
+  void _ensureEventListeners() {
+    if (_eventListenersAdded) return;
+    _eventListenersAdded = true;
+
+    pigeon.FirebaseInAppMessagingFlutterApi.setUp(
+      _FirebaseInAppMessagingFlutterApi(),
+    );
+
+    pigeonChannel.addEventListeners(app!.name).catchError((
+      Object error,
+      StackTrace stackTrace,
+    ) {
+      _eventListenersAdded = false;
+      for (final controller in [
+        clickedController,
+        impressionController,
+        dismissedController,
+        displayErrorController,
+      ]) {
+        if (controller.hasListener) {
+          controller.addError(error, stackTrace);
+        }
+      }
+    });
   }
 }

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/lib/src/pigeon/messages.pigeon.dart
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/lib/src/pigeon/messages.pigeon.dart
@@ -48,6 +48,187 @@ List<Object?> wrapResponse(
   return <Object?>[error.code, error.message, error.details];
 }
 
+bool _deepEquals(Object? a, Object? b) {
+  if (identical(a, b)) {
+    return true;
+  }
+  if (a is double && b is double) {
+    if (a.isNaN && b.isNaN) {
+      return true;
+    }
+    return a == b;
+  }
+  if (a is List && b is List) {
+    return a.length == b.length &&
+        a.indexed
+            .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
+  }
+  if (a is Map && b is Map) {
+    if (a.length != b.length) {
+      return false;
+    }
+    for (final MapEntry<Object?, Object?> entryA in a.entries) {
+      bool found = false;
+      for (final MapEntry<Object?, Object?> entryB in b.entries) {
+        if (_deepEquals(entryA.key, entryB.key)) {
+          if (_deepEquals(entryA.value, entryB.value)) {
+            found = true;
+            break;
+          } else {
+            return false;
+          }
+        }
+      }
+      if (!found) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return a == b;
+}
+
+int _deepHash(Object? value) {
+  if (value is List) {
+    return Object.hashAll(value.map(_deepHash));
+  }
+  if (value is Map) {
+    int result = 0;
+    for (final MapEntry<Object?, Object?> entry in value.entries) {
+      result += (_deepHash(entry.key) * 31) ^ _deepHash(entry.value);
+    }
+    return result;
+  }
+  if (value is double && value.isNaN) {
+    // Normalize NaN to a consistent hash.
+    return 0x7FF8000000000000.hashCode;
+  }
+  if (value is double && value == 0.0) {
+    // Normalize -0.0 to 0.0 so they have the same hash code.
+    return 0.0.hashCode;
+  }
+  return value.hashCode;
+}
+
+/// How an in-app message was dismissed.
+enum FiamDismissType {
+  /// The message was swiped away. Only reported on iOS, for banner messages.
+  swipe,
+
+  /// The user tapped a button to close the message.
+  clickedCancel,
+
+  /// The message was dismissed automatically. Only reported on iOS, for banner
+  /// messages.
+  auto,
+
+  /// The way the message was dismissed is unknown. Always reported on Android,
+  /// which does not expose a dismiss type.
+  unknown,
+}
+
+/// Metadata of the campaign an in-app message belongs to.
+class FiamCampaignMetadata {
+  FiamCampaignMetadata({
+    required this.campaignId,
+    required this.campaignName,
+    required this.isTestMessage,
+  });
+
+  String campaignId;
+
+  String campaignName;
+
+  bool isTestMessage;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      campaignId,
+      campaignName,
+      isTestMessage,
+    ];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static FiamCampaignMetadata decode(Object result) {
+    result as List<Object?>;
+    return FiamCampaignMetadata(
+      campaignId: result[0]! as String,
+      campaignName: result[1]! as String,
+      isTestMessage: result[2]! as bool,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! FiamCampaignMetadata || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(campaignId, other.campaignId) &&
+        _deepEquals(campaignName, other.campaignName) &&
+        _deepEquals(isTestMessage, other.isTestMessage);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
+}
+
+/// The action attached to the button a user tapped on an in-app message.
+class FiamAction {
+  FiamAction({
+    this.actionUrl,
+    this.buttonText,
+  });
+
+  String? actionUrl;
+
+  String? buttonText;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      actionUrl,
+      buttonText,
+    ];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static FiamAction decode(Object result) {
+    result as List<Object?>;
+    return FiamAction(
+      actionUrl: result[0] as String?,
+      buttonText: result[1] as String?,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! FiamAction || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(actionUrl, other.actionUrl) &&
+        _deepEquals(buttonText, other.buttonText);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
+}
+
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -55,6 +236,15 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
+    } else if (value is FiamDismissType) {
+      buffer.putUint8(129);
+      writeValue(buffer, value.index);
+    } else if (value is FiamCampaignMetadata) {
+      buffer.putUint8(130);
+      writeValue(buffer, value.encode());
+    } else if (value is FiamAction) {
+      buffer.putUint8(131);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -63,6 +253,13 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
+      case 129:
+        final value = readValue(buffer) as int?;
+        return value == null ? null : FiamDismissType.values[value];
+      case 130:
+        return FiamCampaignMetadata.decode(readValue(buffer)!);
+      case 131:
+        return FiamAction.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -140,5 +337,149 @@ class FirebaseInAppMessagingHostApi {
       pigeonVar_channelName,
       isNullValid: true,
     );
+  }
+
+  /// Attaches the native message lifecycle listeners that forward events to
+  /// [FirebaseInAppMessagingFlutterApi]. Calling this more than once is a no-op.
+  Future<void> addEventListeners(String appName) async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingHostApi.addEventListeners$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[appName]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
+  }
+}
+
+abstract class FirebaseInAppMessagingFlutterApi {
+  static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
+
+  void onMessageClicked(
+      FiamCampaignMetadata campaignMetadata, FiamAction action);
+
+  void onMessageImpression(FiamCampaignMetadata campaignMetadata);
+
+  void onMessageDismissed(
+      FiamCampaignMetadata campaignMetadata, FiamDismissType dismissType);
+
+  void onMessageDisplayError(
+      FiamCampaignMetadata campaignMetadata, String? errorMessage);
+
+  static void setUp(
+    FirebaseInAppMessagingFlutterApi? api, {
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) {
+    messageChannelSuffix =
+        messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingFlutterApi.onMessageClicked$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final FiamCampaignMetadata arg_campaignMetadata =
+              args[0]! as FiamCampaignMetadata;
+          final FiamAction arg_action = args[1]! as FiamAction;
+          try {
+            api.onMessageClicked(arg_campaignMetadata, arg_action);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingFlutterApi.onMessageImpression$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final FiamCampaignMetadata arg_campaignMetadata =
+              args[0]! as FiamCampaignMetadata;
+          try {
+            api.onMessageImpression(arg_campaignMetadata);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingFlutterApi.onMessageDismissed$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final FiamCampaignMetadata arg_campaignMetadata =
+              args[0]! as FiamCampaignMetadata;
+          final FiamDismissType arg_dismissType = args[1]! as FiamDismissType;
+          try {
+            api.onMessageDismissed(arg_campaignMetadata, arg_dismissType);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingFlutterApi.onMessageDisplayError$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final FiamCampaignMetadata arg_campaignMetadata =
+              args[0]! as FiamCampaignMetadata;
+          final String? arg_errorMessage = args[1] as String?;
+          try {
+            api.onMessageDisplayError(arg_campaignMetadata, arg_errorMessage);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
   }
 }

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/lib/src/platform_interface/platform_interface_firebase_in_app_messaging.dart
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/lib/src/platform_interface/platform_interface_firebase_in_app_messaging.dart
@@ -6,6 +6,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:meta/meta.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import '../events.dart';
 import '../method_channel/method_channel_firebase_in_app_messaging.dart';
 
 abstract class FirebaseInAppMessagingPlatform extends PlatformInterface {
@@ -66,5 +67,26 @@ abstract class FirebaseInAppMessagingPlatform extends PlatformInterface {
     throw UnimplementedError(
       'setAutomaticDataCollectionEnabled() is not implemented',
     );
+  }
+
+  /// Notifies about in-app messages whose action button was tapped.
+  Stream<InAppMessagingClickEvent> get onMessageClicked {
+    throw UnimplementedError('onMessageClicked is not implemented');
+  }
+
+  /// Notifies about in-app messages that were displayed long enough to count
+  /// as an impression.
+  Stream<InAppMessagingImpressionEvent> get onMessageImpression {
+    throw UnimplementedError('onMessageImpression is not implemented');
+  }
+
+  /// Notifies about in-app messages that were dismissed.
+  Stream<InAppMessagingDismissEvent> get onMessageDismissed {
+    throw UnimplementedError('onMessageDismissed is not implemented');
+  }
+
+  /// Notifies about in-app messages that could not be rendered.
+  Stream<InAppMessagingDisplayErrorEvent> get onMessageDisplayError {
+    throw UnimplementedError('onMessageDisplayError is not implemented');
   }
 }

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/pigeons/messages.dart
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/pigeons/messages.dart
@@ -19,6 +19,45 @@ import 'package:pigeon/pigeon.dart';
     copyrightHeader: 'pigeons/copyright.txt',
   ),
 )
+
+/// How an in-app message was dismissed.
+enum FiamDismissType {
+  /// The message was swiped away. Only reported on iOS, for banner messages.
+  swipe,
+
+  /// The user tapped a button to close the message.
+  clickedCancel,
+
+  /// The message was dismissed automatically. Only reported on iOS, for banner
+  /// messages.
+  auto,
+
+  /// The way the message was dismissed is unknown. Always reported on Android,
+  /// which does not expose a dismiss type.
+  unknown,
+}
+
+/// Metadata of the campaign an in-app message belongs to.
+class FiamCampaignMetadata {
+  const FiamCampaignMetadata({
+    required this.campaignId,
+    required this.campaignName,
+    required this.isTestMessage,
+  });
+
+  final String campaignId;
+  final String campaignName;
+  final bool isTestMessage;
+}
+
+/// The action attached to the button a user tapped on an in-app message.
+class FiamAction {
+  const FiamAction({this.actionUrl, this.buttonText});
+
+  final String? actionUrl;
+  final String? buttonText;
+}
+
 @HostApi(dartHostTestHandler: 'TestFirebaseInAppMessagingHostApi')
 abstract class FirebaseInAppMessagingHostApi {
   @async
@@ -29,4 +68,27 @@ abstract class FirebaseInAppMessagingHostApi {
 
   @async
   void setAutomaticDataCollectionEnabled(String appName, bool enabled);
+
+  /// Attaches the native message lifecycle listeners that forward events to
+  /// [FirebaseInAppMessagingFlutterApi]. Calling this more than once is a no-op.
+  @async
+  void addEventListeners(String appName);
+}
+
+@FlutterApi()
+abstract class FirebaseInAppMessagingFlutterApi {
+  void onMessageClicked(
+      FiamCampaignMetadata campaignMetadata, FiamAction action);
+
+  void onMessageImpression(FiamCampaignMetadata campaignMetadata);
+
+  void onMessageDismissed(
+    FiamCampaignMetadata campaignMetadata,
+    FiamDismissType dismissType,
+  );
+
+  void onMessageDisplayError(
+    FiamCampaignMetadata campaignMetadata,
+    String? errorMessage,
+  );
 }

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/test/method_channel/method_channel_firebase_in_app_messaging_test.dart
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/test/method_channel/method_channel_firebase_in_app_messaging_test.dart
@@ -3,7 +3,10 @@
 // found in the LICENSE file.
 
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_in_app_messaging_platform_interface/firebase_in_app_messaging_platform_interface.dart';
 import 'package:firebase_in_app_messaging_platform_interface/src/method_channel/method_channel_firebase_in_app_messaging.dart';
+import 'package:firebase_in_app_messaging_platform_interface/src/pigeon/messages.pigeon.dart'
+    as pigeon;
 import 'package:flutter_test/flutter_test.dart';
 
 import '../mock.dart';
@@ -54,6 +57,108 @@ void main() {
       expect(hostApi.automaticDataCollectionEnabled, isFalse);
     },
   );
+
+  test('listening to an event stream adds the native listeners once', () async {
+    final clicked = inAppMessaging.onMessageClicked.listen((_) {});
+    final dismissed = inAppMessaging.onMessageDismissed.listen((_) {});
+    addTearDown(clicked.cancel);
+    addTearDown(dismissed.cancel);
+
+    // The host API is called without being awaited by the getters.
+    await pumpEventQueue();
+
+    expect(hostApi.addEventListenersCount, 1);
+    expect(hostApi.appName, app.name);
+  });
+
+  test('onMessageClicked emits the campaign metadata and the action', () async {
+    final event = inAppMessaging.onMessageClicked.first;
+
+    await _sendFlutterApiMessage('onMessageClicked', [
+      pigeon.FiamCampaignMetadata(
+        campaignId: 'campaign-id',
+        campaignName: 'campaign-name',
+        isTestMessage: true,
+      ),
+      pigeon.FiamAction(
+        actionUrl: 'https://example.com',
+        buttonText: 'Open',
+      ),
+    ]);
+
+    final clickEvent = await event;
+    expect(clickEvent.campaignMetadata.campaignId, 'campaign-id');
+    expect(clickEvent.campaignMetadata.campaignName, 'campaign-name');
+    expect(clickEvent.campaignMetadata.isTestMessage, isTrue);
+    expect(clickEvent.action.actionUrl, 'https://example.com');
+    expect(clickEvent.action.buttonText, 'Open');
+  });
+
+  test('onMessageImpression emits the campaign metadata', () async {
+    final event = inAppMessaging.onMessageImpression.first;
+
+    await _sendFlutterApiMessage('onMessageImpression', [
+      pigeon.FiamCampaignMetadata(
+        campaignId: 'campaign-id',
+        campaignName: 'campaign-name',
+        isTestMessage: false,
+      ),
+    ]);
+
+    final impressionEvent = await event;
+    expect(impressionEvent.campaignMetadata.campaignId, 'campaign-id');
+    expect(impressionEvent.campaignMetadata.isTestMessage, isFalse);
+  });
+
+  test('onMessageDismissed emits the dismiss type', () async {
+    final event = inAppMessaging.onMessageDismissed.first;
+
+    await _sendFlutterApiMessage('onMessageDismissed', [
+      pigeon.FiamCampaignMetadata(
+        campaignId: 'campaign-id',
+        campaignName: 'campaign-name',
+        isTestMessage: false,
+      ),
+      pigeon.FiamDismissType.clickedCancel,
+    ]);
+
+    final dismissEvent = await event;
+    expect(dismissEvent.campaignMetadata.campaignId, 'campaign-id');
+    expect(dismissEvent.dismissType, InAppMessagingDismissType.clickedCancel);
+  });
+
+  test('onMessageDisplayError emits the error message', () async {
+    final event = inAppMessaging.onMessageDisplayError.first;
+
+    await _sendFlutterApiMessage('onMessageDisplayError', [
+      pigeon.FiamCampaignMetadata(
+        campaignId: 'campaign-id',
+        campaignName: 'campaign-name',
+        isTestMessage: false,
+      ),
+      'IMAGE_FETCH_ERROR',
+    ]);
+
+    final errorEvent = await event;
+    expect(errorEvent.campaignMetadata.campaignId, 'campaign-id');
+    expect(errorEvent.errorMessage, 'IMAGE_FETCH_ERROR');
+  });
+}
+
+/// Simulates the native side calling [pigeon.FirebaseInAppMessagingFlutterApi].
+Future<void> _sendFlutterApiMessage(
+  String methodName,
+  List<Object?> arguments,
+) {
+  const codec = pigeon.FirebaseInAppMessagingFlutterApi.pigeonChannelCodec;
+
+  return TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .handlePlatformMessage(
+    'dev.flutter.pigeon.firebase_in_app_messaging_platform_interface'
+    '.FirebaseInAppMessagingFlutterApi.$methodName',
+    codec.encodeMessage(arguments),
+    (_) {},
+  );
 }
 
 class _TestFirebaseInAppMessagingHostApi
@@ -62,12 +167,14 @@ class _TestFirebaseInAppMessagingHostApi
   String? eventName;
   bool? messagesSuppressed;
   bool? automaticDataCollectionEnabled;
+  int addEventListenersCount = 0;
 
   void reset() {
     appName = null;
     eventName = null;
     messagesSuppressed = null;
     automaticDataCollectionEnabled = null;
+    addEventListenersCount = 0;
   }
 
   @override
@@ -89,5 +196,11 @@ class _TestFirebaseInAppMessagingHostApi
   ) async {
     this.appName = appName;
     automaticDataCollectionEnabled = enabled;
+  }
+
+  @override
+  Future<void> addEventListeners(String appName) async {
+    this.appName = appName;
+    addEventListenersCount++;
   }
 }

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/test/pigeon/test_api.dart
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/test/pigeon/test_api.dart
@@ -20,6 +20,15 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
+    } else if (value is FiamDismissType) {
+      buffer.putUint8(129);
+      writeValue(buffer, value.index);
+    } else if (value is FiamCampaignMetadata) {
+      buffer.putUint8(130);
+      writeValue(buffer, value.encode());
+    } else if (value is FiamAction) {
+      buffer.putUint8(131);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -28,6 +37,13 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
+      case 129:
+        final value = readValue(buffer) as int?;
+        return value == null ? null : FiamDismissType.values[value];
+      case 130:
+        return FiamCampaignMetadata.decode(readValue(buffer)!);
+      case 131:
+        return FiamAction.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -44,6 +60,10 @@ abstract class TestFirebaseInAppMessagingHostApi {
   Future<void> setMessagesSuppressed(String appName, bool suppress);
 
   Future<void> setAutomaticDataCollectionEnabled(String appName, bool enabled);
+
+  /// Attaches the native message lifecycle listeners that forward events to
+  /// [FirebaseInAppMessagingFlutterApi]. Calling this more than once is a no-op.
+  Future<void> addEventListeners(String appName);
 
   static void setUp(
     TestFirebaseInAppMessagingHostApi? api, {
@@ -124,6 +144,32 @@ abstract class TestFirebaseInAppMessagingHostApi {
           try {
             await api.setAutomaticDataCollectionEnabled(
                 arg_appName, arg_enabled);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.firebase_in_app_messaging_platform_interface.FirebaseInAppMessagingHostApi.addEventListeners$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel, null);
+      } else {
+        _testBinaryMessengerBinding!.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(pigeonVar_channel,
+                (Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final String arg_appName = args[0]! as String;
+          try {
+            await api.addEventListeners(arg_appName);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/test/platform_interface/platform_interface_firebase_in_app_messaging_test.dart
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/test/platform_interface/platform_interface_firebase_in_app_messaging_test.dart
@@ -43,6 +43,34 @@ void main() {
         throwsA(isA<UnimplementedError>()),
       );
     });
+
+    test('onMessageClicked throws if not implemented', () {
+      expect(
+        () => platform!.onMessageClicked,
+        throwsA(isA<UnimplementedError>()),
+      );
+    });
+
+    test('onMessageImpression throws if not implemented', () {
+      expect(
+        () => platform!.onMessageImpression,
+        throwsA(isA<UnimplementedError>()),
+      );
+    });
+
+    test('onMessageDismissed throws if not implemented', () {
+      expect(
+        () => platform!.onMessageDismissed,
+        throwsA(isA<UnimplementedError>()),
+      );
+    });
+
+    test('onMessageDisplayError throws if not implemented', () {
+      expect(
+        () => platform!.onMessageDisplayError,
+        throwsA(isA<UnimplementedError>()),
+      );
+    });
   });
 }
 


### PR DESCRIPTION
## Description

- Adds the message lifecycle to `FirebaseInAppMessaging` as `onMessageClicked`, `onMessageImpression`, `onMessageDismissed` and `onMessageDisplayError`, carrying the campaign metadata and, for clicks, the action URL and button text. A new Pigeon `FlutterApi` forwards the events, Android registers its four listeners on a main thread executor, and iOS conforms to `InAppMessagingDisplayDelegate`. Two platform differences are documented rather than emulated: Android reports no dismiss type, so `InAppMessagingDismissType.unknown` is used there, and `onMessageDisplayError` reports the Android `InAppMessagingErrorReason` name on Android and the localized error description on iOS.
- Attaches the native listeners the first time one of the streams is read rather than at plugin registration. On iOS `InAppMessaging.delegate` is a single slot, so attaching eagerly would take it from apps that set it in native code; apps that never use these streams keep the current behavior.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/12984

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
