### PR TITLE
fix(cloud_functions): lowercase Android error codes with Locale.ROOT

### DIFF
--- a/.github/workflows/android_unit_tests.yaml
+++ b/.github/workflows/android_unit_tests.yaml
@@ -43,7 +43,7 @@ jobs:
         # Tasks are listed per package rather than using the root testDebugUnitTest
         # task, which would also build the Dart sources of the aggregate test app.
         # Add a task here when a package gains an android/src/test directory.
-        run: cd tests/android && ./gradlew :firebase_crashlytics:testDebugUnitTest
+        run: cd tests/android && ./gradlew :firebase_crashlytics:testDebugUnitTest :cloud_functions:testDebugUnitTest
       - name: 'Upload test reports'
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/packages/cloud_functions/cloud_functions/android/build.gradle
+++ b/packages/cloud_functions/cloud_functions/android/build.gradle
@@ -78,6 +78,11 @@ android {
     implementation 'com.google.firebase:firebase-functions'
     implementation 'androidx.annotation:annotation:1.7.0'
     implementation 'org.reactivestreams:reactive-streams:1.0.4'
+    testImplementation 'junit:junit:4.13.2'
+  }
+
+  testOptions {
+    unitTests.returnDefaultValues = true
   }
 
 }

--- a/packages/cloud_functions/cloud_functions/android/src/main/kotlin/io/flutter/plugins/firebase/functions/FlutterFirebaseFunctionsPlugin.kt
+++ b/packages/cloud_functions/cloud_functions/android/src/main/kotlin/io/flutter/plugins/firebase/functions/FlutterFirebaseFunctionsPlugin.kt
@@ -136,7 +136,7 @@ class FlutterFirebaseFunctionsPlugin : FlutterPlugin, FlutterFirebasePlugin, Clo
       }
     }
 
-    details["code"] = code.replace("_", "-").lowercase(Locale.getDefault())
+    details["code"] = mapFunctionsErrorCode(code)
     details["message"] = message
 
     if (additionalData != null) {
@@ -164,6 +164,11 @@ class FlutterFirebaseFunctionsPlugin : FlutterPlugin, FlutterFirebasePlugin, Clo
 
   companion object {
     private const val METHOD_CHANNEL_NAME = "plugins.flutter.io/firebase_functions"
+
+    // Locale.ROOT: Turkish/Azerbaijani map 'I' → 'ı' under Locale.getDefault().
+    internal fun mapFunctionsErrorCode(code: String): String {
+      return code.replace("_", "-").lowercase(Locale.ROOT)
+    }
   }
 
   override fun call(arguments: Map<String, Any?>, callback: (Result<Any?>) -> Unit) {

--- a/packages/cloud_functions/cloud_functions/android/src/test/kotlin/io/flutter/plugins/firebase/functions/FlutterFirebaseFunctionsPluginTest.kt
+++ b/packages/cloud_functions/cloud_functions/android/src/test/kotlin/io/flutter/plugins/firebase/functions/FlutterFirebaseFunctionsPluginTest.kt
@@ -66,8 +66,7 @@ class FlutterFirebaseFunctionsPluginTest {
         )
 
     for ((enumName, canonical) in expected) {
-      assertEquals(
-          canonical, FlutterFirebaseFunctionsPlugin.mapFunctionsErrorCode(enumName))
+      assertEquals(canonical, FlutterFirebaseFunctionsPlugin.mapFunctionsErrorCode(enumName))
     }
   }
 }

--- a/packages/cloud_functions/cloud_functions/android/src/test/kotlin/io/flutter/plugins/firebase/functions/FlutterFirebaseFunctionsPluginTest.kt
+++ b/packages/cloud_functions/cloud_functions/android/src/test/kotlin/io/flutter/plugins/firebase/functions/FlutterFirebaseFunctionsPluginTest.kt
@@ -1,0 +1,73 @@
+// Copyright 2026 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+package io.flutter.plugins.firebase.functions
+
+import java.util.Locale
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class FlutterFirebaseFunctionsPluginTest {
+  private lateinit var originalLocale: Locale
+
+  @Before
+  fun setUp() {
+    originalLocale = Locale.getDefault()
+  }
+
+  @After
+  fun tearDown() {
+    Locale.setDefault(originalLocale)
+  }
+
+  @Test
+  fun mapFunctionsErrorCode_usesRootLocaleUnderTurkishDefault() {
+    Locale.setDefault(Locale("tr", "TR"))
+
+    // Canary: the JVM's Turkish locale really does map 'I' to 'ı'.
+    assertEquals(
+        "faıled-precondıtıon",
+        "FAILED_PRECONDITION".replace("_", "-").lowercase(Locale.getDefault()))
+
+    assertMappedCodes()
+  }
+
+  @Test
+  fun mapFunctionsErrorCode_usesRootLocaleUnderAzerbaijaniDefault() {
+    Locale.setDefault(Locale("az", "AZ"))
+
+    assertEquals(
+        "faıled-precondıtıon",
+        "FAILED_PRECONDITION".replace("_", "-").lowercase(Locale.getDefault()))
+
+    assertMappedCodes()
+  }
+
+  private fun assertMappedCodes() {
+    val expected =
+        mapOf(
+            "FAILED_PRECONDITION" to "failed-precondition",
+            "INVALID_ARGUMENT" to "invalid-argument",
+            "PERMISSION_DENIED" to "permission-denied",
+            "UNAUTHENTICATED" to "unauthenticated",
+            "INTERNAL" to "internal",
+            "UNAVAILABLE" to "unavailable",
+            "DEADLINE_EXCEEDED" to "deadline-exceeded",
+            "ALREADY_EXISTS" to "already-exists",
+            "UNIMPLEMENTED" to "unimplemented",
+            "UNKNOWN" to "unknown",
+            "NOT_FOUND" to "not-found",
+            "ABORTED" to "aborted",
+        )
+
+    for ((enumName, canonical) in expected) {
+      assertEquals(
+          canonical, FlutterFirebaseFunctionsPlugin.mapFunctionsErrorCode(enumName))
+    }
+  }
+}


### PR DESCRIPTION
## Description

Android maps Cloud Functions error codes with `String.lowercase(Locale.getDefault())`. On Turkish and Azerbaijani devices, that turns every `I` into a dotless `ı`, so documented comparisons such as `e.code == 'failed-precondition'` fail while codes without `i` still match.

This switches the mapping to `Locale.ROOT` (same approach as `firebase_auth`) and adds a JVM unit test that sets the default locale to `tr-TR` / `az-AZ` and asserts the canonical ASCII codes.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18647

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/

## Test plan

- [x] `:cloud_functions:testDebugUnitTest` passes with Turkish and Azerbaijani default locales
- [ ] Android unit-test workflow runs `:cloud_functions:testDebugUnitTest` on CI