### PR TITLE
fix(auth,windows): complete reauthenticateWithCredential on success

### DIFF
--- a/packages/firebase_auth/firebase_auth/example/integration_test/firebase_auth_user_e2e_test.dart
+++ b/packages/firebase_auth/firebase_auth/example/integration_test/firebase_auth_user_e2e_test.dart
@@ -298,40 +298,33 @@ void main() {
                 defaultTargetPlatform == TargetPlatform.macOS),
       );
 
-      // Kept outside the skipped group so Windows covers the success path
-      // that previously hung. Remaining cases stay skipped on desktop
-      // because they assert platform-specific error messages.
-      test(
-        'reauthenticateWithCredential() should reauthenticate correctly',
-        () async {
-          // Setup
-          await FirebaseAuth.instance.createUserWithEmailAndPassword(
-            email: email,
-            password: testPassword,
-          );
-          final initialUser = FirebaseAuth.instance.currentUser;
-
-          // Test
-          AuthCredential credential = EmailAuthProvider.credential(
-            email: email,
-            password: testPassword,
-          );
-          await FirebaseAuth.instance.currentUser!
-              .reauthenticateWithCredential(credential);
-
-          // Assertions
-          final currentUser = FirebaseAuth.instance.currentUser;
-          expect(currentUser, isNot(equals(null)));
-          expect(initialUser, isNot(equals(null)));
-          expect(currentUser?.email, equals(email));
-          expect(currentUser?.uid, equals(initialUser?.uid));
-        },
-        skip: !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS,
-      );
-
       group(
         'reauthenticateWithCredential()',
         () {
+          test('should reauthenticate correctly', () async {
+            // Setup
+            await FirebaseAuth.instance.createUserWithEmailAndPassword(
+              email: email,
+              password: testPassword,
+            );
+            final initialUser = FirebaseAuth.instance.currentUser;
+
+            // Test
+            AuthCredential credential = EmailAuthProvider.credential(
+              email: email,
+              password: testPassword,
+            );
+            await FirebaseAuth.instance.currentUser!
+                .reauthenticateWithCredential(credential);
+
+            // Assertions
+            final currentUser = FirebaseAuth.instance.currentUser;
+            expect(currentUser, isNot(equals(null)));
+            expect(initialUser, isNot(equals(null)));
+            expect(currentUser?.email, equals(email));
+            expect(currentUser?.uid, equals(initialUser?.uid));
+          });
+
           test('should throw user-mismatch ', () async {
             // Setup
             String emailAlready = generateRandomEmail();
@@ -435,38 +428,41 @@ void main() {
             fail('should have thrown an error');
           });
 
-          test('should throw wrong-password ', () async {
-            // Setup
-            final email = generateRandomEmail();
-            await FirebaseAuth.instance.createUserWithEmailAndPassword(
-              email: email,
-              password: testPassword,
-            );
-
-            await FirebaseAuth.instance.signOut();
-
-            await expectLater(
-              FirebaseAuth.instance.signInWithEmailAndPassword(
+          test(
+            'should throw wrong-password ',
+            () async {
+              // Setup
+              final email = generateRandomEmail();
+              await FirebaseAuth.instance.createUserWithEmailAndPassword(
                 email: email,
-                password: 'wrong password',
-              ),
-              throwsA(
-                isA<FirebaseAuthException>()
-                    .having((e) => e.code, 'code', equals('wrong-password'))
-                    .having(
-                      (e) => e.message,
-                      'message',
-                      equals(
-                        'The password is invalid or the user does not have a password.',
+                password: testPassword,
+              );
+
+              await FirebaseAuth.instance.signOut();
+
+              await expectLater(
+                FirebaseAuth.instance.signInWithEmailAndPassword(
+                  email: email,
+                  password: 'wrong password',
+                ),
+                throwsA(
+                  isA<FirebaseAuthException>()
+                      .having((e) => e.code, 'code', equals('wrong-password'))
+                      .having(
+                        (e) => e.message,
+                        'message',
+                        equals(
+                          'The password is invalid or the user does not have a password.',
+                        ),
                       ),
-                    ),
-              ),
-            );
-          });
+                ),
+              );
+            },
+            // Exercises signInWithEmailAndPassword, not reauthenticateWithCredential.
+            skip: !kIsWeb && defaultTargetPlatform == TargetPlatform.windows,
+          );
         },
-        skip: !kIsWeb &&
-            (defaultTargetPlatform == TargetPlatform.windows ||
-                defaultTargetPlatform == TargetPlatform.macOS),
+        skip: !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS,
       );
 
       group('reload()', () {

--- a/packages/firebase_auth/firebase_auth/example/integration_test/firebase_auth_user_e2e_test.dart
+++ b/packages/firebase_auth/firebase_auth/example/integration_test/firebase_auth_user_e2e_test.dart
@@ -352,8 +352,14 @@ void main() {
               expect(e.code, equals('user-mismatch'));
               expect(
                 e.message,
-                equals(
-                  'The supplied credentials do not correspond to the previously signed in user.',
+                anyOf(
+                  equals(
+                    'The supplied credentials do not correspond to the previously signed in user.',
+                  ),
+                  // Windows C++ SDK omits the trailing period.
+                  equals(
+                    'The supplied credentials do not correspond to the previously signed in user',
+                  ),
                 ),
               );
               await FirebaseAuth.instance.currentUser!.delete(); //clean up
@@ -459,7 +465,10 @@ void main() {
               );
             },
             // Exercises signInWithEmailAndPassword, not reauthenticateWithCredential.
-            skip: !kIsWeb && defaultTargetPlatform == TargetPlatform.windows,
+            // A test-level skip overrides the group skip, so include macOS here too.
+            skip: !kIsWeb &&
+                (defaultTargetPlatform == TargetPlatform.windows ||
+                    defaultTargetPlatform == TargetPlatform.macOS),
           );
         },
         skip: !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS,

--- a/packages/firebase_auth/firebase_auth/example/integration_test/firebase_auth_user_e2e_test.dart
+++ b/packages/firebase_auth/firebase_auth/example/integration_test/firebase_auth_user_e2e_test.dart
@@ -298,33 +298,40 @@ void main() {
                 defaultTargetPlatform == TargetPlatform.macOS),
       );
 
+      // Kept outside the skipped group so Windows covers the success path
+      // that previously hung. Remaining cases stay skipped on desktop
+      // because they assert platform-specific error messages.
+      test(
+        'reauthenticateWithCredential() should reauthenticate correctly',
+        () async {
+          // Setup
+          await FirebaseAuth.instance.createUserWithEmailAndPassword(
+            email: email,
+            password: testPassword,
+          );
+          final initialUser = FirebaseAuth.instance.currentUser;
+
+          // Test
+          AuthCredential credential = EmailAuthProvider.credential(
+            email: email,
+            password: testPassword,
+          );
+          await FirebaseAuth.instance.currentUser!
+              .reauthenticateWithCredential(credential);
+
+          // Assertions
+          final currentUser = FirebaseAuth.instance.currentUser;
+          expect(currentUser, isNot(equals(null)));
+          expect(initialUser, isNot(equals(null)));
+          expect(currentUser?.email, equals(email));
+          expect(currentUser?.uid, equals(initialUser?.uid));
+        },
+        skip: !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS,
+      );
+
       group(
         'reauthenticateWithCredential()',
         () {
-          test('should reauthenticate correctly', () async {
-            // Setup
-            await FirebaseAuth.instance.createUserWithEmailAndPassword(
-              email: email,
-              password: testPassword,
-            );
-            final initialUser = FirebaseAuth.instance.currentUser;
-
-            // Test
-            AuthCredential credential = EmailAuthProvider.credential(
-              email: email,
-              password: testPassword,
-            );
-            await FirebaseAuth.instance.currentUser!
-                .reauthenticateWithCredential(credential);
-
-            // Assertions
-            final currentUser = FirebaseAuth.instance.currentUser;
-            expect(currentUser, isNot(equals(null)));
-            expect(initialUser, isNot(equals(null)));
-            expect(currentUser?.email, equals(email));
-            expect(currentUser?.uid, equals(initialUser?.uid));
-          });
-
           test('should throw user-mismatch ', () async {
             // Setup
             String emailAlready = generateRandomEmail();

--- a/packages/firebase_auth/firebase_auth/windows/firebase_auth_plugin.cpp
+++ b/packages/firebase_auth/firebase_auth/windows/firebase_auth_plugin.cpp
@@ -1039,17 +1039,22 @@ void FirebaseAuthPlugin::ReauthenticateWithCredential(
   firebase::auth::Auth* firebaseAuth = GetAuthFromPigeon(app);
   firebase::auth::User user = firebaseAuth->current_user();
 
-  firebase::Future<void> future =
-      user.Reauthenticate(getCredentialFromArguments(input, app));
+  firebase::Future<firebase::auth::AuthResult> future =
+      user.ReauthenticateAndRetrieveData(
+          getCredentialFromArguments(input, app));
 
-  future.OnCompletion([result](const firebase::Future<void>& completed_future) {
-    // We are probably in a different thread right now.
-    if (completed_future.error() == 0) {
-      // TODO: wrong return type
-    } else {
-      result(FirebaseAuthPlugin::ParseError(completed_future));
-    }
-  });
+  future.OnCompletion(
+      [result](const firebase::Future<firebase::auth::AuthResult>&
+                   completed_future) {
+        // We are probably in a different thread right now.
+        if (completed_future.error() == 0) {
+          InternalUserCredential credential =
+              ParseAuthResult(completed_future.result());
+          result(credential);
+        } else {
+          result(FirebaseAuthPlugin::ParseError(completed_future));
+        }
+      });
 }
 
 void FirebaseAuthPlugin::ReauthenticateWithProvider(


### PR DESCRIPTION
## Description

On Windows, `User.reauthenticateWithCredential()` never completed when the credential was valid. The C++ plugin called `User::Reauthenticate()`, which returns `Future<void>`, then left the Pigeon success branch empty (`// TODO: wrong return type`). Dart's `Future` stayed pending forever. Invalid credentials still failed normally because only the error branch invoked `result`.

This switches to `User::ReauthenticateAndRetrieveData()`, which returns `AuthResult`, and completes the Pigeon callback the same way as `LinkWithCredential` / `ReauthenticateWithProvider`.

The `reauthenticateWithCredential()` e2e group now runs on Windows. The last case in that group is skipped on Windows and macOS because it exercises `signInWithEmailAndPassword`, not reauthentication (a test-level skip overrides the group skip). The `user-mismatch` assertion accepts the Windows C++ SDK message, which omits the trailing period. macOS still skips the rest of the group.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18632

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/