### PR TITLE
fix(messaging,android): skip onMessageOpenedApp for terminated notification taps

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -124,7 +124,9 @@ public class FlutterFirebaseMessagingPlugin
         // The notification tap created this Activity, so the Messaging SDK has already logged
         // `notification_open` from FcmLifecycleCallbacks#onActivityCreated. Handle the intent
         // without logging it a second time.
-        handleNotificationIntent(mainActivity.getIntent());
+        // Terminated launch: getInitialMessage() owns this tap. Do not also fire
+        // onMessageOpenedApp (firebase/flutterfire#18661).
+        handleNotificationIntent(mainActivity.getIntent(), /* shouldNotifyStream= */ false);
       }
     }
   }
@@ -630,7 +632,8 @@ public class FlutterFirebaseMessagingPlugin
     // FcmLifecycleCallbacks#onActivityCreated for this intent and `notification_open` was not
     // logged. Log it here before handling the intent.
     logNotificationOpen(intent);
-    return handleNotificationIntent(intent);
+    // Background resume: onMessageOpenedApp owns this tap.
+    return handleNotificationIntent(intent, /* shouldNotifyStream= */ true);
   }
 
   /**
@@ -700,7 +703,17 @@ public class FlutterFirebaseMessagingPlugin
     return messageId;
   }
 
-  private boolean handleNotificationIntent(@NonNull Intent intent) {
+  /**
+   * Handles a notification-tap intent.
+   *
+   * <p>{@code shouldNotifyStream} is {@code false} when the tap created this Activity (terminated
+   * launch). In that case the message is stored for {@code getInitialMessage()} only, matching iOS
+   * and the Dart API docs. It is {@code true} when the Activity already existed ({@link
+   * #onNewIntent}), which is a resume from background and should fire {@code onMessageOpenedApp}.
+   *
+   * @see <a href="https://github.com/firebase/flutterfire/issues/18661">#18661</a>
+   */
+  private boolean handleNotificationIntent(@NonNull Intent intent, boolean shouldNotifyStream) {
     if (intent.getExtras() == null) {
       return false;
     }
@@ -740,7 +753,10 @@ public class FlutterFirebaseMessagingPlugin
       message.put("notification", initialMessageNotification);
     }
 
-    channel.invokeMethod("Messaging#onMessageOpenedApp", message);
+    // On a terminated launch, getInitialMessage() owns this message.
+    if (shouldNotifyStream) {
+      channel.invokeMethod("Messaging#onMessageOpenedApp", message);
+    }
     mainActivity.setIntent(intent);
     return true;
   }


### PR DESCRIPTION
## Description

On Android, tapping an FCM notification from a terminated state stored the message for `getInitialMessage()` **and** invoked `onMessageOpenedApp`. Apps that subscribe to the stream early (for example in `main()` before `runApp()`) therefore handled the same tap twice, which does not match the Dart docs or iOS.

`onAttachedToActivity` (new Activity / terminated launch) now stores the message only. `onNewIntent` (existing Activity / background resume) still fires `onMessageOpenedApp`.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18661

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/