### PR TITLE
fix(firebase_auth): compile Android Kotlin without checker-qual on inferred types

### DIFF
--- a/packages/firebase_auth/firebase_auth/android/build.gradle
+++ b/packages/firebase_auth/firebase_auth/android/build.gradle
@@ -76,10 +76,6 @@ android {
         implementation platform("com.google.firebase:firebase-bom:${getRootProjectExtOrCoreProperty("FirebaseSDKVersion", firebaseCoreProject)}")
         implementation 'com.google.firebase:firebase-auth'
         implementation 'androidx.annotation:annotation:1.7.0'
-        // firebase-auth class files reference @UnknownInitialization but do not
-        // declare checker-qual. Kotlin needs that annotation to resolve inferred
-        // SAM parameter types (IdTokenListener). See #18608.
-        compileOnly 'org.checkerframework:checker-qual:3.49.5'
     }
 }
 

--- a/packages/firebase_auth/firebase_auth/android/build.gradle
+++ b/packages/firebase_auth/firebase_auth/android/build.gradle
@@ -76,6 +76,10 @@ android {
         implementation platform("com.google.firebase:firebase-bom:${getRootProjectExtOrCoreProperty("FirebaseSDKVersion", firebaseCoreProject)}")
         implementation 'com.google.firebase:firebase-auth'
         implementation 'androidx.annotation:annotation:1.7.0'
+        // firebase-auth class files reference @UnknownInitialization but do not
+        // declare checker-qual. Kotlin needs that annotation to resolve inferred
+        // SAM parameter types (IdTokenListener). See #18608.
+        compileOnly 'org.checkerframework:checker-qual:3.49.5'
     }
 }
 

--- a/packages/firebase_auth/firebase_auth/android/src/main/kotlin/io/flutter/plugins/firebase/auth/AuthStateChannelStreamHandler.kt
+++ b/packages/firebase_auth/firebase_auth/android/src/main/kotlin/io/flutter/plugins/firebase/auth/AuthStateChannelStreamHandler.kt
@@ -20,7 +20,7 @@ class AuthStateChannelStreamHandler(private val firebaseAuth: FirebaseAuth) : St
     val initialAuthState = AtomicBoolean(true)
 
     authStateListener =
-        FirebaseAuth.AuthStateListener { auth ->
+        FirebaseAuth.AuthStateListener { auth: FirebaseAuth ->
           if (initialAuthState.get()) {
             initialAuthState.set(false)
             return@AuthStateListener

--- a/packages/firebase_auth/firebase_auth/android/src/main/kotlin/io/flutter/plugins/firebase/auth/IdTokenChannelStreamHandler.kt
+++ b/packages/firebase_auth/firebase_auth/android/src/main/kotlin/io/flutter/plugins/firebase/auth/IdTokenChannelStreamHandler.kt
@@ -20,7 +20,7 @@ class IdTokenChannelStreamHandler(private val firebaseAuth: FirebaseAuth) : Stre
     val initialAuthState = AtomicBoolean(true)
 
     idTokenListener =
-        FirebaseAuth.IdTokenListener { auth ->
+        FirebaseAuth.IdTokenListener { auth: FirebaseAuth ->
           if (initialAuthState.get()) {
             initialAuthState.set(false)
             return@IdTokenListener

--- a/packages/firebase_auth/firebase_auth/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/firebase_auth/firebase_auth/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/firebase_auth/firebase_auth/example/android/settings.gradle
+++ b/packages/firebase_auth/firebase_auth/example/android/settings.gradle
@@ -18,11 +18,11 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.9.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     // START: FlutterFire Configuration
     id "com.google.gms.google-services" version "4.3.15" apply false
     // END: FlutterFire Configuration
-    id "org.jetbrains.kotlin.android" version "2.3.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.4.10" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Description

`:firebase_auth:compileDebugKotlin` fails on Kotlin 2.4 when `IdTokenChannelStreamHandler` infers the `IdTokenListener` parameter type. `com.google.firebase:firebase-auth` class files reference `@UnknownInitialization` but do not declare `org.checkerframework:checker-qual`, so the inferred type is inaccessible.

Giving the SAM lambda an explicit `FirebaseAuth` parameter type is enough — Kotlin no longer infers the annotated type. Confirmed on Kotlin 2.4.10 with no `checker-qual` on the classpath.

The auth example is bumped to Gradle 8.14, AGP 8.11.1, and Kotlin 2.4.10 so CI compiles the language version that turns this from a 2.3 warning into an error.

Upstream packaging issue: https://github.com/firebase/firebase-android-sdk/issues/8557

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18608

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

This is a Gradle/Kotlin compile fix; there is no Dart behavior change to cover with an integration test. The example toolchain bump makes `e2e-auth` Android compile with Kotlin 2.4.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/

## Test plan

- [x] `:firebase_auth:compileDebugKotlin` fails on Kotlin 2.4.10 without the explicit type
- [x] Same task succeeds on Kotlin 2.4.10 with `{ auth: FirebaseAuth -> }` and no checker-qual
- [ ] Auth Android e2e / example APK still builds on CI