### PR TITLE
fix(remote_config,web): suppress deprecated_member_use on Map.unmodifiable

### DIFF
--- a/packages/firebase_remote_config/firebase_remote_config_web/lib/src/interop/firebase_remote_config.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_web/lib/src/interop/firebase_remote_config.dart
@@ -50,7 +50,10 @@ class RemoteConfig
   /// defaultsMap['x'] = 1;                       // remoteConfig.defaultConfig will not be updated.
   /// remoteConfig.defaultConfig['x'] = 1;        // Runtime error: attempt to modify an unmodifiable map.
   /// ```
-  Map<String, dynamic> get defaultConfig => Map.unmodifiable(
+  Map<String, dynamic> get defaultConfig =>
+      // ignore: deprecated_member_use, Map.unmodifiableOf requires Dart 3.13,
+      // above this package's SDK floor.
+      Map.unmodifiable(
         jsObject.defaultConfig.dartify()! as Map<String, dynamic>,
       );
 


### PR DESCRIPTION
dart:core's `Map.unmodifiable()` is now `@Deprecated("Use Map.unmodifiableOf instead")`, but `Map.unmodifiableOf` needs Dart 3.13.0, which is above this package's SDK floor (see #18634 for the separate discussion on where that floor should sit).

Suppressing the warning here rather than migrating, since raising the floor to 3.13.0 (released weeks ago) just for this one call isn't worth it.