### PR TITLE
chore(release): 2026-08-24 — BoM 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## 2026-08-24
+## 2026-08-24 - [BoM 5.0.0](https://github.com/firebase/flutterfire/blob/main/VERSIONS.md#flutter-bom-500-2026-08-24)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,303 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2026-08-24
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - [`firebase_ai` - `v4.0.0`](#firebase_ai---v400)
+
+Packages with other changes:
+
+ - [`_flutterfire_internals` - `v1.3.77`](#_flutterfire_internals---v1377)
+ - [`cloud_firestore` - `v6.9.0`](#cloud_firestore---v690)
+ - [`cloud_firestore_platform_interface` - `v8.0.7`](#cloud_firestore_platform_interface---v807)
+ - [`cloud_functions` - `v6.4.0`](#cloud_functions---v640)
+ - [`firebase_analytics` - `v12.5.0`](#firebase_analytics---v1250)
+ - [`firebase_analytics_platform_interface` - `v6.0.7`](#firebase_analytics_platform_interface---v607)
+ - [`firebase_app_check` - `v0.4.7`](#firebase_app_check---v047)
+ - [`firebase_app_installations` - `v0.4.3`](#firebase_app_installations---v043)
+ - [`firebase_app_installations_platform_interface` - `v0.1.5`](#firebase_app_installations_platform_interface---v015)
+ - [`firebase_app_installations_web` - `v0.1.7+13`](#firebase_app_installations_web---v01713)
+ - [`firebase_auth` - `v6.6.0`](#firebase_auth---v660)
+ - [`firebase_auth_platform_interface` - `v9.0.7`](#firebase_auth_platform_interface---v907)
+ - [`firebase_core` - `v4.14.0`](#firebase_core---v4140)
+ - [`firebase_core_platform_interface` - `v8.1.1`](#firebase_core_platform_interface---v811)
+ - [`firebase_core_web` - `v3.11.0`](#firebase_core_web---v3110)
+ - [`firebase_crashlytics` - `v5.3.0`](#firebase_crashlytics---v530)
+ - [`firebase_crashlytics_platform_interface` - `v3.9.0`](#firebase_crashlytics_platform_interface---v390)
+ - [`firebase_data_connect` - `v0.3.2`](#firebase_data_connect---v032)
+ - [`firebase_database` - `v12.5.0`](#firebase_database---v1250)
+ - [`firebase_database_web` - `v0.2.7+14`](#firebase_database_web---v02714)
+ - [`firebase_in_app_messaging` - `v0.9.3`](#firebase_in_app_messaging---v093)
+ - [`firebase_in_app_messaging_platform_interface` - `v0.2.5+28`](#firebase_in_app_messaging_platform_interface---v02528)
+ - [`firebase_messaging` - `v16.6.0`](#firebase_messaging---v1660)
+ - [`firebase_messaging_platform_interface` - `v4.10.0`](#firebase_messaging_platform_interface---v4100)
+ - [`firebase_ml_model_downloader` - `v0.4.4`](#firebase_ml_model_downloader---v044)
+ - [`firebase_performance` - `v0.11.5`](#firebase_performance---v0115)
+ - [`firebase_performance_platform_interface` - `v0.2.0+7`](#firebase_performance_platform_interface---v0207)
+ - [`firebase_remote_config` - `v6.6.0`](#firebase_remote_config---v660)
+ - [`firebase_remote_config_platform_interface` - `v3.0.7`](#firebase_remote_config_platform_interface---v307)
+ - [`firebase_storage` - `v13.5.0`](#firebase_storage---v1350)
+ - [`firebase_storage_platform_interface` - `v6.0.7`](#firebase_storage_platform_interface---v607)
+ - [`cloud_firestore_web` - `v5.7.3`](#cloud_firestore_web---v573)
+ - [`firebase_analytics_web` - `v0.6.1+13`](#firebase_analytics_web---v06113)
+ - [`firebase_app_check_platform_interface` - `v0.4.2+1`](#firebase_app_check_platform_interface---v0421)
+ - [`firebase_app_check_web` - `v0.2.6+1`](#firebase_app_check_web---v0261)
+ - [`firebase_database_platform_interface` - `v0.4.0+7`](#firebase_database_platform_interface---v0407)
+ - [`firebase_messaging_web` - `v4.2.5`](#firebase_messaging_web---v425)
+ - [`firebase_performance_web` - `v0.1.8+13`](#firebase_performance_web---v01813)
+ - [`firebase_remote_config_web` - `v1.10.14`](#firebase_remote_config_web---v11014)
+ - [`firebase_storage_web` - `v3.11.13`](#firebase_storage_web---v31113)
+ - [`firebase_auth_web` - `v6.2.7`](#firebase_auth_web---v627)
+ - [`cloud_functions_platform_interface` - `v6.0.7`](#cloud_functions_platform_interface---v607)
+ - [`cloud_functions_web` - `v5.1.13`](#cloud_functions_web---v5113)
+ - [`firebase_ml_model_downloader_platform_interface` - `v0.1.6+1`](#firebase_ml_model_downloader_platform_interface---v0161)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `cloud_firestore_web` - `v5.7.3`
+ - `firebase_analytics_web` - `v0.6.1+13`
+ - `firebase_app_check_platform_interface` - `v0.4.2+1`
+ - `firebase_app_check_web` - `v0.2.6+1`
+ - `firebase_database_platform_interface` - `v0.4.0+7`
+ - `firebase_messaging_web` - `v4.2.5`
+ - `firebase_performance_web` - `v0.1.8+13`
+ - `firebase_remote_config_web` - `v1.10.14`
+ - `firebase_storage_web` - `v3.11.13`
+ - `firebase_auth_web` - `v6.2.7`
+ - `cloud_functions_platform_interface` - `v6.0.7`
+ - `cloud_functions_web` - `v5.1.13`
+ - `firebase_ml_model_downloader_platform_interface` - `v0.1.6+1`
+
+---
+
+#### `firebase_ai` - `v4.0.0`
+
+ - **FIX**(ai): reuse a persistent http.Client in HttpApiClient ([#18603](https://github.com/firebase/flutterfire/issues/18603)). ([87a4137c](https://github.com/firebase/flutterfire/commit/87a4137c08f2eb5c7ba4ba79ded82baa09cafe37))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**(firebaseai): realtime input config ([#18447](https://github.com/firebase/flutterfire/issues/18447)). ([09d423b8](https://github.com/firebase/flutterfire/commit/09d423b800a966fead9eba1f4bdbc322d2720335))
+ - **BREAKING** **REFACTOR**(firebaseai): Removed deprecated Imagen methods and types due to Imagen models being shut down ([#18577](https://github.com/firebase/flutterfire/issues/18577)). ([989a177f](https://github.com/firebase/flutterfire/commit/989a177fb5f3ed93a6c4c0f76d58d2e6ab2b9d87))
+
+#### `_flutterfire_internals` - `v1.3.77`
+
+ - **FIX**(database,windows): fix transaction threwing and native error codes dropped ([#18559](https://github.com/firebase/flutterfire/issues/18559)). ([12f5f32b](https://github.com/firebase/flutterfire/commit/12f5f32b20ad379e7923fd1c22a66ce22f869bf5))
+
+#### `cloud_firestore` - `v6.9.0`
+
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(firestore,android): defer transaction cleanup until stream cancellation ([#18553](https://github.com/firebase/flutterfire/issues/18553)). ([f949c23d](https://github.com/firebase/flutterfire/commit/f949c23d795a9d843ffd1c6deea285a4d9ce5ff3))
+ - **FIX**(android): remove plugin-local AGP and Kotlin Gradle Plugin pins from buildscript blocks ([#18139](https://github.com/firebase/flutterfire/issues/18139)). ([4f6960c4](https://github.com/firebase/flutterfire/commit/4f6960c437da6945e2db2505f4e0a92fef5b76da))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
+#### `cloud_firestore_platform_interface` - `v8.0.7`
+
+ - **REFACTOR**(platform_interface): replace Flutter UI and foundation imports with package:meta ([#18604](https://github.com/firebase/flutterfire/issues/18604)). ([fef6d420](https://github.com/firebase/flutterfire/commit/fef6d42090ea275f07117c085bd04710d9df51bc))
+ - **FIX**(firestore): avoid completing transaction future twice ([#18554](https://github.com/firebase/flutterfire/issues/18554)). ([94e36f1d](https://github.com/firebase/flutterfire/commit/94e36f1da0ad26b3ca74d6bde0799f17a0be5b5e))
+
+#### `cloud_functions` - `v6.4.0`
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(android): remove plugin-local AGP and Kotlin Gradle Plugin pins from buildscript blocks ([#18139](https://github.com/firebase/flutterfire/issues/18139)). ([4f6960c4](https://github.com/firebase/flutterfire/commit/4f6960c437da6945e2db2505f4e0a92fef5b76da))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
+#### `firebase_analytics` - `v12.5.0`
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(android): remove plugin-local AGP and Kotlin Gradle Plugin pins from buildscript blocks ([#18139](https://github.com/firebase/flutterfire/issues/18139)). ([4f6960c4](https://github.com/firebase/flutterfire/commit/4f6960c437da6945e2db2505f4e0a92fef5b76da))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
+#### `firebase_analytics_platform_interface` - `v6.0.7`
+
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+
+#### `firebase_app_check` - `v0.4.7`
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(appcheck,macos): fix how appAttestWithDeviceCheckFallback is working on fallback ([#18568](https://github.com/firebase/flutterfire/issues/18568)). ([a08ff657](https://github.com/firebase/flutterfire/commit/a08ff657a97bc7fe8497830a355322cdb733533b))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(android): remove plugin-local AGP and Kotlin Gradle Plugin pins from buildscript blocks ([#18139](https://github.com/firebase/flutterfire/issues/18139)). ([4f6960c4](https://github.com/firebase/flutterfire/commit/4f6960c437da6945e2db2505f4e0a92fef5b76da))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
+#### `firebase_app_installations` - `v0.4.3`
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **REFACTOR**(app_installations): migrate Android plugin to Kotlin ([#18533](https://github.com/firebase/flutterfire/issues/18533)). ([8a63ccf6](https://github.com/firebase/flutterfire/commit/8a63ccf63c03a1e64c67dbaa442cb8ed3dbff9d4))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+ - **FEAT**(app_installations): add Pigeon support ([#18562](https://github.com/firebase/flutterfire/issues/18562)). ([2d093eb9](https://github.com/firebase/flutterfire/commit/2d093eb9c384f29fdb148289b1245f49a5db6f0c))
+
+#### `firebase_app_installations_platform_interface` - `v0.1.5`
+
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**(app_installations): add Pigeon support ([#18562](https://github.com/firebase/flutterfire/issues/18562)). ([2d093eb9](https://github.com/firebase/flutterfire/commit/2d093eb9c384f29fdb148289b1245f49a5db6f0c))
+
+#### `firebase_app_installations_web` - `v0.1.7+13`
+
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+
+#### `firebase_auth` - `v6.6.0`
+
+ - **REFACTOR**(auth,android): migrate native implementation to Kotlin ([#18582](https://github.com/firebase/flutterfire/issues/18582)). ([6131eddc](https://github.com/firebase/flutterfire/commit/6131eddc724aac2005f839e612617953572422fc))
+ - **REFACTOR**(auth,apple): migrate iOS/macOS plugin implementation to Swift ([#18581](https://github.com/firebase/flutterfire/issues/18581)). ([8d97b561](https://github.com/firebase/flutterfire/commit/8d97b56120900eee4e78bd52577b12831604cce9))
+ - **REFACTOR**(core,android): migrate native implementation to Kotlin ([#18570](https://github.com/firebase/flutterfire/issues/18570)). ([7a0f5856](https://github.com/firebase/flutterfire/commit/7a0f5856cbb2ae64c530dcbdb43b03d43912465c))
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(auth,macos): throw a clear error for unsupported provider sign-in flows ([#18571](https://github.com/firebase/flutterfire/issues/18571)). ([6d48e7c3](https://github.com/firebase/flutterfire/commit/6d48e7c303761d6db9e71188c63a2a3bc3aaefcd))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+ - **DOCS**(auth): update account-exists guidance after fetchSignInMethodsForEmail removal ([#18547](https://github.com/firebase/flutterfire/issues/18547)). ([b0585f0e](https://github.com/firebase/flutterfire/commit/b0585f0e32e40771b62fd711b87e91fc408d8520))
+
+#### `firebase_auth_platform_interface` - `v9.0.7`
+
+ - **REFACTOR**(platform_interface): replace Flutter UI and foundation imports with package:meta ([#18604](https://github.com/firebase/flutterfire/issues/18604)). ([fef6d420](https://github.com/firebase/flutterfire/commit/fef6d42090ea275f07117c085bd04710d9df51bc))
+ - **REFACTOR**(auth,android): migrate native implementation to Kotlin ([#18582](https://github.com/firebase/flutterfire/issues/18582)). ([6131eddc](https://github.com/firebase/flutterfire/commit/6131eddc724aac2005f839e612617953572422fc))
+ - **REFACTOR**(auth,apple): migrate iOS/macOS plugin implementation to Swift ([#18581](https://github.com/firebase/flutterfire/issues/18581)). ([8d97b561](https://github.com/firebase/flutterfire/commit/8d97b56120900eee4e78bd52577b12831604cce9))
+ - **DOCS**(auth): update account-exists guidance after fetchSignInMethodsForEmail removal ([#18547](https://github.com/firebase/flutterfire/issues/18547)). ([b0585f0e](https://github.com/firebase/flutterfire/commit/b0585f0e32e40771b62fd711b87e91fc408d8520))
+
+#### `firebase_core` - `v4.14.0`
+
+ - **REFACTOR**(core,android): migrate native implementation to Kotlin ([#18570](https://github.com/firebase/flutterfire/issues/18570)). ([7a0f5856](https://github.com/firebase/flutterfire/commit/7a0f5856cbb2ae64c530dcbdb43b03d43912465c))
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**(core): bump Firebase Android SDK to 34.18.0 ([#18597](https://github.com/firebase/flutterfire/issues/18597)). ([9bc9d9ce](https://github.com/firebase/flutterfire/commit/9bc9d9ce406e868a958f6e36b2a07682834d0458))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+ - **FEAT**(core): bump Firebase C++ SDK to 13.11.0 ([#18599](https://github.com/firebase/flutterfire/issues/18599)). ([9a357750](https://github.com/firebase/flutterfire/commit/9a357750b28c9b9a5cb4c64e13ea497616a39a22))
+
+#### `firebase_core_platform_interface` - `v8.1.1`
+
+ - **REFACTOR**(core,android): migrate native implementation to Kotlin ([#18570](https://github.com/firebase/flutterfire/issues/18570)). ([7a0f5856](https://github.com/firebase/flutterfire/commit/7a0f5856cbb2ae64c530dcbdb43b03d43912465c))
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(core,crashlytics): drop `flutter_test` from published dependencies ([#18575](https://github.com/firebase/flutterfire/issues/18575)). ([a54439f9](https://github.com/firebase/flutterfire/commit/a54439f91e0d84c169b5f09def5174b590619f0d))
+
+#### `firebase_core_web` - `v3.11.0`
+
+ - **FIX**(core,web): keep App Check registered for secondary Firebase apps ([#18557](https://github.com/firebase/flutterfire/issues/18557)). ([1345dbb3](https://github.com/firebase/flutterfire/commit/1345dbb38af36c2d1c3f6582f474f5520a185021))
+ - **FIX**(core,web): preserve non-JavaScript app errors ([#18552](https://github.com/firebase/flutterfire/issues/18552)). ([e6943a68](https://github.com/firebase/flutterfire/commit/e6943a682f2a6e93076cd068d49ee7c47738c079))
+ - **FEAT**(core): bump Firebase JS SDK to 12.18.0 ([#18598](https://github.com/firebase/flutterfire/issues/18598)). ([f29565bb](https://github.com/firebase/flutterfire/commit/f29565bb191ddc32973f5b3be9fb4173ae3896b4))
+
+#### `firebase_crashlytics` - `v5.3.0`
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **REFACTOR**(crashlytics,apple): migrate iOS/macOS plugin implementation to Swift ([#18560](https://github.com/firebase/flutterfire/issues/18560)). ([80f06a78](https://github.com/firebase/flutterfire/commit/80f06a789dcfeb69eea417ba1725e21007df0432))
+ - **REFACTOR**(crashlytics,android): migrate native implementation to Kotlin ([#18473](https://github.com/firebase/flutterfire/issues/18473)). ([1fb6302a](https://github.com/firebase/flutterfire/commit/1fb6302a4f740329ddaefb9d4ba852fe6b55beaa))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+ - **FEAT**(crashlytics): add Pigeon support ([#18565](https://github.com/firebase/flutterfire/issues/18565)). ([11daba2c](https://github.com/firebase/flutterfire/commit/11daba2cee5d3f919f4f4466e51155fcf4d95f62))
+
+#### `firebase_crashlytics_platform_interface` - `v3.9.0`
+
+ - **REFACTOR**(platform_interface): replace Flutter UI and foundation imports with package:meta ([#18604](https://github.com/firebase/flutterfire/issues/18604)). ([fef6d420](https://github.com/firebase/flutterfire/commit/fef6d42090ea275f07117c085bd04710d9df51bc))
+ - **FIX**(core,crashlytics): drop `flutter_test` from published dependencies ([#18575](https://github.com/firebase/flutterfire/issues/18575)). ([a54439f9](https://github.com/firebase/flutterfire/commit/a54439f91e0d84c169b5f09def5174b590619f0d))
+ - **FEAT**(crashlytics): add Pigeon support ([#18565](https://github.com/firebase/flutterfire/issues/18565)). ([11daba2c](https://github.com/firebase/flutterfire/commit/11daba2cee5d3f919f4f4466e51155fcf4d95f62))
+
+#### `firebase_data_connect` - `v0.3.2`
+
+ - **REFACTOR**(tests): update listener completion logic and improve WebSocket channel handling ([#18524](https://github.com/firebase/flutterfire/issues/18524)). ([6b1fbc93](https://github.com/firebase/flutterfire/commit/6b1fbc93793db381a7d6d8cfb1a6cb4c8f078d9a))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**(sql_connect): update websocket URL for GSLB soft stickiness ([#18531](https://github.com/firebase/flutterfire/issues/18531)). ([5283f143](https://github.com/firebase/flutterfire/commit/5283f1431f9e48e4062c0bbf972c1b558e505014))
+
+#### `firebase_database` - `v12.5.0`
+
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(database,windows): fix transaction threwing and native error codes dropped ([#18559](https://github.com/firebase/flutterfire/issues/18559)). ([12f5f32b](https://github.com/firebase/flutterfire/commit/12f5f32b20ad379e7923fd1c22a66ce22f869bf5))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
+#### `firebase_database_web` - `v0.2.7+14`
+
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+
+#### `firebase_in_app_messaging` - `v0.9.3`
+
+ - **REFACTOR**(in_app_messaging): migrate platform channels to Pigeon ([#18529](https://github.com/firebase/flutterfire/issues/18529)). ([17c4d6fd](https://github.com/firebase/flutterfire/commit/17c4d6fda76cfe2010b22811fb71d8211b8bcca2))
+ - **REFACTOR**(in_app_messaging): migrate iOS plugin to Swift ([#18528](https://github.com/firebase/flutterfire/issues/18528)). ([10cf4aa9](https://github.com/firebase/flutterfire/commit/10cf4aa9513d8d2b4c24281915483a27d24b04bb))
+ - **REFACTOR**(in_app_messaging): migrate Android plugin to Kotlin ([#18526](https://github.com/firebase/flutterfire/issues/18526)). ([f8ec3482](https://github.com/firebase/flutterfire/commit/f8ec3482aa711488b42a107757e1992078db35eb))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
+#### `firebase_in_app_messaging_platform_interface` - `v0.2.5+28`
+
+ - **REFACTOR**(in_app_messaging): migrate platform channels to Pigeon ([#18529](https://github.com/firebase/flutterfire/issues/18529)). ([17c4d6fd](https://github.com/firebase/flutterfire/commit/17c4d6fda76cfe2010b22811fb71d8211b8bcca2))
+
+#### `firebase_messaging` - `v16.6.0`
+
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(messaging,android): fixing an issue with analytics being triggered twice ([#18544](https://github.com/firebase/flutterfire/issues/18544)). ([ef1cac4c](https://github.com/firebase/flutterfire/commit/ef1cac4c0c5154921f70400d46a5d0eeade2dab0))
+ - **FIX**(messaging,macos): unwrap UNNotificationResponse launch payload ([#18527](https://github.com/firebase/flutterfire/issues/18527)). ([584acc9f](https://github.com/firebase/flutterfire/commit/584acc9fb2d805733c33060b875b674b9d434a7e))
+ - **FIX**(messaging,android): fix an issue that could cause duplicate call stack ([#18122](https://github.com/firebase/flutterfire/issues/18122)). ([1522bd8f](https://github.com/firebase/flutterfire/commit/1522bd8f7771da70508fa26422fc9447e3ffa8ad))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+ - **FEAT**(messaging,ios): migrate example iOS runner from ObjC to Swift ([#18578](https://github.com/firebase/flutterfire/issues/18578)). ([69d16e44](https://github.com/firebase/flutterfire/commit/69d16e44cb7f70d8eaaed3e4fe9d2a186194e3d4))
+ - **FEAT**(messaging,android): improve how messaging is determining permission on Android ([#18101](https://github.com/firebase/flutterfire/issues/18101)). ([1c89b686](https://github.com/firebase/flutterfire/commit/1c89b686209c79ef800e61885bcbfbd555b589ee))
+
+#### `firebase_messaging_platform_interface` - `v4.10.0`
+
+ - **FEAT**(messaging,android): improve how messaging is determining permission on Android ([#18101](https://github.com/firebase/flutterfire/issues/18101)). ([1c89b686](https://github.com/firebase/flutterfire/commit/1c89b686209c79ef800e61885bcbfbd555b589ee))
+
+#### `firebase_ml_model_downloader` - `v0.4.4`
+
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
+#### `firebase_performance` - `v0.11.5`
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(android): remove plugin-local AGP and Kotlin Gradle Plugin pins from buildscript blocks ([#18139](https://github.com/firebase/flutterfire/issues/18139)). ([4f6960c4](https://github.com/firebase/flutterfire/commit/4f6960c437da6945e2db2505f4e0a92fef5b76da))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
+#### `firebase_performance_platform_interface` - `v0.2.0+7`
+
+ - **REFACTOR**(platform_interface): replace Flutter UI and foundation imports with package:meta ([#18604](https://github.com/firebase/flutterfire/issues/18604)). ([fef6d420](https://github.com/firebase/flutterfire/commit/fef6d42090ea275f07117c085bd04710d9df51bc))
+
+#### `firebase_remote_config` - `v6.6.0`
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(remote_config): classify fetch failures instead of reporting them all as `internal` ([#18585](https://github.com/firebase/flutterfire/issues/18585)). ([128912e8](https://github.com/firebase/flutterfire/commit/128912e884c815b498ff943cd7b38838104d89f0))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(android): remove plugin-local AGP and Kotlin Gradle Plugin pins from buildscript blocks ([#18139](https://github.com/firebase/flutterfire/issues/18139)). ([4f6960c4](https://github.com/firebase/flutterfire/commit/4f6960c437da6945e2db2505f4e0a92fef5b76da))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
+#### `firebase_remote_config_platform_interface` - `v3.0.7`
+
+ - **REFACTOR**(platform_interface): replace Flutter UI and foundation imports with package:meta ([#18604](https://github.com/firebase/flutterfire/issues/18604)). ([fef6d420](https://github.com/firebase/flutterfire/commit/fef6d42090ea275f07117c085bd04710d9df51bc))
+ - **FIX**(remote_config): classify fetch failures instead of reporting them all as `internal` ([#18585](https://github.com/firebase/flutterfire/issues/18585)). ([128912e8](https://github.com/firebase/flutterfire/commit/128912e884c815b498ff943cd7b38838104d89f0))
+
+#### `firebase_storage` - `v13.5.0`
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(android): remove plugin-local AGP and Kotlin Gradle Plugin pins from buildscript blocks ([#18139](https://github.com/firebase/flutterfire/issues/18139)). ([4f6960c4](https://github.com/firebase/flutterfire/commit/4f6960c437da6945e2db2505f4e0a92fef5b76da))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
+#### `firebase_storage_platform_interface` - `v6.0.7`
+
+ - **REFACTOR**(platform_interface): replace Flutter UI and foundation imports with package:meta ([#18604](https://github.com/firebase/flutterfire/issues/18604)). ([fef6d420](https://github.com/firebase/flutterfire/commit/fef6d42090ea275f07117c085bd04710d9df51bc))
+
+
 ## 2026-08-03 - [BoM 4.18.0](https://github.com/firebase/flutterfire/blob/main/VERSIONS.md#flutter-bom-4180-2026-08-03)
 
 ### Changes

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,44 @@ This document is listing all the compatible versions of the FlutterFire plugins.
 
 # Versions
 
+## [Flutter BoM 5.0.0 (2026-08-24)](https://github.com/firebase/flutterfire/blob/main/CHANGELOG.md#2026-08-24)
+
+Install this version using FlutterFire CLI
+
+```bash
+flutterfire install 5.0.0
+```
+
+### Included Native Firebase SDK Versions
+| Firebase SDK | Version | Link |
+|--------------|---------|------|
+| Android SDK | 34.18.0 | [Release Notes](https://firebase.google.com/support/release-notes/android) |
+| iOS SDK | 12.18.0 | [Release Notes](https://firebase.google.com/support/release-notes/ios) |
+| Web SDK | 12.18.0 | [Release Notes](https://firebase.google.com/support/release-notes/js) |
+| Windows SDK | 13.11.0 | [Release Notes](https://firebase.google.com/support/release-notes/cpp-relnotes) |
+
+### FlutterFire Plugin Versions
+| Plugin | Version | Dart Version | Flutter Version |
+|--------|---------|--------------|-----------------|
+| [cloud_firestore](https://pub.dev/packages/cloud_firestore/versions/6.9.0) | 6.9.0 | ^3.6.0 | >=3.27.0 |
+| [cloud_functions](https://pub.dev/packages/cloud_functions/versions/6.4.0) | 6.4.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_ai](https://pub.dev/packages/firebase_ai/versions/4.0.0) | 4.0.0 | ^3.6.0 | >=3.16.0 |
+| [firebase_analytics](https://pub.dev/packages/firebase_analytics/versions/12.5.0) | 12.5.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_app_check](https://pub.dev/packages/firebase_app_check/versions/0.4.7) | 0.4.7 | ^3.6.0 | >=3.27.0 |
+| [firebase_app_installations](https://pub.dev/packages/firebase_app_installations/versions/0.4.3) | 0.4.3 | ^3.6.0 | >=3.27.0 |
+| [firebase_auth](https://pub.dev/packages/firebase_auth/versions/6.6.0) | 6.6.0 | ^3.6.0 | >=3.16.0 |
+| [firebase_core](https://pub.dev/packages/firebase_core/versions/4.14.0) | 4.14.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_crashlytics](https://pub.dev/packages/firebase_crashlytics/versions/5.3.0) | 5.3.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_data_connect](https://pub.dev/packages/firebase_data_connect/versions/0.3.2) | 0.3.2 | ^3.6.0 | >=3.27.0 |
+| [firebase_database](https://pub.dev/packages/firebase_database/versions/12.5.0) | 12.5.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_in_app_messaging](https://pub.dev/packages/firebase_in_app_messaging/versions/0.9.3) | 0.9.3 | ^3.6.0 | >=3.27.0 |
+| [firebase_messaging](https://pub.dev/packages/firebase_messaging/versions/16.6.0) | 16.6.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_ml_model_downloader](https://pub.dev/packages/firebase_ml_model_downloader/versions/0.4.4) | 0.4.4 | ^3.6.0 | >=3.27.0 |
+| [firebase_performance](https://pub.dev/packages/firebase_performance/versions/0.11.5) | 0.11.5 | ^3.6.0 | >=3.27.0 |
+| [firebase_remote_config](https://pub.dev/packages/firebase_remote_config/versions/6.6.0) | 6.6.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_storage](https://pub.dev/packages/firebase_storage/versions/13.5.0) | 13.5.0 | ^3.6.0 | >=3.27.0 |
+
+
 ## [Flutter BoM 4.18.0 (2026-08-03)](https://github.com/firebase/flutterfire/blob/main/CHANGELOG.md#2026-08-03)
 
 Install this version using FlutterFire CLI

--- a/packages/_flutterfire_internals/CHANGELOG.md
+++ b/packages/_flutterfire_internals/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.77
+
+ - **FIX**(database,windows): fix transaction threwing and native error codes dropped ([#18559](https://github.com/firebase/flutterfire/issues/18559)). ([12f5f32b](https://github.com/firebase/flutterfire/commit/12f5f32b20ad379e7923fd1c22a66ce22f869bf5))
+
 ## 1.3.76
 
  - Update a dependency to the latest release.

--- a/packages/_flutterfire_internals/pubspec.yaml
+++ b/packages/_flutterfire_internals/pubspec.yaml
@@ -2,7 +2,7 @@ name: _flutterfire_internals
 description: A package hosting Dart code shared between FlutterFire plugins.
 homepage: https://firebase.google.com/docs/firestore
 repository: https://github.com/firebase/flutterfire/tree/main/packages/_flutterfire_internals
-version: 1.3.76
+version: 1.3.77
 resolution: workspace
 
 environment:
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   collection: ^1.0.0
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
   flutter:
     sdk: flutter
   meta: ^1.8.0

--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 6.9.0
+
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(firestore,android): defer transaction cleanup until stream cancellation ([#18553](https://github.com/firebase/flutterfire/issues/18553)). ([f949c23d](https://github.com/firebase/flutterfire/commit/f949c23d795a9d843ffd1c6deea285a4d9ce5ff3))
+ - **FIX**(android): remove plugin-local AGP and Kotlin Gradle Plugin pins from buildscript blocks ([#18139](https://github.com/firebase/flutterfire/issues/18139)). ([4f6960c4](https://github.com/firebase/flutterfire/commit/4f6960c437da6945e2db2505f4e0a92fef5b76da))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
 ## 6.8.0
 
  - **FIX**(firestore,core,windows): per-engine BinaryMessenger, Firestore/Auth link order, Profile builds ([#18516](https://github.com/firebase/flutterfire/issues/18516)). ([5dfd289e](https://github.com/firebase/flutterfire/commit/5dfd289ea45260c15d73894dcf2cb092fc8ddb9d))

--- a/packages/cloud_firestore/cloud_firestore/example/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  cloud_firestore: ^6.8.0
-  firebase_core: ^4.13.0
+  cloud_firestore: ^6.9.0
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   http: ^1.0.0

--- a/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Package.swift
+++ b/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "6.8.0"
+let libraryVersion = "6.9.0"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/cloud_firestore/cloud_firestore/macos/cloud_firestore/Package.swift
+++ b/packages/cloud_firestore/cloud_firestore/macos/cloud_firestore/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "6.8.0"
+let libraryVersion = "6.9.0"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/cloud_firestore/cloud_firestore/pipeline_example/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pipeline_example/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   cloud_firestore:
     path: ..
-  firebase_core: ^4.13.0
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   http: ^1.0.0

--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -4,7 +4,7 @@ description:
   live synchronization and offline support on Android and iOS.
 homepage: https://firebase.google.com/docs/firestore
 repository: https://github.com/firebase/flutterfire/tree/main/packages/cloud_firestore/cloud_firestore
-version: 6.8.0
+version: 6.9.0
 resolution: workspace
 topics:
   - firebase
@@ -21,11 +21,11 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  cloud_firestore_platform_interface: ^8.0.6
-  cloud_firestore_web: ^5.7.2
+  cloud_firestore_platform_interface: ^8.0.7
+  cloud_firestore_web: ^5.7.3
   collection: ^1.0.0
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
   flutter:
     sdk: flutter
   meta: ^1.8.0

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.0.7
+
+ - **REFACTOR**(platform_interface): replace Flutter UI and foundation imports with package:meta ([#18604](https://github.com/firebase/flutterfire/issues/18604)). ([fef6d420](https://github.com/firebase/flutterfire/commit/fef6d42090ea275f07117c085bd04710d9df51bc))
+ - **FIX**(firestore): avoid completing transaction future twice ([#18554](https://github.com/firebase/flutterfire/issues/18554)). ([94e36f1d](https://github.com/firebase/flutterfire/commit/94e36f1da0ad26b3ca74d6bde0799f17a0be5b5e))
+
 ## 8.0.6
 
  - **FIX**(firestore,android): clean up Android transaction listeners on completion ([#18475](https://github.com/firebase/flutterfire/issues/18475)). ([ae002c7c](https://github.com/firebase/flutterfire/commit/ae002c7ca8ae405ebc901bfe17e6724a48075bca))

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_firestore_platform_interface
 description: A common platform interface for the cloud_firestore plugin.
-version: 8.0.6
+version: 8.0.7
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/cloud_firestore/cloud_firestore_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/cloud_firestore/cloud_firestore_platform_interface
@@ -10,16 +10,16 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
+  _flutterfire_internals: ^1.3.77
   collection: ^1.15.0
-  firebase_core: ^4.13.0
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.7.3
+
+ - Update a dependency to the latest release.
+
 ## 5.7.2
 
  - **FIX**(firestore): Preserves microseconds when serializing implicit DateTime values ([#18435](https://github.com/firebase/flutterfire/issues/18435)). ([068c3094](https://github.com/firebase/flutterfire/commit/068c30946912d8a3d5f24455fcb4bc00202e60ee))

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/cloud_firestore_version.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/cloud_firestore_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '6.8.0';
+const packageVersion = '6.9.0';

--- a/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: The web implementation of cloud_firestore
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/cloud_firestore/cloud_firestore_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/cloud_firestore/cloud_firestore_web
 
-version: 5.7.2
+version: 5.7.3
 resolution: workspace
 
 environment:
@@ -11,18 +11,18 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
-  cloud_firestore_platform_interface: ^8.0.6
+  _flutterfire_internals: ^1.3.77
+  cloud_firestore_platform_interface: ^8.0.7
   collection: ^1.0.0
-  firebase_core: ^4.13.0
-  firebase_core_web: ^3.10.0
+  firebase_core: ^4.14.0
+  firebase_core_web: ^3.11.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/cloud_functions/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 6.4.0
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(android): remove plugin-local AGP and Kotlin Gradle Plugin pins from buildscript blocks ([#18139](https://github.com/firebase/flutterfire/issues/18139)). ([4f6960c4](https://github.com/firebase/flutterfire/commit/4f6960c437da6945e2db2505f4e0a92fef5b76da))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
 ## 6.3.6
 
  - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))

--- a/packages/cloud_functions/cloud_functions/example/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  cloud_functions: ^6.3.6
-  firebase_core: ^4.13.0
+  cloud_functions: ^6.4.0
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
 

--- a/packages/cloud_functions/cloud_functions/ios/cloud_functions/Sources/cloud_functions/Constants.swift
+++ b/packages/cloud_functions/cloud_functions/ios/cloud_functions/Sources/cloud_functions/Constants.swift
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// Auto-generated file. Do not edit.
-public let versionNumber = "6.3.6"
+public let versionNumber = "6.4.0"

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: A Flutter plugin allowing you to use Firebase Cloud Functions.
-version: 6.3.6
+version: 6.4.0
 resolution: workspace
 homepage: https://firebase.google.com/docs/functions
 repository: https://github.com/firebase/flutterfire/tree/main/packages/cloud_functions/cloud_functions
@@ -18,10 +18,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  cloud_functions_platform_interface: ^6.0.6
-  cloud_functions_web: ^5.1.12
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
+  cloud_functions_platform_interface: ^6.0.7
+  cloud_functions_web: ^5.1.13
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
   flutter:
     sdk: flutter
 

--- a/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.7
+
+ - Update a dependency to the latest release.
+
 ## 6.0.6
 
  - Update a dependency to the latest release.

--- a/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/firebase/flutterfire/tree/main/packages/cloud_fun
 
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 6.0.6
+version: 6.0.7
 resolution: workspace
 
 environment:
@@ -13,14 +13,14 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.13
+
+ - Update a dependency to the latest release.
+
 ## 5.1.12
 
  - Update a dependency to the latest release.

--- a/packages/cloud_functions/cloud_functions_web/lib/src/cloud_functions_version.dart
+++ b/packages/cloud_functions/cloud_functions_web/lib/src/cloud_functions_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '6.3.6';
+const packageVersion = '6.4.0';

--- a/packages/cloud_functions/cloud_functions_web/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: The web implementation of cloud_functions
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/cloud_functions/cloud_functions_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/cloud_functions/cloud_functions_web
 
-version: 5.1.12
+version: 5.1.13
 resolution: workspace
 
 environment:
@@ -11,9 +11,9 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  cloud_functions_platform_interface: ^6.0.6
-  firebase_core: ^4.13.0
-  firebase_core_web: ^3.10.0
+  cloud_functions_platform_interface: ^6.0.7
+  firebase_core: ^4.14.0
+  firebase_core_web: ^3.11.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -21,7 +21,7 @@ dependencies:
   web: ^1.1.1
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_ai/firebase_ai/CHANGELOG.md
+++ b/packages/firebase_ai/firebase_ai/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 4.0.0
+
+> Note: This release has breaking changes.
+
+ - **FIX**(ai): reuse a persistent http.Client in HttpApiClient ([#18603](https://github.com/firebase/flutterfire/issues/18603)). ([87a4137c](https://github.com/firebase/flutterfire/commit/87a4137c08f2eb5c7ba4ba79ded82baa09cafe37))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**(firebaseai): realtime input config ([#18447](https://github.com/firebase/flutterfire/issues/18447)). ([09d423b8](https://github.com/firebase/flutterfire/commit/09d423b800a966fead9eba1f4bdbc322d2720335))
+ - **BREAKING** **REFACTOR**(firebaseai): Removed deprecated Imagen methods and types due to Imagen models being shut down ([#18577](https://github.com/firebase/flutterfire/issues/18577)). ([989a177f](https://github.com/firebase/flutterfire/commit/989a177fb5f3ed93a6c4c0f76d58d2e6ab2b9d87))
+
 ## 3.15.0
 
  - **FEAT**(firebaseai): Rename vertexAI to agentPlatform ([#18467](https://github.com/firebase/flutterfire/issues/18467)). ([2f942f28](https://github.com/firebase/flutterfire/commit/2f942f28586a6fcc82b1de454b707633ba8e2e04))

--- a/packages/firebase_ai/firebase_ai/example/pubspec.yaml
+++ b/packages/firebase_ai/firebase_ai/example/pubspec.yaml
@@ -23,9 +23,9 @@ dependencies:
 
   camera: ^0.12.0+1
   cupertino_icons: ^1.0.6
-  firebase_ai: ^3.15.0
-  firebase_core: ^4.13.0
-  firebase_storage: ^13.4.6
+  firebase_ai: ^4.0.0
+  firebase_core: ^4.14.0
+  firebase_storage: ^13.5.0
   flutter:
     sdk: flutter
   flutter_animate: ^4.5.2
@@ -41,7 +41,7 @@ dev_dependencies:
   # `firebase_ai_mock_test.dart` installs a mock platform via
   # `firebase_core_platform_interface/test.dart`, which firebase_core does not
   # re-export.
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter

--- a/packages/firebase_ai/firebase_ai/lib/src/firebaseai_version.dart
+++ b/packages/firebase_ai/firebase_ai/lib/src/firebaseai_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '0.3.1';
+const packageVersion = '4.0.0';

--- a/packages/firebase_ai/firebase_ai/pubspec.yaml
+++ b/packages/firebase_ai/firebase_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_ai
 description: Firebase AI Logic SDK.
-version: 3.15.0
+version: 4.0.0
 resolution: workspace
 homepage: https://firebase.google.com/docs/vertex-ai/get-started?platform=flutter
 topics:
@@ -21,10 +21,10 @@ environment:
   flutter: ">=3.16.0"
 
 dependencies:
-  firebase_app_check: ^0.4.6
-  firebase_auth: ^6.5.7
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
+  firebase_app_check: ^0.4.7
+  firebase_auth: ^6.6.0
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
   flutter:
     sdk: flutter
   http: ^1.1.0

--- a/packages/firebase_analytics/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 12.5.0
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(android): remove plugin-local AGP and Kotlin Gradle Plugin pins from buildscript blocks ([#18139](https://github.com/firebase/flutterfire/issues/18139)). ([4f6960c4](https://github.com/firebase/flutterfire/commit/4f6960c437da6945e2db2505f4e0a92fef5b76da))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
 ## 12.4.6
 
  - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))

--- a/packages/firebase_analytics/firebase_analytics/example/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_analytics: ^12.4.6
-  firebase_core: ^4.13.0
+  firebase_analytics: ^12.5.0
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   in_app_purchase: ^3.2.3

--- a/packages/firebase_analytics/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description:
   solution that provides insight on app usage and user engagement on Android and iOS.
 homepage: https://firebase.google.com/docs/analytics
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_analytics/firebase_analytics
-version: 12.4.6
+version: 12.5.0
 resolution: workspace
 topics:
   - firebase
@@ -20,10 +20,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_analytics_platform_interface: ^6.0.6
-  firebase_analytics_web: ^0.6.1+12
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
+  firebase_analytics_platform_interface: ^6.0.7
+  firebase_analytics_web: ^0.6.1+13
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
   flutter:
     sdk: flutter
 

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.7
+
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+
 ## 6.0.6
 
  - Update a dependency to the latest release.

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_analytics_platform_interface
 description: A common platform interface for the firebase_analytics plugin.
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_analytics/firebase_analytics_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_analytics/firebase_analytics_platform_interface
-version: 6.0.6
+version: 6.0.7
 resolution: workspace
 
 environment:
@@ -10,15 +10,15 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
-  firebase_core: ^4.13.0
+  _flutterfire_internals: ^1.3.77
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   pigeon: 26.3.4

--- a/packages/firebase_analytics/firebase_analytics_web/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1+13
+
+ - Update a dependency to the latest release.
+
 ## 0.6.1+12
 
  - Update a dependency to the latest release.

--- a/packages/firebase_analytics/firebase_analytics_web/lib/src/firebase_analytics_version.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/src/firebase_analytics_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '12.4.6';
+const packageVersion = '12.5.0';

--- a/packages/firebase_analytics/firebase_analytics_web/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_analytics_web
 description: The web implementation of firebase_analytics
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_analytics/firebase_analytics_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_analytics/firebase_analytics_web
-version: 0.6.1+12
+version: 0.6.1+13
 resolution: workspace
 
 environment:
@@ -10,10 +10,10 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
-  firebase_analytics_platform_interface: ^6.0.6
-  firebase_core: ^4.13.0
-  firebase_core_web: ^3.10.0
+  _flutterfire_internals: ^1.3.77
+  firebase_analytics_platform_interface: ^6.0.7
+  firebase_core: ^4.14.0
+  firebase_core_web: ^3.11.0
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/firebase_app_check/firebase_app_check/CHANGELOG.md
+++ b/packages/firebase_app_check/firebase_app_check/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.4.7
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(appcheck,macos): fix how appAttestWithDeviceCheckFallback is working on fallback ([#18568](https://github.com/firebase/flutterfire/issues/18568)). ([a08ff657](https://github.com/firebase/flutterfire/commit/a08ff657a97bc7fe8497830a355322cdb733533b))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(android): remove plugin-local AGP and Kotlin Gradle Plugin pins from buildscript blocks ([#18139](https://github.com/firebase/flutterfire/issues/18139)). ([4f6960c4](https://github.com/firebase/flutterfire/commit/4f6960c437da6945e2db2505f4e0a92fef5b76da))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
 ## 0.4.6
 
  - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))

--- a/packages/firebase_app_check/firebase_app_check/example/pubspec.yaml
+++ b/packages/firebase_app_check/firebase_app_check/example/pubspec.yaml
@@ -11,9 +11,9 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  cloud_firestore: ^6.8.0
-  firebase_app_check: ^0.4.6
-  firebase_core: ^4.13.0
+  cloud_firestore: ^6.9.0
+  firebase_app_check: ^0.4.7
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
 

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/Constants.swift
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/Constants.swift
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// Auto-generated file. Do not edit.
-public let versionNumber = "0.4.6"
+public let versionNumber = "0.4.7"

--- a/packages/firebase_app_check/firebase_app_check/pubspec.yaml
+++ b/packages/firebase_app_check/firebase_app_check/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_app_check
 description: App Check works alongside other Firebase services to help protect your backend resources from abuse, such as billing fraud or phishing.
 homepage: https://firebase.google.com/docs/app-check
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_check/firebase_app_check
-version: 0.4.6
+version: 0.4.7
 resolution: workspace
 topics:
   - firebase
@@ -18,10 +18,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_app_check_platform_interface: ^0.4.2
-  firebase_app_check_web: ^0.2.6
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
+  firebase_app_check_platform_interface: ^0.4.2+1
+  firebase_app_check_web: ^0.2.6+1
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
   flutter:
     sdk: flutter
 

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/CHANGELOG.md
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2+1
+
+ - Update a dependency to the latest release.
+
 ## 0.4.2
 
  - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/pubspec.yaml
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_app_check_platform_interface
 description: A common platform interface for the firebase_app_check plugin.
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_check/firebase_app_check_platform_interface
-version: 0.4.2
+version: 0.4.2+1
 resolution: workspace
 
 environment:
@@ -9,15 +9,15 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
-  firebase_core: ^4.13.0
+  _flutterfire_internals: ^1.3.77
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_app_check/firebase_app_check_web/CHANGELOG.md
+++ b/packages/firebase_app_check/firebase_app_check_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.6+1
+
+ - Update a dependency to the latest release.
+
 ## 0.2.6
 
  - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))

--- a/packages/firebase_app_check/firebase_app_check_web/lib/src/firebase_app_check_version.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/src/firebase_app_check_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '0.4.6';
+const packageVersion = '0.4.7';

--- a/packages/firebase_app_check/firebase_app_check_web/pubspec.yaml
+++ b/packages/firebase_app_check/firebase_app_check_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_app_check_web
 description: The web implementation of firebase_app_check
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_check/firebase_app_check_web
-version: 0.2.6
+version: 0.2.6+1
 resolution: workspace
 
 environment:
@@ -9,10 +9,10 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
-  firebase_app_check_platform_interface: ^0.4.2
-  firebase_core: ^4.13.0
-  firebase_core_web: ^3.10.0
+  _flutterfire_internals: ^1.3.77
+  firebase_app_check_platform_interface: ^0.4.2+1
+  firebase_core: ^4.14.0
+  firebase_core_web: ^3.11.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -21,7 +21,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.3.3
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_app_installations/firebase_app_installations/CHANGELOG.md
+++ b/packages/firebase_app_installations/firebase_app_installations/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.4.3
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **REFACTOR**(app_installations): migrate Android plugin to Kotlin ([#18533](https://github.com/firebase/flutterfire/issues/18533)). ([8a63ccf6](https://github.com/firebase/flutterfire/commit/8a63ccf63c03a1e64c67dbaa442cb8ed3dbff9d4))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+ - **FEAT**(app_installations): add Pigeon support ([#18562](https://github.com/firebase/flutterfire/issues/18562)). ([2d093eb9](https://github.com/firebase/flutterfire/commit/2d093eb9c384f29fdb148289b1245f49a5db6f0c))
+
 ## 0.4.2+7
 
  - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))

--- a/packages/firebase_app_installations/firebase_app_installations/example/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations/example/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
-  firebase_app_installations: ^0.4.2+7
+  firebase_core: ^4.14.0
+  firebase_app_installations: ^0.4.3
   flutter:
     sdk: flutter
 

--- a/packages/firebase_app_installations/firebase_app_installations/ios/firebase_app_installations/Sources/firebase_app_installations/Constants.swift
+++ b/packages/firebase_app_installations/firebase_app_installations/ios/firebase_app_installations/Sources/firebase_app_installations/Constants.swift
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// Auto-generated file. Do not edit.
-public let versionNumber = "0.4.2+7"
+public let versionNumber = "0.4.3"

--- a/packages/firebase_app_installations/firebase_app_installations/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_app_installations
 description: A Flutter plugin allowing you to use Firebase Installations.
-version: 0.4.2+7
+version: 0.4.3
 resolution: workspace
 homepage: https://firebase.google.com/docs/projects/manage-installations#flutter
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_installations/firebase_app_installations
@@ -18,10 +18,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_app_installations_platform_interface: ^0.1.4+75
-  firebase_app_installations_web: ^0.1.7+12
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
+  firebase_app_installations_platform_interface: ^0.1.5
+  firebase_app_installations_web: ^0.1.7+13
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
   flutter:
     sdk: flutter
 

--- a/packages/firebase_app_installations/firebase_app_installations_platform_interface/CHANGELOG.md
+++ b/packages/firebase_app_installations/firebase_app_installations_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.5
+
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**(app_installations): add Pigeon support ([#18562](https://github.com/firebase/flutterfire/issues/18562)). ([2d093eb9](https://github.com/firebase/flutterfire/commit/2d093eb9c384f29fdb148289b1245f49a5db6f0c))
+
 ## 0.1.4+75
 
  - Update a dependency to the latest release.

--- a/packages/firebase_app_installations/firebase_app_installations_platform_interface/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_app_installations_platform_interface
 description: A common platform interface for the firebase_app_installations plugin.
-version: 0.1.4+75
+version: 0.1.5
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_installations/firebase_app_installations_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_installations/firebase_app_installations_platform_interface
@@ -10,15 +10,15 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
-  firebase_core: ^4.13.0
+  _flutterfire_internals: ^1.3.77
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0

--- a/packages/firebase_app_installations/firebase_app_installations_web/CHANGELOG.md
+++ b/packages/firebase_app_installations/firebase_app_installations_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.7+13
+
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+
 ## 0.1.7+12
 
  - Update a dependency to the latest release.

--- a/packages/firebase_app_installations/firebase_app_installations_web/lib/src/firebase_app_installations_version.dart
+++ b/packages/firebase_app_installations/firebase_app_installations_web/lib/src/firebase_app_installations_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '0.4.2+7';
+const packageVersion = '0.4.3';

--- a/packages/firebase_app_installations/firebase_app_installations_web/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_app_installations_web
 description: The web implementation of firebase_app_installations.
-version: 0.1.7+12
+version: 0.1.7+13
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_installations/firebase_app_installations_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_installations/firebase_app_installations_web
@@ -10,17 +10,17 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
-  firebase_app_installations_platform_interface: ^0.1.4+75
-  firebase_core: ^4.13.0
-  firebase_core_web: ^3.10.0
+  _flutterfire_internals: ^1.3.77
+  firebase_app_installations_platform_interface: ^0.1.5
+  firebase_core: ^4.14.0
+  firebase_core_web: ^3.11.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0

--- a/packages/firebase_auth/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 6.6.0
+
+ - **REFACTOR**(auth,android): migrate native implementation to Kotlin ([#18582](https://github.com/firebase/flutterfire/issues/18582)). ([6131eddc](https://github.com/firebase/flutterfire/commit/6131eddc724aac2005f839e612617953572422fc))
+ - **REFACTOR**(auth,apple): migrate iOS/macOS plugin implementation to Swift ([#18581](https://github.com/firebase/flutterfire/issues/18581)). ([8d97b561](https://github.com/firebase/flutterfire/commit/8d97b56120900eee4e78bd52577b12831604cce9))
+ - **REFACTOR**(core,android): migrate native implementation to Kotlin ([#18570](https://github.com/firebase/flutterfire/issues/18570)). ([7a0f5856](https://github.com/firebase/flutterfire/commit/7a0f5856cbb2ae64c530dcbdb43b03d43912465c))
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(auth,macos): throw a clear error for unsupported provider sign-in flows ([#18571](https://github.com/firebase/flutterfire/issues/18571)). ([6d48e7c3](https://github.com/firebase/flutterfire/commit/6d48e7c303761d6db9e71188c63a2a3bc3aaefcd))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+ - **DOCS**(auth): update account-exists guidance after fetchSignInMethodsForEmail removal ([#18547](https://github.com/firebase/flutterfire/issues/18547)). ([b0585f0e](https://github.com/firebase/flutterfire/commit/b0585f0e32e40771b62fd711b87e91fc408d8520))
+
 ## 6.5.7
 
  - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))

--- a/packages/firebase_auth/firebase_auth/example/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/example/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
 
 dependencies:
   barcode_widget: ^2.0.4
-  firebase_auth: ^6.5.7
-  firebase_core: ^4.13.0
-  firebase_messaging: ^16.5.0
+  firebase_auth: ^6.6.0
+  firebase_core: ^4.14.0
+  firebase_messaging: ^16.6.0
   flutter:
     sdk: flutter
   # 7.2.0 is the first release shipping Package.swift; the iOS e2e job builds

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Package.swift
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "6.5.7"
+let libraryVersion = "6.6.0"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_auth/firebase_auth/macos/firebase_auth/Package.swift
+++ b/packages/firebase_auth/firebase_auth/macos/firebase_auth/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "6.5.7"
+let libraryVersion = "6.6.0"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling
   like Google, Facebook and Twitter.
 homepage: https://firebase.google.com/docs/auth
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_auth/firebase_auth
-version: 6.5.7
+version: 6.6.0
 resolution: workspace
 topics:
   - firebase
@@ -21,10 +21,10 @@ environment:
   flutter: '>=3.16.0'
 
 dependencies:
-  firebase_auth_platform_interface: ^9.0.6
-  firebase_auth_web: ^6.2.6
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
+  firebase_auth_platform_interface: ^9.0.7
+  firebase_auth_web: ^6.2.7
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
   flutter:
     sdk: flutter
   meta: ^1.8.0

--- a/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 9.0.7
+
+ - **REFACTOR**(platform_interface): replace Flutter UI and foundation imports with package:meta ([#18604](https://github.com/firebase/flutterfire/issues/18604)). ([fef6d420](https://github.com/firebase/flutterfire/commit/fef6d42090ea275f07117c085bd04710d9df51bc))
+ - **REFACTOR**(auth,android): migrate native implementation to Kotlin ([#18582](https://github.com/firebase/flutterfire/issues/18582)). ([6131eddc](https://github.com/firebase/flutterfire/commit/6131eddc724aac2005f839e612617953572422fc))
+ - **REFACTOR**(auth,apple): migrate iOS/macOS plugin implementation to Swift ([#18581](https://github.com/firebase/flutterfire/issues/18581)). ([8d97b561](https://github.com/firebase/flutterfire/commit/8d97b56120900eee4e78bd52577b12831604cce9))
+ - **DOCS**(auth): update account-exists guidance after fetchSignInMethodsForEmail removal ([#18547](https://github.com/firebase/flutterfire/issues/18547)). ([b0585f0e](https://github.com/firebase/flutterfire/commit/b0585f0e32e40771b62fd711b87e91fc408d8520))
+
 ## 9.0.6
 
  - Update a dependency to the latest release.

--- a/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_au
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_auth/firebase_auth_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 9.0.6
+version: 9.0.7
 resolution: workspace
 
 environment:
@@ -12,9 +12,9 @@ environment:
   flutter: '>=3.16.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
+  _flutterfire_internals: ^1.3.77
   collection: ^1.16.0
-  firebase_core: ^4.13.0
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   http: ^1.1.0
@@ -22,7 +22,7 @@ dependencies:
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.4.0

--- a/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.7
+
+ - Update a dependency to the latest release.
+
 ## 6.2.6
 
  - Update a dependency to the latest release.

--- a/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_version.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '6.5.7';
+const packageVersion = '6.6.0';

--- a/packages/firebase_auth/firebase_auth_web/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_auth_web
 description: The web implementation of firebase_auth
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_auth/firebase_auth_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_auth/firebase_auth_web
-version: 6.2.6
+version: 6.2.7
 resolution: workspace
 
 environment:
@@ -10,9 +10,9 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  firebase_auth_platform_interface: ^9.0.6
-  firebase_core: ^4.13.0
-  firebase_core_web: ^3.10.0
+  firebase_auth_platform_interface: ^9.0.7
+  firebase_core: ^4.14.0
+  firebase_core_web: ^3.11.0
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/firebase_core/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 4.14.0
+
+ - **REFACTOR**(core,android): migrate native implementation to Kotlin ([#18570](https://github.com/firebase/flutterfire/issues/18570)). ([7a0f5856](https://github.com/firebase/flutterfire/commit/7a0f5856cbb2ae64c530dcbdb43b03d43912465c))
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**(core): bump Firebase Android SDK to 34.18.0 ([#18597](https://github.com/firebase/flutterfire/issues/18597)). ([9bc9d9ce](https://github.com/firebase/flutterfire/commit/9bc9d9ce406e868a958f6e36b2a07682834d0458))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+ - **FEAT**(core): bump Firebase C++ SDK to 13.11.0 ([#18599](https://github.com/firebase/flutterfire/issues/18599)). ([9a357750](https://github.com/firebase/flutterfire/commit/9a357750b28c9b9a5cb4c64e13ea497616a39a22))
+
 ## 4.13.0
 
  - **FIX**(firestore,core,windows): per-engine BinaryMessenger, Firestore/Auth link order, Profile builds ([#18516](https://github.com/firebase/flutterfire/issues/18516)). ([5dfd289e](https://github.com/firebase/flutterfire/commit/5dfd289ea45260c15d73894dcf2cb092fc8ddb9d))

--- a/packages/firebase_core/firebase_core/example/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
 

--- a/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
+++ b/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersionString = "4.13.0"
+let libraryVersionString = "4.14.0"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_core/firebase_core/ios/firebase_core/Sources/firebase_core/Constants.swift
+++ b/packages/firebase_core/firebase_core/ios/firebase_core/Sources/firebase_core/Constants.swift
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// Auto-generated file. Do not edit.
-public let versionNumber = "4.13.0"
+public let versionNumber = "4.14.0"

--- a/packages/firebase_core/firebase_core/macos/firebase_core/Package.swift
+++ b/packages/firebase_core/firebase_core/macos/firebase_core/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersionString = "4.13.0"
+let libraryVersionString = "4.14.0"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 homepage: https://firebase.google.com/docs/flutter/setup
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_core/firebase_core
-version: 4.13.0
+version: 4.14.0
 resolution: workspace
 topics:
   - firebase
@@ -17,8 +17,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core_platform_interface: ^8.1.0
-  firebase_core_web: ^3.10.0
+  firebase_core_platform_interface: ^8.1.1
+  firebase_core_web: ^3.11.0
   flutter:
     sdk: flutter
   meta: ^1.8.0

--- a/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 8.1.1
+
+ - **REFACTOR**(core,android): migrate native implementation to Kotlin ([#18570](https://github.com/firebase/flutterfire/issues/18570)). ([7a0f5856](https://github.com/firebase/flutterfire/commit/7a0f5856cbb2ae64c530dcbdb43b03d43912465c))
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(core,crashlytics): drop `flutter_test` from published dependencies ([#18575](https://github.com/firebase/flutterfire/issues/18575)). ([a54439f9](https://github.com/firebase/flutterfire/commit/a54439f91e0d84c169b5f09def5174b590619f0d))
+
 ## 8.1.0
 
  - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))

--- a/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_co
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_core/firebase_core_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 8.1.0
+version: 8.1.1
 resolution: workspace
 
 environment:

--- a/packages/firebase_core/firebase_core_web/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_web/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.11.0
+
+ - **FIX**(core,web): keep App Check registered for secondary Firebase apps ([#18557](https://github.com/firebase/flutterfire/issues/18557)). ([1345dbb3](https://github.com/firebase/flutterfire/commit/1345dbb38af36c2d1c3f6582f474f5520a185021))
+ - **FIX**(core,web): preserve non-JavaScript app errors ([#18552](https://github.com/firebase/flutterfire/issues/18552)). ([e6943a68](https://github.com/firebase/flutterfire/commit/e6943a682f2a6e93076cd068d49ee7c47738c079))
+ - **FEAT**(core): bump Firebase JS SDK to 12.18.0 ([#18598](https://github.com/firebase/flutterfire/issues/18598)). ([f29565bb](https://github.com/firebase/flutterfire/commit/f29565bb191ddc32973f5b3be9fb4173ae3896b4))
+
 ## 3.10.0
 
  - **FIX**(core,web): load firebase-app.js before component bundles to avoid WebKit import race ([#18443](https://github.com/firebase/flutterfire/issues/18443)). ([4b731aed](https://github.com/firebase/flutterfire/commit/4b731aed0a1346070d8548c342e2e4b012844d58))

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_version.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '4.13.0';
+const packageVersion = '4.14.0';

--- a/packages/firebase_core/firebase_core_web/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_core_web
 description: The web implementation of firebase_core
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_core/firebase_core_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_core/firebase_core_web
-version: 3.10.0
+version: 3.11.0
 resolution: workspace
 
 environment:
@@ -10,7 +10,7 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/firebase_crashlytics/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 5.3.0
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **REFACTOR**(crashlytics,apple): migrate iOS/macOS plugin implementation to Swift ([#18560](https://github.com/firebase/flutterfire/issues/18560)). ([80f06a78](https://github.com/firebase/flutterfire/commit/80f06a789dcfeb69eea417ba1725e21007df0432))
+ - **REFACTOR**(crashlytics,android): migrate native implementation to Kotlin ([#18473](https://github.com/firebase/flutterfire/issues/18473)). ([1fb6302a](https://github.com/firebase/flutterfire/commit/1fb6302a4f740329ddaefb9d4ba852fe6b55beaa))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+ - **FEAT**(crashlytics): add Pigeon support ([#18565](https://github.com/firebase/flutterfire/issues/18565)). ([11daba2c](https://github.com/firebase/flutterfire/commit/11daba2cee5d3f919f4f4466e51155fcf4d95f62))
+
 ## 5.2.7
 
  - **FIX**(crashlytics,android): avoid heap-loading libapp.so for build ID ([#18483](https://github.com/firebase/flutterfire/issues/18483)). ([8d0afcdd](https://github.com/firebase/flutterfire/commit/8d0afcdd9d8d7353a47a6339b09c7964d8eabf84))

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/pubspec.yaml
@@ -7,9 +7,9 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_analytics: ^12.4.6
-  firebase_core: ^4.13.0
-  firebase_crashlytics: ^5.2.7
+  firebase_analytics: ^12.5.0
+  firebase_core: ^4.14.0
+  firebase_crashlytics: ^5.3.0
   flutter:
     sdk: flutter
 

--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics/Sources/firebase_crashlytics/Constants.swift
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics/Sources/firebase_crashlytics/Constants.swift
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// Auto-generated file. Do not edit.
-public let versionNumber = "5.2.7"
+public let versionNumber = "5.3.0"

--- a/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 5.2.7
+version: 5.3.0
 resolution: workspace
 homepage: https://firebase.google.com/docs/crashlytics
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_crashlytics/firebase_crashlytics
@@ -20,9 +20,9 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
-  firebase_crashlytics_platform_interface: ^3.8.27
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
+  firebase_crashlytics_platform_interface: ^3.9.0
   flutter:
     sdk: flutter
   stack_trace: ^1.10.0

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/CHANGELOG.md
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.9.0
+
+ - **REFACTOR**(platform_interface): replace Flutter UI and foundation imports with package:meta ([#18604](https://github.com/firebase/flutterfire/issues/18604)). ([fef6d420](https://github.com/firebase/flutterfire/commit/fef6d42090ea275f07117c085bd04710d9df51bc))
+ - **FIX**(core,crashlytics): drop `flutter_test` from published dependencies ([#18575](https://github.com/firebase/flutterfire/issues/18575)). ([a54439f9](https://github.com/firebase/flutterfire/commit/a54439f91e0d84c169b5f09def5174b590619f0d))
+ - **FEAT**(crashlytics): add Pigeon support ([#18565](https://github.com/firebase/flutterfire/issues/18565)). ([11daba2c](https://github.com/firebase/flutterfire/commit/11daba2cee5d3f919f4f4466e51155fcf4d95f62))
+
 ## 3.8.27
 
  - Update a dependency to the latest release.

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_crashlytics_platform_interface
 description: A common platform interface for the firebase_crashlytics plugin.
-version: 3.8.27
+version: 3.9.0
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_crashlytics/firebase_crashlytics_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_crashlytics/firebase_crashlytics_platform_interface
@@ -10,13 +10,13 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
+  _flutterfire_internals: ^1.3.77
   collection: ^1.15.0
-  firebase_core: ^4.13.0
+  firebase_core: ^4.14.0
   # The generated Pigeon test API in `lib/` imports the test binding shim from
   # this package, so it has to be a regular dependency. It is already in the
   # dependency graph through firebase_core.
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter:
     sdk: flutter
   meta: ^1.8.0

--- a/packages/firebase_data_connect/firebase_data_connect/CHANGELOG.md
+++ b/packages/firebase_data_connect/firebase_data_connect/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.2
+
+ - **REFACTOR**(tests): update listener completion logic and improve WebSocket channel handling ([#18524](https://github.com/firebase/flutterfire/issues/18524)). ([6b1fbc93](https://github.com/firebase/flutterfire/commit/6b1fbc93793db381a7d6d8cfb1a6cb4c8f078d9a))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**(sql_connect): update websocket URL for GSLB soft stickiness ([#18531](https://github.com/firebase/flutterfire/issues/18531)). ([5283f143](https://github.com/firebase/flutterfire/commit/5283f1431f9e48e4062c0bbf972c1b558e505014))
+
 ## 0.3.1
 
  - **FIX**(sql_connect): e2e listen test ([#18496](https://github.com/firebase/flutterfire/issues/18496)). ([e512d39a](https://github.com/firebase/flutterfire/commit/e512d39a88f3d8df0eaeb2b7d7a439460b00b8e7))

--- a/packages/firebase_data_connect/firebase_data_connect/example/pubspec.yaml
+++ b/packages/firebase_data_connect/firebase_data_connect/example/pubspec.yaml
@@ -13,16 +13,16 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_core: ^4.13.0
+  firebase_core: ^4.14.0
   google_sign_in: ^6.1.0
-  firebase_auth: ^6.5.7
+  firebase_auth: ^6.6.0
   firebase_data_connect:
     path: ../
 
   cupertino_icons: ^1.0.6
   flutter_rating_bar: ^4.0.1
   protobuf: ^6.0.0
-  firebase_app_check: ^0.4.6
+  firebase_app_check: ^0.4.7
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/dataconnect_version.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/dataconnect_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// version number for the package, should be align with pubspec.yaml.
-const packageVersion = '0.3.1';
+const packageVersion = '0.3.2';

--- a/packages/firebase_data_connect/firebase_data_connect/pubspec.yaml
+++ b/packages/firebase_data_connect/firebase_data_connect/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_data_connect
 description: 'Flutter plugin for Firebase Data Connect, a relational database service that lets you build and scale using a fully-managed PostgreSQL database powered by Cloud SQL.'
-version: 0.3.1
+version: 0.3.2
 resolution: workspace
 homepage: https://firebase.google.com/docs/data-connect/quickstart?platform=flutter
 false_secrets:
@@ -13,10 +13,10 @@ environment:
 
 dependencies:
   crypto: ^3.0.6
-  firebase_app_check: ^0.4.6
-  firebase_auth: ^6.5.7
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
+  firebase_app_check: ^0.4.7
+  firebase_auth: ^6.6.0
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
   fixnum: ^1.1.1
   flutter:
     sdk: flutter
@@ -31,8 +31,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.12
-  firebase_app_check_platform_interface: ^0.4.2
-  firebase_auth_platform_interface: ^9.0.6
+  firebase_app_check_platform_interface: ^0.4.2+1
+  firebase_auth_platform_interface: ^9.0.7
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter

--- a/packages/firebase_database/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/firebase_database/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 12.5.0
+
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(database,windows): fix transaction threwing and native error codes dropped ([#18559](https://github.com/firebase/flutterfire/issues/18559)). ([12f5f32b](https://github.com/firebase/flutterfire/commit/12f5f32b20ad379e7923fd1c22a66ce22f869bf5))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
 ## 12.4.7
 
  - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))

--- a/packages/firebase_database/firebase_database/example/pubspec.yaml
+++ b/packages/firebase_database/firebase_database/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
-  firebase_database: ^12.4.7
+  firebase_core: ^4.14.0
+  firebase_database: ^12.5.0
   flutter:
     sdk: flutter
 
@@ -17,10 +17,10 @@ dev_dependencies:
   collection: ^1.15.0
   # The e2e suite reaches for MethodChannelFirebase, which firebase_core
   # deliberately hides from its own re-export.
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   # `web_only.dart` (conditionally imported) asserts on the web plugin's
   # JS-interop surface directly.
-  firebase_database_web: ^0.2.7+13
+  firebase_database_web: ^0.2.7+14
   flutter_test:
     sdk: flutter
   integration_test:

--- a/packages/firebase_database/firebase_database/ios/firebase_database/Package.swift
+++ b/packages/firebase_database/firebase_database/ios/firebase_database/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "12.4.7"
+let libraryVersion = "12.5.0"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_database/firebase_database/macos/firebase_database/Package.swift
+++ b/packages/firebase_database/firebase_database/macos/firebase_database/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "12.4.7"
+let libraryVersion = "12.5.0"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_database/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 homepage: https://firebase.google.com/docs/database
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_database/firebase_database
-version: 12.4.7
+version: 12.5.0
 resolution: workspace
 topics:
   - firebase
@@ -18,10 +18,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
-  firebase_database_platform_interface: ^0.4.0+6
-  firebase_database_web: ^0.2.7+13
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
+  firebase_database_platform_interface: ^0.4.0+7
+  firebase_database_web: ^0.2.7+14
   flutter:
     sdk: flutter
 

--- a/packages/firebase_database/firebase_database_platform_interface/CHANGELOG.md
+++ b/packages/firebase_database/firebase_database_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+7
+
+ - Update a dependency to the latest release.
+
 ## 0.4.0+6
 
  - Update a dependency to the latest release.

--- a/packages/firebase_database/firebase_database_platform_interface/pubspec.yaml
+++ b/packages/firebase_database/firebase_database_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_database_platform_interface
 description: A common platform interface for the firebase_database plugin.
-version: 0.4.0+6
+version: 0.4.0+7
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_database/firebase_database_platform_interface
 
@@ -9,16 +9,16 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
+  _flutterfire_internals: ^1.3.77
   collection: ^1.14.3
-  firebase_core: ^4.13.0
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.2

--- a/packages/firebase_database/firebase_database_web/CHANGELOG.md
+++ b/packages/firebase_database/firebase_database_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.7+14
+
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+
 ## 0.2.7+13
 
  - Update a dependency to the latest release.

--- a/packages/firebase_database/firebase_database_web/lib/src/firebase_database_version.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/firebase_database_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '12.4.7';
+const packageVersion = '12.5.0';

--- a/packages/firebase_database/firebase_database_web/pubspec.yaml
+++ b/packages/firebase_database/firebase_database_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_database_web
 description: The web implementation of firebase_database
-version: 0.2.7+13
+version: 0.2.7+14
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_database/firebase_database_web
 
@@ -10,16 +10,16 @@ environment:
 
 dependencies:
   collection: ^1.18.0
-  firebase_core: ^4.13.0
-  firebase_core_web: ^3.10.0
-  firebase_database_platform_interface: ^0.4.0+6
+  firebase_core: ^4.14.0
+  firebase_core_web: ^3.11.0
+  firebase_database_platform_interface: ^0.4.0+7
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/CHANGELOG.md
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.9.3
+
+ - **REFACTOR**(in_app_messaging): migrate platform channels to Pigeon ([#18529](https://github.com/firebase/flutterfire/issues/18529)). ([17c4d6fd](https://github.com/firebase/flutterfire/commit/17c4d6fda76cfe2010b22811fb71d8211b8bcca2))
+ - **REFACTOR**(in_app_messaging): migrate iOS plugin to Swift ([#18528](https://github.com/firebase/flutterfire/issues/18528)). ([10cf4aa9](https://github.com/firebase/flutterfire/commit/10cf4aa9513d8d2b4c24281915483a27d24b04bb))
+ - **REFACTOR**(in_app_messaging): migrate Android plugin to Kotlin ([#18526](https://github.com/firebase/flutterfire/issues/18526)). ([f8ec3482](https://github.com/firebase/flutterfire/commit/f8ec3482aa711488b42a107757e1992078db35eb))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
 ## 0.9.2+7
 
  - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/example/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/example/pubspec.yaml
@@ -8,10 +8,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_analytics: ^12.4.6
-  firebase_core: ^4.13.0
-  firebase_in_app_messaging: ^0.9.2+7
-  firebase_in_app_messaging_platform_interface: ^0.2.5+27
+  firebase_analytics: ^12.5.0
+  firebase_core: ^4.14.0
+  firebase_in_app_messaging: ^0.9.3
+  firebase_in_app_messaging_platform_interface: ^0.2.5+28
   flutter:
     sdk: flutter
 

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/firebase_in_app_messaging/Sources/firebase_in_app_messaging/Constants.swift
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/firebase_in_app_messaging/Sources/firebase_in_app_messaging/Constants.swift
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// Auto-generated file. Do not edit.
-public let versionNumber = "0.9.2+7"
+public let versionNumber = "0.9.3"

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_in_app_messaging
 description: Flutter plugin for Firebase In-App Messaging.
-version: 0.9.2+7
+version: 0.9.3
 resolution: workspace
 homepage: https://firebase.google.com/docs/in-app-messaging
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_in_app_messaging
@@ -18,9 +18,9 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
-  firebase_in_app_messaging_platform_interface: ^0.2.5+27
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
+  firebase_in_app_messaging_platform_interface: ^0.2.5+28
   flutter:
     sdk: flutter
   meta: ^1.8.0

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/CHANGELOG.md
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5+28
+
+ - **REFACTOR**(in_app_messaging): migrate platform channels to Pigeon ([#18529](https://github.com/firebase/flutterfire/issues/18529)). ([17c4d6fd](https://github.com/firebase/flutterfire/commit/17c4d6fda76cfe2010b22811fb71d8211b8bcca2))
+
 ## 0.2.5+27
 
  - Update a dependency to the latest release.

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the firebase_in_app_messaging plugi
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_in_app_messaging/firebase_in_app_messagin_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_in_app_messaging/firebase_in_app_messagin_platform_interface
 
-version: 0.2.5+27
+version: 0.2.5+28
 resolution: workspace
 
 environment:
@@ -11,15 +11,15 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
-  firebase_core: ^4.13.0
+  _flutterfire_internals: ^1.3.77
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   pigeon: 26.3.4

--- a/packages/firebase_messaging/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 16.6.0
+
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(messaging,android): fixing an issue with analytics being triggered twice ([#18544](https://github.com/firebase/flutterfire/issues/18544)). ([ef1cac4c](https://github.com/firebase/flutterfire/commit/ef1cac4c0c5154921f70400d46a5d0eeade2dab0))
+ - **FIX**(messaging,macos): unwrap UNNotificationResponse launch payload ([#18527](https://github.com/firebase/flutterfire/issues/18527)). ([584acc9f](https://github.com/firebase/flutterfire/commit/584acc9fb2d805733c33060b875b674b9d434a7e))
+ - **FIX**(messaging,android): fix an issue that could cause duplicate call stack ([#18122](https://github.com/firebase/flutterfire/issues/18122)). ([1522bd8f](https://github.com/firebase/flutterfire/commit/1522bd8f7771da70508fa26422fc9447e3ffa8ad))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+ - **FEAT**(messaging,ios): migrate example iOS runner from ObjC to Swift ([#18578](https://github.com/firebase/flutterfire/issues/18578)). ([69d16e44](https://github.com/firebase/flutterfire/commit/69d16e44cb7f70d8eaaed3e4fe9d2a186194e3d4))
+ - **FEAT**(messaging,android): improve how messaging is determining permission on Android ([#18101](https://github.com/firebase/flutterfire/issues/18101)). ([1c89b686](https://github.com/firebase/flutterfire/commit/1c89b686209c79ef800e61885bcbfbd555b589ee))
+
 ## 16.5.0
 
  - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))

--- a/packages/firebase_messaging/firebase_messaging/example/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
-  firebase_messaging: ^16.5.0
+  firebase_core: ^4.14.0
+  firebase_messaging: ^16.6.0
   flutter:
     sdk: flutter
   flutter_local_notifications: ^21.0.0

--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Package.swift
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "16.5.0"
+let libraryVersion = "16.6.0"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_messaging/firebase_messaging/macos/firebase_messaging/Package.swift
+++ b/packages/firebase_messaging/firebase_messaging/macos/firebase_messaging/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "16.5.0"
+let libraryVersion = "16.6.0"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_messaging/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 homepage: https://firebase.google.com/docs/cloud-messaging
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_messaging/firebase_messaging
-version: 16.5.0
+version: 16.6.0
 resolution: workspace
 topics:
   - firebase
@@ -18,10 +18,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
-  firebase_messaging_platform_interface: ^4.9.3
-  firebase_messaging_web: ^4.2.4
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
+  firebase_messaging_platform_interface: ^4.10.0
+  firebase_messaging_web: ^4.2.5
   flutter:
     sdk: flutter
   meta: ^1.8.0

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/CHANGELOG.md
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.10.0
+
+ - **FEAT**(messaging,android): improve how messaging is determining permission on Android ([#18101](https://github.com/firebase/flutterfire/issues/18101)). ([1c89b686](https://github.com/firebase/flutterfire/commit/1c89b686209c79ef800e61885bcbfbd555b589ee))
+
 ## 4.9.3
 
  - Update a dependency to the latest release.

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_messaging_platform_interface
 description: A common platform interface for the firebase_messaging plugin.
-version: 4.9.3
+version: 4.10.0
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_messaging/firebase_messaging_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_messaging/firebase_messaging_platform_interface
@@ -10,15 +10,15 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
-  firebase_core: ^4.13.0
+  _flutterfire_internals: ^1.3.77
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_messaging/firebase_messaging_web/CHANGELOG.md
+++ b/packages/firebase_messaging/firebase_messaging_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.5
+
+ - Update a dependency to the latest release.
+
 ## 4.2.4
 
  - Update a dependency to the latest release.

--- a/packages/firebase_messaging/firebase_messaging_web/lib/src/firebase_messaging_version.dart
+++ b/packages/firebase_messaging/firebase_messaging_web/lib/src/firebase_messaging_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '16.5.0';
+const packageVersion = '16.6.0';

--- a/packages/firebase_messaging/firebase_messaging_web/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_messaging_web
 description: The web implementation of firebase_messaging
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_messaging/firebase_messaging_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_messaging/firebase_messaging_web
-version: 4.2.4
+version: 4.2.5
 resolution: workspace
 
 environment:
@@ -10,10 +10,10 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
-  firebase_core: ^4.13.0
-  firebase_core_web: ^3.10.0
-  firebase_messaging_platform_interface: ^4.9.3
+  _flutterfire_internals: ^1.3.77
+  firebase_core: ^4.14.0
+  firebase_core_web: ^3.11.0
+  firebase_messaging_platform_interface: ^4.10.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -22,7 +22,7 @@ dependencies:
   web: ^1.0.0
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/CHANGELOG.md
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.4
+
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
 ## 0.4.3
 
  - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/example/pubspec.yaml
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/example/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  firebase_core: ^4.13.0
-  firebase_ml_model_downloader: ^0.4.3
+  firebase_core: ^4.14.0
+  firebase_ml_model_downloader: ^0.4.4
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/ios/firebase_ml_model_downloader/Sources/firebase_ml_model_downloader/Constants.swift
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/ios/firebase_ml_model_downloader/Sources/firebase_ml_model_downloader/Constants.swift
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// Auto-generated file. Do not edit.
-public let versionNumber = "0.4.3"
+public let versionNumber = "0.4.4"

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/pubspec.yaml
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_ml_model_downloader
 description: "Deprecated: A Flutter plugin for Firebase ML Model Downloader. Firebase ML shuts down June 15, 2027."
-version: 0.4.3
+version: 0.4.4
 resolution: workspace
 homepage: https://firebase.google.com/docs/ml/flutter/use-custom-models
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_ml_model_downloader/firebase_ml_model_downloader
@@ -18,9 +18,9 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
-  firebase_ml_model_downloader_platform_interface: ^0.1.6
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
+  firebase_ml_model_downloader_platform_interface: ^0.1.6+1
   flutter:
     sdk: flutter
 

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/CHANGELOG.md
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.6+1
+
+ - Update a dependency to the latest release.
+
 ## 0.1.6
 
  - **FEAT**(ml): adding depreciation notice to ML plugin ([#18472](https://github.com/firebase/flutterfire/issues/18472)). ([fb20da9c](https://github.com/firebase/flutterfire/commit/fb20da9c88d0e7ac20b89fc27000ae4eeb50654d))

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/pubspec.yaml
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_ml_model_downloader_platform_interface
 description: "Deprecated: The platform interface for the firebase_ml_model_downloader plugin."
-version: 0.1.6
+version: 0.1.6+1
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface
@@ -10,14 +10,14 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_performance/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/firebase_performance/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.11.5
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(android): remove plugin-local AGP and Kotlin Gradle Plugin pins from buildscript blocks ([#18139](https://github.com/firebase/flutterfire/issues/18139)). ([4f6960c4](https://github.com/firebase/flutterfire/commit/4f6960c437da6945e2db2505f4e0a92fef5b76da))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
 ## 0.11.4+6
 
  - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))

--- a/packages/firebase_performance/firebase_performance/example/pubspec.yaml
+++ b/packages/firebase_performance/firebase_performance/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
-  firebase_performance: ^0.11.4+6
+  firebase_core: ^4.14.0
+  firebase_performance: ^0.11.5
   flutter:
     sdk: flutter
   http: ^1.0.0

--- a/packages/firebase_performance/firebase_performance/ios/firebase_performance/Package.swift
+++ b/packages/firebase_performance/firebase_performance/ios/firebase_performance/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "0.11.4-6"
+let libraryVersion = "0.11.5"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_performance/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/firebase_performance/pubspec.yaml
@@ -5,7 +5,7 @@ description:
   iOS.
 homepage: https://firebase.google.com/docs/perf-mon
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_performance/firebase_performance
-version: 0.11.4+6
+version: 0.11.5
 resolution: workspace
 topics:
   - firebase
@@ -21,10 +21,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
-  firebase_performance_platform_interface: ^0.2.0+6
-  firebase_performance_web: ^0.1.8+12
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
+  firebase_performance_platform_interface: ^0.2.0+7
+  firebase_performance_web: ^0.1.8+13
   flutter:
     sdk: flutter
 

--- a/packages/firebase_performance/firebase_performance_platform_interface/CHANGELOG.md
+++ b/packages/firebase_performance/firebase_performance_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+7
+
+ - **REFACTOR**(platform_interface): replace Flutter UI and foundation imports with package:meta ([#18604](https://github.com/firebase/flutterfire/issues/18604)). ([fef6d420](https://github.com/firebase/flutterfire/commit/fef6d42090ea275f07117c085bd04710d9df51bc))
+
 ## 0.2.0+6
 
  - Update a dependency to the latest release.

--- a/packages/firebase_performance/firebase_performance_platform_interface/pubspec.yaml
+++ b/packages/firebase_performance/firebase_performance_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_performance_platform_interface
 description: A common platform interface for the firebase_performance plugin.
-version: 0.2.0+6
+version: 0.2.0+7
 resolution: workspace
 homepage: https://firebase.google.com/docs/perf-mon/flutter/get-started
 
@@ -9,15 +9,15 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
-  firebase_core: ^4.13.0
+  _flutterfire_internals: ^1.3.77
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   pigeon: 26.3.4

--- a/packages/firebase_performance/firebase_performance_web/CHANGELOG.md
+++ b/packages/firebase_performance/firebase_performance_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.8+13
+
+ - Update a dependency to the latest release.
+
 ## 0.1.8+12
 
  - Update a dependency to the latest release.

--- a/packages/firebase_performance/firebase_performance_web/lib/src/firebase_performance_version.dart
+++ b/packages/firebase_performance/firebase_performance_web/lib/src/firebase_performance_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '0.11.4+6';
+const packageVersion = '0.11.5';

--- a/packages/firebase_performance/firebase_performance_web/pubspec.yaml
+++ b/packages/firebase_performance/firebase_performance_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_performance_web
 description: Web implementation of Firebase Performance monitoring.
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_performance/firebase_performance_web
-version: 0.1.8+12
+version: 0.1.8+13
 resolution: workspace
 
 environment:
@@ -9,10 +9,10 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
-  firebase_core: ^4.13.0
-  firebase_core_web: ^3.10.0
-  firebase_performance_platform_interface: ^0.2.0+6
+  _flutterfire_internals: ^1.3.77
+  firebase_core: ^4.14.0
+  firebase_core_web: ^3.11.0
+  firebase_performance_platform_interface: ^0.2.0+7
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/firebase_remote_config/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/firebase_remote_config/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 6.6.0
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(remote_config): classify fetch failures instead of reporting them all as `internal` ([#18585](https://github.com/firebase/flutterfire/issues/18585)). ([128912e8](https://github.com/firebase/flutterfire/commit/128912e884c815b498ff943cd7b38838104d89f0))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(android): remove plugin-local AGP and Kotlin Gradle Plugin pins from buildscript blocks ([#18139](https://github.com/firebase/flutterfire/issues/18139)). ([4f6960c4](https://github.com/firebase/flutterfire/commit/4f6960c437da6945e2db2505f4e0a92fef5b76da))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
 ## 6.5.6
 
  - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))

--- a/packages/firebase_remote_config/firebase_remote_config/example/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  firebase_core: ^4.13.0
-  firebase_remote_config: ^6.5.6
+  firebase_core: ^4.14.0
+  firebase_remote_config: ^6.6.0
   flutter:
     sdk: flutter
 

--- a/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Sources/firebase_remote_config/Constants.swift
+++ b/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Sources/firebase_remote_config/Constants.swift
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// Auto-generated file. Do not edit.
-public let versionNumber = "6.5.6"
+public let versionNumber = "6.6.0"

--- a/packages/firebase_remote_config/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config/pubspec.yaml
@@ -4,7 +4,7 @@ description:
   re-releasing.
 homepage: https://firebase.google.com/docs/remote-config
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_remote_config/firebase_remote_config
-version: 6.5.6
+version: 6.6.0
 resolution: workspace
 topics:
   - firebase
@@ -20,10 +20,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
-  firebase_remote_config_platform_interface: ^3.0.6
-  firebase_remote_config_web: ^1.10.13
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
+  firebase_remote_config_platform_interface: ^3.0.7
+  firebase_remote_config_web: ^1.10.14
   flutter:
     sdk: flutter
 

--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/CHANGELOG.md
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.7
+
+ - **REFACTOR**(platform_interface): replace Flutter UI and foundation imports with package:meta ([#18604](https://github.com/firebase/flutterfire/issues/18604)). ([fef6d420](https://github.com/firebase/flutterfire/commit/fef6d42090ea275f07117c085bd04710d9df51bc))
+ - **FIX**(remote_config): classify fetch failures instead of reporting them all as `internal` ([#18585](https://github.com/firebase/flutterfire/issues/18585)). ([128912e8](https://github.com/firebase/flutterfire/commit/128912e884c815b498ff943cd7b38838104d89f0))
+
 ## 3.0.6
 
  - **FIX**(remote_config): restores the Apple error mapping and accepts both throttling status spellings ([#18458](https://github.com/firebase/flutterfire/issues/18458)). ([523d985a](https://github.com/firebase/flutterfire/commit/523d985a8219fd20a7071915ee539c19692975fa))

--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_re
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_remote_config/firebase_remote_config_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.0.6
+version: 3.0.7
 resolution: workspace
 
 environment:
@@ -12,15 +12,15 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
-  firebase_core: ^4.13.0
+  _flutterfire_internals: ^1.3.77
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_remote_config/firebase_remote_config_web/CHANGELOG.md
+++ b/packages/firebase_remote_config/firebase_remote_config_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.14
+
+ - Update a dependency to the latest release.
+
 ## 1.10.13
 
  - Update a dependency to the latest release.

--- a/packages/firebase_remote_config/firebase_remote_config_web/lib/src/firebase_remote_config_version.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_web/lib/src/firebase_remote_config_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '6.5.6';
+const packageVersion = '6.6.0';

--- a/packages/firebase_remote_config/firebase_remote_config_web/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: The web implementation of firebase_remote_config
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_remote_config/firebase_remote_config_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_remote_config/firebase_remote_config_web
 
-version: 1.10.13
+version: 1.10.14
 resolution: workspace
 
 environment:
@@ -11,10 +11,10 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
-  firebase_core: ^4.13.0
-  firebase_core_web: ^3.10.0
-  firebase_remote_config_platform_interface: ^3.0.6
+  _flutterfire_internals: ^1.3.77
+  firebase_core: ^4.14.0
+  firebase_core_web: ^3.11.0
+  firebase_remote_config_platform_interface: ^3.0.7
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -22,7 +22,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.3.3
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_storage/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/firebase_storage/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 13.5.0
+
+ - **REFACTOR**(core,apple): migrate iOS/macOS plugin implementation to Swift ([#18569](https://github.com/firebase/flutterfire/issues/18569)). ([3b9a655b](https://github.com/firebase/flutterfire/commit/3b9a655b8ac8ac5f6efa23ea63e210b597f2ec02))
+ - **FIX**(ci): bump Kotlin Gradle plugin to 2.3.0 ([#18600](https://github.com/firebase/flutterfire/issues/18600)). ([4c3865e2](https://github.com/firebase/flutterfire/commit/4c3865e2e56bf59904a9f48a6e70f0f963df2cda))
+ - **FIX**(ci): align Android toolchain and analyzer with Flutter 3.47 ([#18566](https://github.com/firebase/flutterfire/issues/18566)). ([87ace849](https://github.com/firebase/flutterfire/commit/87ace8496fec75c461f3b29a9b8a85d46e286957))
+ - **FIX**(android): remove plugin-local AGP and Kotlin Gradle Plugin pins from buildscript blocks ([#18139](https://github.com/firebase/flutterfire/issues/18139)). ([4f6960c4](https://github.com/firebase/flutterfire/commit/4f6960c437da6945e2db2505f4e0a92fef5b76da))
+ - **FEAT**: bump Firebase iOS SDK to 12.18.0 ([#18596](https://github.com/firebase/flutterfire/issues/18596)). ([07febc37](https://github.com/firebase/flutterfire/commit/07febc37617ab8b4f6f06e7208baa6a15ce2ef70))
+
 ## 13.4.6
 
  - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))

--- a/packages/firebase_storage/firebase_storage/example/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
-  firebase_storage: ^13.4.6
+  firebase_core: ^4.14.0
+  firebase_storage: ^13.5.0
   flutter:
     sdk: flutter
   image_picker: ^1.1.2
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   # The e2e suite reaches for MethodChannelFirebase, which firebase_core
   # deliberately hides from its own re-export.
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   integration_test:

--- a/packages/firebase_storage/firebase_storage/ios/firebase_storage/Package.swift
+++ b/packages/firebase_storage/firebase_storage/ios/firebase_storage/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "13.4.6"
+let libraryVersion = "13.5.0"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_storage/firebase_storage/macos/firebase_storage/Package.swift
+++ b/packages/firebase_storage/firebase_storage/macos/firebase_storage/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "13.4.6"
+let libraryVersion = "13.5.0"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_storage/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 homepage: https://firebase.google.com/docs/storage/flutter/start
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_storage/firebase_storage
-version: 13.4.6
+version: 13.5.0
 resolution: workspace
 topics:
   - firebase
@@ -20,10 +20,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
-  firebase_storage_platform_interface: ^6.0.6
-  firebase_storage_web: ^3.11.12
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
+  firebase_storage_platform_interface: ^6.0.7
+  firebase_storage_web: ^3.11.13
   flutter:
     sdk: flutter
   mime: ^2.0.0

--- a/packages/firebase_storage/firebase_storage_platform_interface/CHANGELOG.md
+++ b/packages/firebase_storage/firebase_storage_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.7
+
+ - **REFACTOR**(platform_interface): replace Flutter UI and foundation imports with package:meta ([#18604](https://github.com/firebase/flutterfire/issues/18604)). ([fef6d420](https://github.com/firebase/flutterfire/commit/fef6d42090ea275f07117c085bd04710d9df51bc))
+
 ## 6.0.6
 
  - Update a dependency to the latest release.

--- a/packages/firebase_storage/firebase_storage_platform_interface/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_storage_platform_interface
 description: A common platform interface for the firebase_storage plugin.
-version: 6.0.6
+version: 6.0.7
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_storage/firebase_storage_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_storage/firebase_storage_platform_interface
@@ -10,16 +10,16 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
+  _flutterfire_internals: ^1.3.77
   collection: ^1.15.0
-  firebase_core: ^4.13.0
+  firebase_core: ^4.14.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_storage/firebase_storage_web/CHANGELOG.md
+++ b/packages/firebase_storage/firebase_storage_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.11.13
+
+ - Update a dependency to the latest release.
+
 ## 3.11.12
 
  - Update a dependency to the latest release.

--- a/packages/firebase_storage/firebase_storage_web/lib/src/firebase_storage_version.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/firebase_storage_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '13.4.6';
+const packageVersion = '13.5.0';

--- a/packages/firebase_storage/firebase_storage_web/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_storage_web
 description: The web implementation of firebase_storage
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_storage/firebase_storage_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_storage/firebase_storage_web
-version: 3.11.12
+version: 3.11.13
 resolution: workspace
 
 environment:
@@ -10,11 +10,11 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.76
+  _flutterfire_internals: ^1.3.77
   async: ^2.5.0
-  firebase_core: ^4.13.0
-  firebase_core_web: ^3.10.0
-  firebase_storage_platform_interface: ^6.0.6
+  firebase_core: ^4.14.0
+  firebase_core_web: ^3.11.0
+  firebase_storage_platform_interface: ^6.0.7
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -24,7 +24,7 @@ dependencies:
   web: ^1.0.0
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.1.0
+  firebase_core_platform_interface: ^8.1.1
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,7 +96,7 @@ melos:
           dart run scripts/generate_dataconnect_version.dart && \
           dart run scripts/generate_versions_web.dart && \
           dart run scripts/generate_versions_spm.dart && \
-          git add packages/firebase_data_connect/firebase_data_connect/lib/src/dataconnect_version.dart && git add packages/*/*_web/lib/src/*_version.dart && git add packages/*/*/ios/*/Package.swift packages/*/*/macos/*/Package.swift && git add packages/*/*/ios/*/Sources/*/Constants.swift
+          git add packages/firebase_ai/firebase_ai/lib/src/firebaseai_version.dart && git add packages/firebase_data_connect/firebase_data_connect/lib/src/dataconnect_version.dart && git add packages/*/*_web/lib/src/*_version.dart && git add packages/*/*/ios/*/Package.swift packages/*/*/macos/*/Package.swift && git add packages/*/*/ios/*/Sources/*/Constants.swift
 
     bootstrap:
       # It seems so that running "pub get" in parallel has some issues (like

--- a/scripts/generate_firebaseai_version.dart
+++ b/scripts/generate_firebaseai_version.dart
@@ -33,8 +33,8 @@ Future<void> main() async {
     [
       Directory.current.path,
       'packages',
-      'firebase_data_connect',
-      'firebase_data_connect',
+      'firebase_ai',
+      'firebase_ai',
       'pubspec.yaml',
     ],
   );

--- a/scripts/versions.json
+++ b/scripts/versions.json
@@ -1,4 +1,32 @@
 {
+  "5.0.0": {
+    "date": "2026-08-24",
+    "firebase_sdk": {
+      "android": "34.18.0",
+      "ios": "12.18.0",
+      "web": "12.18.0",
+      "windows": "13.11.0"
+    },
+    "packages": {
+      "cloud_firestore": "6.9.0",
+      "cloud_functions": "6.4.0",
+      "firebase_ai": "4.0.0",
+      "firebase_analytics": "12.5.0",
+      "firebase_app_check": "0.4.7",
+      "firebase_app_installations": "0.4.3",
+      "firebase_auth": "6.6.0",
+      "firebase_core": "4.14.0",
+      "firebase_crashlytics": "5.3.0",
+      "firebase_data_connect": "0.3.2",
+      "firebase_database": "12.5.0",
+      "firebase_in_app_messaging": "0.9.3",
+      "firebase_messaging": "16.6.0",
+      "firebase_ml_model_downloader": "0.4.4",
+      "firebase_performance": "0.11.5",
+      "firebase_remote_config": "6.6.0",
+      "firebase_storage": "13.5.0"
+    }
+  },
   "4.18.0": {
     "date": "2026-08-03",
     "firebase_sdk": {

--- a/tests/pubspec.yaml
+++ b/tests/pubspec.yaml
@@ -10,43 +10,43 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  cloud_functions: ^6.3.6
-  cloud_functions_platform_interface: ^6.0.6
-  cloud_functions_web: ^5.1.12
+  cloud_functions: ^6.4.0
+  cloud_functions_platform_interface: ^6.0.7
+  cloud_functions_web: ^5.1.13
   collection: ^1.15.0
-  firebase_ai: ^3.15.0
-  firebase_analytics: ^12.4.6
-  firebase_analytics_platform_interface: ^6.0.6
-  firebase_analytics_web: ^0.6.1+12
-  firebase_app_check: ^0.4.6
-  firebase_app_check_platform_interface: ^0.4.2
-  firebase_app_check_web: ^0.2.6
-  firebase_app_installations: ^0.4.2+7
-  firebase_app_installations_platform_interface: ^0.1.4+75
-  firebase_app_installations_web: ^0.1.7+12
-  firebase_auth: ^6.5.7
-  firebase_auth_platform_interface: ^9.0.6
-  firebase_auth_web: ^6.2.6
-  firebase_core: ^4.13.0
-  firebase_core_platform_interface: ^8.1.0
-  firebase_core_web: ^3.10.0
-  firebase_crashlytics: ^5.2.7
-  firebase_crashlytics_platform_interface: ^3.8.27
-  firebase_database: ^12.4.7
-  firebase_database_platform_interface: ^0.4.0+6
-  firebase_database_web: ^0.2.7+13
-  firebase_messaging: ^16.5.0
-  firebase_messaging_platform_interface: ^4.9.3
-  firebase_messaging_web: ^4.2.4
-  firebase_ml_model_downloader: ^0.4.3
-  firebase_ml_model_downloader_platform_interface: ^0.1.6
-  firebase_performance: ^0.11.4+6
-  firebase_remote_config: ^6.5.6
-  firebase_remote_config_platform_interface: ^3.0.6
-  firebase_remote_config_web: ^1.10.13
-  firebase_storage: ^13.4.6
-  firebase_storage_platform_interface: ^6.0.6
-  firebase_storage_web: ^3.11.12
+  firebase_ai: ^4.0.0
+  firebase_analytics: ^12.5.0
+  firebase_analytics_platform_interface: ^6.0.7
+  firebase_analytics_web: ^0.6.1+13
+  firebase_app_check: ^0.4.7
+  firebase_app_check_platform_interface: ^0.4.2+1
+  firebase_app_check_web: ^0.2.6+1
+  firebase_app_installations: ^0.4.3
+  firebase_app_installations_platform_interface: ^0.1.5
+  firebase_app_installations_web: ^0.1.7+13
+  firebase_auth: ^6.6.0
+  firebase_auth_platform_interface: ^9.0.7
+  firebase_auth_web: ^6.2.7
+  firebase_core: ^4.14.0
+  firebase_core_platform_interface: ^8.1.1
+  firebase_core_web: ^3.11.0
+  firebase_crashlytics: ^5.3.0
+  firebase_crashlytics_platform_interface: ^3.9.0
+  firebase_database: ^12.5.0
+  firebase_database_platform_interface: ^0.4.0+7
+  firebase_database_web: ^0.2.7+14
+  firebase_messaging: ^16.6.0
+  firebase_messaging_platform_interface: ^4.10.0
+  firebase_messaging_web: ^4.2.5
+  firebase_ml_model_downloader: ^0.4.4
+  firebase_ml_model_downloader_platform_interface: ^0.1.6+1
+  firebase_performance: ^0.11.5
+  firebase_remote_config: ^6.6.0
+  firebase_remote_config_platform_interface: ^3.0.7
+  firebase_remote_config_web: ^1.10.14
+  firebase_storage: ^13.5.0
+  firebase_storage_platform_interface: ^6.0.7
+  firebase_storage_web: ^3.11.13
   flutter:
     sdk: flutter
   http: ^1.0.0


### PR DESCRIPTION
## Release 2026-08-24 — BoM 5.0.0

### Versioning
`melos version` bumped **45 packages**. Full details in the per-package CHANGELOGs and the root `CHANGELOG.md`.

Aggregate: `minor: 10, major: 1, patch: 6` across the 17 BoM-tracked plugins.

### ⚠️ Breaking change — `firebase_ai` 3.15.0 → 4.0.0
Driven by #18577 (`refactor(firebaseai)!:` removal of deprecated Imagen methods and types, following the Imagen model shutdown).

Because the BoM bumps major whenever any tracked package does, this takes the BoM **4.18.0 → 5.0.0**.

### Native SDK versions in this BoM
| SDK | Version |
|---|---|
| Android | 34.18.0 |
| iOS | 12.18.0 |
| Web | 12.18.0 |
| Windows | 13.11.0 |
