### PR TITLE
fix(remote_config,ios): emit onConfigUpdated events on the platform thread

### DIFF
--- a/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Sources/firebase_remote_config/FirebaseRemoteConfigPlugin.swift
+++ b/packages/firebase_remote_config/firebase_remote_config/ios/firebase_remote_config/Sources/firebase_remote_config/FirebaseRemoteConfigPlugin.swift
@@ -211,7 +211,10 @@ public class FirebaseRemoteConfigPlugin: NSObject, FlutterPlugin, FlutterStreamH
         return
       }
       if let update {
-        events(Array(update.updatedKeys))
+        let updatedKeys = Array(update.updatedKeys)
+        DispatchQueue.main.async {
+          events(updatedKeys)
+        }
       }
     }
     return nil


### PR DESCRIPTION
## Description

iOS `onConfigUpdated` called `FlutterEventSink` directly from Firebase's `addOnConfigUpdateListener` callback, which is not guaranteed to run on the main queue. Flutter then warned that `plugins.flutter.io/firebase_remote_config_updated` sent a message on a non-platform thread.

Copy the updated keys on the callback thread and hop the event onto `DispatchQueue.main`, matching Android's `mainThreadHandler.post` and other Apple stream handlers. macOS shares this Swift file via symlink.

## Related Issues

- Fixes https://github.com/firebase/flutterfire/issues/18670

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/