### PR TITLE
fix(auth,ios): guard URL and notification hooks when no default FirebaseApp exists

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.swift
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth/Sources/firebase_auth/FLTFirebaseAuthPlugin.swift
@@ -166,6 +166,7 @@ public class FLTFirebaseAuthPlugin: NSObject, FlutterPlugin, FLTFirebasePluginPr
         didReceiveRemoteNotification notification: [AnyHashable: Any],
         fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
       ) -> Bool {
+        guard FirebaseApp.app() != nil else { return false }
         if Auth.auth().canHandleNotification(notification) {
           completionHandler(.noData)
           return true
@@ -186,11 +187,13 @@ public class FLTFirebaseAuthPlugin: NSObject, FlutterPlugin, FLTFirebasePluginPr
       open url: URL,
       options: [UIApplication.OpenURLOptionsKey: Any] = [:]
     ) -> Bool {
-      Auth.auth().canHandle(url)
+      guard FirebaseApp.app() != nil else { return false }
+      return Auth.auth().canHandle(url)
     }
 
     public func scene(_ scene: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>) -> Bool
     {
+      guard FirebaseApp.app() != nil else { return false }
       for urlContext in urlContexts where Auth.auth().canHandle(urlContext.url) {
         return true
       }


### PR DESCRIPTION
## Description

`Auth.auth()` calls `fatalError` when no default `FirebaseApp` has been configured. On iOS, `FLTFirebaseAuthPlugin`'s URL and notification hooks call it unguarded, and Flutter hands every incoming URL to every registered plugin, so those hooks run for URLs that have nothing to do with Auth.

If the app configures Firebase from Dart (`Firebase.initializeApp(options: ...)`, which is what the FlutterFire CLI generates), the default app doesn't exist until Dart has run. iOS can deliver a URL before that, e.g. opening a document into the app from Files on a cold launch. `Auth.auth()` trips the assertion and the process dies with SIGABRT over a URL Auth was never going to handle. I hit this on a TestFlight build; the crashing frame is `Auth.auth()` (Auth.swift:151) called from `FLTFirebaseAuthPlugin.scene(_:openURLContexts:)`.

The fix adds the same `guard FirebaseApp.app() != nil else { return false }` the plugin already uses in `ensureAPNSTokenSetting()` to `application(_:open:options:)`, `scene(_:openURLContexts:)` and `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)`. With no default app there's no default Auth and nothing to handle, so `false` is the right answer and the URL or notification carries on to the other plugins. When a default app exists, behavior is unchanged. macOS is unaffected since all three hooks are inside `#if os(iOS)`.

This is the same crash as #8205 from 2022, which was closed with "configure Firebase natively" as the workaround.

No test added: this package has no iOS unit test target, and the integration tests all run with a default app already configured, which is the precondition the bug needs to be absent. Happy to add one if there's a harness you'd want it in. No CHANGELOG change since Melos generates those from commit messages.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/firebase/flutterfire/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
