### PR TITLE
fix(ai): reuse a persistent http.Client in HttpApiClient

### DIFF
--- a/packages/firebase_ai/firebase_ai/lib/src/client.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/client.dart
@@ -45,10 +45,12 @@ final class HttpApiClient implements ApiClient {
       http.Client? httpClient,
       FutureOr<Map<String, String>> Function()? requestHeaders})
       : _apiKey = apiKey,
-        _httpClient = httpClient,
+        // package:http top-level helpers (http.post, Request.send) create and
+        // close a Client per call, which prevents TCP/TLS connection reuse.
+        _httpClient = httpClient ?? http.Client(),
         _requestHeaders = requestHeaders;
   final String _apiKey;
-  final http.Client? _httpClient;
+  final http.Client _httpClient;
 
   final FutureOr<Map<String, String>> Function()? _requestHeaders;
 
@@ -64,7 +66,7 @@ final class HttpApiClient implements ApiClient {
   Future<Map<String, Object?>> makeRequest(
       Uri uri, Map<String, Object?> body) async {
     final headers = await _headers();
-    final response = await (_httpClient?.post ?? http.post)(
+    final response = await _httpClient.post(
       uri,
       headers: headers,
       body: _utf8Json.encode(body),
@@ -84,7 +86,7 @@ final class HttpApiClient implements ApiClient {
     final request = http.Request('POST', streamUri)
       ..bodyBytes = _utf8Json.encode(body)
       ..headers.addAll(await _headers());
-    final response = await (_httpClient?.send(request) ?? request.send());
+    final response = await _httpClient.send(request);
     if (response.statusCode != 200) {
       final body = await response.stream.bytesToString();
       // Yield a potential error object like a normal result for consistency

--- a/packages/firebase_ai/firebase_ai/test/client_test.dart
+++ b/packages/firebase_ai/firebase_ai/test/client_test.dart
@@ -1,0 +1,102 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:firebase_ai/src/client.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  final uri = Uri.parse('https://example.com/v1/models/test:generateContent');
+  const requestBody = {'prompt': 'hello'};
+  const responseJson = {'ok': true};
+
+  MockClient jsonClient() => MockClient((request) async {
+        return http.Response(
+          jsonEncode(responseJson),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+  MockClient sseClient() => MockClient((request) async {
+        return http.Response(
+          'data: ${jsonEncode(responseJson)}\n',
+          200,
+          headers: {'content-type': 'text/event-stream'},
+        );
+      });
+
+  group('HttpApiClient', () {
+    test('reuses a single Client for unary requests when none is injected',
+        () async {
+      var created = 0;
+
+      await http.runWithClient(() async {
+        final client = HttpApiClient(apiKey: 'test-key');
+        await client.makeRequest(uri, requestBody);
+        await client.makeRequest(uri, requestBody);
+        expect(created, 1);
+      }, () {
+        created++;
+        return jsonClient();
+      });
+    });
+
+    test('reuses a single Client for streaming requests when none is injected',
+        () async {
+      var created = 0;
+
+      await http.runWithClient(() async {
+        final client = HttpApiClient(apiKey: 'test-key');
+        await client.streamRequest(uri, requestBody).drain<void>();
+        await client.streamRequest(uri, requestBody).drain<void>();
+        expect(created, 1);
+      }, () {
+        created++;
+        return sseClient();
+      });
+    });
+
+    test('uses an injected Client for unary and streaming requests', () async {
+      final requests = <http.BaseRequest>[];
+      final mock = MockClient((request) async {
+        requests.add(request);
+        if (request.url.queryParameters['alt'] == 'sse') {
+          return http.Response(
+            'data: ${jsonEncode(responseJson)}\n',
+            200,
+            headers: {'content-type': 'text/event-stream'},
+          );
+        }
+        return http.Response(
+          jsonEncode(responseJson),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final client = HttpApiClient(apiKey: 'test-key', httpClient: mock);
+      await client.makeRequest(uri, requestBody);
+      await client.streamRequest(uri, requestBody).drain<void>();
+
+      expect(requests, hasLength(2));
+      expect(requests.first.method, 'POST');
+      expect(requests.last.method, 'POST');
+      expect(requests.last.url.queryParameters['alt'], 'sse');
+    });
+  });
+}


### PR DESCRIPTION
## Description

`HttpApiClient` fell back to `http.post` / `Request.send()` when no client was injected. Those helpers create and close an `http.Client` per call, which tears down the TCP/TLS connection and forces a fresh handshake on every `generateContent`.

This keeps a long-lived `http.Client` on each `HttpApiClient` (`httpClient ?? http.Client()`) so keep-alive reuse can work for the lifetime of the model. Injected clients are unchanged. `idleTimeout` is still the `dart:io` default (15s); apps that need a longer pool can already pass a tuned `IOClient` via `FirebaseAI.generativeModel(httpClient: …)`.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18602

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Test plan

- [x] `flutter test test/client_test.dart` in `packages/firebase_ai/firebase_ai` (3 tests passed)
- [ ] Confirm default `generateContent` still works against a real backend
- [ ] Optional: two back-to-back calls within 15s should reuse the connection (no extra handshake)

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/