### PR TITLE
docs(app_check): document native configure() workaround on Apple

### DIFF
--- a/docs/app-check/debug-provider.md
+++ b/docs/app-check/debug-provider.md
@@ -44,6 +44,13 @@ To use the debug provider while running your app in a simulator interactively
     }
     ```
 
+    If your iOS `AppDelegate` calls `FirebaseApp.configure()`, Dart
+    `AppleDebugProvider` is ignored on **physical devices**. Remove the native
+    `configure()` call, or install an `AppCheckProviderFactory` that returns
+    `AppCheckDebugProvider` *before* `configure()`. See
+    [Get started using App Check in Flutter apps](/docs/app-check/flutter/default-providers#native-configure)
+    and [flutterfire#18613](https://github.com/firebase/flutterfire/issues/18613).
+
 1.  Enable debug logging in your Xcode project (v11.0 or newer):
 
     1.  Open **Product > Scheme > Edit scheme**.

--- a/docs/app-check/default-providers.md
+++ b/docs/app-check/default-providers.md
@@ -98,6 +98,40 @@ Future<void> main() async {
 }
 ```
 
+### Native `FirebaseApp.configure()` on Apple platforms {:#native-configure}
+
+Do **not** call `FirebaseApp.configure()` in your `AppDelegate` unless you
+have a specific reason. `Firebase.initializeApp()`
+already configures the native default app.
+
+If you *must* call `FirebaseApp.configure()` natively, you must also install
+an App Check provider factory **before** `configure()`. Otherwise the Apple
+SDK locks in DeviceCheck on physical devices, and `providerApple` passed to
+Dart `activate()` is ignored. `activate()` on Android is unaffected.
+
+```swift
+import FirebaseAppCheck
+import FirebaseCore
+
+final class MyAppCheckProviderFactory: NSObject, AppCheckProviderFactory {
+  func createProvider(with app: FirebaseApp) -> (any AppCheckProvider)? {
+    #if DEBUG || targetEnvironment(simulator)
+      return AppCheckDebugProvider(app: app)
+    #else
+      return AppAttestProvider(app: app)
+    #endif
+  }
+}
+
+// In application(_:didFinishLaunchingWithOptions:), in this order:
+AppCheck.setAppCheckProviderFactory(MyAppCheckProviderFactory())
+FirebaseApp.configure()
+```
+
+This limitation is easiest to miss on a simulator, where the Apple SDK
+already defaults to the debug provider. See
+[flutterfire#18613](https://github.com/firebase/flutterfire/issues/18613).
+
 ## Next steps
 
 Once the App Check library is installed in your app, start distributing the

--- a/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check/lib/src/firebase_app_check.dart
@@ -73,6 +73,12 @@ class FirebaseAppCheck extends FirebasePlugin implements FirebaseService {
   /// "app attest with fallback to device check" via `AppleAppCheckProvider`.
   /// Note: App Attest is only available on iOS 14.0+ and macOS 14.0+.
   ///
+  /// Do not call `FirebaseApp.configure()` in `AppDelegate` unless you also
+  /// call `AppCheck.setAppCheckProviderFactory` first; otherwise
+  /// `providerApple` is ignored on physical Apple devices. Prefer
+  /// `Firebase.initializeApp()` only.
+  /// See https://github.com/firebase/flutterfire/issues/18613.
+  ///
   /// **Windows**: Only the debug provider is supported. You **must** supply a
   /// debug token — the desktop C++ SDK does not auto-generate one. Either pass
   /// it via `providerWindows: WindowsDebugProvider(debugToken: 'your-token')`

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/platform_interface/platform_interface_firebase_app_check.dart
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/lib/src/platform_interface/platform_interface_firebase_app_check.dart
@@ -67,6 +67,12 @@ abstract class FirebaseAppCheckPlatform extends PlatformInterface {
   /// "app attest with fallback to device check" via `AppleAppCheckProvider`.
   /// Note: App Attest is only available on iOS 14.0+ and macOS 14.0+.
   ///
+  /// Do not call `FirebaseApp.configure()` in `AppDelegate` unless you also
+  /// call `AppCheck.setAppCheckProviderFactory` first; otherwise
+  /// `providerApple` is ignored on physical Apple devices. Prefer
+  /// `Firebase.initializeApp()` only.
+  /// See https://github.com/firebase/flutterfire/issues/18613.
+  ///
   /// **Windows**: Only the debug provider is supported. You **must** supply a
   /// debug token — the desktop C++ SDK does not auto-generate one. Either pass
   /// it via `providerWindows: WindowsDebugProvider(debugToken: 'your-token')`


### PR DESCRIPTION
## Description

Documents a known limitation of `firebase_app_check` on Apple platforms: if an app calls `FirebaseApp.configure()` in `AppDelegate` (before plugin registration), Dart `activate()` `providerApple` is ignored on physical devices and the SDK attests with DeviceCheck. This is because the Apple SDK requires `AppCheck.setAppCheckProviderFactory` to be called *before* `configure()`.

This PR does not change plugin behavior. It documents the supported FlutterFire path (`Firebase.initializeApp()` only) and the native workaround for apps that must configure Firebase in `AppDelegate`.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18613

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/