### PR TITLE
fix(firestore,windows): report unimplemented for sum/average aggregations

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
@@ -4139,6 +4139,40 @@ void runQueryTests() {
         },
         skip: defaultTargetPlatform == TargetPlatform.windows,
       );
+
+      test(
+        'sum() & average() report that they are unsupported on Windows',
+        () async {
+          final collection = await initializeTest('unsupported-aggregations');
+
+          await collection.add({'foo': 1});
+
+          final unsupportedError = isA<FirebaseException>()
+              .having((error) => error.code, 'code', 'unimplemented')
+              .having(
+                (error) => error.message,
+                'message',
+                'Sum and average aggregations are not supported by the '
+                    'Firebase C++ SDK on Windows.',
+              );
+
+          await expectLater(
+            collection.aggregate(sum('foo')).get(),
+            throwsA(unsupportedError),
+          );
+          await expectLater(
+            collection.aggregate(average('foo')).get(),
+            throwsA(unsupportedError),
+          );
+          // A mixed request used to resolve with the count and a null sum,
+          // which reads as a successful query returning no sum.
+          await expectLater(
+            collection.aggregate(count(), sum('foo')).get(),
+            throwsA(unsupportedError),
+          );
+        },
+        skip: defaultTargetPlatform != TargetPlatform.windows,
+      );
     });
 
     group('startAfterDocument', () {

--- a/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.cpp
+++ b/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.cpp
@@ -1639,7 +1639,6 @@ void CloudFirestorePlugin::AggregateQuery(
   Firestore* firestore = GetFirestoreFromPigeon(app);
   Query query = ParseQuery(firestore, path, is_collection_group, parameters);
 
-  // C++ SDK does not support average and sum
   firebase::firestore::AggregateQuery aggregate_query;
 
   for (auto& queryRequest : queries) {
@@ -1652,11 +1651,15 @@ void CloudFirestorePlugin::AggregateQuery(
         aggregate_query = query.Count();
         break;
       case AggregateType::kSum:
-        std::cout << "Sum is not supported on C++" << std::endl;
-        break;
       case AggregateType::kAverage:
-        std::cout << "Average is not supported on C++" << std::endl;
-        break;
+        // The Firebase C++ SDK only implements count() aggregations. Reject
+        // the request instead of dropping the unsupported aggregations from
+        // the response, which left `getSum()` / `getAverage()` returning null
+        // as if the query had succeeded.
+        result(FlutterError("unimplemented",
+                            "Sum and average aggregations are not supported by "
+                            "the Firebase C++ SDK on Windows."));
+        return;
     }
   }
 
@@ -1686,14 +1689,10 @@ void CloudFirestorePlugin::AggregateQuery(
                     CustomEncodableValue(aggregateResponse));
                 break;
               }
-              case AggregateType::kSum: {
-                std::cout << "Sum is not supported on C++" << std::endl;
+              case AggregateType::kSum:
+              case AggregateType::kAverage:
+                // Unreachable: requests containing these are rejected above.
                 break;
-              }
-              case AggregateType::kAverage: {
-                std::cout << "Average is not supported on C++" << std::endl;
-                break;
-              }
             }
           }
 

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_aggregate_query.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_aggregate_query.dart
@@ -4,6 +4,7 @@
 
 import '../../cloud_firestore_platform_interface.dart';
 import 'method_channel_firestore.dart';
+import 'utils/exception.dart';
 
 /// An implementation of [AggregateQueryPlatform] for the [MethodChannel]
 class MethodChannelAggregateQuery extends AggregateQueryPlatform {
@@ -27,39 +28,43 @@ class MethodChannelAggregateQuery extends AggregateQueryPlatform {
   Future<AggregateQuerySnapshotPlatform> get({
     required AggregateSource source,
   }) async {
-    final data =
-        await MethodChannelFirebaseFirestore.pigeonChannel.aggregateQuery(
-      _pigeonApp,
-      _path,
-      _pigeonParameters,
-      source,
-      _aggregateQueries,
-      _isCollectionGroupQuery,
-    );
+    try {
+      final data =
+          await MethodChannelFirebaseFirestore.pigeonChannel.aggregateQuery(
+        _pigeonApp,
+        _path,
+        _pigeonParameters,
+        source,
+        _aggregateQueries,
+        _isCollectionGroupQuery,
+      );
 
-    int? count;
-    List<AggregateQueryResponse> sum = [];
-    List<AggregateQueryResponse> average = [];
-    for (final query in data) {
-      if (query == null) continue;
-      switch (query.type) {
-        case AggregateType.count:
-          count = query.value?.toInt();
-          break;
-        case AggregateType.sum:
-          sum.add(query);
-          break;
-        case AggregateType.average:
-          average.add(query);
-          break;
+      int? count;
+      List<AggregateQueryResponse> sum = [];
+      List<AggregateQueryResponse> average = [];
+      for (final query in data) {
+        if (query == null) continue;
+        switch (query.type) {
+          case AggregateType.count:
+            count = query.value?.toInt();
+            break;
+          case AggregateType.sum:
+            sum.add(query);
+            break;
+          case AggregateType.average:
+            average.add(query);
+            break;
+        }
       }
-    }
 
-    return AggregateQuerySnapshotPlatform(
-      count: count,
-      sum: sum,
-      average: average,
-    );
+      return AggregateQuerySnapshotPlatform(
+        count: count,
+        sum: sum,
+        average: average,
+      );
+    } catch (e, stack) {
+      convertPlatformException(e, stack);
+    }
   }
 
   @override


### PR DESCRIPTION
## Description

On Windows, `sum()` and `average()` aggregations are silently unsupported.

The Firebase C++ SDK exposes only `Query::Count()` — there is no sum or average aggregation in `firebase/firestore/aggregate_query.h`. The Windows plugin handled that by printing to stdout and moving on:

```cpp
case AggregateType::kSum:
  std::cout << "Sum is not supported on C++" << std::endl;
  break;
```

Two user-visible consequences:

- `collection.aggregate(count(), sum('foo'))` **resolves successfully** with the count filled in and `getSum('foo')` returning `null`. `getSum` is typed `double?`, so this is indistinguishable from a query that legitimately has no sum — the app silently reads wrong data.
- `collection.aggregate(sum('foo'))` leaves `aggregate_query` default constructed, so `AggregateQuery::Get()` returns `FailedFuture` ([aggregate_query.cc](https://github.com/firebase/firebase-cpp-sdk/blob/main/firestore/src/common/aggregate_query.cc#L97-L101)) and the caller gets an opaque error with no indication that the operation is unsupported on this platform.

This PR rejects any aggregation request containing `sum()` or `average()` with an explicit `unimplemented` error, following the precedent set for Windows Storage listing in #18449 (*"throw unimplemented instead of returning misleading empty results"*). `count()` is unaffected.

While adding the integration test I found that `MethodChannelAggregateQuery.get` is the only Firestore method-channel call not wrapped in `convertPlatformException`, so the error reached callers as a raw `PlatformException` instead of a `FirebaseException`. That is fixed here too, the same way `MethodChannelQuery.get` does it — it also affects Android/iOS, where any aggregate-query failure (for example `permission-denied`) currently surfaces in the wrong exception type.

## Related Issues

No existing issue — found while auditing the Windows plugin. Happy to file one if you'd prefer the report tracked separately.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

An app that today reads `null` from `getSum()` on Windows will now see a `FirebaseException`. That is the point of the change: the previous value was wrong, not absent.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
