### PR TITLE
fix(core,web): compile isA checks on Dart < 3.12

### DIFF
--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -400,12 +400,11 @@ class FirebaseCoreWeb extends FirebasePlatform {
           rethrow;
         }
 
-        final jsError = e as JSError;
-        if (_getJSErrorCode(jsError) == 'app/duplicate-app') {
+        if (_getJSErrorCode(e) == 'app/duplicate-app') {
           throw duplicateApp(name);
         }
 
-        throw _catchJSError(jsError);
+        throw _catchJSError(e);
       }
     }
 
@@ -453,12 +452,11 @@ class FirebaseCoreWeb extends FirebasePlatform {
         rethrow;
       }
 
-      final jsError = e as JSError;
-      if (_getJSErrorCode(jsError) == 'app/no-app') {
+      if (_getJSErrorCode(e) == 'app/no-app') {
         throw noAppExists(name);
       }
 
-      throw _catchJSError(jsError);
+      throw _catchJSError(e);
     }
   }
 }

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -394,7 +394,9 @@ class FirebaseCoreWeb extends FirebasePlatform {
           measurementId: options.measurementId,
         );
       } catch (e) {
-        if (!e.isA<JSObject>()) {
+        // isA on Object requires Dart 3.12; this package supports 3.6.
+        // ignore: invalid_runtime_check_with_js_interop_types
+        if (e is! JSError) {
           rethrow;
         }
 
@@ -445,7 +447,9 @@ class FirebaseCoreWeb extends FirebasePlatform {
       app = guardNotInitialized(() => firebase.app(name));
       return _createFromJsApp(app);
     } catch (e) {
-      if (!e.isA<JSObject>()) {
+      // isA on Object requires Dart 3.12; this package supports 3.6.
+      // ignore: invalid_runtime_check_with_js_interop_types
+      if (e is! JSError) {
         rethrow;
       }
 


### PR DESCRIPTION
## Summary

- Fixes https://github.com/firebase/flutterfire/issues/18611: `firebase_core_web` 3.11.0 fails to dart2js on Flutter &lt; 3.44 (`The method 'isA' isn't defined for the type 'Object'`).
- Keeps the #18548 behavior: Dart exceptions from `guardNotInitialized()` (e.g. `core/not-initialized`) are rethrown instead of being force-cast to `JSError`.
- Does **not** raise the SDK constraint (`sdk: ^3.6.0`).

## Why `is! JSError` instead of `isA`

[#18552](https://github.com/firebase/flutterfire/pull/18552) added `e.isA<JSObject>()` on `catch (e)` so we could distinguish JS Firebase errors from Dart exceptions without an `invalid_runtime_check_with_js_interop_types` ignore.

That only compiles on **Dart ≥ 3.12**. `isA` lived on `JSAny?` until 3.12, when it moved to `NullableObjectUtilExtension on Object?` ([Dart changelog](https://dart.dev/changelog)). `catch (e)` types `e` as `Object`, so on Dart 3.6–3.11 the extension does not apply.

FlutterFire CI did not catch this: web jobs run on floating `stable` (currently Flutter 3.44 / Dart 3.12). Users still on Flutter 3.35 / 3.38 (Dart 3.9 / 3.10) — which `sdk: ^3.6.0` still allows — cannot compile for web.

Raising the constraint to `^3.12.0` would “fix” the compile error by refusing to resolve on those SDKs. That would drop Flutter 3.35/3.38, which is a much larger break than this patch.

So this PR uses `e is! JSError` with the same lint ignore already used in FlutterFire web (`firebase_auth_web`, `cloud_functions_web`, and this file’s `flutterfire_ignore_scripts` path). That:

- compiles on Dart 3.6+
- still rethrows non-JS errors (the #18548 fix)
- still maps JS `FirebaseError`s through `_getJSErrorCode` / `_catchJSError`

We do **not** use `(e as JSAny).isA<JSObject>()` to keep calling `isA`. That recasts Dart exceptions into JS types and can reintroduce the #18548 `TypeError`, especially on dart2wasm.

## Test plan

- [ ] `flutter test --platform chrome` in `packages/firebase_core/firebase_core_web` (covers the #18548 `core/not-initialized` regression test)
- [ ] `flutter build web` against this package on Flutter 3.35 or 3.38 (the reported failure)
- [ ] `flutter build web` on current stable (3.44+) still succeeds