### PR TITLE
fix(app_installations,android): dispatch ID-change events on the main thread

### DIFF
--- a/packages/firebase_app_installations/firebase_app_installations/android/src/main/kotlin/io/flutter/plugins/firebase/installations/firebase_app_installations/TokenChannelStreamHandler.kt
+++ b/packages/firebase_app_installations/firebase_app_installations/android/src/main/kotlin/io/flutter/plugins/firebase/installations/firebase_app_installations/TokenChannelStreamHandler.kt
@@ -3,25 +3,36 @@
 // found in the LICENSE file.
 package io.flutter.plugins.firebase.installations.firebase_app_installations
 
+import android.os.Handler
+import android.os.Looper
 import com.google.firebase.installations.FirebaseInstallations
 import com.google.firebase.installations.internal.FidListener
+import com.google.firebase.installations.internal.FidListenerHandle
 import io.flutter.plugin.common.EventChannel
 
 class TokenChannelStreamHandler(private val firebaseInstallations: FirebaseInstallations) :
     EventChannel.StreamHandler {
 
   private var listener: FidListener? = null
+  private var listenerHandle: FidListenerHandle? = null
+  private val mainHandler = Handler(Looper.getMainLooper())
 
   override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
     listener = createTokenEventListener(events)
-    firebaseInstallations.registerFidListener(listener!!)
+    listenerHandle = firebaseInstallations.registerFidListener(listener!!)
   }
 
   override fun onCancel(arguments: Any?) {
+    listenerHandle?.unregister()
+    listenerHandle = null
     listener = null
   }
 
   internal fun createTokenEventListener(events: EventChannel.EventSink): FidListener {
-    return FidListener { token -> events.success(mapOf("token" to token)) }
+    return FidListener { token ->
+      // FidListener is invoked on Firebase's blocking executor. EventSink
+      // must be used on the main thread.
+      mainHandler.post { events.success(mapOf("token" to token)) }
+    }
   }
 }


### PR DESCRIPTION
## Description

`FidListener.onFidChanged()` is invoked on Firebase's blocking executor. The Android installations plugin was calling `EventSink.success()` on that background thread, which FlutterJNI rejects (`@UiThread`).

This posts the event onto the main looper (same pattern as Firestore / Functions / Remote Config stream handlers) and unregisters the `FidListenerHandle` on cancel.

Reproduced on a Pixel_9a emulator with a fresh install: subscribe to `onIdChange`, then `getId()` + `getToken()` with no delay. Before the fix, logcat showed:

```
java.lang.RuntimeException: Methods marked with @UiThread must be executed on the main thread. Current thread: Firebase Blocking Thread #0
  at TokenChannelStreamHandler.kt:25
```

After the fix, `getId`/`getToken` complete and `onIdChange` delivers the FID with no exception.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18646

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/