### PR TITLE
fix(firestore,windows): honor persistenceEnabled: false

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/instance_e2e.dart
@@ -188,6 +188,73 @@ void runInstanceTests() {
       );
 
       test(
+        'Settings() - persistenceEnabled: false does not persist across terminate()',
+        () async {
+          // Regression test for https://github.com/firebase/flutterfire/issues/18659
+          // Windows ignored persistenceEnabled: false (pointer-to-bool + never
+          // forwarded to the C++ SDK). Disk cache is the only state that
+          // survives terminate(); in-memory cache does not.
+          FirebaseFirestore firestoreFor(
+            String databaseId, {
+            required bool persistenceEnabled,
+          }) {
+            final firestore = FirebaseFirestore.instanceFor(
+              app: Firebase.app(),
+              databaseId: databaseId,
+            );
+            firestore.settings =
+                Settings(persistenceEnabled: persistenceEnabled);
+            firestore.useFirestoreEmulator('localhost', 8080);
+            return firestore;
+          }
+
+          Future<void> writeThenTerminate(FirebaseFirestore firestore) async {
+            await firestore
+                .doc('flutter-tests/persistence-across-terminate')
+                .set({'foo': 'bar'});
+            await firestore.waitForPendingWrites();
+            await firestore.terminate();
+          }
+
+          const docPath = 'flutter-tests/persistence-across-terminate';
+          const cacheGet = GetOptions(source: Source.cache);
+
+          // Control: persistence on → cache must survive terminate. If this
+          // fails, Windows is not keeping a disk cache and the disabled case
+          // would not prove the setting was forwarded.
+          final enabled = firestoreFor(
+            'persistence-enabled-18659',
+            persistenceEnabled: true,
+          );
+          await writeThenTerminate(enabled);
+
+          final cachedWhenEnabled = await enabled.doc(docPath).get(cacheGet);
+          expect(cachedWhenEnabled.data(), {'foo': 'bar'});
+          expect(cachedWhenEnabled.metadata.isFromCache, isTrue);
+          await enabled.terminate();
+
+          final disabled = firestoreFor(
+            'persistence-disabled-18659',
+            persistenceEnabled: false,
+          );
+          await writeThenTerminate(disabled);
+
+          await expectLater(
+            disabled.doc(docPath).get(cacheGet),
+            throwsA(
+              isA<FirebaseException>().having(
+                (e) => e.code,
+                'code',
+                'unavailable',
+              ),
+            ),
+          );
+          await disabled.terminate();
+        },
+        skip: defaultTargetPlatform != TargetPlatform.windows,
+      );
+
+      test(
         'setIndexConfigurationFromJSON()',
         () async {
           final json = jsonEncode({

--- a/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.cpp
+++ b/packages/cloud_firestore/cloud_firestore/windows/cloud_firestore_plugin.cpp
@@ -400,7 +400,10 @@ Firestore* GetFirestoreFromPigeon(const FirestorePigeonFirebaseApp& pigeonApp) {
   firebase::firestore::Settings settings;
 
   if (pigeonApp.settings().persistence_enabled()) {
-    bool persistEnabled = pigeonApp.settings().persistence_enabled();
+    // The getter returns `const bool*` (null when unset); dereference to read
+    // the actual value rather than testing pointer presence.
+    bool persistEnabled = *pigeonApp.settings().persistence_enabled();
+    settings.set_persistence_enabled(persistEnabled);
 
     // This is the maximum amount of cache allowed. We use the same number on
     // android.


### PR DESCRIPTION
## Description

On Windows, `Settings(persistenceEnabled: false)` never reached the C++ Firestore client.

`GetFirestoreFromPigeon` assigns `pigeonApp.settings().persistence_enabled()` (a `const bool*`) to a `bool`, so the assignment tests pointer presence rather than the value — an explicit `false` is read as `true`. The plugin also never calls `settings.set_persistence_enabled(...)`, and the C++ SDK defaults persistence to on, so even a correct dereference would not disable it.

This dereferences the pointer and forwards the value. A Windows-only e2e writes a doc, terminates the client, then `get(source: cache)`: disk cache is the only state that survives terminate. A persistence-on control must hit cache; the disabled instance must miss.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18659

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
