### PR TITLE
fix(messaging,ios): register for APNs when UIScene plugins miss launch callbacks

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
@@ -135,6 +135,14 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
     if ([registrar respondsToSelector:@selector(addSceneDelegate:)]) {
       [registrar performSelector:@selector(addSceneDelegate:) withObject:instance];
     }
+    // UIScene registers plugins after didFinishLaunching / scene:willConnect.
+    // If a scene is already connected those callbacks were missed, so run
+    // setup now. setupNotificationHandling is idempotent if a callback still
+    // arrives later. iOS re-delivers the APNs token when we register again.
+    if ([UIApplication sharedApplication].connectedScenes.count > 0) {
+      instance->_sceneDidConnect = YES;
+      [instance setupNotificationHandlingWithRemoteNotification:nil];
+    }
   }
 #endif
 }


### PR DESCRIPTION
## Description

UIScene apps can register `firebase_messaging` after `didFinishLaunching` and `scene:willConnect` have already fired. Setup (and therefore `registerForRemoteNotifications()`) was skipped, so `getAPNSToken()` stayed null and `getToken()` threw `apns-token-not-set`.

If a scene is already connected at plugin registration, run setup immediately (same catch-up macOS already has when the app is running). The existing `_notificationHandlingSetup` guard keeps a later scene callback idempotent.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18555

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/

## Test plan

- [ ] Delete the app on a physical iPhone (no cached APNs token).
- [ ] UIScene + `FlutterImplicitEngineDelegate` app on `firebase_messaging` with this change.
- [ ] After `Firebase.initializeApp()`, `getAPNSToken()` / `getToken()` succeed instead of staying null / throwing `apns-token-not-set`.
- [ ] Confirm a non-UIScene app still obtains a token as before.