### PR TITLE
chore(release): 2026-08-27 — BoM 4.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## 2026-08-27
+## 2026-08-27 - [BoM 4.20.0](https://github.com/firebase/flutterfire/blob/main/VERSIONS.md#flutter-bom-4200-2026-08-27)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2026-08-27
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`firebase_auth` - `v6.6.1`](#firebase_auth---v661)
+ - [`firebase_core` - `v4.15.0`](#firebase_core---v4150)
+ - [`firebase_core_web` - `v3.11.1`](#firebase_core_web---v3111)
+
+---
+
+#### `firebase_auth` - `v6.6.1`
+
+ - **FIX**(firebase_auth): compile Android Kotlin without checker-qual on inferred types ([#18610](https://github.com/firebase/flutterfire/issues/18610)). ([28e30cb9](https://github.com/firebase/flutterfire/commit/28e30cb961c64f138d36be6f12b7fa67ea10e596))
+
+#### `firebase_core` - `v4.15.0`
+
+ - **FEAT**(core): bump Firebase C++ SDK to 13.12.0 ([#18618](https://github.com/firebase/flutterfire/issues/18618)). ([d54b9308](https://github.com/firebase/flutterfire/commit/d54b93083c33d845873b11a901b9c469538b810f))
+
+#### `firebase_core_web` - `v3.11.1`
+
+ - **FIX**(core,web): compile isA checks on Dart < 3.12 ([#18612](https://github.com/firebase/flutterfire/issues/18612)). ([3bd7c069](https://github.com/firebase/flutterfire/commit/3bd7c069f791f5482f79e6f80cf6fd833b6245f8))
+
+
 ## 2026-08-24 - [BoM 4.19.0](https://github.com/firebase/flutterfire/blob/main/VERSIONS.md#flutter-bom-4190-2026-08-24)
 
 ### Changes

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,44 @@ This document is listing all the compatible versions of the FlutterFire plugins.
 
 # Versions
 
+## [Flutter BoM 4.20.0 (2026-08-27)](https://github.com/firebase/flutterfire/blob/main/CHANGELOG.md#2026-08-27)
+
+Install this version using FlutterFire CLI
+
+```bash
+flutterfire install 4.20.0
+```
+
+### Included Native Firebase SDK Versions
+| Firebase SDK | Version | Link |
+|--------------|---------|------|
+| Android SDK | 34.18.0 | [Release Notes](https://firebase.google.com/support/release-notes/android) |
+| iOS SDK | 12.18.0 | [Release Notes](https://firebase.google.com/support/release-notes/ios) |
+| Web SDK | 12.18.0 | [Release Notes](https://firebase.google.com/support/release-notes/js) |
+| Windows SDK | 13.12.0 | [Release Notes](https://firebase.google.com/support/release-notes/cpp-relnotes) |
+
+### FlutterFire Plugin Versions
+| Plugin | Version | Dart Version | Flutter Version |
+|--------|---------|--------------|-----------------|
+| [cloud_firestore](https://pub.dev/packages/cloud_firestore/versions/6.9.0) | 6.9.0 | ^3.6.0 | >=3.27.0 |
+| [cloud_functions](https://pub.dev/packages/cloud_functions/versions/6.4.0) | 6.4.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_ai](https://pub.dev/packages/firebase_ai/versions/4.0.0) | 4.0.0 | ^3.6.0 | >=3.16.0 |
+| [firebase_analytics](https://pub.dev/packages/firebase_analytics/versions/12.5.0) | 12.5.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_app_check](https://pub.dev/packages/firebase_app_check/versions/0.4.7) | 0.4.7 | ^3.6.0 | >=3.27.0 |
+| [firebase_app_installations](https://pub.dev/packages/firebase_app_installations/versions/0.4.3) | 0.4.3 | ^3.6.0 | >=3.27.0 |
+| [firebase_auth](https://pub.dev/packages/firebase_auth/versions/6.6.1) | 6.6.1 | ^3.6.0 | >=3.16.0 |
+| [firebase_core](https://pub.dev/packages/firebase_core/versions/4.15.0) | 4.15.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_crashlytics](https://pub.dev/packages/firebase_crashlytics/versions/5.3.0) | 5.3.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_data_connect](https://pub.dev/packages/firebase_data_connect/versions/0.3.2) | 0.3.2 | ^3.6.0 | >=3.27.0 |
+| [firebase_database](https://pub.dev/packages/firebase_database/versions/12.5.0) | 12.5.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_in_app_messaging](https://pub.dev/packages/firebase_in_app_messaging/versions/0.9.3) | 0.9.3 | ^3.6.0 | >=3.27.0 |
+| [firebase_messaging](https://pub.dev/packages/firebase_messaging/versions/16.6.0) | 16.6.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_ml_model_downloader](https://pub.dev/packages/firebase_ml_model_downloader/versions/0.4.4) | 0.4.4 | ^3.6.0 | >=3.27.0 |
+| [firebase_performance](https://pub.dev/packages/firebase_performance/versions/0.11.5) | 0.11.5 | ^3.6.0 | >=3.27.0 |
+| [firebase_remote_config](https://pub.dev/packages/firebase_remote_config/versions/6.6.0) | 6.6.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_storage](https://pub.dev/packages/firebase_storage/versions/13.5.0) | 13.5.0 | ^3.6.0 | >=3.27.0 |
+
+
 ## [Flutter BoM 4.19.0 (2026-08-24)](https://github.com/firebase/flutterfire/blob/main/CHANGELOG.md#2026-08-24)
 
 Install this version using FlutterFire CLI

--- a/packages/firebase_auth/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.6.1
+
+ - **FIX**(firebase_auth): compile Android Kotlin without checker-qual on inferred types ([#18610](https://github.com/firebase/flutterfire/issues/18610)). ([28e30cb9](https://github.com/firebase/flutterfire/commit/28e30cb961c64f138d36be6f12b7fa67ea10e596))
+
 ## 6.6.0
 
  - **REFACTOR**(auth,android): migrate native implementation to Kotlin ([#18582](https://github.com/firebase/flutterfire/issues/18582)). ([6131eddc](https://github.com/firebase/flutterfire/commit/6131eddc724aac2005f839e612617953572422fc))

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Package.swift
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "6.6.0"
+let libraryVersion = "6.6.1"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_auth/firebase_auth/macos/firebase_auth/Package.swift
+++ b/packages/firebase_auth/firebase_auth/macos/firebase_auth/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "6.6.0"
+let libraryVersion = "6.6.1"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling
   like Google, Facebook and Twitter.
 homepage: https://firebase.google.com/docs/auth
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_auth/firebase_auth
-version: 6.6.0
+version: 6.6.1
 resolution: workspace
 topics:
   - firebase

--- a/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_version.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '6.6.0';
+const packageVersion = '6.6.1';

--- a/packages/firebase_core/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.15.0
+
+ - **FEAT**(core): bump Firebase C++ SDK to 13.12.0 ([#18618](https://github.com/firebase/flutterfire/issues/18618)). ([d54b9308](https://github.com/firebase/flutterfire/commit/d54b93083c33d845873b11a901b9c469538b810f))
+
 ## 4.14.0
 
  - **REFACTOR**(core,android): migrate native implementation to Kotlin ([#18570](https://github.com/firebase/flutterfire/issues/18570)). ([7a0f5856](https://github.com/firebase/flutterfire/commit/7a0f5856cbb2ae64c530dcbdb43b03d43912465c))

--- a/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
+++ b/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersionString = "4.14.0"
+let libraryVersionString = "4.15.0"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_core/firebase_core/ios/firebase_core/Sources/firebase_core/Constants.swift
+++ b/packages/firebase_core/firebase_core/ios/firebase_core/Sources/firebase_core/Constants.swift
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// Auto-generated file. Do not edit.
-public let versionNumber = "4.14.0"
+public let versionNumber = "4.15.0"

--- a/packages/firebase_core/firebase_core/macos/firebase_core/Package.swift
+++ b/packages/firebase_core/firebase_core/macos/firebase_core/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersionString = "4.14.0"
+let libraryVersionString = "4.15.0"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 homepage: https://firebase.google.com/docs/flutter/setup
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_core/firebase_core
-version: 4.14.0
+version: 4.15.0
 resolution: workspace
 topics:
   - firebase

--- a/packages/firebase_core/firebase_core_web/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.11.1
+
+ - **FIX**(core,web): compile isA checks on Dart < 3.12 ([#18612](https://github.com/firebase/flutterfire/issues/18612)). ([3bd7c069](https://github.com/firebase/flutterfire/commit/3bd7c069f791f5482f79e6f80cf6fd833b6245f8))
+
 ## 3.11.0
 
  - **FIX**(core,web): keep App Check registered for secondary Firebase apps ([#18557](https://github.com/firebase/flutterfire/issues/18557)). ([1345dbb3](https://github.com/firebase/flutterfire/commit/1345dbb38af36c2d1c3f6582f474f5520a185021))

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_version.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '4.14.0';
+const packageVersion = '4.15.0';

--- a/packages/firebase_core/firebase_core_web/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_core_web
 description: The web implementation of firebase_core
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_core/firebase_core_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_core/firebase_core_web
-version: 3.11.0
+version: 3.11.1
 resolution: workspace
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,10 +70,10 @@ workspace:
   - tests
 
 dev_dependencies:
-  cli_util: ^0.4.1
+  cli_util: ^0.5.0
   glob: ^2.1.2
   intl: ^0.20.2
-  melos: ^7.5.1
+  melos: ^8.5.0
   path: ^1.9.0
   pub_semver: ^2.1.4
   yaml: ^3.1.2
@@ -90,6 +90,8 @@ melos:
       # branch: main
       # Additionally build a changelog at the root of the workspace.
       workspaceChangelog: true
+      # Don't bump dependents whose constraints already allow the new version.
+      smartDependents: true
       hooks:
         preCommit: |
           dart run scripts/generate_firebaseai_version.dart && \

--- a/scripts/versions.json
+++ b/scripts/versions.json
@@ -1,4 +1,32 @@
 {
+  "4.20.0": {
+    "date": "2026-08-27",
+    "firebase_sdk": {
+      "android": "34.18.0",
+      "ios": "12.18.0",
+      "web": "12.18.0",
+      "windows": "13.12.0"
+    },
+    "packages": {
+      "cloud_firestore": "6.9.0",
+      "cloud_functions": "6.4.0",
+      "firebase_ai": "4.0.0",
+      "firebase_analytics": "12.5.0",
+      "firebase_app_check": "0.4.7",
+      "firebase_app_installations": "0.4.3",
+      "firebase_auth": "6.6.1",
+      "firebase_core": "4.15.0",
+      "firebase_crashlytics": "5.3.0",
+      "firebase_data_connect": "0.3.2",
+      "firebase_database": "12.5.0",
+      "firebase_in_app_messaging": "0.9.3",
+      "firebase_messaging": "16.6.0",
+      "firebase_ml_model_downloader": "0.4.4",
+      "firebase_performance": "0.11.5",
+      "firebase_remote_config": "6.6.0",
+      "firebase_storage": "13.5.0"
+    }
+  },
   "4.19.0": {
     "date": "2026-08-24",
     "firebase_sdk": {


### PR DESCRIPTION
## Release 2026-08-27 — BoM 4.20.0

### Versioning
`melos version` bumped **3 packages**: `firebase_auth` 6.6.1, `firebase_core` 4.15.0, `firebase_core_web` 3.11.1. Full details in the per-package CHANGELOGs and the root `CHANGELOG.md`.

Aggregate: `minor: 1, major: 0, patch: 1` across the 17 BoM-tracked plugins.

This release also upgrades melos to 8.5.0 and enables `smartDependents`, so dependent packages whose constraints already allow the updated dependency are no longer bumped and republished with no functional change (invertase/melos#1063). Under the previous behaviour this release would have versioned 44 packages instead of 3.

### Native SDK versions in this BoM
| SDK | Version |
|---|---|
| Android | 34.18.0 |
| iOS | 12.18.0 |
| Web | 12.18.0 |
| Windows | 13.12.0 |
