### PR TITLE
chore(release): 2026-08-27 — BoM 4.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## 2026-08-27
+## 2026-08-27 - [BoM 4.19.1](https://github.com/firebase/flutterfire/blob/main/VERSIONS.md#flutter-bom-4191-2026-08-27)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2026-08-27
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`firebase_auth` - `v6.6.1`](#firebase_auth---v661)
+
+---
+
+#### `firebase_auth` - `v6.6.1`
+
+ - **FIX**(firebase_auth): compile Android Kotlin without checker-qual on inferred types ([#18610](https://github.com/firebase/flutterfire/issues/18610)). ([811b07db](https://github.com/firebase/flutterfire/commit/811b07dbac4a980d50520ea262b281ec1464f6ad))
+
+
 ## 2026-08-24 - [BoM 4.19.0](https://github.com/firebase/flutterfire/blob/main/VERSIONS.md#flutter-bom-4190-2026-08-24)
 
 ### Changes

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,44 @@ This document is listing all the compatible versions of the FlutterFire plugins.
 
 # Versions
 
+## [Flutter BoM 4.19.1 (2026-08-27)](https://github.com/firebase/flutterfire/blob/main/CHANGELOG.md#2026-08-27)
+
+Install this version using FlutterFire CLI
+
+```bash
+flutterfire install 4.19.1
+```
+
+### Included Native Firebase SDK Versions
+| Firebase SDK | Version | Link |
+|--------------|---------|------|
+| Android SDK | 34.18.0 | [Release Notes](https://firebase.google.com/support/release-notes/android) |
+| iOS SDK | 12.18.0 | [Release Notes](https://firebase.google.com/support/release-notes/ios) |
+| Web SDK | 12.18.0 | [Release Notes](https://firebase.google.com/support/release-notes/js) |
+| Windows SDK | 13.11.0 | [Release Notes](https://firebase.google.com/support/release-notes/cpp-relnotes) |
+
+### FlutterFire Plugin Versions
+| Plugin | Version | Dart Version | Flutter Version |
+|--------|---------|--------------|-----------------|
+| [cloud_firestore](https://pub.dev/packages/cloud_firestore/versions/6.9.0) | 6.9.0 | ^3.6.0 | >=3.27.0 |
+| [cloud_functions](https://pub.dev/packages/cloud_functions/versions/6.4.0) | 6.4.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_ai](https://pub.dev/packages/firebase_ai/versions/4.0.0) | 4.0.0 | ^3.6.0 | >=3.16.0 |
+| [firebase_analytics](https://pub.dev/packages/firebase_analytics/versions/12.5.0) | 12.5.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_app_check](https://pub.dev/packages/firebase_app_check/versions/0.4.7) | 0.4.7 | ^3.6.0 | >=3.27.0 |
+| [firebase_app_installations](https://pub.dev/packages/firebase_app_installations/versions/0.4.3) | 0.4.3 | ^3.6.0 | >=3.27.0 |
+| [firebase_auth](https://pub.dev/packages/firebase_auth/versions/6.6.1) | 6.6.1 | ^3.6.0 | >=3.16.0 |
+| [firebase_core](https://pub.dev/packages/firebase_core/versions/4.14.0) | 4.14.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_crashlytics](https://pub.dev/packages/firebase_crashlytics/versions/5.3.0) | 5.3.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_data_connect](https://pub.dev/packages/firebase_data_connect/versions/0.3.2) | 0.3.2 | ^3.6.0 | >=3.27.0 |
+| [firebase_database](https://pub.dev/packages/firebase_database/versions/12.5.0) | 12.5.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_in_app_messaging](https://pub.dev/packages/firebase_in_app_messaging/versions/0.9.3) | 0.9.3 | ^3.6.0 | >=3.27.0 |
+| [firebase_messaging](https://pub.dev/packages/firebase_messaging/versions/16.6.0) | 16.6.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_ml_model_downloader](https://pub.dev/packages/firebase_ml_model_downloader/versions/0.4.4) | 0.4.4 | ^3.6.0 | >=3.27.0 |
+| [firebase_performance](https://pub.dev/packages/firebase_performance/versions/0.11.5) | 0.11.5 | ^3.6.0 | >=3.27.0 |
+| [firebase_remote_config](https://pub.dev/packages/firebase_remote_config/versions/6.6.0) | 6.6.0 | ^3.6.0 | >=3.27.0 |
+| [firebase_storage](https://pub.dev/packages/firebase_storage/versions/13.5.0) | 13.5.0 | ^3.6.0 | >=3.27.0 |
+
+
 ## [Flutter BoM 4.19.0 (2026-08-24)](https://github.com/firebase/flutterfire/blob/main/CHANGELOG.md#2026-08-24)
 
 Install this version using FlutterFire CLI

--- a/packages/firebase_auth/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.6.1
+
+ - **FIX**(firebase_auth): compile Android Kotlin without checker-qual on inferred types ([#18610](https://github.com/firebase/flutterfire/issues/18610)). ([811b07db](https://github.com/firebase/flutterfire/commit/811b07dbac4a980d50520ea262b281ec1464f6ad))
+
 ## 6.6.0
 
  - **REFACTOR**(auth,android): migrate native implementation to Kotlin ([#18582](https://github.com/firebase/flutterfire/issues/18582)). ([6131eddc](https://github.com/firebase/flutterfire/commit/6131eddc724aac2005f839e612617953572422fc))

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Package.swift
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "6.6.0"
+let libraryVersion = "6.6.1"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_auth/firebase_auth/macos/firebase_auth/Package.swift
+++ b/packages/firebase_auth/firebase_auth/macos/firebase_auth/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "6.6.0"
+let libraryVersion = "6.6.1"
 let firebaseSdkVersion: Version = "12.18.0"
 
 let package = Package(

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling
   like Google, Facebook and Twitter.
 homepage: https://firebase.google.com/docs/auth
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_auth/firebase_auth
-version: 6.6.0
+version: 6.6.1
 resolution: workspace
 topics:
   - firebase

--- a/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_version.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '6.6.0';
+const packageVersion = '6.6.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,10 +70,10 @@ workspace:
   - tests
 
 dev_dependencies:
-  cli_util: ^0.4.1
+  cli_util: ^0.5.0
   glob: ^2.1.2
   intl: ^0.20.2
-  melos: ^7.5.1
+  melos: ^8.5.0
   path: ^1.9.0
   pub_semver: ^2.1.4
   yaml: ^3.1.2
@@ -90,6 +90,8 @@ melos:
       # branch: main
       # Additionally build a changelog at the root of the workspace.
       workspaceChangelog: true
+      # Don't bump dependents whose constraints already allow the new version.
+      smartDependents: true
       hooks:
         preCommit: |
           dart run scripts/generate_firebaseai_version.dart && \

--- a/scripts/versions.json
+++ b/scripts/versions.json
@@ -1,4 +1,32 @@
 {
+  "4.19.1": {
+    "date": "2026-08-27",
+    "firebase_sdk": {
+      "android": "34.18.0",
+      "ios": "12.18.0",
+      "web": "12.18.0",
+      "windows": "13.11.0"
+    },
+    "packages": {
+      "cloud_firestore": "6.9.0",
+      "cloud_functions": "6.4.0",
+      "firebase_ai": "4.0.0",
+      "firebase_analytics": "12.5.0",
+      "firebase_app_check": "0.4.7",
+      "firebase_app_installations": "0.4.3",
+      "firebase_auth": "6.6.1",
+      "firebase_core": "4.14.0",
+      "firebase_crashlytics": "5.3.0",
+      "firebase_data_connect": "0.3.2",
+      "firebase_database": "12.5.0",
+      "firebase_in_app_messaging": "0.9.3",
+      "firebase_messaging": "16.6.0",
+      "firebase_ml_model_downloader": "0.4.4",
+      "firebase_performance": "0.11.5",
+      "firebase_remote_config": "6.6.0",
+      "firebase_storage": "13.5.0"
+    }
+  },
   "4.19.0": {
     "date": "2026-08-24",
     "firebase_sdk": {


### PR DESCRIPTION
## Release 2026-08-27 — BoM 4.19.1

Hotfix release for #18608 (`:firebase_auth:compileDebugKotlin` fails). Scoped to #18610 — #18612, #18614 and #18618 stay unreleased on `main` and go out with the next release.

### Versioning
`melos version` bumped **1 package**: `firebase_auth` 6.6.1.

Aggregate: `minor: 0, major: 0, patch: 1` across the 17 BoM-tracked plugins.

Also upgrades melos to 8.5.0 and enables `smartDependents` (invertase/melos#1063), so dependents whose constraints already allow the new version are no longer bumped and republished with no functional change. Without it this release would also have versioned `firebase_ai` and `firebase_data_connect`.

### Native SDK versions in this BoM
| SDK | Version |
|---|---|
| Android | 34.18.0 |
| iOS | 12.18.0 |
| Web | 12.18.0 |
| Windows | 13.11.0 |
