### PR TITLE
fix(remote_config): classify fetch failures instead of reporting them all as `internal`

### DIFF
--- a/packages/firebase_remote_config/firebase_remote_config/android/src/main/kotlin/io/flutter/plugins/firebase/firebaseremoteconfig/FirebaseRemoteConfigPlugin.kt
+++ b/packages/firebase_remote_config/firebase_remote_config/android/src/main/kotlin/io/flutter/plugins/firebase/firebaseremoteconfig/FirebaseRemoteConfigPlugin.kt
@@ -229,7 +229,10 @@ class FirebaseRemoteConfigPlugin :
       details["message"] = "frequency of requests exceeds throttled limits"
     } else if (exception is FirebaseRemoteConfigClientException) {
       details["code"] = "internal"
-      details["message"] = "internal remote config fetch error"
+      // The native message is the only thing that says what went wrong here,
+      // for example a missing data connection, so it is passed on as is and
+      // the Dart side refines the code from it.
+      details["message"] = exception.message ?: "internal remote config fetch error"
     } else if (exception is FirebaseRemoteConfigServerException) {
       details["code"] = "remote-config-server-error"
       details["message"] = exception.message
@@ -244,7 +247,7 @@ class FirebaseRemoteConfigPlugin :
       }
     } else {
       details["code"] = "unknown"
-      details["message"] = "unknown remote config error"
+      details["message"] = exception?.message ?: "unknown remote config error"
     }
     callback(Result.failure(FlutterError("firebase_remote_config", exception?.message, details)))
   }

--- a/packages/firebase_remote_config/firebase_remote_config/lib/src/firebase_remote_config.dart
+++ b/packages/firebase_remote_config/firebase_remote_config/lib/src/firebase_remote_config.dart
@@ -75,6 +75,27 @@ class FirebaseRemoteConfig extends FirebasePlugin {
   }
 
   /// Fetches and caches configuration from the Remote Config service.
+  ///
+  /// A [FirebaseException] may be thrown with one of the following codes:
+  /// - **network-error**:
+  ///  - Thrown if the Remote Config backend could not be reached, for example
+  ///    when the device has no data connection, the request timed out or the
+  ///    host could not be resolved. Transient, the fetch can be retried.
+  /// - **cancelled**:
+  ///  - Thrown if the fetch was cancelled before it completed. Transient.
+  /// - **throttled**:
+  ///  - Thrown if the frequency of requests exceeds the throttled limits.
+  /// - **forbidden**:
+  ///  - Thrown if the Google Cloud Platform Firebase Remote Config API is
+  ///    disabled for the project.
+  /// - **remote-config-server-error**:
+  ///  - Thrown if the Remote Config backend answered with an error status.
+  /// - **internal** or **unknown**:
+  ///  - Thrown if the failure could not be classified. Read
+  ///    [FirebaseException.message] for the description the native SDK gave.
+  ///
+  /// On the web the codes come from the Firebase JavaScript SDK instead, for
+  /// example `fetch-client-network`, `fetch-timeout` and `fetch-throttle`.
   Future<void> fetch() {
     return _delegate.fetch();
   }
