### PR TITLE
fix(auth, iOS): guard URL handlers when no FirebaseApp is configured

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.swift
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.swift
@@ -186,11 +186,15 @@ public class FLTFirebaseAuthPlugin: NSObject, FlutterPlugin, FLTFirebasePluginPr
       open url: URL,
       options: [UIApplication.OpenURLOptionsKey: Any] = [:]
     ) -> Bool {
-      Auth.auth().canHandle(url)
+      // Auth.auth() traps when no FirebaseApp has been configured yet (e.g. an
+      // app that initialises Firebase from Dart-side options after start-up).
+      guard FirebaseApp.app() != nil else { return false }
+      return Auth.auth().canHandle(url)
     }
 
     public func scene(_ scene: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>) -> Bool
     {
+      guard FirebaseApp.app() != nil else { return false }
       for urlContext in urlContexts where Auth.auth().canHandle(urlContext.url) {
         return true
       }


### PR DESCRIPTION
## Description

`FLTFirebaseAuthPlugin` (iOS) handles incoming URLs in `application(_:open:options:)` and `scene(_:openURLContexts:)` by calling `Auth.auth()` unconditionally. When the default `FirebaseApp` has not been configured yet, `Auth.auth()` hits FirebaseAuth's fatal error

> The default FirebaseApp instance must be configured before the default Auth instance can be initialized

and the process dies on any URL delivered through one of the app's `CFBundleURLSchemes`.

This happens in apps that initialise Firebase from Dart with explicit `FirebaseOptions` (no `GoogleService-Info.plist`) some time after start-up — e.g. after reading which environment to use from local storage — and in debug/test binaries that never call `Firebase.initializeApp` at all. In both cases the plugin is still registered as an app/scene lifecycle delegate and receives the URL.

`ensureAPNSTokenSetting()` in the same file already guards with `FirebaseApp.app() != nil`. This PR applies the same guard to the two URL handlers: when no app is configured they return `false` (not handled) instead of trapping.

**Reproduction** (firebase_auth 6.6.1, iOS 26 simulator): a `CFBundleURLTypes` entry with a custom scheme, no `GoogleService-Info.plist`, `Firebase.initializeApp` not yet called, then `xcrun simctl openurl booted "<scheme>:///x"` → crash in `scene(_:openURLContexts:)` (`Auth.swift:151`, `FLTFirebaseAuthPlugin.swift:194`).

## Related Issues

None found for this exact trap; happy to link one if maintainers know of it.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors — the change is a two-line guard in native iOS lifecycle-delegate code; there is no existing harness for delivering a URL before `FirebaseApp.configure`. I can add one if you point me at the right place.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
