### PR TITLE
feat: bump Firebase iOS SDK to 12.18.0

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Package.swift
+++ b/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "6.8.0"
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "cloud_firestore",

--- a/packages/cloud_firestore/cloud_firestore/macos/cloud_firestore/Package.swift
+++ b/packages/cloud_firestore/cloud_firestore/macos/cloud_firestore/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "6.8.0"
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "cloud_firestore",

--- a/packages/cloud_functions/cloud_functions/ios/cloud_functions/Package.swift
+++ b/packages/cloud_functions/cloud_functions/ios/cloud_functions/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "cloud_functions",

--- a/packages/cloud_functions/cloud_functions/macos/cloud_functions/Package.swift
+++ b/packages/cloud_functions/cloud_functions/macos/cloud_functions/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "cloud_functions",

--- a/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics/Package.swift
+++ b/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics/Package.swift
@@ -8,7 +8,7 @@
 import Foundation
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 // Set FIREBASE_ANALYTICS_WITHOUT_ADID=true to use FirebaseAnalyticsCore.
 // e.g. FIREBASE_ANALYTICS_WITHOUT_ADID=true flutter build ios

--- a/packages/firebase_analytics/firebase_analytics/macos/firebase_analytics/Package.swift
+++ b/packages/firebase_analytics/firebase_analytics/macos/firebase_analytics/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_analytics",

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Package.swift
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_app_check",

--- a/packages/firebase_app_check/firebase_app_check/macos/firebase_app_check/Package.swift
+++ b/packages/firebase_app_check/firebase_app_check/macos/firebase_app_check/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_app_check",

--- a/packages/firebase_app_installations/firebase_app_installations/ios/firebase_app_installations/Package.swift
+++ b/packages/firebase_app_installations/firebase_app_installations/ios/firebase_app_installations/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_app_installations",

--- a/packages/firebase_app_installations/firebase_app_installations/macos/firebase_app_installations/Package.swift
+++ b/packages/firebase_app_installations/firebase_app_installations/macos/firebase_app_installations/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_app_installations",

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Package.swift
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "6.5.7"
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_auth",

--- a/packages/firebase_auth/firebase_auth/macos/firebase_auth/Package.swift
+++ b/packages/firebase_auth/firebase_auth/macos/firebase_auth/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "6.5.7"
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_auth",

--- a/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
+++ b/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersionString = "4.13.0"
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_core",

--- a/packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb
+++ b/packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb
@@ -1,4 +1,4 @@
 # https://firebase.google.com/support/release-notes/ios
 def firebase_sdk_version!()
-  '12.17.0'
+  '12.18.0'
 end

--- a/packages/firebase_core/firebase_core/macos/firebase_core/Package.swift
+++ b/packages/firebase_core/firebase_core/macos/firebase_core/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersionString = "4.13.0"
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_core",

--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics/Package.swift
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_crashlytics",

--- a/packages/firebase_crashlytics/firebase_crashlytics/macos/firebase_crashlytics/Package.swift
+++ b/packages/firebase_crashlytics/firebase_crashlytics/macos/firebase_crashlytics/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_crashlytics",

--- a/packages/firebase_database/firebase_database/ios/firebase_database/Package.swift
+++ b/packages/firebase_database/firebase_database/ios/firebase_database/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "12.4.7"
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_database",

--- a/packages/firebase_database/firebase_database/macos/firebase_database/Package.swift
+++ b/packages/firebase_database/firebase_database/macos/firebase_database/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "12.4.7"
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_database",

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/firebase_in_app_messaging/Package.swift
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/firebase_in_app_messaging/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_in_app_messaging",

--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Package.swift
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "16.5.0"
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_messaging",

--- a/packages/firebase_messaging/firebase_messaging/macos/firebase_messaging/Package.swift
+++ b/packages/firebase_messaging/firebase_messaging/macos/firebase_messaging/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "16.5.0"
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_messaging",

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/ios/firebase_ml_model_downloader/Package.swift
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/ios/firebase_ml_model_downloader/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_ml_model_downloader",

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/macos/firebase_ml_model_downloader/Package.swift
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/macos/firebase_ml_model_downloader/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_ml_model_downloader",

--- a/packages/firebase_performance/firebase_performance/ios/firebase_performance/Package.swift
+++ b/packages/firebase_performance/firebase_performance/ios/firebase_performance/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "0.11.4-6"
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_performance",

--- a/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Package.swift
+++ b/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_remote_config",

--- a/packages/firebase_remote_config/firebase_remote_config/macos/firebase_remote_config/Package.swift
+++ b/packages/firebase_remote_config/firebase_remote_config/macos/firebase_remote_config/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_remote_config",

--- a/packages/firebase_storage/firebase_storage/ios/firebase_storage/Package.swift
+++ b/packages/firebase_storage/firebase_storage/ios/firebase_storage/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "13.4.6"
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_storage",

--- a/packages/firebase_storage/firebase_storage/macos/firebase_storage/Package.swift
+++ b/packages/firebase_storage/firebase_storage/macos/firebase_storage/Package.swift
@@ -8,7 +8,7 @@
 import PackageDescription
 
 let libraryVersion = "13.4.6"
-let firebaseSdkVersion: Version = "12.17.0"
+let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(
   name: "firebase_storage",


### PR DESCRIPTION
## Description

Bumps the Firebase iOS SDK pin from 12.17.0 to 12.18.0.

## Related Issues

- Fixes #18592

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/