### PR TITLE
fix(messaging,ios): register for APNs after Dart Firebase.initializeApp()

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
@@ -291,22 +291,18 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 // Safe to call repeatedly: APNs registration is only requested once per process.
 - (void)registerForRemoteNotificationsIfAutoInitEnabled {
   if (_apnsRegistrationRequested) {
-    NSLog(@"APNS-REG skip: already requested");
     return;
   }
   // Checked via FIRApp.allApps rather than `[FIRApp defaultApp]` / `[FIRMessaging messaging]` so
   // a not-yet-configured app does not log the misleading "default Firebase app has not yet been
   // configured" (I-COR000003) warning during launch.
   if ([FLTFirebasePlugin firebaseAppNamed:@"[DEFAULT]"] == nil) {
-    NSLog(@"APNS-REG skip: no default FIRApp");
     return;
   }
   if (![FIRMessaging messaging].isAutoInitEnabled) {
-    NSLog(@"APNS-REG skip: auto-init disabled");
     return;
   }
   _apnsRegistrationRequested = YES;
-  NSLog(@"APNS-REG requesting registerForRemoteNotifications");
   [self registerForRemoteNotifications];
   // Forward an APNs token that may have arrived before Firebase was configured.
   [self ensureAPNSTokenSetting];
@@ -634,7 +630,6 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 - (void)application:(UIApplication *)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
 #endif
-  NSLog(@"APNS-REG didRegister tokenBytes=%lu", (unsigned long)deviceToken.length);
   FIRMessaging *messaging = [FIRMessaging messaging];
   if (!messaging.isAutoInitEnabled) {
     _apnsToken = deviceToken;
@@ -655,7 +650,6 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 - (void)application:(UIApplication *)application
     didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
 #endif
-  NSLog(@"APNS-REG didFail %@", error);
   NSLog(@"%@", error.localizedDescription);
 }
 
@@ -958,7 +952,6 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   // Called by firebase_core right after `Firebase.initializeApp()` has configured the app. For
   // apps initialized from Dart this is the first point where `[FIRMessaging messaging]` exists,
   // so re-run the auto-init check that was skipped during launch.
-  NSLog(@"APNS-REG pluginConstantsForFIRApp name=%@", firebase_app.name);
   [self registerForRemoteNotificationsIfAutoInitEnabled];
   return @{
     @"AUTO_INIT_ENABLED" : @([FIRMessaging messaging].isAutoInitEnabled),

--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging/Sources/firebase_messaging/FLTFirebaseMessagingPlugin.m
@@ -47,6 +47,11 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   BOOL _notificationHandlingSetup;
   BOOL _applicationObserverRegistered;
 
+  // Set once APNs registration has been requested because FCM auto-init is enabled, so the
+  // auto-init check is not re-run (and registerForRemoteNotifications not re-issued) on every
+  // Firebase app initialization.
+  BOOL _apnsRegistrationRequested;
+
 #if TARGET_OS_OSX
   // Tracks when plugin registration occurred after the macOS launch notification.
   BOOL _missedApplicationDidFinishLaunchingNotification;
@@ -273,6 +278,40 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 #endif
 }
 
+// Registers for APNs if FCM auto-init is enabled. Registration is deferred while auto-init is
+// disabled so the APNs token cannot trigger FCM registration before the user opts in (see
+// `messagingSetAutoInitEnabled:`, which registers once they do).
+//
+// `[FIRMessaging messaging]` requires a configured default FIRApp. When Firebase is initialized
+// from Dart (`Firebase.initializeApp(options:)` with no GoogleService-Info.plist / native
+// `FirebaseApp.configure()`), the default app does not exist yet at launch, so `[FIRMessaging
+// messaging]` is nil and `isAutoInitEnabled` reads as NO. In that case the check is skipped here
+// and re-run from `pluginConstantsForFIRApp:` once Dart has configured the app.
+//
+// Safe to call repeatedly: APNs registration is only requested once per process.
+- (void)registerForRemoteNotificationsIfAutoInitEnabled {
+  if (_apnsRegistrationRequested) {
+    NSLog(@"APNS-REG skip: already requested");
+    return;
+  }
+  // Checked via FIRApp.allApps rather than `[FIRApp defaultApp]` / `[FIRMessaging messaging]` so
+  // a not-yet-configured app does not log the misleading "default Firebase app has not yet been
+  // configured" (I-COR000003) warning during launch.
+  if ([FLTFirebasePlugin firebaseAppNamed:@"[DEFAULT]"] == nil) {
+    NSLog(@"APNS-REG skip: no default FIRApp");
+    return;
+  }
+  if (![FIRMessaging messaging].isAutoInitEnabled) {
+    NSLog(@"APNS-REG skip: auto-init disabled");
+    return;
+  }
+  _apnsRegistrationRequested = YES;
+  NSLog(@"APNS-REG requesting registerForRemoteNotifications");
+  [self registerForRemoteNotifications];
+  // Forward an APNs token that may have arrived before Firebase was configured.
+  [self ensureAPNSTokenSetting];
+}
+
 #ifdef __FF_NOTIFICATIONS_SUPPORTED_PLATFORM
 - (void)configureNotificationCenterDelegate {
   // Set UNUserNotificationCenter but preserve original delegate if necessary.
@@ -416,11 +455,9 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   // We automatically register for remote notifications as
   // application:didReceiveRemoteNotification:fetchCompletionHandler: will not get called unless
   // registerForRemoteNotifications is called early on during app initialization, calling this from
-  // Dart would be too late. Defer registration when auto-init is disabled so the APNs token cannot
-  // trigger FCM registration before the user opts in.
-  if ([FIRMessaging messaging].isAutoInitEnabled) {
-    [self registerForRemoteNotifications];
-  }
+  // Dart would be too late. Registration is skipped when auto-init is disabled, or deferred to
+  // `pluginConstantsForFIRApp:` when Firebase has not been configured natively yet.
+  [self registerForRemoteNotificationsIfAutoInitEnabled];
 }
 
 - (void)markInitialNotificationGatheredAfterDelay {
@@ -597,6 +634,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 - (void)application:(UIApplication *)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
 #endif
+  NSLog(@"APNS-REG didRegister tokenBytes=%lu", (unsigned long)deviceToken.length);
   FIRMessaging *messaging = [FIRMessaging messaging];
   if (!messaging.isAutoInitEnabled) {
     _apnsToken = deviceToken;
@@ -617,6 +655,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 - (void)application:(UIApplication *)application
     didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
 #endif
+  NSLog(@"APNS-REG didFail %@", error);
   NSLog(@"%@", error.localizedDescription);
 }
 
@@ -785,6 +824,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   BOOL enabled = [arguments[@"enabled"] boolValue];
   messaging.autoInitEnabled = enabled;
   if (enabled) {
+    _apnsRegistrationRequested = YES;
     [self registerForRemoteNotifications];
     [self ensureAPNSTokenSetting];
   }
@@ -915,6 +955,11 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 }
 
 - (NSDictionary *_Nonnull)pluginConstantsForFIRApp:(FIRApp *)firebase_app {
+  // Called by firebase_core right after `Firebase.initializeApp()` has configured the app. For
+  // apps initialized from Dart this is the first point where `[FIRMessaging messaging]` exists,
+  // so re-run the auto-init check that was skipped during launch.
+  NSLog(@"APNS-REG pluginConstantsForFIRApp name=%@", firebase_app.name);
+  [self registerForRemoteNotificationsIfAutoInitEnabled];
   return @{
     @"AUTO_INIT_ENABLED" : @([FIRMessaging messaging].isAutoInitEnabled),
   };


### PR DESCRIPTION
## Description

`firebase_messaging` 16.5.0+ skips `registerForRemoteNotifications` at launch when Firebase is initialized from Dart only (no `GoogleService-Info.plist` in the iOS app bundle, no native `FirebaseApp.configure()`).

`isAutoInitEnabled` is read in `didFinishLaunching`, before Dart `initializeApp()`. Without a bundled plist, `[FIRMessaging messaging]` is nil, the gate reads as `NO`, and APNs registration never happens. Result: `getAPNSToken()` stays `null`, `getToken()` throws `apns-token-not-set`, and `onTokenRefresh` never fires.

This PR re-runs the auto-init check from `pluginConstantsForFIRApp:` after `firebase_core` has configured the default app. Launch-time registration is unchanged for apps that still bundle a plist. `FirebaseMessagingAutoInitEnabled = NO` is still honored (no registration until `setAutoInitEnabled(true)`).

## Related Issues

Fixes https://github.com/firebase/flutterfire/issues/18643

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.

## Test plan

- [ ] Run an iOS **device** build of this branch with Dart-only Firebase init (no `GoogleService-Info.plist` in Copy Bundle Resources).
- [ ] `getAPNSToken()` is non-null and `getToken()` succeeds without `apns-token-not-set`.
- [ ] Apps that still bundle `GoogleService-Info.plist` continue to register at launch.
- [ ] `FirebaseMessagingAutoInitEnabled = NO` still skips registration until `setAutoInitEnabled(true)`.