### PR TITLE
chore(gemini): silence PR open help banner and auto-review drafts

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -4,6 +4,7 @@ code_review:
   comment_severity_threshold: LOW
   max_review_comments: -1
   pull_request_opened:
-    help: true
+    help: false
     summary: false
     code_review: true
+    include_drafts: true


### PR DESCRIPTION
- Set pull_request_opened.help to false to eliminate the noisy command cheat sheet comment on new PRs.
- Add pull_request_opened.include_drafts: true so Gemini automatically performs code reviews on draft PRs upon open.
