### PR TITLE
fix(auth,android): declare checker-qual so Kotlin 2.4 can compile firebase_auth

### DIFF
--- a/packages/firebase_auth/firebase_auth/android/build.gradle
+++ b/packages/firebase_auth/firebase_auth/android/build.gradle
@@ -76,6 +76,12 @@ android {
         implementation platform("com.google.firebase:firebase-bom:${getRootProjectExtOrCoreProperty("FirebaseSDKVersion", firebaseCoreProject)}")
         implementation 'com.google.firebase:firebase-auth'
         implementation 'androidx.annotation:annotation:1.7.0'
+        // firebase-auth annotates its public API (for example
+        // FirebaseAuth.IdTokenListener) with Checker Framework type annotations,
+        // but does not expose checker-qual to consumers. Kotlin 2.4 rejects type
+        // annotations it cannot resolve, so this module's Kotlin sources fail to
+        // compile without it on the compile classpath.
+        compileOnly 'org.checkerframework:checker-qual:3.55.1'
     }
 }
 


### PR DESCRIPTION
## Description

`firebase_auth`'s Android sources fail to compile with Kotlin 2.4:

```
e: .../android/src/main/kotlin/io/flutter/plugins/firebase/auth/IdTokenChannelStreamHandler.kt:23:40
   Type annotation class 'org.checkerframework.checker.initialization.qual.UnknownInitialization'
   of the inferred type is inaccessible. Check the module classpath for missing or conflicting dependencies.

* What went wrong:
Execution failed for task ':firebase_auth:compileReleaseKotlin'.
```

Line 23 is the `FirebaseAuth.IdTokenListener { auth -> ... }` lambda. Kotlin has to
infer the type of `auth`, and that type carries a Checker Framework annotation —
`com/google/firebase/auth/FirebaseAuth$IdTokenListener.class` in the `firebase-auth`
AAR references `org/checkerframework/checker/initialization/qual/UnknownInitialization`.

`com.google.firebase:firebase-auth:24.2.0` declares 17 compile-scope dependencies
and `checker-qual` is not among them, so that annotation is not resolvable from a
consumer's compile classpath. Kotlin 2.3 and earlier silently ignored it; Kotlin 2.4
makes it an error.

This adds `checker-qual` as `compileOnly` — required to type-check against
`firebase-auth`'s API surface, not at runtime, so it does not reach consumers' APKs.

### Why this hasn't shown up in CI

Two things had to line up, and they only recently did:

1. **6.6.0 rewrote this module's Android sources from Java to Kotlin** (13 `.java` →
   13 `.kt`). `javac` does not care about unresolvable type annotations, so before
   6.6.0 nothing in this package was exposed to this.
2. **CI is on Kotlin 2.3.0** (`fix(ci): bump Kotlin Gradle plugin to 2.3.0`) — one
   minor below where the diagnostic became an error.

So this is latent rather than hypothetical: it surfaces on the next KGP bump.

### Verification

Reproduced in a Flutter 3.47.1 app (AGP 8.13.2) using `firebase_auth` 6.6.0:

| Kotlin | result |
|---|---|
| 2.3.20 | builds |
| 2.4.0  | fails as above |
| 2.4.10 | fails as above |

With **only** this change applied to `firebase_auth/android/build.gradle` and no
workaround in the consuming app, `flutter clean && flutter build apk --release`
succeeds on Kotlin 2.4.10. The file it was applied to is byte-identical to `main`.

No other Firebase plugin is affected: `firebase_storage` ships Kotlin but does not
reference `com.google.firebase.auth`, and `firebase_core` / `firebase_crashlytics`
ship no Kotlin, so the fix is correctly scoped to this package.

### Note on the underlying cause

Arguably the real fix belongs in the Firebase Android SDK — `firebase-auth`
annotates its public API with Checker Framework annotations without exposing
`checker-qual` to consumers. This is the consumer-side fix that unblocks Kotlin 2.4
today, and can be reverted if `firebase-auth` later declares the dependency itself.

## Related Issues

None found open for this. Happy to file one to track it if you would prefer that
first.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

Being explicit about the four unchecked boxes rather than ticking them:

- **Tests** — this is a Gradle dependency declaration; there is no Dart or Kotlin
  behavior to assert on. The meaningful verification is that the module compiles
  under Kotlin 2.4, which is the table above. If you have a preferred place to pin
  a build-configuration regression, point me at it and I will add one.
- **Existing tests / `melos run analyze`** — not run. This change touches no Dart,
  and I verified against a real consuming app rather than a `melos bootstrap`
  workspace. Say the word and I will run the full workspace checks.
- **CLA** — not yet signed on this account. I will sign before you spend review
  time on it; flagging rather than pre-ticking.
- **Documentation** — ticked for the explanatory comment on the dependency itself;
  there is no public API surface to document.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
