### PR TITLE
fix(app_check,ios): compile RecaptchaProvider only when RecaptchaEnterprise is linked

### DIFF
--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FirebaseAppCheckPlugin.swift
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check/Sources/firebase_app_check/FirebaseAppCheckPlugin.swift
@@ -380,7 +380,10 @@ class AppCheckProviderWrapper: NSObject, AppCheckProvider {
       }
       delegateProvider = appAttestProvider ?? DeviceCheckProvider(app: app)
     case "recaptcha":
-      #if os(iOS)
+      // RecaptchaProvider is only usable when RecaptchaEnterprise is linked
+      // (SPM Package.swift). CocoaPods does not ship that dependency, and some
+      // Podfile setups fail to compile if this type is referenced at all.
+      #if os(iOS) && canImport(RecaptchaEnterprise)
         if let recaptchaSiteKey {
           delegateProvider = RecaptchaProvider(app: app, siteKey: recaptchaSiteKey)
         } else {
@@ -391,6 +394,11 @@ class AppCheckProviderWrapper: NSObject, AppCheckProvider {
             "Firebase App Check: failed to initialize RecaptchaProvider. Ensure site key is provided."
           )
         }
+      #elseif os(iOS)
+        print(
+          "Firebase App Check: RecaptchaProvider requires Swift Package Manager with RecaptchaEnterprise."
+        )
+        delegateProvider = nil
       #else
         print("Firebase App Check: reCAPTCHA is only supported on iOS.")
       #endif


### PR DESCRIPTION
## Description

`firebase_app_check` referenced `RecaptchaProvider` in the Apple plugin's `configure` switch. That type is only usable when RecaptchaEnterprise is linked (SPM `Package.swift`). CocoaPods does not ship that extra dependency, and in some Podfile setups the type is not in scope at all — so iOS builds fail even for apps that only use debug / DeviceCheck / App Attest.

Guard the recaptcha case with `canImport(RecaptchaEnterprise)` so CocoaPods builds compile. SPM builds still construct `RecaptchaProvider(app:siteKey:)`.

The `FlutterError: Error` redundant conformance from #18648 is already fixed in 0.4.7 (#18569).

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18648

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/