### PR TITLE
fix(firestore,android): abort timed-out transactions without crashing on a later get

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -635,6 +635,8 @@ public class FlutterFirebaseFirestorePlugin
                     DocumentSnapshot.ServerTimestampBehavior.NONE));
           } catch (Exception e) {
             ExceptionConverter.sendErrorToFlutter(result, e);
+          } catch (Throwable t) {
+            ExceptionConverter.sendErrorToFlutter(result, new Exception(t));
           }
         });
   }

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/TransactionStreamHandler.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/streamhandler/TransactionStreamHandler.java
@@ -87,11 +87,15 @@ public class TransactionStreamHandler implements OnTransactionResultListener, St
 
               try {
                 if (!semaphore.tryAcquire(timeout, TimeUnit.MILLISECONDS)) {
-                  return FlutterFirebaseFirestoreTransactionResult.failed(
+                  // Throw a non-FirebaseFirestoreException so the Android SDK
+                  // does not retry or commit. Returning a failed result object
+                  // makes apply() succeed, which commits and then crashes a later
+                  // transaction.get (see #18666).
+                  throw new RuntimeException(
                       new FirebaseFirestoreException("timed out", Code.DEADLINE_EXCEEDED));
                 }
               } catch (InterruptedException e) {
-                return FlutterFirebaseFirestoreTransactionResult.failed(
+                throw new RuntimeException(
                     new FirebaseFirestoreException("interrupted", Code.DEADLINE_EXCEEDED));
               }
 

--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/transaction_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/transaction_e2e.dart
@@ -302,6 +302,34 @@ void runTransactionTests() {
         skip: kIsWeb || defaultTargetPlatform == TargetPlatform.windows,
       );
 
+      test(
+        'should not crash when a get is issued after the transaction timeout',
+        () async {
+          final DocumentReference<Map<String, dynamic>> first =
+              await initializeTest('timeout-second-get-1');
+          final DocumentReference<Map<String, dynamic>> second =
+              await initializeTest('timeout-second-get-2');
+          await first.set(<String, Object>{'v': 1});
+          await second.set(<String, Object>{'v': 2});
+
+          await expectLater(
+            firestore.runTransaction(
+              (Transaction transaction) async {
+                await transaction.get(first);
+                await Future<void>.delayed(const Duration(seconds: 2));
+                await transaction.get(second);
+              },
+              timeout: const Duration(seconds: 1),
+            ),
+            throwsA(
+              isA<FirebaseException>()
+                  .having((e) => e.code, 'code', 'deadline-exceeded'),
+            ),
+          );
+        },
+        skip: kIsWeb || defaultTargetPlatform != TargetPlatform.android,
+      );
+
       test('should throw with exception', () async {
         try {
           await firestore.runTransaction((Transaction transaction) async {


### PR DESCRIPTION
## Description

Android `runTransaction` timed out by returning a failed result from the native update callback. The Firestore SDK treated that as success, committed, and a later `transaction.get` hit `ensureCommitNotCalled`. `AssertionError` is not an `Exception`, so the process died instead of Dart seeing `deadline-exceeded`.

Abort the callback with a non-retryable error (still mapped to `deadline-exceeded`) and catch `Throwable` in `transactionGet`.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18666

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/