### PR TITLE
fix(messaging,android): defer background engine startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,227 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2026-08-03
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`cloud_firestore` - `v6.8.0`](#cloud_firestore---v680)
+ - [`cloud_firestore_platform_interface` - `v8.0.6`](#cloud_firestore_platform_interface---v806)
+ - [`cloud_firestore_web` - `v5.7.2`](#cloud_firestore_web---v572)
+ - [`cloud_functions` - `v6.3.6`](#cloud_functions---v636)
+ - [`firebase_ai` - `v3.15.0`](#firebase_ai---v3150)
+ - [`firebase_analytics` - `v12.4.6`](#firebase_analytics---v1246)
+ - [`firebase_app_check` - `v0.4.6`](#firebase_app_check---v046)
+ - [`firebase_app_check_platform_interface` - `v0.4.2`](#firebase_app_check_platform_interface---v042)
+ - [`firebase_app_check_web` - `v0.2.6`](#firebase_app_check_web---v026)
+ - [`firebase_app_installations` - `v0.4.2+7`](#firebase_app_installations---v0427)
+ - [`firebase_auth` - `v6.5.7`](#firebase_auth---v657)
+ - [`firebase_core` - `v4.13.0`](#firebase_core---v4130)
+ - [`firebase_core_platform_interface` - `v8.1.0`](#firebase_core_platform_interface---v810)
+ - [`firebase_core_web` - `v3.10.0`](#firebase_core_web---v3100)
+ - [`firebase_crashlytics` - `v5.2.7`](#firebase_crashlytics---v527)
+ - [`firebase_data_connect` - `v0.3.1`](#firebase_data_connect---v031)
+ - [`firebase_database` - `v12.4.7`](#firebase_database---v1247)
+ - [`firebase_in_app_messaging` - `v0.9.2+7`](#firebase_in_app_messaging---v0927)
+ - [`firebase_messaging` - `v16.5.0`](#firebase_messaging---v1650)
+ - [`firebase_ml_model_downloader` - `v0.4.3`](#firebase_ml_model_downloader---v043)
+ - [`firebase_ml_model_downloader_platform_interface` - `v0.1.6`](#firebase_ml_model_downloader_platform_interface---v016)
+ - [`firebase_performance` - `v0.11.4+6`](#firebase_performance---v01146)
+ - [`firebase_remote_config` - `v6.5.6`](#firebase_remote_config---v656)
+ - [`firebase_remote_config_platform_interface` - `v3.0.6`](#firebase_remote_config_platform_interface---v306)
+ - [`firebase_storage` - `v13.4.6`](#firebase_storage---v1346)
+ - [`_flutterfire_internals` - `v1.3.76`](#_flutterfire_internals---v1376)
+ - [`cloud_functions_platform_interface` - `v6.0.6`](#cloud_functions_platform_interface---v606)
+ - [`cloud_functions_web` - `v5.1.12`](#cloud_functions_web---v5112)
+ - [`firebase_analytics_platform_interface` - `v6.0.6`](#firebase_analytics_platform_interface---v606)
+ - [`firebase_analytics_web` - `v0.6.1+12`](#firebase_analytics_web---v06112)
+ - [`firebase_app_installations_platform_interface` - `v0.1.4+75`](#firebase_app_installations_platform_interface---v01475)
+ - [`firebase_app_installations_web` - `v0.1.7+12`](#firebase_app_installations_web---v01712)
+ - [`firebase_auth_platform_interface` - `v9.0.6`](#firebase_auth_platform_interface---v906)
+ - [`firebase_auth_web` - `v6.2.6`](#firebase_auth_web---v626)
+ - [`firebase_crashlytics_platform_interface` - `v3.8.27`](#firebase_crashlytics_platform_interface---v3827)
+ - [`firebase_database_platform_interface` - `v0.4.0+6`](#firebase_database_platform_interface---v0406)
+ - [`firebase_database_web` - `v0.2.7+13`](#firebase_database_web---v02713)
+ - [`firebase_in_app_messaging_platform_interface` - `v0.2.5+27`](#firebase_in_app_messaging_platform_interface---v02527)
+ - [`firebase_messaging_platform_interface` - `v4.9.3`](#firebase_messaging_platform_interface---v493)
+ - [`firebase_messaging_web` - `v4.2.4`](#firebase_messaging_web---v424)
+ - [`firebase_performance_platform_interface` - `v0.2.0+6`](#firebase_performance_platform_interface---v0206)
+ - [`firebase_performance_web` - `v0.1.8+12`](#firebase_performance_web---v01812)
+ - [`firebase_remote_config_web` - `v1.10.13`](#firebase_remote_config_web---v11013)
+ - [`firebase_storage_platform_interface` - `v6.0.6`](#firebase_storage_platform_interface---v606)
+ - [`firebase_storage_web` - `v3.11.12`](#firebase_storage_web---v31112)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `_flutterfire_internals` - `v1.3.76`
+ - `cloud_functions_platform_interface` - `v6.0.6`
+ - `cloud_functions_web` - `v5.1.12`
+ - `firebase_analytics_platform_interface` - `v6.0.6`
+ - `firebase_analytics_web` - `v0.6.1+12`
+ - `firebase_app_installations_platform_interface` - `v0.1.4+75`
+ - `firebase_app_installations_web` - `v0.1.7+12`
+ - `firebase_auth_platform_interface` - `v9.0.6`
+ - `firebase_auth_web` - `v6.2.6`
+ - `firebase_crashlytics_platform_interface` - `v3.8.27`
+ - `firebase_database_platform_interface` - `v0.4.0+6`
+ - `firebase_database_web` - `v0.2.7+13`
+ - `firebase_in_app_messaging_platform_interface` - `v0.2.5+27`
+ - `firebase_messaging_platform_interface` - `v4.9.3`
+ - `firebase_messaging_web` - `v4.2.4`
+ - `firebase_performance_platform_interface` - `v0.2.0+6`
+ - `firebase_performance_web` - `v0.1.8+12`
+ - `firebase_remote_config_web` - `v1.10.13`
+ - `firebase_storage_platform_interface` - `v6.0.6`
+ - `firebase_storage_web` - `v3.11.12`
+
+---
+
+#### `cloud_firestore` - `v6.8.0`
+
+ - **FIX**(firestore,core,windows): per-engine BinaryMessenger, Firestore/Auth link order, Profile builds ([#18516](https://github.com/firebase/flutterfire/issues/18516)). ([5dfd289e](https://github.com/firebase/flutterfire/commit/5dfd289ea45260c15d73894dcf2cb092fc8ddb9d))
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FIX**(firestore,android): clean up Android transaction listeners on completion ([#18475](https://github.com/firebase/flutterfire/issues/18475)). ([ae002c7c](https://github.com/firebase/flutterfire/commit/ae002c7ca8ae405ebc901bfe17e6724a48075bca))
+ - **FIX**(firestore,windows): reply on platform thread to prevent warnings ([#18459](https://github.com/firebase/flutterfire/issues/18459)). ([cfeddb1b](https://github.com/firebase/flutterfire/commit/cfeddb1b4e2a519d77440a8ec4799eb9b9c12a37))
+ - **FIX**(firestore,windows): Prevents lost Windows transaction responses ([#18448](https://github.com/firebase/flutterfire/issues/18448)). ([ed1a551d](https://github.com/firebase/flutterfire/commit/ed1a551d41bc3303e66985e30d4d2b570606bc7f))
+ - **FIX**(firestore): Preserves microseconds when serializing implicit DateTime values ([#18435](https://github.com/firebase/flutterfire/issues/18435)). ([068c3094](https://github.com/firebase/flutterfire/commit/068c30946912d8a3d5f24455fcb4bc00202e60ee))
+ - **FEAT**(firestore): add string manipulation functions for Android and iOS ([#18493](https://github.com/firebase/flutterfire/issues/18493)). ([b3bd7e9d](https://github.com/firebase/flutterfire/commit/b3bd7e9ddd61942530883501f285ed32b55f9953))
+
+#### `cloud_firestore_platform_interface` - `v8.0.6`
+
+ - **FIX**(firestore,android): clean up Android transaction listeners on completion ([#18475](https://github.com/firebase/flutterfire/issues/18475)). ([ae002c7c](https://github.com/firebase/flutterfire/commit/ae002c7ca8ae405ebc901bfe17e6724a48075bca))
+ - **FIX**(firestore): Preserves microseconds when serializing implicit DateTime values ([#18435](https://github.com/firebase/flutterfire/issues/18435)). ([068c3094](https://github.com/firebase/flutterfire/commit/068c30946912d8a3d5f24455fcb4bc00202e60ee))
+
+#### `cloud_firestore_web` - `v5.7.2`
+
+ - **FIX**(firestore): Preserves microseconds when serializing implicit DateTime values ([#18435](https://github.com/firebase/flutterfire/issues/18435)). ([068c3094](https://github.com/firebase/flutterfire/commit/068c30946912d8a3d5f24455fcb4bc00202e60ee))
+
+#### `cloud_functions` - `v6.3.6`
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+
+#### `firebase_ai` - `v3.15.0`
+
+ - **FEAT**(firebaseai): Rename vertexAI to agentPlatform ([#18467](https://github.com/firebase/flutterfire/issues/18467)). ([2f942f28](https://github.com/firebase/flutterfire/commit/2f942f28586a6fcc82b1de454b707633ba8e2e04))
+
+#### `firebase_analytics` - `v12.4.6`
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+
+#### `firebase_app_check` - `v0.4.6`
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))
+ - **FEAT**(appcheck): getTokenResult ([#18492](https://github.com/firebase/flutterfire/issues/18492)). ([361f7199](https://github.com/firebase/flutterfire/commit/361f7199a1a6f930a7ad298c7f4eb3f1d5e6bb0d))
+
+#### `firebase_app_check_platform_interface` - `v0.4.2`
+
+ - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))
+ - **FEAT**(appcheck): getTokenResult ([#18492](https://github.com/firebase/flutterfire/issues/18492)). ([361f7199](https://github.com/firebase/flutterfire/commit/361f7199a1a6f930a7ad298c7f4eb3f1d5e6bb0d))
+
+#### `firebase_app_check_web` - `v0.2.6`
+
+ - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))
+ - **FEAT**(appcheck): getTokenResult ([#18492](https://github.com/firebase/flutterfire/issues/18492)). ([361f7199](https://github.com/firebase/flutterfire/commit/361f7199a1a6f930a7ad298c7f4eb3f1d5e6bb0d))
+
+#### `firebase_app_installations` - `v0.4.2+7`
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+
+#### `firebase_auth` - `v6.5.7`
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FIX**(auth,ios): Generic OAuth credentials on iOS passed a missing access token through a non-nullable Firebase SDK selector ([#18450](https://github.com/firebase/flutterfire/issues/18450)). ([32ae2701](https://github.com/firebase/flutterfire/commit/32ae2701f5ff9e132a6ac95a9520d24c12cce769))
+
+#### `firebase_core` - `v4.13.0`
+
+ - **FIX**(firestore,core,windows): per-engine BinaryMessenger, Firestore/Auth link order, Profile builds ([#18516](https://github.com/firebase/flutterfire/issues/18516)). ([5dfd289e](https://github.com/firebase/flutterfire/commit/5dfd289ea45260c15d73894dcf2cb092fc8ddb9d))
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FIX**(remote_config,windows): move CMake dependency from Core to Remote Config ([#18498](https://github.com/firebase/flutterfire/issues/18498)). ([d6ef43f6](https://github.com/firebase/flutterfire/commit/d6ef43f616d03a57b76469b77f4cfd3d8325075a))
+ - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))
+ - **FEAT**(core): bump Firebase android SDK to 34.16.0 ([#18465](https://github.com/firebase/flutterfire/issues/18465)). ([fc599349](https://github.com/firebase/flutterfire/commit/fc5993493fbaaf405680eb1e0c8cc0b2604ef1a0))
+ - **FEAT**(core): bump Firebase iOS SDK to 12.16.0 ([#18464](https://github.com/firebase/flutterfire/issues/18464)). ([07c1bbe8](https://github.com/firebase/flutterfire/commit/07c1bbe82a8becd5ab673101a8a6561e0af725af))
+
+#### `firebase_core_platform_interface` - `v8.1.0`
+
+ - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))
+ - **DOCS**: fix code snippets that do not compile ([#18468](https://github.com/firebase/flutterfire/issues/18468)). ([85cbdcab](https://github.com/firebase/flutterfire/commit/85cbdcabe0f0f6230f63ebc4018c7358353b15a4))
+
+#### `firebase_core_web` - `v3.10.0`
+
+ - **FIX**(core,web): load firebase-app.js before component bundles to avoid WebKit import race ([#18443](https://github.com/firebase/flutterfire/issues/18443)). ([4b731aed](https://github.com/firebase/flutterfire/commit/4b731aed0a1346070d8548c342e2e4b012844d58))
+ - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))
+ - **FEAT**(core): bump Firebase web SDK to 12.16.0 ([#18466](https://github.com/firebase/flutterfire/issues/18466)). ([ff707788](https://github.com/firebase/flutterfire/commit/ff707788d48cf73e23e25b8c66205d6758a5022e))
+ - **DOCS**: fix code snippets that do not compile ([#18468](https://github.com/firebase/flutterfire/issues/18468)). ([85cbdcab](https://github.com/firebase/flutterfire/commit/85cbdcabe0f0f6230f63ebc4018c7358353b15a4))
+
+#### `firebase_crashlytics` - `v5.2.7`
+
+ - **FIX**(crashlytics,android): avoid heap-loading libapp.so for build ID ([#18483](https://github.com/firebase/flutterfire/issues/18483)). ([8d0afcdd](https://github.com/firebase/flutterfire/commit/8d0afcdd9d8d7353a47a6339b09c7964d8eabf84))
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+
+#### `firebase_data_connect` - `v0.3.1`
+
+ - **FIX**(sql_connect): e2e listen test ([#18496](https://github.com/firebase/flutterfire/issues/18496)). ([e512d39a](https://github.com/firebase/flutterfire/commit/e512d39a88f3d8df0eaeb2b7d7a439460b00b8e7))
+ - **FIX**(sql_connect): Refactor to improve caching performance for large result sets ([#18430](https://github.com/firebase/flutterfire/issues/18430)). ([fba86301](https://github.com/firebase/flutterfire/commit/fba86301665944a72959cba30bc433842ada37b3))
+ - **FEAT**(sql_connect): merge "X-Client-Platform" header into "X-Client-Version" ([#18502](https://github.com/firebase/flutterfire/issues/18502)). ([049fe5ea](https://github.com/firebase/flutterfire/commit/049fe5ea61bbb88bef409788cbabd7ef53226f3e))
+ - **FEAT**(sql_connect): add "X-Client-Platform" and "X-Client-Version" headers ([#18484](https://github.com/firebase/flutterfire/issues/18484)). ([04b94acf](https://github.com/firebase/flutterfire/commit/04b94acf8f0a0188d6abbf3770edfe31b4e5ef2e))
+ - **FEAT**(data_connect,web): implement hot restart guard for WebSocket transport ([#18370](https://github.com/firebase/flutterfire/issues/18370)). ([3e0ae979](https://github.com/firebase/flutterfire/commit/3e0ae979d4786ace3becbbfc432f585b4f45eb04))
+
+#### `firebase_database` - `v12.4.7`
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+
+#### `firebase_in_app_messaging` - `v0.9.2+7`
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+
+#### `firebase_messaging` - `v16.5.0`
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FIX**(messaging,android): fix an issue that could cause ANRs when receiving multiple notifications at the same time ([#18359](https://github.com/firebase/flutterfire/issues/18359)). ([a45f8d92](https://github.com/firebase/flutterfire/commit/a45f8d925c7404f81aae8a08dc2088149f3f2e7a))
+ - **FIX**(messaging,ios): fix an issue where FirebaseMessaging could init even if FirebaseMessagingAutoInitEnabled was disabled ([#18452](https://github.com/firebase/flutterfire/issues/18452)). ([6f22596b](https://github.com/firebase/flutterfire/commit/6f22596baced28bf135f7cd40fdb5c008df2f328))
+ - **FIX**(messaging,macos): fix an issue where getInitialMessage could hang forever in macOS ([#18457](https://github.com/firebase/flutterfire/issues/18457)). ([87d88d20](https://github.com/firebase/flutterfire/commit/87d88d200df9a5e0536d458a1bb02ace8933e682))
+ - **FEAT**(messaging,ios): support early notification delegate setup for UIScene apps ([#18501](https://github.com/firebase/flutterfire/issues/18501)). ([b69bbc0d](https://github.com/firebase/flutterfire/commit/b69bbc0d950aef8edaf843edb8cda12613103440))
+
+#### `firebase_ml_model_downloader` - `v0.4.3`
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FEAT**(ml): adding depreciation notice to ML plugin ([#18472](https://github.com/firebase/flutterfire/issues/18472)). ([fb20da9c](https://github.com/firebase/flutterfire/commit/fb20da9c88d0e7ac20b89fc27000ae4eeb50654d))
+
+#### `firebase_ml_model_downloader_platform_interface` - `v0.1.6`
+
+ - **FEAT**(ml): adding depreciation notice to ML plugin ([#18472](https://github.com/firebase/flutterfire/issues/18472)). ([fb20da9c](https://github.com/firebase/flutterfire/commit/fb20da9c88d0e7ac20b89fc27000ae4eeb50654d))
+
+#### `firebase_performance` - `v0.11.4+6`
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+
+#### `firebase_remote_config` - `v6.5.6`
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FIX**(remote_config,windows): move CMake dependency from Core to Remote Config ([#18498](https://github.com/firebase/flutterfire/issues/18498)). ([d6ef43f6](https://github.com/firebase/flutterfire/commit/d6ef43f616d03a57b76469b77f4cfd3d8325075a))
+ - **FIX**(remote_config): restores the Apple error mapping and accepts both throttling status spellings ([#18458](https://github.com/firebase/flutterfire/issues/18458)). ([523d985a](https://github.com/firebase/flutterfire/commit/523d985a8219fd20a7071915ee539c19692975fa))
+
+#### `firebase_remote_config_platform_interface` - `v3.0.6`
+
+ - **FIX**(remote_config): restores the Apple error mapping and accepts both throttling status spellings ([#18458](https://github.com/firebase/flutterfire/issues/18458)). ([523d985a](https://github.com/firebase/flutterfire/commit/523d985a8219fd20a7071915ee539c19692975fa))
+
+#### `firebase_storage` - `v13.4.6`
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FIX**(storage,android): firebase_storage now respects android.builtInKotlin=true and only applies kotlin-android when built-in Kotlin is disabled ([#18351](https://github.com/firebase/flutterfire/issues/18351)). ([d8a79f77](https://github.com/firebase/flutterfire/commit/d8a79f774ef956e3f081df51907fa896b29590c2))
+ - **FIX**(storage,windows): Windows list()/listAll() now throw unimplemented instead of returning misleading empty results ([#18449](https://github.com/firebase/flutterfire/issues/18449)). ([ef0a4ffa](https://github.com/firebase/flutterfire/commit/ef0a4ffad2f7ccd8df3f9e2919fd2834187d117c))
+
+
 ## 2026-07-14
 
 ### Changes

--- a/packages/_flutterfire_internals/CHANGELOG.md
+++ b/packages/_flutterfire_internals/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.76
+
+ - Update a dependency to the latest release.
+
 ## 1.3.75
 
  - Update a dependency to the latest release.

--- a/packages/_flutterfire_internals/pubspec.yaml
+++ b/packages/_flutterfire_internals/pubspec.yaml
@@ -2,7 +2,7 @@ name: _flutterfire_internals
 description: A package hosting Dart code shared between FlutterFire plugins.
 homepage: https://firebase.google.com/docs/firestore
 repository: https://github.com/firebase/flutterfire/tree/main/packages/_flutterfire_internals
-version: 1.3.75
+version: 1.3.76
 resolution: workspace
 
 environment:
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   collection: ^1.0.0
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
   flutter:
     sdk: flutter
   meta: ^1.8.0

--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 6.8.0
+
+ - **FIX**(firestore,core,windows): per-engine BinaryMessenger, Firestore/Auth link order, Profile builds ([#18516](https://github.com/firebase/flutterfire/issues/18516)). ([5dfd289e](https://github.com/firebase/flutterfire/commit/5dfd289ea45260c15d73894dcf2cb092fc8ddb9d))
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FIX**(firestore,android): clean up Android transaction listeners on completion ([#18475](https://github.com/firebase/flutterfire/issues/18475)). ([ae002c7c](https://github.com/firebase/flutterfire/commit/ae002c7ca8ae405ebc901bfe17e6724a48075bca))
+ - **FIX**(firestore,windows): reply on platform thread to prevent warnings ([#18459](https://github.com/firebase/flutterfire/issues/18459)). ([cfeddb1b](https://github.com/firebase/flutterfire/commit/cfeddb1b4e2a519d77440a8ec4799eb9b9c12a37))
+ - **FIX**(firestore,windows): Prevents lost Windows transaction responses ([#18448](https://github.com/firebase/flutterfire/issues/18448)). ([ed1a551d](https://github.com/firebase/flutterfire/commit/ed1a551d41bc3303e66985e30d4d2b570606bc7f))
+ - **FIX**(firestore): Preserves microseconds when serializing implicit DateTime values ([#18435](https://github.com/firebase/flutterfire/issues/18435)). ([068c3094](https://github.com/firebase/flutterfire/commit/068c30946912d8a3d5f24455fcb4bc00202e60ee))
+ - **FEAT**(firestore): add string manipulation functions for Android and iOS ([#18493](https://github.com/firebase/flutterfire/issues/18493)). ([b3bd7e9d](https://github.com/firebase/flutterfire/commit/b3bd7e9ddd61942530883501f285ed32b55f9953))
+
 ## 6.7.1
 
  - Update a dependency to the latest release.

--- a/packages/cloud_firestore/cloud_firestore/example/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  cloud_firestore: ^6.7.1
-  firebase_core: ^4.12.1
+  cloud_firestore: ^6.8.0
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   http: ^1.0.0

--- a/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Package.swift
+++ b/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "6.7.1"
+let libraryVersion = "6.8.0"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/cloud_firestore/cloud_firestore/macos/cloud_firestore/Package.swift
+++ b/packages/cloud_firestore/cloud_firestore/macos/cloud_firestore/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "6.7.1"
+let libraryVersion = "6.8.0"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/cloud_firestore/cloud_firestore/pipeline_example/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pipeline_example/pubspec.yaml
@@ -31,7 +31,7 @@ environment:
 dependencies:
   cloud_firestore:
     path: ..
-  firebase_core: ^4.12.1
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   http: ^1.0.0

--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -4,7 +4,7 @@ description:
   live synchronization and offline support on Android and iOS.
 homepage: https://firebase.google.com/docs/firestore
 repository: https://github.com/firebase/flutterfire/tree/main/packages/cloud_firestore/cloud_firestore
-version: 6.7.1
+version: 6.8.0
 resolution: workspace
 topics:
   - firebase
@@ -21,11 +21,11 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  cloud_firestore_platform_interface: ^8.0.5
-  cloud_firestore_web: ^5.7.1
+  cloud_firestore_platform_interface: ^8.0.6
+  cloud_firestore_web: ^5.7.2
   collection: ^1.0.0
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
   flutter:
     sdk: flutter
   meta: ^1.8.0

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.0.6
+
+ - **FIX**(firestore,android): clean up Android transaction listeners on completion ([#18475](https://github.com/firebase/flutterfire/issues/18475)). ([ae002c7c](https://github.com/firebase/flutterfire/commit/ae002c7ca8ae405ebc901bfe17e6724a48075bca))
+ - **FIX**(firestore): Preserves microseconds when serializing implicit DateTime values ([#18435](https://github.com/firebase/flutterfire/issues/18435)). ([068c3094](https://github.com/firebase/flutterfire/commit/068c30946912d8a3d5f24455fcb4bc00202e60ee))
+
 ## 8.0.5
 
  - Update a dependency to the latest release.

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_firestore_platform_interface
 description: A common platform interface for the cloud_firestore plugin.
-version: 8.0.5
+version: 8.0.6
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/cloud_firestore/cloud_firestore_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/cloud_firestore/cloud_firestore_platform_interface
@@ -10,16 +10,16 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
+  _flutterfire_internals: ^1.3.76
   collection: ^1.15.0
-  firebase_core: ^4.12.1
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.7.2
+
+ - **FIX**(firestore): Preserves microseconds when serializing implicit DateTime values ([#18435](https://github.com/firebase/flutterfire/issues/18435)). ([068c3094](https://github.com/firebase/flutterfire/commit/068c30946912d8a3d5f24455fcb4bc00202e60ee))
+
 ## 5.7.1
 
  - Update a dependency to the latest release.

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/cloud_firestore_version.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/cloud_firestore_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '6.7.1';
+const packageVersion = '6.8.0';

--- a/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: The web implementation of cloud_firestore
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/cloud_firestore/cloud_firestore_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/cloud_firestore/cloud_firestore_web
 
-version: 5.7.1
+version: 5.7.2
 resolution: workspace
 
 environment:
@@ -11,18 +11,18 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
-  cloud_firestore_platform_interface: ^8.0.5
+  _flutterfire_internals: ^1.3.76
+  cloud_firestore_platform_interface: ^8.0.6
   collection: ^1.0.0
-  firebase_core: ^4.12.1
-  firebase_core_web: ^3.9.1
+  firebase_core: ^4.13.0
+  firebase_core_web: ^3.10.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/cloud_functions/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.3.6
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+
 ## 6.3.5
 
  - Update a dependency to the latest release.

--- a/packages/cloud_functions/cloud_functions/example/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  cloud_functions: ^6.3.5
-  firebase_core: ^4.12.1
+  cloud_functions: ^6.3.6
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
 

--- a/packages/cloud_functions/cloud_functions/ios/cloud_functions/Sources/cloud_functions/Constants.swift
+++ b/packages/cloud_functions/cloud_functions/ios/cloud_functions/Sources/cloud_functions/Constants.swift
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// Auto-generated file. Do not edit.
-public let versionNumber = "6.3.5"
+public let versionNumber = "6.3.6"

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: A Flutter plugin allowing you to use Firebase Cloud Functions.
-version: 6.3.5
+version: 6.3.6
 resolution: workspace
 homepage: https://firebase.google.com/docs/functions
 repository: https://github.com/firebase/flutterfire/tree/main/packages/cloud_functions/cloud_functions
@@ -18,10 +18,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  cloud_functions_platform_interface: ^6.0.5
-  cloud_functions_web: ^5.1.11
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
+  cloud_functions_platform_interface: ^6.0.6
+  cloud_functions_web: ^5.1.12
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
   flutter:
     sdk: flutter
 

--- a/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.6
+
+ - Update a dependency to the latest release.
+
 ## 6.0.5
 
  - Update a dependency to the latest release.

--- a/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/firebase/flutterfire/tree/main/packages/cloud_fun
 
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 6.0.5
+version: 6.0.6
 resolution: workspace
 
 environment:
@@ -13,14 +13,14 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.12
+
+ - Update a dependency to the latest release.
+
 ## 5.1.11
 
  - Update a dependency to the latest release.

--- a/packages/cloud_functions/cloud_functions_web/lib/src/cloud_functions_version.dart
+++ b/packages/cloud_functions/cloud_functions_web/lib/src/cloud_functions_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '6.3.5';
+const packageVersion = '6.3.6';

--- a/packages/cloud_functions/cloud_functions_web/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: The web implementation of cloud_functions
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/cloud_functions/cloud_functions_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/cloud_functions/cloud_functions_web
 
-version: 5.1.11
+version: 5.1.12
 resolution: workspace
 
 environment:
@@ -11,9 +11,9 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  cloud_functions_platform_interface: ^6.0.5
-  firebase_core: ^4.12.1
-  firebase_core_web: ^3.9.1
+  cloud_functions_platform_interface: ^6.0.6
+  firebase_core: ^4.13.0
+  firebase_core_web: ^3.10.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -21,7 +21,7 @@ dependencies:
   web: ^1.1.1
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_ai/firebase_ai/CHANGELOG.md
+++ b/packages/firebase_ai/firebase_ai/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.15.0
+
+ - **FEAT**(firebaseai): Rename vertexAI to agentPlatform ([#18467](https://github.com/firebase/flutterfire/issues/18467)). ([2f942f28](https://github.com/firebase/flutterfire/commit/2f942f28586a6fcc82b1de454b707633ba8e2e04))
+
 ## 3.14.1
 
  - Update a dependency to the latest release.

--- a/packages/firebase_ai/firebase_ai/example/pubspec.yaml
+++ b/packages/firebase_ai/firebase_ai/example/pubspec.yaml
@@ -23,9 +23,9 @@ dependencies:
 
   camera: ^0.12.0+1
   cupertino_icons: ^1.0.6
-  firebase_ai: ^3.14.1
-  firebase_core: ^4.12.1
-  firebase_storage: ^13.4.5
+  firebase_ai: ^3.15.0
+  firebase_core: ^4.13.0
+  firebase_storage: ^13.4.6
   flutter:
     sdk: flutter
   flutter_animate: ^4.5.2

--- a/packages/firebase_ai/firebase_ai/pubspec.yaml
+++ b/packages/firebase_ai/firebase_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_ai
 description: Firebase AI Logic SDK.
-version: 3.14.1
+version: 3.15.0
 resolution: workspace
 homepage: https://firebase.google.com/docs/vertex-ai/get-started?platform=flutter
 topics:
@@ -21,10 +21,10 @@ environment:
   flutter: ">=3.16.0"
 
 dependencies:
-  firebase_app_check: ^0.4.5+2
-  firebase_auth: ^6.5.6
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
+  firebase_app_check: ^0.4.6
+  firebase_auth: ^6.5.7
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
   flutter:
     sdk: flutter
   http: ^1.1.0

--- a/packages/firebase_analytics/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.4.6
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+
 ## 12.4.5
 
  - Update a dependency to the latest release.

--- a/packages/firebase_analytics/firebase_analytics/example/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_analytics: ^12.4.5
-  firebase_core: ^4.12.1
+  firebase_analytics: ^12.4.6
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   in_app_purchase: ^3.2.3

--- a/packages/firebase_analytics/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics/pubspec.yaml
@@ -4,7 +4,7 @@ description:
   solution that provides insight on app usage and user engagement on Android and iOS.
 homepage: https://firebase.google.com/docs/analytics
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_analytics/firebase_analytics
-version: 12.4.5
+version: 12.4.6
 resolution: workspace
 topics:
   - firebase
@@ -20,10 +20,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_analytics_platform_interface: ^6.0.5
-  firebase_analytics_web: ^0.6.1+11
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
+  firebase_analytics_platform_interface: ^6.0.6
+  firebase_analytics_web: ^0.6.1+12
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
   flutter:
     sdk: flutter
 

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.6
+
+ - Update a dependency to the latest release.
+
 ## 6.0.5
 
  - Update a dependency to the latest release.

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_analytics_platform_interface
 description: A common platform interface for the firebase_analytics plugin.
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_analytics/firebase_analytics_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_analytics/firebase_analytics_platform_interface
-version: 6.0.5
+version: 6.0.6
 resolution: workspace
 
 environment:
@@ -10,15 +10,15 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
-  firebase_core: ^4.12.1
+  _flutterfire_internals: ^1.3.76
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   pigeon: 26.3.4

--- a/packages/firebase_analytics/firebase_analytics_web/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1+12
+
+ - Update a dependency to the latest release.
+
 ## 0.6.1+11
 
  - Update a dependency to the latest release.

--- a/packages/firebase_analytics/firebase_analytics_web/lib/src/firebase_analytics_version.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/src/firebase_analytics_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '12.4.5';
+const packageVersion = '12.4.6';

--- a/packages/firebase_analytics/firebase_analytics_web/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_analytics_web
 description: The web implementation of firebase_analytics
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_analytics/firebase_analytics_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_analytics/firebase_analytics_web
-version: 0.6.1+11
+version: 0.6.1+12
 resolution: workspace
 
 environment:
@@ -10,10 +10,10 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
-  firebase_analytics_platform_interface: ^6.0.5
-  firebase_core: ^4.12.1
-  firebase_core_web: ^3.9.1
+  _flutterfire_internals: ^1.3.76
+  firebase_analytics_platform_interface: ^6.0.6
+  firebase_core: ^4.13.0
+  firebase_core_web: ^3.10.0
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/firebase_app_check/firebase_app_check/CHANGELOG.md
+++ b/packages/firebase_app_check/firebase_app_check/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.6
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))
+ - **FEAT**(appcheck): getTokenResult ([#18492](https://github.com/firebase/flutterfire/issues/18492)). ([361f7199](https://github.com/firebase/flutterfire/commit/361f7199a1a6f930a7ad298c7f4eb3f1d5e6bb0d))
+
 ## 0.4.5+2
 
  - Update a dependency to the latest release.

--- a/packages/firebase_app_check/firebase_app_check/example/pubspec.yaml
+++ b/packages/firebase_app_check/firebase_app_check/example/pubspec.yaml
@@ -11,9 +11,9 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  cloud_firestore: ^6.7.1
-  firebase_app_check: ^0.4.5+2
-  firebase_core: ^4.12.1
+  cloud_firestore: ^6.8.0
+  firebase_app_check: ^0.4.6
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
 

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/Constants.swift
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/Constants.swift
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// Auto-generated file. Do not edit.
-public let versionNumber = "0.4.5+2"
+public let versionNumber = "0.4.6"

--- a/packages/firebase_app_check/firebase_app_check/pubspec.yaml
+++ b/packages/firebase_app_check/firebase_app_check/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_app_check
 description: App Check works alongside other Firebase services to help protect your backend resources from abuse, such as billing fraud or phishing.
 homepage: https://firebase.google.com/docs/app-check
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_check/firebase_app_check
-version: 0.4.5+2
+version: 0.4.6
 resolution: workspace
 topics:
   - firebase
@@ -18,10 +18,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_app_check_platform_interface: ^0.4.1+2
-  firebase_app_check_web: ^0.2.5+2
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
+  firebase_app_check_platform_interface: ^0.4.2
+  firebase_app_check_web: ^0.2.6
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
   flutter:
     sdk: flutter
 

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/CHANGELOG.md
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.2
+
+ - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))
+ - **FEAT**(appcheck): getTokenResult ([#18492](https://github.com/firebase/flutterfire/issues/18492)). ([361f7199](https://github.com/firebase/flutterfire/commit/361f7199a1a6f930a7ad298c7f4eb3f1d5e6bb0d))
+
 ## 0.4.1+2
 
  - Update a dependency to the latest release.

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/pubspec.yaml
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_app_check_platform_interface
 description: A common platform interface for the firebase_app_check plugin.
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_check/firebase_app_check_platform_interface
-version: 0.4.1+2
+version: 0.4.2
 resolution: workspace
 
 environment:
@@ -9,15 +9,15 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
-  firebase_core: ^4.12.1
+  _flutterfire_internals: ^1.3.76
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_app_check/firebase_app_check_web/CHANGELOG.md
+++ b/packages/firebase_app_check/firebase_app_check_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.6
+
+ - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))
+ - **FEAT**(appcheck): getTokenResult ([#18492](https://github.com/firebase/flutterfire/issues/18492)). ([361f7199](https://github.com/firebase/flutterfire/commit/361f7199a1a6f930a7ad298c7f4eb3f1d5e6bb0d))
+
 ## 0.2.5+2
 
  - Update a dependency to the latest release.

--- a/packages/firebase_app_check/firebase_app_check_web/lib/src/firebase_app_check_version.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/src/firebase_app_check_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '0.4.5+2';
+const packageVersion = '0.4.6';

--- a/packages/firebase_app_check/firebase_app_check_web/pubspec.yaml
+++ b/packages/firebase_app_check/firebase_app_check_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_app_check_web
 description: The web implementation of firebase_app_check
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_check/firebase_app_check_web
-version: 0.2.5+2
+version: 0.2.6
 resolution: workspace
 
 environment:
@@ -9,10 +9,10 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
-  firebase_app_check_platform_interface: ^0.4.1+2
-  firebase_core: ^4.12.1
-  firebase_core_web: ^3.9.1
+  _flutterfire_internals: ^1.3.76
+  firebase_app_check_platform_interface: ^0.4.2
+  firebase_core: ^4.13.0
+  firebase_core_web: ^3.10.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -21,7 +21,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.3.3
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_app_installations/firebase_app_installations/CHANGELOG.md
+++ b/packages/firebase_app_installations/firebase_app_installations/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2+7
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+
 ## 0.4.2+6
 
  - Update a dependency to the latest release.

--- a/packages/firebase_app_installations/firebase_app_installations/example/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations/example/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
-  firebase_app_installations: ^0.4.2+6
+  firebase_core: ^4.13.0
+  firebase_app_installations: ^0.4.2+7
   flutter:
     sdk: flutter
 

--- a/packages/firebase_app_installations/firebase_app_installations/ios/firebase_app_installations/Sources/firebase_app_installations/Constants.swift
+++ b/packages/firebase_app_installations/firebase_app_installations/ios/firebase_app_installations/Sources/firebase_app_installations/Constants.swift
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// Auto-generated file. Do not edit.
-public let versionNumber = "0.4.2+6"
+public let versionNumber = "0.4.2+7"

--- a/packages/firebase_app_installations/firebase_app_installations/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_app_installations
 description: A Flutter plugin allowing you to use Firebase Installations.
-version: 0.4.2+6
+version: 0.4.2+7
 resolution: workspace
 homepage: https://firebase.google.com/docs/projects/manage-installations#flutter
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_installations/firebase_app_installations
@@ -18,10 +18,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_app_installations_platform_interface: ^0.1.4+74
-  firebase_app_installations_web: ^0.1.7+11
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
+  firebase_app_installations_platform_interface: ^0.1.4+75
+  firebase_app_installations_web: ^0.1.7+12
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
   flutter:
     sdk: flutter
 

--- a/packages/firebase_app_installations/firebase_app_installations_platform_interface/CHANGELOG.md
+++ b/packages/firebase_app_installations/firebase_app_installations_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4+75
+
+ - Update a dependency to the latest release.
+
 ## 0.1.4+74
 
  - Update a dependency to the latest release.

--- a/packages/firebase_app_installations/firebase_app_installations_platform_interface/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_app_installations_platform_interface
 description: A common platform interface for the firebase_app_installations plugin.
-version: 0.1.4+74
+version: 0.1.4+75
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_installations/firebase_app_installations_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_installations/firebase_app_installations_platform_interface
@@ -10,15 +10,15 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
-  firebase_core: ^4.12.1
+  _flutterfire_internals: ^1.3.76
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0

--- a/packages/firebase_app_installations/firebase_app_installations_web/CHANGELOG.md
+++ b/packages/firebase_app_installations/firebase_app_installations_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.7+12
+
+ - Update a dependency to the latest release.
+
 ## 0.1.7+11
 
  - Update a dependency to the latest release.

--- a/packages/firebase_app_installations/firebase_app_installations_web/lib/src/firebase_app_installations_version.dart
+++ b/packages/firebase_app_installations/firebase_app_installations_web/lib/src/firebase_app_installations_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '0.4.2+6';
+const packageVersion = '0.4.2+7';

--- a/packages/firebase_app_installations/firebase_app_installations_web/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_app_installations_web
 description: The web implementation of firebase_app_installations.
-version: 0.1.7+11
+version: 0.1.7+12
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_installations/firebase_app_installations_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_app_installations/firebase_app_installations_web
@@ -10,17 +10,17 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
-  firebase_app_installations_platform_interface: ^0.1.4+74
-  firebase_core: ^4.12.1
-  firebase_core_web: ^3.9.1
+  _flutterfire_internals: ^1.3.76
+  firebase_app_installations_platform_interface: ^0.1.4+75
+  firebase_core: ^4.13.0
+  firebase_core_web: ^3.10.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0

--- a/packages/firebase_auth/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.5.7
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FIX**(auth,ios): Generic OAuth credentials on iOS passed a missing access token through a non-nullable Firebase SDK selector ([#18450](https://github.com/firebase/flutterfire/issues/18450)). ([32ae2701](https://github.com/firebase/flutterfire/commit/32ae2701f5ff9e132a6ac95a9520d24c12cce769))
+
 ## 6.5.6
 
  - Update a dependency to the latest release.

--- a/packages/firebase_auth/firebase_auth/example/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/example/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
 
 dependencies:
   barcode_widget: ^2.0.4
-  firebase_auth: ^6.5.6
-  firebase_core: ^4.12.1
-  firebase_messaging: ^16.4.3
+  firebase_auth: ^6.5.7
+  firebase_core: ^4.13.0
+  firebase_messaging: ^16.5.0
   flutter:
     sdk: flutter
   flutter_facebook_auth: ^7.1.5

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Package.swift
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "6.5.6"
+let libraryVersion = "6.5.7"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/firebase_auth/firebase_auth/macos/firebase_auth/Package.swift
+++ b/packages/firebase_auth/firebase_auth/macos/firebase_auth/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "6.5.6"
+let libraryVersion = "6.5.7"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling
   like Google, Facebook and Twitter.
 homepage: https://firebase.google.com/docs/auth
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_auth/firebase_auth
-version: 6.5.6
+version: 6.5.7
 resolution: workspace
 topics:
   - firebase
@@ -21,10 +21,10 @@ environment:
   flutter: '>=3.16.0'
 
 dependencies:
-  firebase_auth_platform_interface: ^9.0.5
-  firebase_auth_web: ^6.2.5
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
+  firebase_auth_platform_interface: ^9.0.6
+  firebase_auth_web: ^6.2.6
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
   flutter:
     sdk: flutter
   meta: ^1.8.0

--- a/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.0.6
+
+ - Update a dependency to the latest release.
+
 ## 9.0.5
 
  - Update a dependency to the latest release.

--- a/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_au
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_auth/firebase_auth_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 9.0.5
+version: 9.0.6
 resolution: workspace
 
 environment:
@@ -12,9 +12,9 @@ environment:
   flutter: '>=3.16.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
+  _flutterfire_internals: ^1.3.76
   collection: ^1.16.0
-  firebase_core: ^4.12.1
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   http: ^1.1.0
@@ -22,7 +22,7 @@ dependencies:
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.4.0

--- a/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.6
+
+ - Update a dependency to the latest release.
+
 ## 6.2.5
 
  - Update a dependency to the latest release.

--- a/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_version.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '6.5.6';
+const packageVersion = '6.5.7';

--- a/packages/firebase_auth/firebase_auth_web/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_auth_web
 description: The web implementation of firebase_auth
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_auth/firebase_auth_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_auth/firebase_auth_web
-version: 6.2.5
+version: 6.2.6
 resolution: workspace
 
 environment:
@@ -10,9 +10,9 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  firebase_auth_platform_interface: ^9.0.5
-  firebase_core: ^4.12.1
-  firebase_core_web: ^3.9.1
+  firebase_auth_platform_interface: ^9.0.6
+  firebase_core: ^4.13.0
+  firebase_core_web: ^3.10.0
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/firebase_core/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 4.13.0
+
+ - **FIX**(firestore,core,windows): per-engine BinaryMessenger, Firestore/Auth link order, Profile builds ([#18516](https://github.com/firebase/flutterfire/issues/18516)). ([5dfd289e](https://github.com/firebase/flutterfire/commit/5dfd289ea45260c15d73894dcf2cb092fc8ddb9d))
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FIX**(remote_config,windows): move CMake dependency from Core to Remote Config ([#18498](https://github.com/firebase/flutterfire/issues/18498)). ([d6ef43f6](https://github.com/firebase/flutterfire/commit/d6ef43f616d03a57b76469b77f4cfd3d8325075a))
+ - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))
+ - **FEAT**(core): bump Firebase android SDK to 34.16.0 ([#18465](https://github.com/firebase/flutterfire/issues/18465)). ([fc599349](https://github.com/firebase/flutterfire/commit/fc5993493fbaaf405680eb1e0c8cc0b2604ef1a0))
+ - **FEAT**(core): bump Firebase iOS SDK to 12.16.0 ([#18464](https://github.com/firebase/flutterfire/issues/18464)). ([07c1bbe8](https://github.com/firebase/flutterfire/commit/07c1bbe82a8becd5ab673101a8a6561e0af725af))
+
 ## 4.12.1
 
  - **FIX**(core): clarify initialization requirement ([#18441](https://github.com/firebase/flutterfire/issues/18441)). ([9cfde82a](https://github.com/firebase/flutterfire/commit/9cfde82af1872c485e7b2f8fb091195e2287666d))

--- a/packages/firebase_core/firebase_core/example/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
 

--- a/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
+++ b/packages/firebase_core/firebase_core/ios/firebase_core/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersionString = "4.12.1"
+let libraryVersionString = "4.13.0"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/firebase_core/firebase_core/macos/firebase_core/Package.swift
+++ b/packages/firebase_core/firebase_core/macos/firebase_core/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersionString = "4.12.1"
+let libraryVersionString = "4.13.0"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 homepage: https://firebase.google.com/docs/flutter/setup
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_core/firebase_core
-version: 4.12.1
+version: 4.13.0
 resolution: workspace
 topics:
   - firebase
@@ -17,8 +17,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core_platform_interface: ^8.0.0
-  firebase_core_web: ^3.9.1
+  firebase_core_platform_interface: ^8.1.0
+  firebase_core_web: ^3.10.0
   flutter:
     sdk: flutter
   meta: ^1.8.0

--- a/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.1.0
+
+ - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))
+ - **DOCS**: fix code snippets that do not compile ([#18468](https://github.com/firebase/flutterfire/issues/18468)). ([85cbdcab](https://github.com/firebase/flutterfire/commit/85cbdcabe0f0f6230f63ebc4018c7358353b15a4))
+
 ## 8.0.0
 
 ## 7.1.0

--- a/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_co
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_core/firebase_core_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 8.0.0
+version: 8.1.0
 resolution: workspace
 
 environment:

--- a/packages/firebase_core/firebase_core_web/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_web/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.10.0
+
+ - **FIX**(core,web): load firebase-app.js before component bundles to avoid WebKit import race ([#18443](https://github.com/firebase/flutterfire/issues/18443)). ([4b731aed](https://github.com/firebase/flutterfire/commit/4b731aed0a1346070d8548c342e2e4b012844d58))
+ - **FEAT**(appcheck): rCE provider api update ([#18505](https://github.com/firebase/flutterfire/issues/18505)). ([a56649a4](https://github.com/firebase/flutterfire/commit/a56649a41539c559a08e4f566128db8de390c284))
+ - **FEAT**(core): bump Firebase web SDK to 12.16.0 ([#18466](https://github.com/firebase/flutterfire/issues/18466)). ([ff707788](https://github.com/firebase/flutterfire/commit/ff707788d48cf73e23e25b8c66205d6758a5022e))
+ - **DOCS**: fix code snippets that do not compile ([#18468](https://github.com/firebase/flutterfire/issues/18468)). ([85cbdcab](https://github.com/firebase/flutterfire/commit/85cbdcabe0f0f6230f63ebc4018c7358353b15a4))
+
 ## 3.9.1
 
  - **FIX**: update `firebase_core_platform_interface` constraint to support `8.0.0`.

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_version.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '4.12.1';
+const packageVersion = '4.13.0';

--- a/packages/firebase_core/firebase_core_web/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_core_web
 description: The web implementation of firebase_core
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_core/firebase_core_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_core/firebase_core_web
-version: 3.9.1
+version: 3.10.0
 resolution: workspace
 
 environment:
@@ -10,7 +10,7 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/firebase_crashlytics/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.2.7
+
+ - **FIX**(crashlytics,android): avoid heap-loading libapp.so for build ID ([#18483](https://github.com/firebase/flutterfire/issues/18483)). ([8d0afcdd](https://github.com/firebase/flutterfire/commit/8d0afcdd9d8d7353a47a6339b09c7964d8eabf84))
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+
 ## 5.2.6
 
  - Update a dependency to the latest release.

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/pubspec.yaml
@@ -7,9 +7,9 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_analytics: ^12.4.5
-  firebase_core: ^4.12.1
-  firebase_crashlytics: ^5.2.6
+  firebase_analytics: ^12.4.6
+  firebase_core: ^4.13.0
+  firebase_crashlytics: ^5.2.7
   flutter:
     sdk: flutter
 

--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics/Package.swift
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "5.2.6"
+let libraryVersion = "5.2.7"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/firebase_crashlytics/firebase_crashlytics/macos/firebase_crashlytics/Package.swift
+++ b/packages/firebase_crashlytics/firebase_crashlytics/macos/firebase_crashlytics/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "5.2.6"
+let libraryVersion = "5.2.7"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 5.2.6
+version: 5.2.7
 resolution: workspace
 homepage: https://firebase.google.com/docs/crashlytics
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_crashlytics/firebase_crashlytics
@@ -20,9 +20,9 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
-  firebase_crashlytics_platform_interface: ^3.8.26
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
+  firebase_crashlytics_platform_interface: ^3.8.27
   flutter:
     sdk: flutter
   stack_trace: ^1.10.0

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/CHANGELOG.md
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.27
+
+ - Update a dependency to the latest release.
+
 ## 3.8.26
 
  - Update a dependency to the latest release.

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_crashlytics_platform_interface
 description: A common platform interface for the firebase_crashlytics plugin.
-version: 3.8.26
+version: 3.8.27
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_crashlytics/firebase_crashlytics_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_crashlytics/firebase_crashlytics_platform_interface
@@ -10,16 +10,16 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
+  _flutterfire_internals: ^1.3.76
   collection: ^1.15.0
-  firebase_core: ^4.12.1
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_data_connect/firebase_data_connect/CHANGELOG.md
+++ b/packages/firebase_data_connect/firebase_data_connect/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.1
+
+ - **FIX**(sql_connect): e2e listen test ([#18496](https://github.com/firebase/flutterfire/issues/18496)). ([e512d39a](https://github.com/firebase/flutterfire/commit/e512d39a88f3d8df0eaeb2b7d7a439460b00b8e7))
+ - **FIX**(sql_connect): Refactor to improve caching performance for large result sets ([#18430](https://github.com/firebase/flutterfire/issues/18430)). ([fba86301](https://github.com/firebase/flutterfire/commit/fba86301665944a72959cba30bc433842ada37b3))
+ - **FEAT**(sql_connect): merge "X-Client-Platform" header into "X-Client-Version" ([#18502](https://github.com/firebase/flutterfire/issues/18502)). ([049fe5ea](https://github.com/firebase/flutterfire/commit/049fe5ea61bbb88bef409788cbabd7ef53226f3e))
+ - **FEAT**(sql_connect): add "X-Client-Platform" and "X-Client-Version" headers ([#18484](https://github.com/firebase/flutterfire/issues/18484)). ([04b94acf](https://github.com/firebase/flutterfire/commit/04b94acf8f0a0188d6abbf3770edfe31b4e5ef2e))
+ - **FEAT**(data_connect,web): implement hot restart guard for WebSocket transport ([#18370](https://github.com/firebase/flutterfire/issues/18370)). ([3e0ae979](https://github.com/firebase/flutterfire/commit/3e0ae979d4786ace3becbbfc432f585b4f45eb04))
+
 ## 0.3.0+7
 
  - Update a dependency to the latest release.

--- a/packages/firebase_data_connect/firebase_data_connect/example/pubspec.yaml
+++ b/packages/firebase_data_connect/firebase_data_connect/example/pubspec.yaml
@@ -13,16 +13,16 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_core: ^4.12.1
+  firebase_core: ^4.13.0
   google_sign_in: ^6.1.0
-  firebase_auth: ^6.5.6
+  firebase_auth: ^6.5.7
   firebase_data_connect:
     path: ../
 
   cupertino_icons: ^1.0.6
   flutter_rating_bar: ^4.0.1
   protobuf: ^6.0.0
-  firebase_app_check: ^0.4.5+2
+  firebase_app_check: ^0.4.6
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/packages/firebase_data_connect/firebase_data_connect/lib/src/dataconnect_version.dart
+++ b/packages/firebase_data_connect/firebase_data_connect/lib/src/dataconnect_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// version number for the package, should be align with pubspec.yaml.
-const packageVersion = '0.3.0+7';
+const packageVersion = '0.3.1';

--- a/packages/firebase_data_connect/firebase_data_connect/pubspec.yaml
+++ b/packages/firebase_data_connect/firebase_data_connect/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_data_connect
 description: 'Flutter plugin for Firebase Data Connect, a relational database service that lets you build and scale using a fully-managed PostgreSQL database powered by Cloud SQL.'
-version: 0.3.0+7
+version: 0.3.1
 resolution: workspace
 homepage: https://firebase.google.com/docs/data-connect/quickstart?platform=flutter
 false_secrets:
@@ -13,10 +13,10 @@ environment:
 
 dependencies:
   crypto: ^3.0.6
-  firebase_app_check: ^0.4.5+2
-  firebase_auth: ^6.5.6
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
+  firebase_app_check: ^0.4.6
+  firebase_auth: ^6.5.7
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
   fixnum: ^1.1.1
   flutter:
     sdk: flutter
@@ -31,8 +31,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.12
-  firebase_app_check_platform_interface: ^0.4.1+2
-  firebase_auth_platform_interface: ^9.0.5
+  firebase_app_check_platform_interface: ^0.4.2
+  firebase_auth_platform_interface: ^9.0.6
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter

--- a/packages/firebase_database/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.4.7
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+
 ## 12.4.6
 
  - Update a dependency to the latest release.

--- a/packages/firebase_database/firebase_database/example/pubspec.yaml
+++ b/packages/firebase_database/firebase_database/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
-  firebase_database: ^12.4.6
+  firebase_core: ^4.13.0
+  firebase_database: ^12.4.7
   flutter:
     sdk: flutter
 

--- a/packages/firebase_database/firebase_database/ios/firebase_database/Package.swift
+++ b/packages/firebase_database/firebase_database/ios/firebase_database/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "12.4.6"
+let libraryVersion = "12.4.7"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/firebase_database/firebase_database/macos/firebase_database/Package.swift
+++ b/packages/firebase_database/firebase_database/macos/firebase_database/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "12.4.6"
+let libraryVersion = "12.4.7"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/firebase_database/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 homepage: https://firebase.google.com/docs/database
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_database/firebase_database
-version: 12.4.6
+version: 12.4.7
 resolution: workspace
 topics:
   - firebase
@@ -18,10 +18,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
-  firebase_database_platform_interface: ^0.4.0+5
-  firebase_database_web: ^0.2.7+12
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
+  firebase_database_platform_interface: ^0.4.0+6
+  firebase_database_web: ^0.2.7+13
   flutter:
     sdk: flutter
 

--- a/packages/firebase_database/firebase_database_platform_interface/CHANGELOG.md
+++ b/packages/firebase_database/firebase_database_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+6
+
+ - Update a dependency to the latest release.
+
 ## 0.4.0+5
 
  - Update a dependency to the latest release.

--- a/packages/firebase_database/firebase_database_platform_interface/pubspec.yaml
+++ b/packages/firebase_database/firebase_database_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_database_platform_interface
 description: A common platform interface for the firebase_database plugin.
-version: 0.4.0+5
+version: 0.4.0+6
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_database/firebase_database_platform_interface
 
@@ -9,16 +9,16 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
+  _flutterfire_internals: ^1.3.76
   collection: ^1.14.3
-  firebase_core: ^4.12.1
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.2

--- a/packages/firebase_database/firebase_database_web/CHANGELOG.md
+++ b/packages/firebase_database/firebase_database_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.7+13
+
+ - Update a dependency to the latest release.
+
 ## 0.2.7+12
 
  - Update a dependency to the latest release.

--- a/packages/firebase_database/firebase_database_web/lib/src/firebase_database_version.dart
+++ b/packages/firebase_database/firebase_database_web/lib/src/firebase_database_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '12.4.6';
+const packageVersion = '12.4.7';

--- a/packages/firebase_database/firebase_database_web/pubspec.yaml
+++ b/packages/firebase_database/firebase_database_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_database_web
 description: The web implementation of firebase_database
-version: 0.2.7+12
+version: 0.2.7+13
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_database/firebase_database_web
 
@@ -10,16 +10,16 @@ environment:
 
 dependencies:
   collection: ^1.18.0
-  firebase_core: ^4.12.1
-  firebase_core_web: ^3.9.1
-  firebase_database_platform_interface: ^0.4.0+5
+  firebase_core: ^4.13.0
+  firebase_core_web: ^3.10.0
+  firebase_database_platform_interface: ^0.4.0+6
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/CHANGELOG.md
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.2+7
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+
 ## 0.9.2+6
 
  - Update a dependency to the latest release.

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/example/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/example/pubspec.yaml
@@ -8,10 +8,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_analytics: ^12.4.5
-  firebase_core: ^4.12.1
-  firebase_in_app_messaging: ^0.9.2+6
-  firebase_in_app_messaging_platform_interface: ^0.2.5+26
+  firebase_analytics: ^12.4.6
+  firebase_core: ^4.13.0
+  firebase_in_app_messaging: ^0.9.2+7
+  firebase_in_app_messaging_platform_interface: ^0.2.5+27
   flutter:
     sdk: flutter
 

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/firebase_in_app_messaging/Package.swift
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/ios/firebase_in_app_messaging/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "0.9.2-6"
+let libraryVersion = "0.9.2-7"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_in_app_messaging
 description: Flutter plugin for Firebase In-App Messaging.
-version: 0.9.2+6
+version: 0.9.2+7
 resolution: workspace
 homepage: https://firebase.google.com/docs/in-app-messaging
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_in_app_messaging
@@ -18,9 +18,9 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
-  firebase_in_app_messaging_platform_interface: ^0.2.5+26
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
+  firebase_in_app_messaging_platform_interface: ^0.2.5+27
   flutter:
     sdk: flutter
   meta: ^1.8.0

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/CHANGELOG.md
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5+27
+
+ - Update a dependency to the latest release.
+
 ## 0.2.5+26
 
  - Update a dependency to the latest release.

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the firebase_in_app_messaging plugi
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_in_app_messaging/firebase_in_app_messagin_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_in_app_messaging/firebase_in_app_messagin_platform_interface
 
-version: 0.2.5+26
+version: 0.2.5+27
 resolution: workspace
 
 environment:
@@ -11,14 +11,14 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
-  firebase_core: ^4.12.1
+  _flutterfire_internals: ^1.3.76
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter

--- a/packages/firebase_messaging/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 16.5.0
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FIX**(messaging,android): fix an issue that could cause ANRs when receiving multiple notifications at the same time ([#18359](https://github.com/firebase/flutterfire/issues/18359)). ([a45f8d92](https://github.com/firebase/flutterfire/commit/a45f8d925c7404f81aae8a08dc2088149f3f2e7a))
+ - **FIX**(messaging,ios): fix an issue where FirebaseMessaging could init even if FirebaseMessagingAutoInitEnabled was disabled ([#18452](https://github.com/firebase/flutterfire/issues/18452)). ([6f22596b](https://github.com/firebase/flutterfire/commit/6f22596baced28bf135f7cd40fdb5c008df2f328))
+ - **FIX**(messaging,macos): fix an issue where getInitialMessage could hang forever in macOS ([#18457](https://github.com/firebase/flutterfire/issues/18457)). ([87d88d20](https://github.com/firebase/flutterfire/commit/87d88d200df9a5e0536d458a1bb02ace8933e682))
+ - **FEAT**(messaging,ios): support early notification delegate setup for UIScene apps ([#18501](https://github.com/firebase/flutterfire/issues/18501)). ([b69bbc0d](https://github.com/firebase/flutterfire/commit/b69bbc0d950aef8edaf843edb8cda12613103440))
+
 ## 16.4.3
 
  - Update a dependency to the latest release.

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -23,7 +23,6 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.RemoteMessage;
-import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
@@ -458,19 +457,8 @@ public class FlutterFirebaseMessagingPlugin
               "Expected 'Long' or 'Integer' type for 'userCallbackHandle'.");
         }
 
-        FlutterShellArgs shellArgs = null;
-        if (mainActivity != null) {
-          // Supports both Flutter Activity types:
-          //    io.flutter.embedding.android.FlutterFragmentActivity
-          //    io.flutter.embedding.android.FlutterActivity
-          // We could use `getFlutterShellArgs()` but this is only available on `FlutterActivity`.
-          shellArgs = FlutterShellArgs.fromIntent(mainActivity.getIntent());
-        }
-
         FlutterFirebaseMessagingBackgroundService.setCallbackDispatcher(pluginCallbackHandle);
         FlutterFirebaseMessagingBackgroundService.setUserCallbackHandle(userCallbackHandle);
-        FlutterFirebaseMessagingBackgroundService.startBackgroundIsolate(
-            pluginCallbackHandle, shellArgs);
         methodCallTask = Tasks.forResult(null);
         break;
       case "Messaging#getInitialMessage":

--- a/packages/firebase_messaging/firebase_messaging/example/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
-  firebase_messaging: ^16.4.3
+  firebase_core: ^4.13.0
+  firebase_messaging: ^16.5.0
   flutter:
     sdk: flutter
   flutter_local_notifications: ^21.0.0

--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Package.swift
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "16.4.3"
+let libraryVersion = "16.5.0"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/firebase_messaging/firebase_messaging/macos/firebase_messaging/Package.swift
+++ b/packages/firebase_messaging/firebase_messaging/macos/firebase_messaging/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "16.4.3"
+let libraryVersion = "16.5.0"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/firebase_messaging/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 homepage: https://firebase.google.com/docs/cloud-messaging
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_messaging/firebase_messaging
-version: 16.4.3
+version: 16.5.0
 resolution: workspace
 topics:
   - firebase
@@ -18,10 +18,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
-  firebase_messaging_platform_interface: ^4.9.2
-  firebase_messaging_web: ^4.2.3
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
+  firebase_messaging_platform_interface: ^4.9.3
+  firebase_messaging_web: ^4.2.4
   flutter:
     sdk: flutter
   meta: ^1.8.0

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/CHANGELOG.md
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.9.3
+
+ - Update a dependency to the latest release.
+
 ## 4.9.2
 
  - Update a dependency to the latest release.

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_messaging_platform_interface
 description: A common platform interface for the firebase_messaging plugin.
-version: 4.9.2
+version: 4.9.3
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_messaging/firebase_messaging_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_messaging/firebase_messaging_platform_interface
@@ -10,15 +10,15 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
-  firebase_core: ^4.12.1
+  _flutterfire_internals: ^1.3.76
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_messaging/firebase_messaging_web/CHANGELOG.md
+++ b/packages/firebase_messaging/firebase_messaging_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.4
+
+ - Update a dependency to the latest release.
+
 ## 4.2.3
 
  - Update a dependency to the latest release.

--- a/packages/firebase_messaging/firebase_messaging_web/lib/src/firebase_messaging_version.dart
+++ b/packages/firebase_messaging/firebase_messaging_web/lib/src/firebase_messaging_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '16.4.3';
+const packageVersion = '16.5.0';

--- a/packages/firebase_messaging/firebase_messaging_web/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_messaging_web
 description: The web implementation of firebase_messaging
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_messaging/firebase_messaging_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_messaging/firebase_messaging_web
-version: 4.2.3
+version: 4.2.4
 resolution: workspace
 
 environment:
@@ -10,10 +10,10 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
-  firebase_core: ^4.12.1
-  firebase_core_web: ^3.9.1
-  firebase_messaging_platform_interface: ^4.9.2
+  _flutterfire_internals: ^1.3.76
+  firebase_core: ^4.13.0
+  firebase_core_web: ^3.10.0
+  firebase_messaging_platform_interface: ^4.9.3
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -22,7 +22,7 @@ dependencies:
   web: ^1.0.0
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/CHANGELOG.md
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.3
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FEAT**(ml): adding depreciation notice to ML plugin ([#18472](https://github.com/firebase/flutterfire/issues/18472)). ([fb20da9c](https://github.com/firebase/flutterfire/commit/fb20da9c88d0e7ac20b89fc27000ae4eeb50654d))
+
 ## 0.4.2+6
 
  - Update a dependency to the latest release.

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/example/pubspec.yaml
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/example/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  firebase_core: ^4.12.1
-  firebase_ml_model_downloader: ^0.4.2+6
+  firebase_core: ^4.13.0
+  firebase_ml_model_downloader: ^0.4.3
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/ios/firebase_ml_model_downloader/Sources/firebase_ml_model_downloader/Constants.swift
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/ios/firebase_ml_model_downloader/Sources/firebase_ml_model_downloader/Constants.swift
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// Auto-generated file. Do not edit.
-public let versionNumber = "0.4.2+6"
+public let versionNumber = "0.4.3"

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/pubspec.yaml
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_ml_model_downloader
 description: "Deprecated: A Flutter plugin for Firebase ML Model Downloader. Firebase ML shuts down June 15, 2027."
-version: 0.4.2+6
+version: 0.4.3
 resolution: workspace
 homepage: https://firebase.google.com/docs/ml/flutter/use-custom-models
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_ml_model_downloader/firebase_ml_model_downloader
@@ -18,9 +18,9 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
-  firebase_ml_model_downloader_platform_interface: ^0.1.5+26
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
+  firebase_ml_model_downloader_platform_interface: ^0.1.6
   flutter:
     sdk: flutter
 

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/CHANGELOG.md
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.6
+
+ - **FEAT**(ml): adding depreciation notice to ML plugin ([#18472](https://github.com/firebase/flutterfire/issues/18472)). ([fb20da9c](https://github.com/firebase/flutterfire/commit/fb20da9c88d0e7ac20b89fc27000ae4eeb50654d))
+
 ## 0.1.5+26
 
  - Update a dependency to the latest release.

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/pubspec.yaml
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_ml_model_downloader_platform_interface
 description: "Deprecated: The platform interface for the firebase_ml_model_downloader plugin."
-version: 0.1.5+26
+version: 0.1.6
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface
@@ -10,14 +10,14 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_performance/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/firebase_performance/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.4+6
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+
 ## 0.11.4+5
 
  - Update a dependency to the latest release.

--- a/packages/firebase_performance/firebase_performance/example/pubspec.yaml
+++ b/packages/firebase_performance/firebase_performance/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
-  firebase_performance: ^0.11.4+5
+  firebase_core: ^4.13.0
+  firebase_performance: ^0.11.4+6
   flutter:
     sdk: flutter
   http: ^1.0.0

--- a/packages/firebase_performance/firebase_performance/ios/firebase_performance/Package.swift
+++ b/packages/firebase_performance/firebase_performance/ios/firebase_performance/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "0.11.4-5"
+let libraryVersion = "0.11.4-6"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/firebase_performance/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/firebase_performance/pubspec.yaml
@@ -5,7 +5,7 @@ description:
   iOS.
 homepage: https://firebase.google.com/docs/perf-mon
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_performance/firebase_performance
-version: 0.11.4+5
+version: 0.11.4+6
 resolution: workspace
 topics:
   - firebase
@@ -21,10 +21,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
-  firebase_performance_platform_interface: ^0.2.0+5
-  firebase_performance_web: ^0.1.8+11
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
+  firebase_performance_platform_interface: ^0.2.0+6
+  firebase_performance_web: ^0.1.8+12
   flutter:
     sdk: flutter
 

--- a/packages/firebase_performance/firebase_performance_platform_interface/CHANGELOG.md
+++ b/packages/firebase_performance/firebase_performance_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+6
+
+ - Update a dependency to the latest release.
+
 ## 0.2.0+5
 
  - Update a dependency to the latest release.

--- a/packages/firebase_performance/firebase_performance_platform_interface/pubspec.yaml
+++ b/packages/firebase_performance/firebase_performance_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_performance_platform_interface
 description: A common platform interface for the firebase_performance plugin.
-version: 0.2.0+5
+version: 0.2.0+6
 resolution: workspace
 homepage: https://firebase.google.com/docs/perf-mon/flutter/get-started
 
@@ -9,15 +9,15 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
-  firebase_core: ^4.12.1
+  _flutterfire_internals: ^1.3.76
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   pigeon: 26.3.4

--- a/packages/firebase_performance/firebase_performance_web/CHANGELOG.md
+++ b/packages/firebase_performance/firebase_performance_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.8+12
+
+ - Update a dependency to the latest release.
+
 ## 0.1.8+11
 
  - Update a dependency to the latest release.

--- a/packages/firebase_performance/firebase_performance_web/lib/src/firebase_performance_version.dart
+++ b/packages/firebase_performance/firebase_performance_web/lib/src/firebase_performance_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '0.11.4+5';
+const packageVersion = '0.11.4+6';

--- a/packages/firebase_performance/firebase_performance_web/pubspec.yaml
+++ b/packages/firebase_performance/firebase_performance_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_performance_web
 description: Web implementation of Firebase Performance monitoring.
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_performance/firebase_performance_web
-version: 0.1.8+11
+version: 0.1.8+12
 resolution: workspace
 
 environment:
@@ -9,10 +9,10 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
-  firebase_core: ^4.12.1
-  firebase_core_web: ^3.9.1
-  firebase_performance_platform_interface: ^0.2.0+5
+  _flutterfire_internals: ^1.3.76
+  firebase_core: ^4.13.0
+  firebase_core_web: ^3.10.0
+  firebase_performance_platform_interface: ^0.2.0+6
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/firebase_remote_config/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/firebase_remote_config/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.5.6
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FIX**(remote_config,windows): move CMake dependency from Core to Remote Config ([#18498](https://github.com/firebase/flutterfire/issues/18498)). ([d6ef43f6](https://github.com/firebase/flutterfire/commit/d6ef43f616d03a57b76469b77f4cfd3d8325075a))
+ - **FIX**(remote_config): restores the Apple error mapping and accepts both throttling status spellings ([#18458](https://github.com/firebase/flutterfire/issues/18458)). ([523d985a](https://github.com/firebase/flutterfire/commit/523d985a8219fd20a7071915ee539c19692975fa))
+
 ## 6.5.5
 
  - Update a dependency to the latest release.

--- a/packages/firebase_remote_config/firebase_remote_config/example/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  firebase_core: ^4.12.1
-  firebase_remote_config: ^6.5.5
+  firebase_core: ^4.13.0
+  firebase_remote_config: ^6.5.6
   flutter:
     sdk: flutter
 

--- a/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Sources/firebase_remote_config/Constants.swift
+++ b/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Sources/firebase_remote_config/Constants.swift
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// Auto-generated file. Do not edit.
-public let versionNumber = "6.5.5"
+public let versionNumber = "6.5.6"

--- a/packages/firebase_remote_config/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config/pubspec.yaml
@@ -4,7 +4,7 @@ description:
   re-releasing.
 homepage: https://firebase.google.com/docs/remote-config
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_remote_config/firebase_remote_config
-version: 6.5.5
+version: 6.5.6
 resolution: workspace
 topics:
   - firebase
@@ -20,10 +20,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
-  firebase_remote_config_platform_interface: ^3.0.5
-  firebase_remote_config_web: ^1.10.12
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
+  firebase_remote_config_platform_interface: ^3.0.6
+  firebase_remote_config_web: ^1.10.13
   flutter:
     sdk: flutter
 

--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/CHANGELOG.md
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.6
+
+ - **FIX**(remote_config): restores the Apple error mapping and accepts both throttling status spellings ([#18458](https://github.com/firebase/flutterfire/issues/18458)). ([523d985a](https://github.com/firebase/flutterfire/commit/523d985a8219fd20a7071915ee539c19692975fa))
+
 ## 3.0.5
 
  - Update a dependency to the latest release.

--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_re
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_remote_config/firebase_remote_config_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.0.5
+version: 3.0.6
 resolution: workspace
 
 environment:
@@ -12,15 +12,15 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
-  firebase_core: ^4.12.1
+  _flutterfire_internals: ^1.3.76
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_remote_config/firebase_remote_config_web/CHANGELOG.md
+++ b/packages/firebase_remote_config/firebase_remote_config_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.13
+
+ - Update a dependency to the latest release.
+
 ## 1.10.12
 
  - Update a dependency to the latest release.

--- a/packages/firebase_remote_config/firebase_remote_config_web/lib/src/firebase_remote_config_version.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_web/lib/src/firebase_remote_config_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '6.5.5';
+const packageVersion = '6.5.6';

--- a/packages/firebase_remote_config/firebase_remote_config_web/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: The web implementation of firebase_remote_config
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_remote_config/firebase_remote_config_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_remote_config/firebase_remote_config_web
 
-version: 1.10.12
+version: 1.10.13
 resolution: workspace
 
 environment:
@@ -11,10 +11,10 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
-  firebase_core: ^4.12.1
-  firebase_core_web: ^3.9.1
-  firebase_remote_config_platform_interface: ^3.0.5
+  _flutterfire_internals: ^1.3.76
+  firebase_core: ^4.13.0
+  firebase_core_web: ^3.10.0
+  firebase_remote_config_platform_interface: ^3.0.6
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -22,7 +22,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.3.3
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_storage/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/firebase_storage/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 13.4.6
+
+ - **FIX**(app_check): sync SPM pins to 12.17.0 and fix Windows Activate override after [#18505](https://github.com/firebase/flutterfire/issues/18505) ([#18515](https://github.com/firebase/flutterfire/issues/18515)). ([ce1f6e05](https://github.com/firebase/flutterfire/commit/ce1f6e05e2d2645c414f8e731d3d082436caa012))
+ - **FIX**(storage,android): firebase_storage now respects android.builtInKotlin=true and only applies kotlin-android when built-in Kotlin is disabled ([#18351](https://github.com/firebase/flutterfire/issues/18351)). ([d8a79f77](https://github.com/firebase/flutterfire/commit/d8a79f774ef956e3f081df51907fa896b29590c2))
+ - **FIX**(storage,windows): Windows list()/listAll() now throw unimplemented instead of returning misleading empty results ([#18449](https://github.com/firebase/flutterfire/issues/18449)). ([ef0a4ffa](https://github.com/firebase/flutterfire/commit/ef0a4ffad2f7ccd8df3f9e2919fd2834187d117c))
+
 ## 13.4.5
 
  - Update a dependency to the latest release.

--- a/packages/firebase_storage/firebase_storage/example/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage/example/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
-  firebase_storage: ^13.4.5
+  firebase_core: ^4.13.0
+  firebase_storage: ^13.4.6
   flutter:
     sdk: flutter
   image_picker: ^1.1.2

--- a/packages/firebase_storage/firebase_storage/ios/firebase_storage/Package.swift
+++ b/packages/firebase_storage/firebase_storage/ios/firebase_storage/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "13.4.5"
+let libraryVersion = "13.4.6"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/firebase_storage/firebase_storage/macos/firebase_storage/Package.swift
+++ b/packages/firebase_storage/firebase_storage/macos/firebase_storage/Package.swift
@@ -7,7 +7,7 @@
 
 import PackageDescription
 
-let libraryVersion = "13.4.5"
+let libraryVersion = "13.4.6"
 let firebaseSdkVersion: Version = "12.17.0"
 
 let package = Package(

--- a/packages/firebase_storage/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 homepage: https://firebase.google.com/docs/storage/flutter/start
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_storage/firebase_storage
-version: 13.4.5
+version: 13.4.6
 resolution: workspace
 topics:
   - firebase
@@ -20,10 +20,10 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
-  firebase_storage_platform_interface: ^6.0.5
-  firebase_storage_web: ^3.11.11
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
+  firebase_storage_platform_interface: ^6.0.6
+  firebase_storage_web: ^3.11.12
   flutter:
     sdk: flutter
   mime: ^2.0.0

--- a/packages/firebase_storage/firebase_storage_platform_interface/CHANGELOG.md
+++ b/packages/firebase_storage/firebase_storage_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.6
+
+ - Update a dependency to the latest release.
+
 ## 6.0.5
 
  - Update a dependency to the latest release.

--- a/packages/firebase_storage/firebase_storage_platform_interface/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_storage_platform_interface
 description: A common platform interface for the firebase_storage plugin.
-version: 6.0.5
+version: 6.0.6
 resolution: workspace
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_storage/firebase_storage_platform_interface
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_storage/firebase_storage_platform_interface
@@ -10,16 +10,16 @@ environment:
   flutter: '>=3.27.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
+  _flutterfire_internals: ^1.3.76
   collection: ^1.15.0
-  firebase_core: ^4.12.1
+  firebase_core: ^4.13.0
   flutter:
     sdk: flutter
   meta: ^1.8.0
   plugin_platform_interface: ^2.1.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/packages/firebase_storage/firebase_storage_web/CHANGELOG.md
+++ b/packages/firebase_storage/firebase_storage_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.11.12
+
+ - Update a dependency to the latest release.
+
 ## 3.11.11
 
  - Update a dependency to the latest release.

--- a/packages/firebase_storage/firebase_storage_web/lib/src/firebase_storage_version.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/firebase_storage_version.dart
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /// generated version number for the package, do not manually edit
-const packageVersion = '13.4.5';
+const packageVersion = '13.4.6';

--- a/packages/firebase_storage/firebase_storage_web/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_storage_web
 description: The web implementation of firebase_storage
 homepage: https://github.com/firebase/flutterfire/tree/main/packages/firebase_storage/firebase_storage_web
 repository: https://github.com/firebase/flutterfire/tree/main/packages/firebase_storage/firebase_storage_web
-version: 3.11.11
+version: 3.11.12
 resolution: workspace
 
 environment:
@@ -10,11 +10,11 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  _flutterfire_internals: ^1.3.75
+  _flutterfire_internals: ^1.3.76
   async: ^2.5.0
-  firebase_core: ^4.12.1
-  firebase_core_web: ^3.9.1
-  firebase_storage_platform_interface: ^6.0.5
+  firebase_core: ^4.13.0
+  firebase_core_web: ^3.10.0
+  firebase_storage_platform_interface: ^6.0.6
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -24,7 +24,7 @@ dependencies:
   web: ^1.0.0
 
 dev_dependencies:
-  firebase_core_platform_interface: ^8.0.0
+  firebase_core_platform_interface: ^8.1.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0

--- a/tests/pubspec.yaml
+++ b/tests/pubspec.yaml
@@ -10,43 +10,43 @@ environment:
   flutter: '>=3.22.0'
 
 dependencies:
-  cloud_functions: ^6.3.5
-  cloud_functions_platform_interface: ^6.0.5
-  cloud_functions_web: ^5.1.11
+  cloud_functions: ^6.3.6
+  cloud_functions_platform_interface: ^6.0.6
+  cloud_functions_web: ^5.1.12
   collection: ^1.15.0
-  firebase_ai: ^3.14.1
-  firebase_analytics: ^12.4.5
-  firebase_analytics_platform_interface: ^6.0.5
-  firebase_analytics_web: ^0.6.1+11
-  firebase_app_check: ^0.4.5+2
-  firebase_app_check_platform_interface: ^0.4.1+2
-  firebase_app_check_web: ^0.2.5+2
-  firebase_app_installations: ^0.4.2+6
-  firebase_app_installations_platform_interface: ^0.1.4+74
-  firebase_app_installations_web: ^0.1.7+11
-  firebase_auth: ^6.5.6
-  firebase_auth_platform_interface: ^9.0.5
-  firebase_auth_web: ^6.2.5
-  firebase_core: ^4.12.1
-  firebase_core_platform_interface: ^8.0.0
-  firebase_core_web: ^3.9.1
-  firebase_crashlytics: ^5.2.6
-  firebase_crashlytics_platform_interface: ^3.8.26
-  firebase_database: ^12.4.6
-  firebase_database_platform_interface: ^0.4.0+5
-  firebase_database_web: ^0.2.7+12
-  firebase_messaging: ^16.4.3
-  firebase_messaging_platform_interface: ^4.9.2
-  firebase_messaging_web: ^4.2.3
-  firebase_ml_model_downloader: ^0.4.2+6
-  firebase_ml_model_downloader_platform_interface: ^0.1.5+26
-  firebase_performance: ^0.11.4+5
-  firebase_remote_config: ^6.5.5
-  firebase_remote_config_platform_interface: ^3.0.5
-  firebase_remote_config_web: ^1.10.12
-  firebase_storage: ^13.4.5
-  firebase_storage_platform_interface: ^6.0.5
-  firebase_storage_web: ^3.11.11
+  firebase_ai: ^3.15.0
+  firebase_analytics: ^12.4.6
+  firebase_analytics_platform_interface: ^6.0.6
+  firebase_analytics_web: ^0.6.1+12
+  firebase_app_check: ^0.4.6
+  firebase_app_check_platform_interface: ^0.4.2
+  firebase_app_check_web: ^0.2.6
+  firebase_app_installations: ^0.4.2+7
+  firebase_app_installations_platform_interface: ^0.1.4+75
+  firebase_app_installations_web: ^0.1.7+12
+  firebase_auth: ^6.5.7
+  firebase_auth_platform_interface: ^9.0.6
+  firebase_auth_web: ^6.2.6
+  firebase_core: ^4.13.0
+  firebase_core_platform_interface: ^8.1.0
+  firebase_core_web: ^3.10.0
+  firebase_crashlytics: ^5.2.7
+  firebase_crashlytics_platform_interface: ^3.8.27
+  firebase_database: ^12.4.7
+  firebase_database_platform_interface: ^0.4.0+6
+  firebase_database_web: ^0.2.7+13
+  firebase_messaging: ^16.5.0
+  firebase_messaging_platform_interface: ^4.9.3
+  firebase_messaging_web: ^4.2.4
+  firebase_ml_model_downloader: ^0.4.3
+  firebase_ml_model_downloader_platform_interface: ^0.1.6
+  firebase_performance: ^0.11.4+6
+  firebase_remote_config: ^6.5.6
+  firebase_remote_config_platform_interface: ^3.0.6
+  firebase_remote_config_web: ^1.10.13
+  firebase_storage: ^13.4.6
+  firebase_storage_platform_interface: ^6.0.6
+  firebase_storage_web: ^3.11.12
   flutter:
     sdk: flutter
   http: ^1.0.0


### PR DESCRIPTION
## Problem

Registering `FirebaseMessaging.onBackgroundMessage` starts a second `FlutterEngine` immediately on every Android foreground launch. The engine then remains resident solely to wait for a possible future background message, significantly increasing steady-state memory.

## Change

Persist the dispatcher and user callback handles during registration, but defer `FlutterFirebaseMessagingBackgroundService` engine startup until the service receives real work. The existing service path already creates the executor in `onCreate`, starts the isolate, queues the first intent while initialization completes, and drains the queue from `onInitialized`.

## Verification

TollNow profile-build integration will verify:

- foreground launch has one Flutter engine instead of two;
- foreground and topic messaging still initialize;
- a cold background data message starts the background engine and invokes the registered Dart handler.