@@ -82,9 +103,8 @@ class FirebaseRemoteConfig extends FirebasePlugin {
   /// Performs a fetch and activate operation, as a convenience.
   ///
   /// Returns [bool] in the same way that is done for [activate].
-  /// A [FirebaseException] maybe thrown with the following error code:
-  /// - **forbidden**:
-  ///  - Thrown if the Google Cloud Platform Firebase Remote Config API is disabled
+  ///
+  /// Throws the same [FirebaseException] codes as [fetch].
   Future<bool> fetchAndActivate() async {
     bool configChanged = await _delegate.fetchAndActivate();
     return configChanged;

--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/lib/src/method_channel/utils/error_code.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/lib/src/method_channel/utils/error_code.dart
@@ -1,0 +1,69 @@
+// Copyright 2026, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// The codes the native SDKs report when they could not tell us what went
+/// wrong, and which therefore carry no information a caller can act on.
+const Set<String> _genericCodes = <String>{'internal', 'unknown'};
+
+/// Message fragments the native SDKs use for a fetch that could not reach the
+/// Remote Config backend.
+const List<String> _networkFragments = <String>[
+  'data connection is not currently allowed',
+  'network',
+  'unable to resolve host',
+  'no internet',
+  'offline',
+  'unreachable',
+  'connection refused',
+  'connection reset',
+  'connection lost',
+  'timed out',
+  'timeout',
+];
+
+/// Message fragments the native SDKs use for a fetch that was cancelled.
+const List<String> _cancelledFragments = <String>['cancelled', 'canceled'];
+
+/// The HTTP status the backend replied with, as the native SDKs word it, e.g.
+/// `Internal Error. Status code: 503`.
+final RegExp _httpStatus = RegExp(r'status(?:\s+code)?:?\s*(\d{3})');
+
+/// Turns a generic native error code into a code describing what actually
+/// failed, so that callers can tell transient failures apart from real ones.
+///
+/// Every failure that is not throttling or a server error arrives from the
+/// native SDKs as `internal` or `unknown`, which is why the native message is
+/// the only thing left to classify on. Codes the native SDKs already
+/// classified, and messages that cannot be classified, are returned unchanged.
+String refineRemoteConfigErrorCode(String? code, String? message) {
+  if (code == null || !_genericCodes.contains(code) || message == null) {
+    return code ?? 'unknown';
+  }
+
+  final String lowerCaseMessage = message.toLowerCase();
+
+  final Match? status = _httpStatus.firstMatch(lowerCaseMessage);
+  if (status != null) {
+    final int? statusCode = int.tryParse(status.group(1)!);
+    if (statusCode == 403) {
+      return 'forbidden';
+    }
+    if (statusCode == 429) {
+      return 'throttled';
+    }
+    if (statusCode != null && statusCode >= 400) {
+      return 'remote-config-server-error';
+    }
+  }
+
+  if (_cancelledFragments.any(lowerCaseMessage.contains)) {
+    return 'cancelled';
+  }
+
+  if (_networkFragments.any(lowerCaseMessage.contains)) {
+    return 'network-error';
+  }
+
+  return code;
+}

--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/lib/src/method_channel/utils/exception.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/lib/src/method_channel/utils/exception.dart
@@ -8,10 +8,41 @@ import 'package:flutter/services.dart';
 
 import 'package:_flutterfire_internals/_flutterfire_internals.dart';
 
+import 'error_code.dart';
+
 /// Catches a [PlatformException] and returns an [Exception].
 ///
 /// If the [Exception] is a [PlatformException], a [FirebaseException] is returned.
+///
+/// The native SDKs report anything that is not throttling or a server error as
+/// `internal` or `unknown`, so the code is refined from the native message
+/// where possible, see [refineRemoteConfigErrorCode].
 Never convertPlatformException(Object exception, StackTrace stackTrace) {
+  if (exception is PlatformException) {
+    final FirebaseException firebaseException =
+        platformExceptionToFirebaseException(
+      exception,
+      plugin: 'firebase_remote_config',
+    );
+
+    final String code = refineRemoteConfigErrorCode(
+      firebaseException.code,
+      firebaseException.message,
+    );
+
+    if (code != firebaseException.code) {
+      Error.throwWithStackTrace(
+        FirebaseException(
+          plugin: firebaseException.plugin,
+          code: code,
+          message: firebaseException.message,
+          stackTrace: firebaseException.stackTrace,
+        ),
+        stackTrace == StackTrace.empty ? StackTrace.current : stackTrace,
+      );
+    }
+  }
+
   convertPlatformExceptionToFirebaseException(
     exception,
     stackTrace,

--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/lib/src/platform_interface/platform_interface_firebase_remote_config.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/lib/src/platform_interface/platform_interface_firebase_remote_config.dart
@@ -115,6 +115,27 @@ abstract class FirebaseRemoteConfigPlatform extends PlatformInterface {
   }
 
   /// Fetches and caches configuration from the Remote Config service.
+  ///
+  /// A [FirebaseException] may be thrown with one of the following codes:
+  /// - **network-error**:
+  ///  - Thrown if the Remote Config backend could not be reached, for example
+  ///    when the device has no data connection, the request timed out or the
+  ///    host could not be resolved. Transient, the fetch can be retried.
+  /// - **cancelled**:
+  ///  - Thrown if the fetch was cancelled before it completed. Transient.
+  /// - **throttled**:
+  ///  - Thrown if the frequency of requests exceeds the throttled limits.
+  /// - **forbidden**:
+  ///  - Thrown if the Google Cloud Platform Firebase Remote Config API is
+  ///    disabled for the project.
+  /// - **remote-config-server-error**:
+  ///  - Thrown if the Remote Config backend answered with an error status.
+  /// - **internal** or **unknown**:
+  ///  - Thrown if the failure could not be classified. Read
+  ///    [FirebaseException.message] for the description the native SDK gave.
+  ///
+  /// On the web the codes come from the Firebase JavaScript SDK instead, for
+  /// example `fetch-client-network`, `fetch-timeout` and `fetch-throttle`.
   Future<void> fetch() {
     throw UnimplementedError('fetch() is not implemented');
   }
@@ -122,9 +143,8 @@ abstract class FirebaseRemoteConfigPlatform extends PlatformInterface {
   /// Performs a fetch and activate operation, as a convenience.
   ///
   /// Returns [bool] in the same way that is done for [activate].
-  /// A [FirebaseException] maybe thrown with the following error code:
-  /// - **forbidden**:
-  ///  - Thrown if the Google Cloud Platform Firebase Remote Config API is disabled
+  ///
+  /// Throws the same [FirebaseException] codes as [fetch].
   Future<bool> fetchAndActivate() {
     throw UnimplementedError('fetchAndActivate() is not implemented');
   }

--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/test/method_channel/utils/exception_test.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/test/method_channel/utils/exception_test.dart
@@ -1,0 +1,168 @@
+// Copyright 2026, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_remote_config_platform_interface/src/method_channel/utils/error_code.dart';
+import 'package:firebase_remote_config_platform_interface/src/method_channel/utils/exception.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('refineRemoteConfigErrorCode', () {
+    test('classifies a missing data connection as a network error', () {
+      // Android, through `FirebaseRemoteConfigClientException`.
+      expect(
+        refineRemoteConfigErrorCode(
+          'internal',
+          'A data connection is not currently allowed.',
+        ),
+        'network-error',
+      );
+      expect(
+        refineRemoteConfigErrorCode(
+          'internal',
+          'Failed to get installations token. A data connection is not '
+              'currently allowed.',
+        ),
+        'network-error',
+      );
+    });
+
+    test('classifies other connectivity failures as a network error', () {
+      for (final String message in <String>[
+        'Fetch failed: Unable to resolve host "firebaseremoteconfig.googleapis.com"',
+        'The request timed out.',
+        'The Internet connection appears to be offline.',
+        'Network error (such as timeout or unreachable host) has occurred.',
+      ]) {
+        expect(
+          refineRemoteConfigErrorCode('internal', message),
+          'network-error',
+          reason: message,
+        );
+      }
+    });
+
+    test('classifies a cancelled fetch', () {
+      expect(refineRemoteConfigErrorCode('internal', 'cancelled'), 'cancelled');
+      expect(refineRemoteConfigErrorCode('unknown', 'Canceled'), 'cancelled');
+    });
+
+    test('classifies a backend status code', () {
+      expect(
+        refineRemoteConfigErrorCode(
+          'internal',
+          'Internal Error. Status code: 503',
+        ),
+        'remote-config-server-error',
+      );
+      expect(
+        refineRemoteConfigErrorCode(
+          'internal',
+          'Internal Error. Status code: 403',
+        ),
+        'forbidden',
+      );
+      expect(
+        refineRemoteConfigErrorCode(
+          'internal',
+          'Internal Error. Status code: 429',
+        ),
+        'throttled',
+      );
+    });
+
+    test('leaves an informative status code alone', () {
+      expect(
+        refineRemoteConfigErrorCode('internal', 'Status code: 200'),
+        'internal',
+      );
+    });
+
+    test('leaves codes the native SDKs classified alone', () {
+      expect(
+        refineRemoteConfigErrorCode(
+          'throttled',
+          'frequency of requests exceeds throttled limits',
+        ),
+        'throttled',
+      );
+      expect(
+        refineRemoteConfigErrorCode(
+          'forbidden',
+          'A data connection is not currently allowed.',
+        ),
+        'forbidden',
+      );
+    });
+
+    test('leaves a message it cannot classify alone', () {
+      expect(
+        refineRemoteConfigErrorCode(
+          'internal',
+          'internal remote config fetch error',
+        ),
+        'internal',
+      );
+      expect(refineRemoteConfigErrorCode('internal', null), 'internal');
+      expect(refineRemoteConfigErrorCode(null, 'cancelled'), 'unknown');
+    });
+  });
+
+  group('convertPlatformException', () {
+    test('throws a FirebaseException with the refined code', () {
+      expect(
+        () => convertPlatformException(
+          PlatformException(
+            code: 'firebase_remote_config',
+            message: 'A data connection is not currently allowed.',
+            details: <String, Object?>{
+              'code': 'internal',
+              'message': 'A data connection is not currently allowed.',
+            },
+          ),
+          StackTrace.empty,
+        ),
+        throwsA(
+          isA<FirebaseException>()
+              .having((e) => e.plugin, 'plugin', 'firebase_remote_config')
+              .having((e) => e.code, 'code', 'network-error')
+              .having(
+                (e) => e.message,
+                'message',
+                'A data connection is not currently allowed.',
+              ),
+        ),
+      );
+    });
+
+    test('keeps the code the native SDK reported', () {
+      expect(
+        () => convertPlatformException(
+          PlatformException(
+            code: 'firebase_remote_config',
+            message: 'frequency of requests exceeds throttled limits',
+            details: <String, Object?>{
+              'code': 'throttled',
+              'message': 'frequency of requests exceeds throttled limits',
+            },
+          ),
+          StackTrace.empty,
+        ),
+        throwsA(
+          isA<FirebaseException>().having((e) => e.code, 'code', 'throttled'),
+        ),
+      );
+    });
+
+    test('rethrows anything that is not a PlatformException', () {
+      final error = StateError('nope');
+
+      expect(
+        () => convertPlatformException(error, StackTrace.empty),
+        throwsA(same(error)),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

- Classifies the Remote Config failures that all arrived as `[firebase_remote_config/internal]` (or `unknown`), so callers can tell a transient failure from a real one and stop reporting tens of thousands of unactionable events. New codes are `network-error` (no data connection, timeout, host not resolved) and `cancelled`; a backend status in the native message now maps onto the existing `forbidden`, `throttled` and `remote-config-server-error` codes. `internal`/`unknown` stay as the fallback, so nothing that is already classified changes. The full list is documented on `fetch()` and `fetchAndActivate()`.
- The classification is a pure function in the platform interface, applied where the plugin already converts platform exceptions, so it covers Android, Apple and Windows from one place and is unit tested against the exact native messages from the report. Android additionally stops replacing the native message with `internal remote config fetch error`, which is what makes those failures classifiable at all - and is the part of umbrella #9943 that applies here.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/10904
- Part of https://github.com/firebase/flutterfire/issues/9943

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
