### PR TITLE
feat: bump Firebase JS SDK to 12.18.0

### DIFF
--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_sdk_version.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_sdk_version.dart
@@ -6,4 +6,4 @@
 part of '../firebase_core_web.dart';
 
 /// The currently supported Firebase JS SDK version.
-const String supportedFirebaseJsSdkVersion = '12.17.0';
+const String supportedFirebaseJsSdkVersion = '12.18.0';


### PR DESCRIPTION
## Description

Bumps the Firebase JS SDK pin from 12.17.0 to 12.18.0.

## Related Issues

- Fixes #18594

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/