### PR TITLE
fix(auth, android): surface the error code when getIdToken() fails

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,3 +67,4 @@ Liu Zhisong <liuzs0666@gmail.com>
 Ievgenii Kovtun <jeka.ns@gmail.com>
 Dinu-Stefan Rusu <rusudinustefan@gmail.com>
 Marwan Salim Ba Matraf <marwans12@hotmail.com>
+Do Yeong Tak <dyt9120@gmail.com>

--- a/packages/firebase_auth/firebase_auth/android/src/main/kotlin/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPluginException.kt
+++ b/packages/firebase_auth/firebase_auth/android/src/main/kotlin/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPluginException.kt
@@ -12,10 +12,75 @@ import com.google.firebase.auth.FirebaseAuthException
 import com.google.firebase.auth.FirebaseAuthMultiFactorException
 import com.google.firebase.auth.FirebaseAuthUserCollisionException
 import com.google.firebase.auth.FirebaseAuthWeakPasswordException
+import java.io.IOException
 import java.util.UUID
 import java.util.concurrent.ExecutionException
 
 object FlutterFirebaseAuthPluginException {
+  /** The wrapper the Android SDK puts around a failure it has no code for. */
+  private const val INTERNAL_ERROR_PREFIX = "An internal error has occurred."
+
+  /**
+   * Phrases that only ever describe a transport failure. Matched inside the wrapper's brackets,
+   * never against arbitrary text, and never widened without a production message that needs it.
+   */
+  private val IO_MESSAGE_FRAGMENTS =
+      arrayOf(
+          "unexpected end of stream",
+          "Unable to resolve host",
+          "Failed to connect",
+          "Connection reset",
+          "Network is unreachable",
+          "Software caused connection abort",
+          "timed out",
+          "SSL",
+          "Broken pipe")
+
+  /**
+   * True when the exception, or anything it was caused by, is an [IOException]. Walks at most five
+   * levels, so a cause chain that loops cannot spin here.
+   */
+  private fun isIoFailure(throwable: Throwable?): Boolean {
+    var current = throwable
+    var depth = 0
+    while (current != null && depth < 5) {
+      if (current is IOException) {
+        return true
+      }
+      val cause = current.cause
+      if (cause === current) {
+        break
+      }
+      current = cause
+      depth++
+    }
+    return false
+  }
+
+  /**
+   * True when the message is the SDK's "internal error" wrapper and what it wrapped reads as an IO
+   * failure. Only the text between the brackets is examined.
+   */
+  private fun isWrappedIoMessage(message: String?): Boolean {
+    if (message == null || !message.startsWith(INTERNAL_ERROR_PREFIX)) {
+      return false
+    }
+    val open = message.indexOf('[')
+    val close = message.lastIndexOf(']')
+    if (open < 0 || close < open) {
+      return false
+    }
+    val wrapped = message.substring(open + 1, close)
+    return IO_MESSAGE_FRAGMENTS.any { wrapped.contains(it) }
+  }
+
+  private fun networkRequestFailed(): FlutterError {
+    return FlutterError(
+        "network-request-failed",
+        "A network error (such as timeout, interrupted connection or unreachable host) has occurred.",
+        null)
+  }
+
   fun parserExceptionToFlutter(rawException: Exception?): FlutterError {
     if (rawException == null) {
       return FlutterError("UNKNOWN", null, null)
@@ -53,10 +118,36 @@ object FlutterFirebaseAuthPluginException {
 
     if (nativeException is FirebaseNetworkException ||
         nativeException.cause is FirebaseNetworkException) {
-      return FlutterError(
-          "network-request-failed",
-          "A network error (such as timeout, interrupted connection or unreachable host) has occurred.",
-          null)
+      return networkRequestFailed()
+    }
+
+    // A token refresh that loses the connection does not always arrive as a
+    // FirebaseNetworkException. Production (2026-09-05) showed two other shapes,
+    // both reaching Dart as [firebase_auth/unknown]:
+    //
+    //   An internal error has occurred.
+    //       [ unexpected end of stream on com.android.okhttp.Address@f7f69f0a ]
+    //   Failure in SSL library, usually a protocol error
+    //       error:100000d7:SSL routines:OPENSSL_internal:SSL_HANDSHAKE_FAILURE ...
+    //
+    // The second is the IOException itself, so the type check comes first: it
+    // reads what the exception *is*, which covers SSLException,
+    // SocketTimeoutException, UnknownHostException and ConnectException alike
+    // without depending on anyone's wording.
+    if (isIoFailure(nativeException)) {
+      return networkRequestFailed()
+    }
+
+    // The first shape is not reachable by type. The Android SDK wraps the IO
+    // failure in a plain FirebaseException, keeps its text inside the brackets
+    // and drops the cause — verified on the emulator, where the chain is one
+    // level deep and getCause() is null. Only the message survives, so this arm
+    // reads it, and is kept narrow on purpose: the exact wrapper prefix, a fixed
+    // list of IO phrases, matched only inside the brackets, and never against a
+    // FirebaseAuthException, which carries a real error code that must never be
+    // relabelled.
+    if (nativeException !is FirebaseAuthException && isWrappedIoMessage(nativeException.message)) {
+      return networkRequestFailed()
     }
 
     if (nativeException is FirebaseApiNotAvailableException ||

--- a/packages/firebase_auth/firebase_auth/android/src/main/kotlin/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPluginException.kt
+++ b/packages/firebase_auth/firebase_auth/android/src/main/kotlin/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPluginException.kt
@@ -13,12 +13,19 @@ import com.google.firebase.auth.FirebaseAuthMultiFactorException
 import com.google.firebase.auth.FirebaseAuthUserCollisionException
 import com.google.firebase.auth.FirebaseAuthWeakPasswordException
 import java.util.UUID
+import java.util.concurrent.ExecutionException
 
 object FlutterFirebaseAuthPluginException {
-  fun parserExceptionToFlutter(nativeException: Exception?): FlutterError {
-    if (nativeException == null) {
+  fun parserExceptionToFlutter(rawException: Exception?): FlutterError {
+    if (rawException == null) {
       return FlutterError("UNKNOWN", null, null)
     }
+    // Tasks.await() reports a failed Task as an ExecutionException wrapping the
+    // Task's own exception, so the FirebaseAuthException carrying the error
+    // code is the cause. Unwrap it, otherwise every such failure reaches Dart
+    // as "unknown".
+    val nativeException =
+        (rawException as? ExecutionException)?.cause as? Exception ?: rawException
     var code = "UNKNOWN"
     var message = nativeException.message
     val additionalData = HashMap<String, Any?>()

--- a/packages/firebase_auth/firebase_auth/example/integration_test/firebase_auth_user_e2e_test.dart
+++ b/packages/firebase_auth/firebase_auth/example/integration_test/firebase_auth_user_e2e_test.dart
@@ -101,6 +101,33 @@ void main() {
             }
             fail('should have thrown an error');
           });
+
+          test('should surface the error code when a forced refresh is refused',
+              () async {
+            // Demonstrate fix for this issue works: https://github.com/firebase/flutterfire/issues/18561
+            // A refresh the backend refuses (user disabled, deleted, token
+            // revoked) reached Dart as `unknown` on Android, because the
+            // failed Task surfaced as an ExecutionException that hid the
+            // FirebaseAuthException carrying the code.
+            final userCredential =
+                await FirebaseAuth.instance.createUserWithEmailAndPassword(
+              email: generateRandomEmail(),
+              password: testPassword,
+            );
+            final user = userCredential.user!;
+
+            // Disable the account behind the signed-in user's back, then force
+            // a refresh so the SDK has to ask the backend again.
+            await emulatorDisableUser(user.uid);
+
+            try {
+              await user.getIdToken(true);
+            } on FirebaseAuthException catch (e) {
+              expect(e.code, 'user-disabled');
+              return;
+            }
+            fail('should have thrown a FirebaseAuthException');
+          });
         },
         skip: !kIsWeb &&
             (defaultTargetPlatform == TargetPlatform.windows ||


### PR DESCRIPTION
## Description

On Android, a token refresh the backend refuses — the account was disabled or deleted, or its refresh token revoked — reaches Dart from `User.getIdToken()` / `getIdTokenResult()` as `[firebase_auth/unknown]` (message `The user's credential is no longer valid. The user must sign in again.` or `The user account has been disabled by an administrator.`) instead of `user-token-expired` / `user-not-found` / `user-disabled`, the codes iOS and web produce for the same situation. An app that branches on the code to sign a dead session out never sees it on Android.

**Cause.** Since #11362, `getIdToken` awaits the native Task with `Tasks.await()`, which reports a failed Task as a `java.util.concurrent.ExecutionException` wrapping the Task's own exception. `FlutterFirebaseAuthPluginException.parserExceptionToFlutter` only reads the error code off the exception it is handed (`nativeException is FirebaseAuthException`), so the wrapped `FirebaseAuthInvalidUserException` is never looked at and `code` stays `UNKNOWN`. The three network-ish arms already check `cause`, which is why `network-request-failed` survived that change and the auth codes did not.

**Fix.** Unwrap an `ExecutionException` to its cause before classifying. `getIdToken` is the only `Tasks.await` call site in the plugin, so this is the only path affected. The message is unchanged — it already came from the cause through `ExecutionException.getMessage()` and the Dart side's `split(': ').last` — only the code changes.

**Verified** on an Android 13 (API 33) emulator against the Auth emulator: disabling the signed-in account behind its back and forcing a refresh yields `user-disabled` with this change and `unknown` without it. The added e2e test (`firebase_auth_user_e2e_test.dart`, `getIdToken()` group) does the same through the existing `emulatorDisableUser` helper; it passes on iOS and web today and fails on Android without the fix.

## Related Issues

- The `[firebase_auth/unknown] "The user's credential is no longer valid…"` noted in step 3 of #18561's repro is this bug.
- Introduced by #11362.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing. — The new test's flow was verified by hand on the Android emulator (above); I have not run the full e2e suite locally and am relying on CI for it.
- [x] I updated/added relevant documentation (doc comments with `///`). — none needed; the change is internal to the Android plugin.
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR. — not run locally (sparse checkout); the only Dart change is one e2e test written in the surrounding file's style.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA]. — will complete when the CLA check asks.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/